### PR TITLE
Add UI for defining a planning area, support for multiple polygon planning areas, and plan creation dialog

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { SessionService } from './session.service';
 import { SharedModule } from './shared/shared.module';
 import { SignupComponent } from './signup/signup.component';
 import { TopBarComponent } from './top-bar/top-bar.component';
+import { PlanCreateDialogComponent } from './map/plan-create-dialog/plan-create-dialog.component';
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     AccountDialogComponent,
     RegionSelectionComponent,
     ProjectCardComponent,
+    PlanCreateDialogComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CookieService } from 'ngx-cookie-service';
+import { ReactiveFormsModule } from '@angular/forms';
 
 import { AccountDialogComponent } from './account-dialog/account-dialog.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -48,6 +49,7 @@ import { PlanCreateDialogComponent } from './map/plan-create-dialog/plan-create-
     LayoutModule,
     MaterialModule,
     SharedModule,
+    ReactiveFormsModule,
   ],
   providers: [
     AuthService,

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,22 +1,30 @@
 <div class="map-container">
   <!-- Info bar above the maps -->
   <div class="map-options-bar">
+
+    <!-- Dropdown for creating a planning area -->
     <button mat-raised-button type="button" name="button" class="plan-options-button roundedButton">
-    <mat-select
-      [(value)]="selectedPlanOption"
-      placeholder="Create a plan"
-      class="plan-options-button"
-      (selectionChange)="onPlanOptionChange($event.value)">
-      <mat-select-trigger *ngIf="selectedPlanOption">
-        <mat-icon class="selection-icon">{{selectedPlanOption.icon}}</mat-icon>{{selectedPlanOption.viewValue}}
-      </mat-select-trigger>
-      <mat-option *ngFor="let option of planOptions" [value]="option">
-        <mat-icon>{{option.icon}}</mat-icon>{{option.viewValue}}
-      </mat-option>
-    </mat-select>
+      <mat-select
+        [(value)]="selectedPlanCreationOption"
+        placeholder="Create a plan"
+        class="plan-options-button"
+        (selectionChange)="onPlanCreationOptionChange($event.value)">
+        <mat-select-trigger *ngIf="selectedPlanCreationOption">
+          <mat-icon class="selection-icon">{{selectedPlanCreationOption.icon}}</mat-icon>
+          {{selectedPlanCreationOption.viewValue}}
+        </mat-select-trigger>
+        <mat-option *ngFor="let option of planCreationOptions" [value]="option">
+          <mat-icon>{{option.icon}}</mat-icon>{{option.viewValue}}
+        </mat-option>
+      </mat-select>
     </button>
 
-    <button *ngIf="showCreatePlanButton" mat-button type="button" name="button" class="create-plan-button roundedButton">
+    <!-- Create plan button -->
+    <button *ngIf="showCreatePlanButton"
+      mat-button type="button"
+      name="button"
+      class="create-plan-button roundedButton"
+      (click)="openCreatePlanDialog()">
       <mat-icon>add</mat-icon>CREATE
     </button>
   </div>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -3,11 +3,11 @@
   <div class="map-options-bar">
 
     <!-- Dropdown for creating a planning area -->
-    <button mat-raised-button type="button" name="button" class="plan-options-button roundedButton">
+    <button mat-raised-button type="button" name="plan-options-button" class="plan-options-button roundedButton">
       <mat-select
         [(value)]="selectedPlanCreationOption"
         placeholder="Create a plan"
-        class="plan-options-button"
+        class="plan-options-select"
         (selectionChange)="onPlanCreationOptionChange($event.value)">
         <mat-select-trigger *ngIf="selectedPlanCreationOption">
           <mat-icon class="selection-icon">{{selectedPlanCreationOption.icon}}</mat-icon>
@@ -22,7 +22,7 @@
     <!-- Create plan button -->
     <button *ngIf="showCreatePlanButton"
       mat-button type="button"
-      name="button"
+      name="create-plan-button"
       class="create-plan-button roundedButton"
       (click)="openCreatePlanDialog()">
       <mat-icon>add</mat-icon>CREATE

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -3,7 +3,7 @@
   <div class="map-options-bar">
 
     <!-- Dropdown for creating a planning area -->
-    <button mat-raised-button type="button" name="plan-options-button" class="plan-options-button roundedButton">
+    <button mat-raised-button type="button" class="plan-options-button roundedButton">
       <mat-select
         [(value)]="selectedPlanCreationOption"
         placeholder="Create a plan"
@@ -11,10 +11,10 @@
         (selectionChange)="onPlanCreationOptionChange($event.value)">
         <mat-select-trigger *ngIf="selectedPlanCreationOption">
           <mat-icon class="selection-icon">{{selectedPlanCreationOption.icon}}</mat-icon>
-          {{selectedPlanCreationOption.viewValue}}
+          {{selectedPlanCreationOption.display}}
         </mat-select-trigger>
         <mat-option *ngFor="let option of planCreationOptions" [value]="option">
-          <mat-icon>{{option.icon}}</mat-icon>{{option.viewValue}}
+          <mat-icon>{{option.icon}}</mat-icon>{{option.display}}
         </mat-option>
       </mat-select>
     </button>
@@ -22,7 +22,6 @@
     <!-- Create plan button -->
     <button *ngIf="showCreatePlanButton"
       mat-button type="button"
-      name="create-plan-button"
       class="create-plan-button roundedButton"
       (click)="openCreatePlanDialog()">
       <mat-icon>add</mat-icon>CREATE

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,4 +1,26 @@
 <div class="map-container">
+  <!-- Info bar above the maps -->
+  <div class="map-options-bar">
+    <button mat-raised-button type="button" name="button" class="plan-options-button roundedButton">
+    <mat-select
+      [(value)]="selectedPlanOption"
+      placeholder="Create a plan"
+      class="plan-options-button"
+      (selectionChange)="onPlanOptionChange($event.value)">
+      <mat-select-trigger *ngIf="selectedPlanOption">
+        <mat-icon class="selection-icon">{{selectedPlanOption.icon}}</mat-icon>{{selectedPlanOption.viewValue}}
+      </mat-select-trigger>
+      <mat-option *ngFor="let option of planOptions" [value]="option">
+        <mat-icon>{{option.icon}}</mat-icon>{{option.viewValue}}
+      </mat-option>
+    </mat-select>
+    </button>
+
+    <button *ngIf="showCreatePlanButton" mat-button type="button" name="button" class="create-plan-button roundedButton">
+      <mat-icon>add</mat-icon>CREATE
+    </button>
+  </div>
+
   <!-- Display containers for leaflet maps (up to 4) -->
   <div class="map-row">
     <div id="map1" class="map" [ngClass]="{'selected': selectedMapIndex === 0}"

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -3,7 +3,7 @@
   <div class="map-options-bar">
 
     <!-- Dropdown for creating a planning area -->
-    <button mat-raised-button type="button" class="plan-options-button roundedButton">
+    <button mat-raised-button type="button" class="plan-options-button">
       <mat-select
         [(value)]="selectedPlanCreationOption"
         placeholder="Create a plan"
@@ -22,7 +22,7 @@
     <!-- Create plan button -->
     <button *ngIf="showCreatePlanButton"
       mat-button type="button"
-      class="create-plan-button roundedButton"
+      class="create-plan-button"
       (click)="openCreatePlanDialog()">
       <mat-icon>add</mat-icon>CREATE
     </button>

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -81,3 +81,25 @@
 .selected {
   border: 4px solid #EF008C;
 }
+
+// Styling for the info bar above the maps
+.map-options-bar {
+  background-color: rgba(0, 0, 0, 0.5);
+  height: 50px;
+  position: absolute;
+  pointer-events: none;
+  width: 100%;
+  z-index: 2;
+}
+
+.plan-options-button {
+  pointer-events: auto;
+  left: 480px;
+  top: 10px;
+}
+
+.create-plan-button {
+  color: #ffffff;
+  left: 500px;
+  top: 10px;
+}

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -93,13 +93,14 @@
 }
 
 .plan-options-button {
-  pointer-events: auto;
   left: 480px;
+  pointer-events: auto;
   top: 10px;
 }
 
 .create-plan-button {
   color: #ffffff;
   left: 500px;
+  pointer-events: auto;
   top: 10px;
 }

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -18,7 +18,7 @@ import { ProjectCardComponent } from './project-card/project-card.component';
 
 export interface PlanCreationOption {
   value: string;
-  viewValue: string;
+  display: string;
   icon: any;
 }
 @Component({
@@ -74,7 +74,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   };
 
   planCreationOptions: PlanCreationOption[] = [
-    {value: 'draw-area', icon: 'edit', viewValue: 'Draw an area'},
+    {value: 'draw-area', icon: 'edit', display: 'Draw an area'},
   ];
   selectedPlanCreationOption: PlanCreationOption | null = null;
   showCreatePlanButton: boolean = false;
@@ -413,7 +413,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
-   * On PlanCreationOption selection change, enables the polygon tool if
+   * On PlanCreationOptions selection change, enables the polygon tool if
    * the drawing option is selected.
    */
   onPlanCreationOptionChange(option: PlanCreationOption) {

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -14,6 +14,11 @@ import { BaseLayerType, Map, MapConfig, Region } from '../types';
 import { Legend } from './../shared/legend/legend.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
 
+export interface PlanOption {
+  value: string;
+  viewValue: string;
+  icon: any;
+}
 @Component({
   selector: 'app-map',
   templateUrl: './map.component.html',
@@ -65,6 +70,12 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       '#508295',
     ],
   };
+
+  planOptions: PlanOption[] = [
+    {value: 'draw-plan', icon: 'edit', viewValue: 'Draw an area'},
+  ];
+  selectedPlanOption: PlanOption | null = null;
+  showCreatePlanButton: boolean = false;
 
   static hillshadeTiles() {
     return L.tileLayer(
@@ -299,44 +310,48 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     map.addLayer(drawingLayer);
 
     const drawOptions: L.Control.DrawConstructorOptions = {
-      position: 'topright',
-      draw: {
-        polygon: {
-          allowIntersection: false,
-          showArea: true,
-          metric: false, // Set measurement units to acres
-          repeatMode: true, // Stays in polygon mode after completing a shape
-          shapeOptions: {
-            color: '#7b61ff',
-          },
-          drawError: {
-            color: '#ff7b61',
-            message: "Can't draw polygons with intersections!",
-          },
-        }, // Set to false to disable each tool
-        polyline: false,
-        circle: false,
-        rectangle: false,
-        marker: false,
-        circlemarker: false,
-      },
-      edit: {
-        featureGroup: drawingLayer, // Required and declares which layer is editable
-      },
+        position: 'bottomright',
+        draw: {
+            polygon: {
+              allowIntersection: false,
+              showArea: true,
+              metric: false, // Set measurement units to acres
+              shapeOptions: {
+                color: '#7b61ff',
+              },
+              drawError: {
+                  color: '#ff7b61',
+                  message: 'Can\'t draw polygons with intersections!',
+              },
+            }, // Set to false to disable each tool
+            polyline: false,
+            circle: false,
+            rectangle: false,
+            marker: false,
+            circlemarker: false,
+        },
+        edit: {
+            featureGroup: drawingLayer, // Required and declares which layer is editable
+        }
     };
 
     const drawControl = new L.Control.Draw(drawOptions);
     map.addControl(drawControl);
 
+    this.setUpDrawingHandlers(map, drawingLayer);
+  }
+
+  private setUpDrawingHandlers(map: L.Map, drawingLayer: L.FeatureGroup) {
     map.on('draw:created', (event) => {
       const layer = (event as L.DrawEvents.Created).layer;
       drawingLayer.addLayer(layer);
-
+      this.showCreatePlanButton = true;
+      // open create plan dialog
       this.createPlan(layer.toGeoJSON());
     });
   }
 
-  private createPlan(shape: GeoJSON.GeoJSON) {
+  createPlan(shape: GeoJSON.GeoJSON) {
     this.selectedRegion$.subscribe((selectedRegion) => {
       if (!selectedRegion) return;
 
@@ -351,6 +366,24 @@ export class MapComponent implements AfterViewInit, OnDestroy {
           console.log(result);
         });
     });
+  }
+
+  onPlanOptionChange(option: PlanOption) {
+    if (option.value === 'draw-plan') {
+      const polygonDrawer = new L.Draw.Polygon(this.maps[0].instance as L.DrawMap, {
+        allowIntersection: false,
+        showArea: true,
+        metric: false,
+        shapeOptions: {
+          color: '#7b61ff',
+        },
+        drawError: {
+            color: '#ff7b61',
+            message: 'Can\'t draw polygons with intersections!',
+        },
+      });
+    polygonDrawer.enable();
+    }
   }
 
   /** Gets the selected region geojson and renders it on the map. */

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
@@ -1,0 +1,26 @@
+<h1 mat-dialog-title>Start a new plan in this planning area?</h1>
+<mat-dialog-content>
+    <mat-form-field [ngStyle]="{'min-width': '480px'}">
+      <mat-label>Plan name</mat-label>
+      <input matInput [formControl]="planNameControl">
+    </mat-form-field>
+  <p>
+    Once a plan is created, you can choose focuses & constraints, create scenarios,
+    and develop your proposal as well as share with collaborators.
+  </p>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button
+    mat-raised-button
+    class="cancel-button roundedButton"
+    (click)="cancel()">
+    Cancel
+  </button>
+  <button
+    mat-raised-button
+    class="submit-button roundedButton"
+    type="submit"
+    (click)="submit()">
+    Confirm
+  </button>
+</mat-dialog-actions>

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
@@ -1,6 +1,6 @@
 <h1 mat-dialog-title>Start a new plan in this planning area?</h1>
 <mat-dialog-content>
-    <mat-form-field [ngStyle]="{'min-width': '480px'}">
+    <mat-form-field>
       <mat-label>Plan name</mat-label>
       <input matInput [formControl]="planNameControl">
     </mat-form-field>
@@ -12,13 +12,13 @@
 <mat-dialog-actions>
   <button
     mat-raised-button
-    class="cancel-button roundedButton"
+    class="cancel-button"
     (click)="cancel()">
     Cancel
   </button>
   <button
     mat-raised-button
-    class="submit-button roundedButton"
+    class="submit-button"
     type="submit"
     (click)="submit()">
     Confirm

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.scss
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+  min-width: 480px;
+}

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
 
 import { PlanCreateDialogComponent } from './plan-create-dialog.component';
 
@@ -8,7 +9,10 @@ describe('PlanCreateDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PlanCreateDialogComponent ]
+      declarations: [ PlanCreateDialogComponent ],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+      ]
     })
     .compileComponents();
 

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 
@@ -12,7 +13,10 @@ describe('PlanCreateDialogComponent', () => {
       declarations: [ PlanCreateDialogComponent ],
       providers: [
         { provide: MatDialogRef, useValue: {} },
-      ]
+      ],
+      schemas: [
+        NO_ERRORS_SCHEMA,
+      ],
     })
     .compileComponents();
 

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlanCreateDialogComponent } from './plan-create-dialog.component';
+
+describe('PlanCreateDialogComponent', () => {
+  let component: PlanCreateDialogComponent;
+  let fixture: ComponentFixture<PlanCreateDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PlanCreateDialogComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlanCreateDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.ts
@@ -1,0 +1,22 @@
+import { MatDialogRef } from '@angular/material/dialog';
+import { FormControl, Validators } from '@angular/forms';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-plan-create-dialog',
+  templateUrl: './plan-create-dialog.component.html',
+  styleUrls: ['./plan-create-dialog.component.scss']
+})
+export class PlanCreateDialogComponent {
+  planNameControl = new FormControl('', Validators.required);
+
+  constructor(private dialogRef: MatDialogRef<PlanCreateDialogComponent>) {}
+
+  submit() {
+    this.dialogRef.close(this.planNameControl);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -27,6 +28,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatListModule,
     MatProgressSpinnerModule,
     MatRadioModule,
+    MatSelectModule,
     MatSidenavModule,
     MatSliderModule,
     MatTabsModule,

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -14,6 +14,7 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { ReactiveFormsModule } from '@angular/forms';
 
 
 @NgModule({
@@ -33,6 +34,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatSliderModule,
     MatTabsModule,
     MatToolbarModule,
+    ReactiveFormsModule,
   ]
 })
 export class MaterialModule { }

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -14,7 +14,6 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { ReactiveFormsModule } from '@angular/forms';
 
 
 @NgModule({
@@ -34,7 +33,6 @@ import { ReactiveFormsModule } from '@angular/forms';
     MatSliderModule,
     MatTabsModule,
     MatToolbarModule,
-    ReactiveFormsModule,
   ]
 })
 export class MaterialModule { }


### PR DESCRIPTION
# Changes:
* Added an information bar above the maps (temporary styling)
* Added plan creation dropdown for defining a planning area
* Auto-enabled polygon tool when "draw an area" is selected
* Added "create" plan button, which shows when 1+ polygon is drawn
* Added a plan creation dialog that opens when "create" is clicked
* Added form validation on plan name
* Added a method for converting multiple polygons in the drawing layer into geojson
* Updated convertToPlanningArea() to only happen once a plan is confirmed
* Added tests

# UI Preview:
<img width="1244" alt="Screen Shot 2022-11-22 at 12 49 40 PM" src="https://user-images.githubusercontent.com/114368235/203418717-cfdf673f-458d-401d-beb4-b986500d096b.png">

# The created Plan object:
<img width="272" alt="Screen Shot 2022-11-22 at 12 51 03 PM" src="https://user-images.githubusercontent.com/114368235/203418746-6bf6bf91-cc31-4b6e-8626-c57bebbca0a0.png">

# Todo:
* Handle polygon deletion (hide "create" button when no polygons left)
* Move services to separate folder
* Adjust drawing tool to multimaps and syncing