### PR TITLE
Small updates and bugfixes to MapService and MapComponent

### DIFF
--- a/src/interface/src/app/map.service.spec.ts
+++ b/src/interface/src/app/map.service.spec.ts
@@ -44,16 +44,17 @@ describe('MapService', () => {
   describe('getExistingProjects', () => {
     it('makes request to endpoint', () => {
       const httpTestingController = TestBed.inject(HttpTestingController);
+      const fakeGeoJsonText: string = JSON.stringify(fakeGeoJson);
 
       service.getExistingProjects().subscribe(res => {
         expect(res).toEqual(fakeGeoJson);
       });
 
       const req = httpTestingController.expectOne(
-        'https://services1.arcgis.com/jUJYIo9tSA7EHvfZ/ArcGIS/rest/services/CMDash_v3_view/FeatureServer/2/query?where=1%3D1&outFields=PROJECT_NAME%2CPROJECT_STATUS&f=GEOJSON'
+        'http://127.0.0.1:8000/projects'
       );
       expect(req.request.method).toEqual('GET');
-      req.flush(fakeGeoJson);
+      req.flush(fakeGeoJsonText);
       httpTestingController.verify();
     });
   });

--- a/src/interface/src/app/map.service.ts
+++ b/src/interface/src/app/map.service.ts
@@ -48,13 +48,6 @@ export class MapService {
 
   // Queries the CalMAPPER ArcGIS Web Feature Service for known land management projects without filtering.
   getExistingProjects(): Observable<GeoJSON.GeoJSON> {
-    const params = {
-      'where': '1=1',
-      'outFields' : 'PROJECT_NAME,PROJECT_STATUS',
-      'f': 'GEOJSON'
-    }
-
-    const url = "https://services1.arcgis.com/jUJYIo9tSA7EHvfZ/ArcGIS/rest/services/CMDash_v3_view/FeatureServer/2/query?" + new URLSearchParams(params).toString();
     return this.http.get<string>('http://127.0.0.1:8000/projects').pipe(map((response: string) => {
       return JSON.parse(response);
     }));

--- a/src/interface/src/app/map.service.ts
+++ b/src/interface/src/app/map.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { EMPTY, Observable } from 'rxjs';
+import { EMPTY, Observable, map } from 'rxjs';
 
 import { Region } from './types';
 
@@ -55,6 +55,8 @@ export class MapService {
     }
 
     const url = "https://services1.arcgis.com/jUJYIo9tSA7EHvfZ/ArcGIS/rest/services/CMDash_v3_view/FeatureServer/2/query?" + new URLSearchParams(params).toString();
-    return this.http.get<GeoJSON.GeoJSON>(url);
+    return this.http.get<string>('http://127.0.0.1:8000/projects').pipe(map((response: string) => {
+      return JSON.parse(response);
+    }));
   }
 }

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -1,4 +1,3 @@
-import { Region } from './../types/region.types';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -8,12 +7,13 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatRadioGroupHarness } from '@angular/material/radio/testing';
-import { of, BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { MapService } from '../map.service';
 import { PopupService } from '../popup.service';
-import { BaseLayerType, MapComponent } from './map.component';
 import { SessionService } from './../session.service';
+import { BaseLayerType, Region } from './../types';
+import { MapComponent } from './map.component';
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -111,12 +111,14 @@ describe('MapComponent', () => {
 
     // Act: select the terrain base layer
     await radioButtonGroup.checkRadioButton({ label: 'Terrain' });
+
     // Assert: expect that the map contains the terrain base layer
     expect(component.changeBaseLayer).toHaveBeenCalled();
     expect(component.map.hasLayer(MapComponent.hillshade_tiles));
 
     // Act: select the road base layer
     await radioButtonGroup.checkRadioButton({ label: 'Road' });
+
     // Assert: expect that the map contains the road base layer
     expect(component.changeBaseLayer).toHaveBeenCalled();
     expect(component.map.hasLayer(MapComponent.open_street_maps_tiles));
@@ -129,12 +131,14 @@ describe('MapComponent', () => {
 
     // Act: uncheck the HUC-12 checkbox
     await checkbox.uncheck();
+
     // Assert: expect that the map does not contain the HUC-12 layer
     expect(component.toggleHUC12BoundariesLayer).toHaveBeenCalled();
     expect(component.map.hasLayer(component.HUC12BoundariesLayer)).toBeFalse();
 
     // Act: check the HUC-12 checkbox
     await checkbox.check();
+
     // Assert: expect that the map contains the HUC-12 layer
     expect(component.toggleHUC12BoundariesLayer).toHaveBeenCalled();
     expect(component.map.hasLayer(component.HUC12BoundariesLayer)).toBeTrue();
@@ -143,14 +147,18 @@ describe('MapComponent', () => {
   it('should toggle existing projects layer', async () => {
     component.ngAfterViewInit();
     spyOn(component, 'toggleExistingProjectsLayer').and.callThrough();
+
     // Act: uncheck the existing projects checkbox
     const checkbox = await loader.getHarness(MatCheckboxHarness.with({ name: 'existing-projects-toggle' }));
     await checkbox.uncheck();
+
     // Assert: expect that the map removes the existing projects layer
     expect(component.toggleExistingProjectsLayer).toHaveBeenCalled();
     expect(component.map.hasLayer(component.existingProjectsLayer)).toBeFalse();
+
     // Act: check the existing projects checkbox
     await checkbox.check();
+
     // Assert: expect that the map adds the existing projects layer
     expect(component.toggleExistingProjectsLayer).toHaveBeenCalled();
     expect(component.map.hasLayer(component.existingProjectsLayer)).toBeTrue();

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -63,6 +63,7 @@ describe('MapComponent', () => {
     fixture = TestBed.createComponent(MapComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   it('can load instance', () => {

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -52,6 +52,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       this.initBoundaryLayer(boundary);
     });
     this.boundaryService.getExistingProjects().pipe(take(1)).subscribe((existingProjects: GeoJSON.GeoJSON) => {
+      console.log('existing projects', existingProjects);
       this.initCalMapperLayer(existingProjects);
     });
   }

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -1,16 +1,11 @@
-import { Subject, take, takeUntil, Observable } from 'rxjs';
-import { Region } from './../types/region.types';
 import { AfterViewInit, Component, OnDestroy } from '@angular/core';
 import * as L from 'leaflet';
+import { Observable, Subject, take, takeUntil } from 'rxjs';
 
 import { MapService } from '../map.service';
 import { PopupService } from '../popup.service';
 import { SessionService } from '../session.service';
-
-export enum BaseLayerType {
-  Road,
-  Terrain,
-}
+import { BaseLayerType, Region } from '../types';
 
 @Component({
   selector: 'app-map',

--- a/src/interface/src/app/types/index.ts
+++ b/src/interface/src/app/types/index.ts
@@ -1,1 +1,2 @@
+export * from "./layer.types";
 export * from "./region.types";

--- a/src/interface/src/app/types/layer.types.ts
+++ b/src/interface/src/app/types/layer.types.ts
@@ -1,0 +1,4 @@
+export enum BaseLayerType {
+  Road,
+  Terrain,
+}


### PR DESCRIPTION
- Updated REST endpoint for `MapService.getExistingProjects()` to point to Django backend
- Fixed failing `map.component.spec.ts` (note to self: run `ng test` before merging PRs)
- Moved `BaseLayerType` from `MapComponent` to `types` folder