### PR TITLE
Setup initial observable service for region

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { SessionService } from './session.service';
 import { LayoutModule } from '@angular/cdk/layout';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
@@ -71,6 +72,7 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     PopupService,
     MapService,
     CookieService,
+    SessionService,
   ],
   bootstrap: [AppComponent],
   entryComponents: [AccountDialogComponent],

--- a/src/interface/src/app/region-selection/region-selection.component.html
+++ b/src/interface/src/app/region-selection/region-selection.component.html
@@ -12,7 +12,7 @@
       class="region-button"
       (click)="setRegion(region)"
       [class.disabled]="!region.available">
-      <div class="blank-region-icon"></div>
+      <div class="blank-region-icon" [class.selected]="region.type === (selectedRegion$ | async)"></div>
       <div class="region-label">{{ region.name }}</div>
     </div>
   </section>

--- a/src/interface/src/app/region-selection/region-selection.component.scss
+++ b/src/interface/src/app/region-selection/region-selection.component.scss
@@ -30,6 +30,7 @@
 .blank-region-icon {
   background-color: #838383;
   border-radius: 50%;
+  box-sizing: border-box;
   display: inline-block;
   height: 59px;
   transition: background-color ease 0.3s;
@@ -38,4 +39,9 @@
   &:hover {
     background-color: #3367D6;
   }
+
+  &.selected {
+    border: 3px solid #91b4ff;
+  }
+
 }

--- a/src/interface/src/app/region-selection/region-selection.component.spec.ts
+++ b/src/interface/src/app/region-selection/region-selection.component.spec.ts
@@ -1,15 +1,31 @@
+import { of, BehaviorSubject } from 'rxjs';
+import { SessionService } from './../session.service';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Region } from '../types';
 
 import { RegionSelectionComponent } from './region-selection.component';
 
+// selector names for getting DOM elements
+enum CssSelector {
+  RegionButton = '.region-button',
+}
+
 describe('RegionSelectionComponent', () => {
   let component: RegionSelectionComponent;
   let fixture: ComponentFixture<RegionSelectionComponent>;
+  let mockSessionService: Partial<SessionService>;
 
   beforeEach(async () => {
+    mockSessionService = {
+      region$: new BehaviorSubject<Region|null>(null),
+      setRegion: () => {},
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ RegionSelectionComponent ]
+      declarations: [ RegionSelectionComponent ],
+      providers: [
+        {provide: SessionService, useValue: mockSessionService},
+      ],
     })
     .compileComponents();
 
@@ -24,19 +40,21 @@ describe('RegionSelectionComponent', () => {
 
   it('should set available region', () => {
     const element: HTMLElement = fixture.nativeElement;
-    const sierraNevadaElement: any = element.querySelectorAll('.region-button')[0];
+    const sierraNevadaElement: any = element.querySelectorAll(CssSelector.RegionButton)[0];
+    const setRegionSpy = spyOn<any>(mockSessionService, 'setRegion');
 
     sierraNevadaElement.click();
 
-    expect(component.selectedRegion).toEqual(Region.SIERRA_NEVADA);
+    expect(setRegionSpy).toHaveBeenCalledWith(Region.SIERRA_NEVADA);
   });
 
   it('should disable unavailable regions', () => {
+    const setRegionSpy = spyOn<any>(mockSessionService, 'setRegion');
     const element: HTMLElement = fixture.nativeElement;
-    const regionElement: any = element.querySelectorAll('.region-button')[2];
+    const regionElement: any = element.querySelectorAll(CssSelector.RegionButton)[2];
 
     regionElement.click();
 
-    expect(component.selectedRegion).toEqual(undefined);
+    expect(setRegionSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/interface/src/app/region-selection/region-selection.component.ts
+++ b/src/interface/src/app/region-selection/region-selection.component.ts
@@ -1,11 +1,14 @@
+import { SessionService } from './../session.service';
 import { Component, OnInit } from '@angular/core';
 import { Region } from '../types';
 
+/**
+ * The main region selection view component.
+ */
 interface RegionButton {
   type: Region;
   name: string;
   available: boolean;
-  iconColor?: string;
 }
 
 const regions: Region[] = [
@@ -25,10 +28,10 @@ const availableRegions = new Set([
   styleUrls: ['./region-selection.component.scss']
 })
 export class RegionSelectionComponent implements OnInit {
-  selectedRegion?: Region;
+  selectedRegion$ = this.sessionService.region$;
   regionButtons: RegionButton[] = [];
 
-  constructor() { }
+  constructor(private sessionService: SessionService) {}
 
   ngOnInit(): void {
     this.regionButtons = regions.map((region) => {
@@ -36,16 +39,16 @@ export class RegionSelectionComponent implements OnInit {
         type: region,
         name: region,
         available: availableRegions.has(region),
-        iconColor: '#838383',
       }
-    })
+    });
   }
 
+  /** Sets the region. */
   setRegion(regionButton: RegionButton) {
     if (!regionButton.available) {
       return;
     }
-    this.selectedRegion = regionButton.type;
+    this.sessionService.setRegion(regionButton.type);
   }
 
 }

--- a/src/interface/src/app/session.service.spec.ts
+++ b/src/interface/src/app/session.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SessionService } from './session.service';
+
+describe('SessionService', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SessionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/session.service.spec.ts
+++ b/src/interface/src/app/session.service.spec.ts
@@ -1,3 +1,4 @@
+import { Region } from './types/region.types';
 import { TestBed } from '@angular/core/testing';
 
 import { SessionService } from './session.service';
@@ -12,5 +13,15 @@ describe('SessionService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should save region', () => {
+    const testRegion = Region.NORTHERN_CALIFORNIA;
+    const spyStorage = spyOn(localStorage, 'setItem');
+
+    service.setRegion(testRegion);
+
+    expect(spyStorage).toHaveBeenCalledOnceWith('region', testRegion);
+    expect(service.region$.value).toBe(testRegion);
   });
 });

--- a/src/interface/src/app/session.service.ts
+++ b/src/interface/src/app/session.service.ts
@@ -16,7 +16,7 @@ export class SessionService {
     this.region$.next(localStorage.getItem('region') as Region|null);
   }
 
-  /** Saves the region in local storage. */
+  /** Emits the region and saves it in local storage. */
   setRegion(value: Region) {
     if (Object.values(Region).includes(value)) {
       localStorage.setItem('region', value);

--- a/src/interface/src/app/session.service.ts
+++ b/src/interface/src/app/session.service.ts
@@ -1,0 +1,26 @@
+import { BehaviorSubject } from 'rxjs';
+import { Region } from './types/region.types';
+import { Injectable } from '@angular/core';
+
+/**
+ * The session service keeps track of where the guest or logged-in user left
+ * off.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionService {
+  readonly region$ = new BehaviorSubject<Region|null>(null);
+
+  constructor() {
+    this.region$.next(localStorage.getItem('region') as Region|null);
+  }
+
+  /** Saves the region in local storage. */
+  setRegion(value: Region) {
+    if (Object.values(Region).includes(value)) {
+      localStorage.setItem('region', value);
+      this.region$.next(value);
+    }
+  }
+}


### PR DESCRIPTION
# Changes:
* Added sessionService to save region to local storage
* Connected region-selection component and sessionService
* Updated UI to show the selected region for verification
* Updated tests

# UI Updates:
<img width="1183" alt="Screen Shot 2022-11-03 at 6 44 03 PM" src="https://user-images.githubusercontent.com/114368235/199869835-a9a89a73-b616-4fbf-b4c3-02e52fd76cb9.png">

# Todo:
* Open up explore component to selected region
* Add region selection dropdown to top bar
* Route "Planscape" title to region selection view