### PR TITLE
Replaced radio buttons for map count with grid buttons

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -22,19 +22,37 @@
   <div id="controls" class="controls-container">
     <div class="layer-controls">
 
-      <!-- Controls for specifying how many maps should be shown -->
-      <h3>Map count</h3>
-      <mat-radio-group name="map-count-select" aria-label="Select an option" class="layer-radio-group"
-        [(ngModel)]="mapCount" (change)="changeMapCount()">
-        <mat-radio-button *ngFor="let mapCountOption of mapCountOptions" [value]="mapCountOption"
-          class="layer-radio-button">
-          {{ mapCountOption }}
-        </mat-radio-button>
-      </mat-radio-group>
-
       <!-- Legend for the currently shown map -->
       <h3>Legend</h3>
       <app-legend [legend]="legend"></app-legend>
+
+      <mat-divider class="layer-controls-divider"></mat-divider>
+
+      <!-- Controls for specifying how many maps should be shown -->
+      <div class="map-count-button-row">
+        <button mat-button class="map-count-button" (click)="changeMapCount(1)" aria-label="Show 1 map"
+        [ngClass]="{'selected': mapCount === 1}">
+          <div class="map-count-button-grid-cell"></div>
+        </button>
+        <button mat-button class="map-count-button" (click)="changeMapCount(2)" aria-label="Show 2 maps"
+        [ngClass]="{'selected': mapCount === 2}">
+          <div class="map-count-button-grid-row">
+            <div class="map-count-button-grid-cell"></div>
+            <div class="map-count-button-grid-cell"></div>
+          </div>
+        </button>
+        <button mat-button class="map-count-button" (click)="changeMapCount(4)" aria-label="Show 4 maps"
+        [ngClass]="{'selected': mapCount === 4}">
+        <div class="map-count-button-grid-row">
+          <div class="map-count-button-grid-cell"></div>
+          <div class="map-count-button-grid-cell"></div>
+        </div>
+        <div class="map-count-button-grid-row">
+          <div class="map-count-button-grid-cell"></div>
+          <div class="map-count-button-grid-cell"></div>
+        </div>
+        </button>
+      </div>
 
       <!-- Layer controls for each map, displayed in tabs -->
       <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true" [selectedIndex]="selectedMapIndex"

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -63,6 +63,11 @@
   flex-direction: row;
 }
 
+.layer-controls-divider {
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
 .layer-radio-group {
   align-items: flex-start;
   display: flex;
@@ -78,6 +83,43 @@
   margin: 0px 5px 0px;
 }
 
-.selected {
+.map-count-button-row {
+  display: flex;
+  justify-content: center;
+}
+
+.map-count-button {
+  align-items: center;
+  background-color: #f1eff2;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  height: 28px;
+  justify-content: center;
+  margin-left: 2px;
+  margin-right: 2px;
+  width: 72px;
+}
+
+.map-count-button.selected {
+  background-color: #e4e2e5;
+}
+
+.map-count-button-grid-row {
+  display: flex;
+  justify-content: center;
+}
+
+.map-count-button-grid-cell {
+  border: 1px solid #656367;
+  border-radius: 1px;
+  box-sizing: border-box;
+  height: 8px;
+  margin-right: 1px;
+  margin-bottom: 1px;
+  width: 8px;
+}
+
+.map.selected {
   border: 4px solid #EF008C;
 }

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -603,7 +603,9 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  changeMapCount() {
+  /* Change how many maps are displayed in the viewport. */
+  changeMapCount(mapCount: number) {
+    this.mapCount = mapCount;
     setTimeout(() => {
       this.maps.forEach((map: Map) => map.instance?.invalidateSize());
     }, 0);

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -3,6 +3,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -21,6 +22,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatCardModule,
     MatCheckboxModule,
     MatDialogModule,
+    MatDividerModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,


### PR DESCRIPTION
- Replaced map count radio buttons with visual buttons, per mocks
- Added divider between legend and map controls sections
- This closes #116 

![image](https://user-images.githubusercontent.com/10444733/203652163-5157744a-a19b-49aa-94e4-339a356ee57d.png)
