### PR TITLE
Add map descriptions and relocate layer controls to side panel

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { AppComponent } from './app.component';
 import { AuthGuard, AuthService } from './auth.service';
 import { LoginComponent } from './login/login.component';
 import { MapService } from './map.service';
+import { MapNameplateComponent } from './map/map-nameplate/map-nameplate.component';
 import { MapComponent } from './map/map.component';
 import { ProjectCardComponent } from './map/project-card/project-card.component';
 import { MaterialModule } from './material/material.module';
@@ -22,6 +23,7 @@ import { RegionSelectionComponent } from './region-selection/region-selection.co
 import { SessionService } from './session.service';
 import { SharedModule } from './shared/shared.module';
 import { SignupComponent } from './signup/signup.component';
+import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
 
 @NgModule({
@@ -35,6 +37,8 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     AccountDialogComponent,
     RegionSelectionComponent,
     ProjectCardComponent,
+    StringifyMapConfigPipe,
+    MapNameplateComponent,
   ],
   imports: [
     AppRoutingModule,
@@ -58,4 +62,4 @@ import { TopBarComponent } from './top-bar/top-bar.component';
   bootstrap: [AppComponent],
   entryComponents: [AccountDialogComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
@@ -1,0 +1,4 @@
+<div class="map-nameplate" [ngClass]="{'selected': selected}">
+  <div class="map-name">{{ map?.name }}</div>
+  <div class="map-config-string">{{ map?.config | stringifyMapConfig }}</div>
+</div>

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.scss
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.scss
@@ -1,0 +1,28 @@
+.map-config-string {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.map-name {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+.map-nameplate {
+  align-items: center;
+  background-color: #ffffff;
+  bottom: 0px;
+  display: flex;
+  height: 30px;
+  min-width: 0;
+  opacity: 50%;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+}
+
+.map-nameplate.selected {
+  opacity: 80%;
+}

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.spec.ts
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StringifyMapConfigPipe } from './../../stringify-map-config.pipe';
+import { MapNameplateComponent } from './map-nameplate.component';
+
+describe('MapNameplateComponent', () => {
+  let component: MapNameplateComponent;
+  let fixture: ComponentFixture<MapNameplateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MapNameplateComponent, StringifyMapConfigPipe],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MapNameplateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.ts
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { Map } from 'src/app/types';
+
+@Component({
+  selector: 'app-map-nameplate',
+  templateUrl: './map-nameplate.component.html',
+  styleUrls: ['./map-nameplate.component.scss'],
+})
+export class MapNameplateComponent {
+  @Input() map!: Map | null;
+  @Input() selected: boolean = false;
+}

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,32 +1,4 @@
 <div class="root-container">
-  <!-- Info bar above the maps -->
-  <div class="map-options-bar">
-
-    <!-- Dropdown for creating a planning area -->
-    <button mat-raised-button type="button" class="plan-options-button">
-      <mat-select
-        [(value)]="selectedPlanCreationOption"
-        placeholder="Create a plan"
-        class="plan-options-select"
-        (selectionChange)="onPlanCreationOptionChange($event.value)">
-        <mat-select-trigger *ngIf="selectedPlanCreationOption">
-          <mat-icon class="selection-icon">{{selectedPlanCreationOption.icon}}</mat-icon>
-          {{selectedPlanCreationOption.display}}
-        </mat-select-trigger>
-        <mat-option *ngFor="let option of planCreationOptions" [value]="option">
-          <mat-icon>{{option.icon}}</mat-icon>{{option.display}}
-        </mat-option>
-      </mat-select>
-    </button>
-
-    <!-- Create plan button -->
-    <button *ngIf="showCreatePlanButton"
-      mat-button type="button"
-      class="create-plan-button"
-      (click)="openCreatePlanDialog()">
-      <mat-icon>add</mat-icon>CREATE
-    </button>
-  </div>
 
   <!-- Map control panel -->
   <div id="controls" class="controls-container">
@@ -130,6 +102,35 @@
 
   <!-- Display containers for leaflet maps (up to 4) -->
   <div class="maps-container">
+    <!-- Info bar above the maps -->
+    <div class="map-options-bar">
+      <!-- Dropdown for creating a planning area -->
+      <button mat-raised-button type="button" class="plan-options-button">
+        <mat-select
+          [(value)]="selectedPlanCreationOption"
+          placeholder="Create a plan"
+          class="plan-options-select"
+          (selectionChange)="onPlanCreationOptionChange($event.value)">
+          <mat-select-trigger *ngIf="selectedPlanCreationOption">
+            <mat-icon class="selection-icon">{{selectedPlanCreationOption.icon}}</mat-icon>
+            {{selectedPlanCreationOption.display}}
+          </mat-select-trigger>
+          <mat-option *ngFor="let option of planCreationOptions" [value]="option">
+            <mat-icon>{{option.icon}}</mat-icon>{{option.display}}
+          </mat-option>
+        </mat-select>
+      </button>
+
+      <!-- Create plan button -->
+      <button *ngIf="showCreatePlanButton"
+        mat-button type="button"
+        class="create-plan-button"
+        (click)="openCreatePlanDialog()">
+        <mat-icon>add</mat-icon>CREATE
+      </button>
+    </div>
+
+    <!-- Maps (1, 2, or 4) -->
     <div class="map-row" [ngStyle]="{'height': mapCount > 2 ? '50%' : '100%'}">
       <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 0}"
         data-testid="map1">

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,23 +1,29 @@
 <div class="map-container">
   <!-- Display containers for leaflet maps (up to 4) -->
   <div class="map-row">
-    <div id="map1" class="map" [ngClass]="{'selected': selectedMapIndex === 0}"
+    <div id="map1-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 0}"
       [ngStyle]="{'height': mapCount > 2 ? '50%' : '100%', 'width': mapCount === 1 ? '100%' : '50%'}"
       data-testid="map1">
+      <app-map-nameplate [map]="maps[0]" [selected]="selectedMapIndex === 0"></app-map-nameplate>
+      <div id="map1" class="map"></div>
     </div>
-    <div id="map2" class="map" [ngClass]="{'selected': selectedMapIndex === 1}"
+    <div id="map2-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 1}"
       [ngStyle]="{'height': mapCount > 2 ? '50%' : '100%'}" [hidden]="mapCount < 2"
       data-testid="map2">
+      <app-map-nameplate [map]="maps[1]" [selected]="selectedMapIndex === 1"></app-map-nameplate>
+      <div id="map2" class="map"></div>
     </div>
   </div>
   <div class="map-row">
-    <div id="map3" class="map" [ngClass]="{'selected': selectedMapIndex === 2}"
-      [hidden]="mapCount < 4"
-      data-testid="map3">
+    <div id="map3-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 2}"
+      [hidden]="mapCount < 4" data-testid="map3">
+      <app-map-nameplate [map]="maps[2]" [selected]="selectedMapIndex === 2"></app-map-nameplate>
+      <div id="map3" class="map"></div>
     </div>
-    <div id="map4" class="map" [ngClass]="{'selected': selectedMapIndex === 3}"
-      [hidden]="mapCount < 4"
-      data-testid="map4">
+    <div id="map4-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 3}"
+      [hidden]="mapCount < 4" data-testid="map4">
+      <app-map-nameplate [map]="maps[3]" [selected]="selectedMapIndex === 3"></app-map-nameplate>
+      <div id="map4" class="map"></div>
     </div>
   </div>
 

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,32 +1,4 @@
-<div class="map-container">
-  <!-- Display containers for leaflet maps (up to 4) -->
-  <div class="map-row">
-    <div id="map1-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 0}"
-      [ngStyle]="{'height': mapCount > 2 ? '50%' : '100%', 'width': mapCount === 1 ? '100%' : '50%'}"
-      data-testid="map1">
-      <app-map-nameplate [map]="maps[0]" [selected]="selectedMapIndex === 0"></app-map-nameplate>
-      <div id="map1" class="map"></div>
-    </div>
-    <div id="map2-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 1}"
-      [ngStyle]="{'height': mapCount > 2 ? '50%' : '100%'}" [hidden]="mapCount < 2"
-      data-testid="map2">
-      <app-map-nameplate [map]="maps[1]" [selected]="selectedMapIndex === 1"></app-map-nameplate>
-      <div id="map2" class="map"></div>
-    </div>
-  </div>
-  <div class="map-row">
-    <div id="map3-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 2}"
-      [hidden]="mapCount < 4" data-testid="map3">
-      <app-map-nameplate [map]="maps[2]" [selected]="selectedMapIndex === 2"></app-map-nameplate>
-      <div id="map3" class="map"></div>
-    </div>
-    <div id="map4-box" class="map-box" [ngClass]="{'selected': selectedMapIndex === 3}"
-      [hidden]="mapCount < 4" data-testid="map4">
-      <app-map-nameplate [map]="maps[3]" [selected]="selectedMapIndex === 3"></app-map-nameplate>
-      <div id="map4" class="map"></div>
-    </div>
-  </div>
-
+<div class="root-container">
   <!-- Map control panel -->
   <div id="controls" class="controls-container">
     <div class="layer-controls">
@@ -136,6 +108,35 @@
           </div>
         </mat-tab>
       </mat-tab-group>
+    </div>
+  </div>
+
+  <!-- Display containers for leaflet maps (up to 4) -->
+  <div class="maps-container">
+    <div class="map-row" [ngStyle]="{'height': mapCount > 2 ? '50%' : '100%'}">
+      <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 0}"
+        data-testid="map1">
+        <app-map-nameplate [map]="maps[0]" [selected]="selectedMapIndex === 0"></app-map-nameplate>
+        <div id="map1" class="map"></div>
+      </div>
+      <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 1}"
+        [hidden]="mapCount < 2"
+        data-testid="map2">
+        <app-map-nameplate [map]="maps[1]" [selected]="selectedMapIndex === 1"></app-map-nameplate>
+        <div id="map2" class="map"></div>
+      </div>
+    </div>
+    <div class="map-row" [ngStyle]="{'height': mapCount > 2 ? '50%' : '0%'}">
+      <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 2}"
+        [hidden]="mapCount < 4" data-testid="map3">
+        <app-map-nameplate [map]="maps[2]" [selected]="selectedMapIndex === 2"></app-map-nameplate>
+        <div id="map3" class="map"></div>
+      </div>
+      <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 3}"
+        [hidden]="mapCount < 4" data-testid="map4">
+        <app-map-nameplate [map]="maps[3]" [selected]="selectedMapIndex === 3"></app-map-nameplate>
+        <div id="map4" class="map"></div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -1,69 +1,16 @@
-.map {
-  height: 100%;
-  position: absolute;
-  width: 100%;
-  z-index: 1;
-}
-
-.map-box {
-  border: 1px solid black;
-  box-sizing: border-box;
-  height: 100%;
-  position: absolute;
-  width: 100%;
-  z-index: 1;
-}
-
-.map-box.selected {
-  border: 4px solid #ef008c;
-}
-
-.map-container {
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
-  position: relative;
-}
-
-.map-row {
+.root-container {
+  display: flex;
   flex-direction: row;
-}
-
-#map2-box {
-  left: 50%;
-  width: 50%;
-}
-
-#map3-box {
-  height: 50%;
-  top: 50%;
-  width: 50%;
-}
-
-#map4-box {
-  height: 50%;
-  left: 50%;
-  top: 50%;
-  width: 50%;
-}
-
-// Workaround for unresolved Angular bug re: tab width on desktop
-// (https://github.com/angular/components/issues/2829).
-::ng-deep .mat-tab-label {
-  min-width: 60px !important;
+  height: 100%;
+  width: 100%;
 }
 
 .controls-container {
-  padding: 20px;
-  position: absolute;
   width: 450px;
-  z-index: 10;
 }
 
 .layer-controls {
   background-color: white;
-  border: 1px solid black;
-  border-radius: 8px;
   height: match-parent;
   padding: 20px;
   width: match-parent;
@@ -87,4 +34,42 @@
 
 .layer-checkbox {
   margin: 0px 5px 0px;
+}
+
+.maps-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.map-row {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+}
+
+.map-box {
+  border: 1px solid black;
+  box-sizing: border-box;
+  height: 100%;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+
+.map-box.selected {
+  border: 4px solid #ef008c;
+}
+
+.map {
+  height: 100%;
+  width: 100%;
+  z-index: 1;
+}
+
+// Workaround for unresolved Angular bug re: tab width on desktop
+// (https://github.com/angular/components/issues/2829).
+::ng-deep .mat-tab-label {
+  min-width: 60px !important;
 }

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -1,3 +1,23 @@
+.map {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.map-box {
+  border: 1px solid black;
+  box-sizing: border-box;
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.map-box.selected {
+  border: 4px solid #ef008c;
+}
+
 .map-container {
   flex-direction: column;
   height: 100%;
@@ -9,27 +29,18 @@
   flex-direction: row;
 }
 
-.map {
-  border: 1px solid black;
-  box-sizing: border-box;
-  height: 100%;
-  position: absolute;
-  width: 100%;
-  z-index: 1;
-}
-
-#map2 {
+#map2-box {
   left: 50%;
   width: 50%;
 }
 
-#map3 {
+#map3-box {
   height: 50%;
   top: 50%;
   width: 50%;
 }
 
-#map4 {
+#map4-box {
   height: 50%;
   left: 50%;
   top: 50%;
@@ -76,8 +87,4 @@
 
 .layer-checkbox {
   margin: 0px 5px 0px;
-}
-
-.selected {
-  border: 4px solid #EF008C;
 }

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -45,6 +45,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
   width: 100%;
 }
 
@@ -128,14 +129,14 @@
 }
 
 .plan-options-button {
-  left: 480px;
+  left: 20px;
   pointer-events: auto;
   top: 10px;
 }
 
 .create-plan-button {
   color: #ffffff;
-  left: 500px;
+  left: 100px;
   pointer-events: auto;
   top: 10px;
 }

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -148,9 +148,8 @@ describe('MapComponent', () => {
     let map2: DebugElement;
     let map3: DebugElement;
     let map4: DebugElement;
-    let matCountRadioButtonGroup: MatRadioGroupHarness;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       map1 = fixture.debugElement.query(
         By.css('[data-testid="map1"]')
       ).nativeElement;
@@ -163,18 +162,17 @@ describe('MapComponent', () => {
       map4 = fixture.debugElement.query(
         By.css('[data-testid="map4"]')
       ).nativeElement;
-      matCountRadioButtonGroup = await loader.getHarness(
-        MatRadioGroupHarness.with({ name: 'map-count-select' })
-      );
     });
 
-    it('shows 2 maps by default', () => {
+    it('shows 2 maps by default', async () => {
       expect(component.mapCount).toBe(2);
-      matCountRadioButtonGroup
-        .getCheckedValue()
-        .then((value: string | null) => {
-          expect(value).toBe('2');
-        });
+
+      const radioButtonGroup = await loader.getHarness(
+        MatRadioGroupHarness.with({ name: 'map-count-select' })
+      );
+      radioButtonGroup.getCheckedValue().then((value: string | null) => {
+        expect(value).toBe('2');
+      });
 
       expect(map1.attributes['hidden']).toBeUndefined();
       expect(map2.attributes['hidden']).toBeUndefined();
@@ -183,7 +181,10 @@ describe('MapComponent', () => {
     });
 
     it('toggles to show 1 map', async () => {
-      await matCountRadioButtonGroup.checkRadioButton({ label: '1' });
+      const radioButtonGroup = await loader.getHarness(
+        MatRadioGroupHarness.with({ name: 'map-count-select' })
+      );
+      await radioButtonGroup.checkRadioButton({ label: '1' });
 
       expect(component.mapCount).toBe(1);
       expect(map1.attributes['hidden']).toBeUndefined();
@@ -193,7 +194,10 @@ describe('MapComponent', () => {
     });
 
     it('toggles to show 4 maps', async () => {
-      await matCountRadioButtonGroup.checkRadioButton({ label: '4' });
+      const radioButtonGroup = await loader.getHarness(
+        MatRadioGroupHarness.with({ name: 'map-count-select' })
+      );
+      await radioButtonGroup.checkRadioButton({ label: '4' });
 
       expect(component.mapCount).toBe(4);
       expect(map1.attributes['hidden']).toBeUndefined();

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -1,9 +1,16 @@
-import { AfterViewInit, ApplicationRef, Component, createComponent, EnvironmentInjector, OnDestroy } from '@angular/core';
+import {
+  AfterViewInit,
+  ApplicationRef,
+  Component,
+  createComponent,
+  EnvironmentInjector,
+  OnDestroy,
+} from '@angular/core';
 import { Feature, Geometry } from 'geojson';
 import * as L from 'leaflet';
 import 'leaflet-draw';
 import 'leaflet.sync';
-import { BehaviorSubject, map, Observable, Subject, take, takeUntil } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, take, takeUntil } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 import { MapService } from '../map.service';

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -1,0 +1,39 @@
+import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
+import { BaseLayerType, MapConfig } from './types';
+
+describe('StringifyMapConfigPipe', () => {
+  let pipe: StringifyMapConfigPipe;
+
+  beforeEach(() => {
+    pipe = new StringifyMapConfigPipe();
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  describe('transform', () => {
+    it('should return empty string if input config is undefined', () => {
+      let transformedStr = pipe.transform(undefined);
+
+      expect(transformedStr).toEqual('');
+    });
+
+    it('should return formatted config string', () => {
+      let mapConfig: MapConfig = {
+        baseLayerType: BaseLayerType.Road,
+        showExistingProjectsLayer: true,
+        showHuc12BoundaryLayer: true,
+        showDataLayer: true,
+        showHuc10BoundaryLayer: false,
+        showUsForestBoundaryLayer: false,
+        showCountyBoundaryLayer: false,
+      };
+      let mapConfigStr = 'Existing Projects | HUC-12 Boundaries | Data';
+
+      let transformedStr = pipe.transform(mapConfig);
+
+      expect(transformedStr).toEqual(mapConfigStr);
+    });
+  });
+});

--- a/src/interface/src/app/stringify-map-config.pipe.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.ts
@@ -1,0 +1,47 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { MapConfig } from './types';
+
+/*
+ *  Transforms a MapConfig object into a human-readable string
+ *  for display at the bottom of a Leaflet map.
+ */
+@Pipe({
+  name: 'stringifyMapConfig',
+  pure: false,
+})
+export class StringifyMapConfigPipe implements PipeTransform {
+  transform(mapConfig: MapConfig | undefined): string {
+    if (!mapConfig) {
+      return '';
+    }
+
+    let str: string = '';
+    let labels: string[] = [];
+    if (mapConfig.showExistingProjectsLayer) {
+      labels.push('Existing Projects');
+    }
+    if (mapConfig.showHuc12BoundaryLayer) {
+      labels.push('HUC-12 Boundaries');
+    }
+    if (mapConfig.showHuc10BoundaryLayer) {
+      labels.push('HUC-10 Boundaries');
+    }
+    if (mapConfig.showCountyBoundaryLayer) {
+      labels.push('County Boundaries');
+    }
+    if (mapConfig.showUsForestBoundaryLayer) {
+      labels.push('US Forest Boundaries');
+    }
+    if (mapConfig.showDataLayer) {
+      labels.push('Data');
+    }
+    labels.forEach((label, index) => {
+      if (index > 0) {
+        str = str.concat(' | ');
+      }
+      str = str.concat(label);
+    });
+    return str;
+  }
+}

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -107,5 +107,10 @@ $planscape-frontend-theme: mat.define-light-theme((
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
+// Adjust the Leaflet attribution control to make room for the map nameplate.
+.leaflet-container .leaflet-control-attribution {
+  margin-bottom: 30px;
+}
+
 // Must manually import leaflet draw css. https://github.com/Leaflet/Leaflet.draw/issues/617
 @import "~leaflet-draw/dist/leaflet.draw.css";


### PR DESCRIPTION
## Changes
- Added semitransparent nameplate at bottom of each map containing the map's name and a description of its layers.
- `StringifyMapConfigPipe` generates a string from a map's configuration options (for the nameplate).
- Moved map and layer controls into a side panel; they no longer float over the first map.

![image](https://user-images.githubusercontent.com/10444733/203438591-b3e9dd02-fa53-4853-ad5b-487b73385cb9.png)

## Todo
- Adjust colors of the legend to match the colors from the heatmap (pass these from the backend?).
- Change map count selection from a radio button group to the icons from the mocks.