### PR TITLE
Setup initial state management for user and region

### DIFF
--- a/src/interface/package-lock.json
+++ b/src/interface/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-browser": "^14.2.0",
         "@angular/platform-browser-dynamic": "^14.2.0",
         "@angular/router": "^14.2.0",
+        "@ngrx/store": "^14.3.2",
         "leaflet": "^1.9.1",
         "material": "^0.4.3",
         "moment": "^2.29.4",
@@ -2683,6 +2684,18 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "node_modules/@ngrx/store": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-14.3.2.tgz",
+      "integrity": "sha512-XGHjr0arh6gClo8Ce+xqJLvW9PkeXPW2tCo9Z5qMtHFI/z5dUppLVKGmMgD/fQBDyoqWTK5xu+89tDkdeZfRjQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^14.0.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
     },
     "node_modules/@ngtools/webpack": {
       "version": "14.2.3",
@@ -13750,6 +13763,14 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "@ngrx/store": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-14.3.2.tgz",
+      "integrity": "sha512-XGHjr0arh6gClo8Ce+xqJLvW9PkeXPW2tCo9Z5qMtHFI/z5dUppLVKGmMgD/fQBDyoqWTK5xu+89tDkdeZfRjQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "@ngtools/webpack": {
       "version": "14.2.3",

--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^14.2.0",
     "@angular/platform-browser-dynamic": "^14.2.0",
     "@angular/router": "^14.2.0",
+    "@ngrx/store": "^14.3.2",
     "leaflet": "^1.9.1",
     "material": "^0.4.3",
     "moment": "^2.29.4",

--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CookieService } from 'ngx-cookie-service';
+import { StoreModule } from '@ngrx/store';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -25,6 +26,7 @@ import { PopupService } from './popup.service';
 import { SignupComponent } from './signup/signup.component';
 import { TopBarComponent } from './top-bar/top-bar.component';
 import { RegionSelectionComponent } from './region-selection/region-selection.component';
+import { appReducerMap } from './state';
 
 @NgModule({
   declarations: [
@@ -52,6 +54,12 @@ import { RegionSelectionComponent } from './region-selection/region-selection.co
     FormsModule,
     CommonModule,
     MatIconModule,
+    StoreModule.forRoot(appReducerMap, {
+      runtimeChecks: {
+        strictActionImmutability: true,
+        strictStateImmutability: true,
+      }
+    })
   ],
   providers: [
     AuthService,

--- a/src/interface/src/app/region-selection/region-selection.component.spec.ts
+++ b/src/interface/src/app/region-selection/region-selection.component.spec.ts
@@ -1,18 +1,30 @@
+import { AppState, userUpdateRegionAction } from '../state';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Region } from '../types';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
 
 import { RegionSelectionComponent } from './region-selection.component';
 
 describe('RegionSelectionComponent', () => {
   let component: RegionSelectionComponent;
   let fixture: ComponentFixture<RegionSelectionComponent>;
+  let store: MockStore<AppState>;
+
+  const initialState = {
+    user: {
+      currentUser: undefined,
+      region: undefined,
+    }
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ RegionSelectionComponent ]
+      declarations: [ RegionSelectionComponent ],
+      providers: [ provideMockStore({initialState})]
     })
     .compileComponents();
 
+    store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(RegionSelectionComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -23,20 +35,24 @@ describe('RegionSelectionComponent', () => {
   });
 
   it('should set available region', () => {
+    const dispatchSpy = spyOn(store, 'dispatch').and.callThrough();
     const element: HTMLElement = fixture.nativeElement;
     const sierraNevadaElement: any = element.querySelectorAll('.region-button')[0];
 
     sierraNevadaElement.click();
 
-    expect(component.selectedRegion).toEqual(Region.SIERRA_NEVADA);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      userUpdateRegionAction({region: Region.SIERRA_NEVADA})
+    );
   });
 
   it('should disable unavailable regions', () => {
+    const dispatchSpy = spyOn(store, 'dispatch').and.callThrough();
     const element: HTMLElement = fixture.nativeElement;
     const regionElement: any = element.querySelectorAll('.region-button')[2];
 
     regionElement.click();
 
-    expect(component.selectedRegion).toEqual(undefined);
+    expect(dispatchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/interface/src/app/region-selection/region-selection.component.ts
+++ b/src/interface/src/app/region-selection/region-selection.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from '@angular/core';
+import { select, Store } from '@ngrx/store';
+
 import { Region } from '../types';
+import { AppState, userRegionSelector, userUpdateRegionAction } from '../state';
 
 interface RegionButton {
-  type: Region;
+  region: Region;
   name: string;
   available: boolean;
   iconColor?: string;
@@ -25,15 +28,15 @@ const availableRegions = new Set([
   styleUrls: ['./region-selection.component.scss']
 })
 export class RegionSelectionComponent implements OnInit {
-  selectedRegion?: Region;
+  selectedRegion$ = this.store.pipe(select(userRegionSelector));
   regionButtons: RegionButton[] = [];
 
-  constructor() { }
+  constructor(private store: Store<AppState>) { }
 
   ngOnInit(): void {
     this.regionButtons = regions.map((region) => {
       return {
-        type: region,
+        region: region,
         name: region,
         available: availableRegions.has(region),
         iconColor: '#838383',
@@ -45,7 +48,7 @@ export class RegionSelectionComponent implements OnInit {
     if (!regionButton.available) {
       return;
     }
-    this.selectedRegion = regionButton.type;
+    this.store.dispatch(userUpdateRegionAction({region: regionButton.region}));
   }
 
 }

--- a/src/interface/src/app/state/app.reducer.ts
+++ b/src/interface/src/app/state/app.reducer.ts
@@ -1,0 +1,27 @@
+import { state } from '@angular/animations';
+import { ActionReducerMap } from '@ngrx/store';
+import { UserState, userReducer } from './user/user.reducer';
+
+/** The interface for the entire ngrx store. */
+export interface AppState {
+ user: UserState;
+}
+/**
+ * The main app reducer that combines all other reducers and returns
+ * the global state object:
+ *
+ * {
+ *   user: {
+ *     currentUser: {
+ *      id: ...,
+ *      username: ...,
+ *      region: undefined,
+ *      ...,
+ *     }
+ *   }
+ *  ...
+ * }
+ */
+export const appReducerMap: ActionReducerMap<AppState> = {
+  user: userReducer,
+};

--- a/src/interface/src/app/state/index.ts
+++ b/src/interface/src/app/state/index.ts
@@ -1,0 +1,2 @@
+export * from './app.reducer';
+export * from './user';

--- a/src/interface/src/app/state/user/index.ts
+++ b/src/interface/src/app/state/user/index.ts
@@ -1,0 +1,3 @@
+export * from './user.actions';
+export * from './user.reducer';
+export * from './user.selectors';

--- a/src/interface/src/app/state/user/user.actions.ts
+++ b/src/interface/src/app/state/user/user.actions.ts
@@ -1,0 +1,22 @@
+import { createAction, props } from '@ngrx/store';
+
+import { Region } from '../../types'
+
+/**
+ * Actions are dispatched by components to make changes to state.
+ *
+ * Each ngrx action has a type and an optional payload:
+ * The type is a string that represents the type of action that will be
+ * dispatched to the store, and the payload (props) adds any data needed for
+ * the action.
+ */
+
+export enum UserActionType {
+  USER_UPDATE_REGION = '[USER] update region',
+}
+
+/** Action for updating the user's selected region. */
+export const userUpdateRegionAction = createAction(
+  UserActionType.USER_UPDATE_REGION,
+  props<{ region: Region }>(),
+);

--- a/src/interface/src/app/state/user/user.reducer.spec.ts
+++ b/src/interface/src/app/state/user/user.reducer.spec.ts
@@ -1,0 +1,35 @@
+import { initialState, UserState, userReducer } from './user.reducer';
+import * as userActions from './user.actions';
+import { Region } from '../../types'
+
+describe('userReducer', () => {
+  let state: UserState;
+
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  it('should return state untouched if action is not meant for this reducer',
+      () => {
+    const unrelatedAction = {type: 'unrelated'};
+    const newState = userReducer(state, unrelatedAction);
+
+    // Check that it's same instance
+    expect(newState).toBe(state);
+    // Check that state wasn't mutated - deep equality check.
+    expect(newState).toEqual(state);
+  });
+
+  it('should update user selected region', () => {
+    const testRegion = Region.SIERRA_NEVADA;
+    const action = userActions.userUpdateRegionAction({region: testRegion});
+
+    const newState = userReducer(state, action);
+
+    // State should be a new instance
+    expect(newState).not.toBe(state);
+    expect(newState).toEqual(jasmine.objectContaining({
+      region: testRegion,
+    }));
+  });
+});

--- a/src/interface/src/app/state/user/user.reducer.ts
+++ b/src/interface/src/app/state/user/user.reducer.ts
@@ -1,0 +1,32 @@
+import {createReducer, on} from '@ngrx/store';
+
+import { Region, User } from '../../types'
+import * as actions from './user.actions';
+
+/**
+ * A reducer is called when an action is dispatched and returns
+ * the state.
+ * Each reducer function takes the action dispatched, the current
+ * state, and determines whether to return a newly modified state or the
+ * original state.
+ */
+
+export interface UserState {
+  currentUser?: User;
+  region?: Region;
+}
+
+export const initialState: UserState = {
+  currentUser: undefined,
+  region: undefined,
+};
+
+export const userReducer = createReducer(
+  initialState,
+  on(actions.userUpdateRegionAction, (state, {region}): UserState => {
+    return {
+      ...state,
+      region,
+    }
+  }),
+)

--- a/src/interface/src/app/state/user/user.selectors.spec.ts
+++ b/src/interface/src/app/state/user/user.selectors.spec.ts
@@ -1,0 +1,20 @@
+import { AppState } from './../app.reducer';
+import { Region } from '../../types'
+import { userRegionSelector } from './user.selectors';
+
+describe('userSelectors', () => {
+  let state: AppState;
+
+  beforeEach(() => {
+    state = {
+      user: {
+        currentUser: undefined,
+        region: Region.CENTRAL_COAST,
+      }
+    };
+  });
+
+  it('userRegionSelector should get region', () => {
+    expect(userRegionSelector(state)).toEqual(state.user.region);
+  });
+});

--- a/src/interface/src/app/state/user/user.selectors.ts
+++ b/src/interface/src/app/state/user/user.selectors.ts
@@ -1,0 +1,16 @@
+import { createSelector } from '@ngrx/store';
+import { AppState } from '../app.reducer';
+
+/**
+ * Selectors are pure functions that components call to get specific data from
+ * the store.
+ */
+
+export const userStateSelector = (state: AppState) => state.user;
+
+export const userRegionSelector = createSelector(
+  userStateSelector,
+  (userState) => {
+    return userState.region;
+  }
+);

--- a/src/interface/src/app/types/index.ts
+++ b/src/interface/src/app/types/index.ts
@@ -1,1 +1,2 @@
-export * from "./region.types";
+export * from './region.types';
+export * from './user.types';

--- a/src/interface/src/app/types/user.types.ts
+++ b/src/interface/src/app/types/user.types.ts
@@ -1,0 +1,5 @@
+
+export interface User {
+  id?: string;
+  username?: string;
+}


### PR DESCRIPTION
Experimental / do not merge / no review needed

# Changes:
* Added ngrx store
* Added actions, reducers, and selectors for region
* Updated region-selection component to utilize the store
* Added initial user type
* Added and updated tests
* Added more index.ts files, which are barrel files for centralizing exports from several modules into a single module

Here is a high-level diagram of how the store works:
![IMG_2627](https://user-images.githubusercontent.com/114368235/199404608-b3e11d34-ccd4-48f0-9dfa-b1964fa6a7d8.JPG)

# Future Changes:
* Open up explore component to selected region
* Add region selection dropdown to top bar