### PR TITLE
Show selected map and its controls in single-map view

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -39,7 +39,7 @@
       <!-- Layer controls for each map, displayed in tabs -->
       <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true" [selectedIndex]="selectedMapIndex"
         [dynamicHeight]="true">
-        <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}" [disabled]="i > (mapCount - 1)">
+        <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}" [disabled]="!isMapVisible(i)">
           <h3>Base layer</h3>
           <mat-radio-group name="{{ map.id + '-base-layer-select' }}" aria-label="Select an option"
             class="layer-radio-group" [(ngModel)]="map.config.baseLayerType" (change)="changeBaseLayer(map)">
@@ -131,27 +131,26 @@
     </div>
 
     <!-- Maps (1, 2, or 4) -->
-    <div class="map-row" [ngStyle]="{'height': mapCount > 2 ? '50%' : '100%'}">
+    <div class="map-row" [ngStyle]="{'height': mapRowHeight(0)}">
       <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 0}"
-        data-testid="map1">
+        [hidden]="!isMapVisible(0)" data-testid="map1">
         <app-map-nameplate [map]="maps[0]" [selected]="selectedMapIndex === 0"></app-map-nameplate>
         <div id="map1" class="map"></div>
       </div>
       <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 1}"
-        [hidden]="mapCount < 2"
-        data-testid="map2">
+        [hidden]="!isMapVisible(1)" data-testid="map2">
         <app-map-nameplate [map]="maps[1]" [selected]="selectedMapIndex === 1"></app-map-nameplate>
         <div id="map2" class="map"></div>
       </div>
     </div>
-    <div class="map-row" [ngStyle]="{'height': mapCount > 2 ? '50%' : '0%'}">
+    <div class="map-row" [ngStyle]="{'height': mapRowHeight(1)}">
       <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 2}"
-        [hidden]="mapCount < 4" data-testid="map3">
+        [hidden]="!isMapVisible(2)" data-testid="map3">
         <app-map-nameplate [map]="maps[2]" [selected]="selectedMapIndex === 2"></app-map-nameplate>
         <div id="map3" class="map"></div>
       </div>
       <div class="map-box" [ngClass]="{'selected': selectedMapIndex === 3}"
-        [hidden]="mapCount < 4" data-testid="map4">
+        [hidden]="!isMapVisible(3)" data-testid="map4">
         <app-map-nameplate [map]="maps[3]" [selected]="selectedMapIndex === 3"></app-map-nameplate>
         <div id="map4" class="map"></div>
       </div>

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -13,8 +13,8 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BehaviorSubject, of } from 'rxjs';
 import * as L from 'leaflet';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { MapService } from '../map.service';
 import { PopupService } from '../popup.service';
@@ -73,19 +73,31 @@ describe('MapComponent', () => {
       'MatDialog',
       {
         open: {
-          afterClosed: () => of({
-            value: 'test name'
-          })
+          afterClosed: () =>
+            of({
+              value: 'test name',
+            }),
         } as MatDialogRef<any>,
       },
-      {});
-      const popupServiceStub = () => ({
-        makeDetailsPopup: (shape_name: any) => ({}),
-      });
+      {}
+    );
+    const popupServiceStub = () => ({
+      makeDetailsPopup: (shape_name: any) => ({}),
+    });
     TestBed.configureTestingModule({
-      imports: [FormsModule, MatCheckboxModule, MatRadioModule, MatSelectModule, BrowserAnimationsModule],
+      imports: [
+        FormsModule,
+        MatCheckboxModule,
+        MatRadioModule,
+        MatSelectModule,
+        BrowserAnimationsModule,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
-      declarations: [MapComponent, ProjectCardComponent, PlanCreateDialogComponent],
+      declarations: [
+        MapComponent,
+        ProjectCardComponent,
+        PlanCreateDialogComponent,
+      ],
       providers: [
         { provide: MatDialog, useValue: fakeMatDialog },
         { provide: MapService, useValue: fakeMapService },
@@ -115,6 +127,7 @@ describe('MapComponent', () => {
           showCountyBoundaryLayer: false,
           showUsForestBoundaryLayer: false,
           showDataLayer: false,
+          showDataLayerNormalized: false,
         });
       });
     });
@@ -237,6 +250,66 @@ describe('MapComponent', () => {
       component.maps[2].instance?.fireEvent('click');
 
       expect(component.selectedMapIndex).toBe(2);
+    });
+
+    it('selected map is always visible', () => {
+      [0, 1, 2, 3].forEach((selectedMapIndex: number) => {
+        component.selectedMapIndex = selectedMapIndex;
+        [1, 2, 4].forEach((mapCount: number) => {
+          component.mapCount = mapCount;
+
+          expect(component.isMapVisible(component.selectedMapIndex)).toBeTrue();
+        });
+      });
+    });
+
+    it('all maps are visible in 4-map view', () => {
+      component.mapCount = 4;
+
+      [0, 1, 2, 3].forEach((mapIndex: number) => {
+        expect(component.isMapVisible(mapIndex)).toBeTrue();
+      });
+    });
+
+    it('only selected map is visible in 1-map view', () => {
+      component.mapCount = 1;
+
+      [0, 1, 2, 3].forEach((selectedMapIndex: number) => {
+        component.selectedMapIndex = selectedMapIndex;
+        [0, 1, 2, 3].forEach((mapIndex: number) => {
+          if (selectedMapIndex === mapIndex) {
+            expect(component.isMapVisible(mapIndex)).toBeTrue();
+          } else {
+            expect(component.isMapVisible(mapIndex)).toBeFalse();
+          }
+        });
+      });
+    });
+
+    it('row containing selected map height is 100% in 1-map view', () => {
+      component.mapCount = 1;
+
+      [0, 1].forEach((selectedMapIndex: number) => {
+        component.selectedMapIndex = selectedMapIndex;
+
+        expect(component.mapRowHeight(0)).toEqual('100%');
+        expect(component.mapRowHeight(1)).toEqual('0%');
+      });
+
+      [2, 3].forEach((selectedMapIndex: number) => {
+        component.selectedMapIndex = selectedMapIndex;
+
+        expect(component.mapRowHeight(0)).toEqual('0%');
+        expect(component.mapRowHeight(1)).toEqual('100%');
+      });
+    });
+
+    it('all row heights are 50% in 4-map view', () => {
+      component.mapCount = 4;
+
+      [0, 1].forEach((mapRowIndex: number) => {
+        expect(component.mapRowHeight(mapRowIndex)).toEqual('50%');
+      });
     });
   });
 
@@ -404,13 +477,14 @@ describe('MapComponent', () => {
 
   describe('Create plan', () => {
     it('opens create plan dialog', async () => {
-      const fakeMatDialog: MatDialog = fixture.debugElement.injector.get(
-        MatDialog
-      );
+      const fakeMatDialog: MatDialog =
+        fixture.debugElement.injector.get(MatDialog);
       fixture.componentInstance.showCreatePlanButton = true;
-      const button = await loader.getHarness(MatButtonHarness.with({
-        'selector': '.create-plan-button'
-      }));
+      const button = await loader.getHarness(
+        MatButtonHarness.with({
+          selector: '.create-plan-button',
+        })
+      );
 
       await button.click();
 
@@ -422,12 +496,14 @@ describe('MapComponent', () => {
         type: 'FeatureCollection',
         features: [],
       };
-      const createPlanSpy = spyOn<any>(component, 'createPlan').and.callThrough();
+      const createPlanSpy = spyOn<any>(
+        component,
+        'createPlan'
+      ).and.callThrough();
 
       fixture.componentInstance.openCreatePlanDialog();
 
       expect(createPlanSpy).toHaveBeenCalledWith('test name', emptyGeoJson);
     });
   });
-
 });

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -1,6 +1,19 @@
-import { AfterViewInit, ApplicationRef, Component, createComponent, EnvironmentInjector, OnDestroy } from '@angular/core';
+import {
+  AfterViewInit,
+  ApplicationRef,
+  Component,
+  createComponent,
+  EnvironmentInjector,
+  OnDestroy,
+} from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { Feature, FeatureCollection, Geometry, MultiPolygon, Polygon } from 'geojson';
+import {
+  Feature,
+  FeatureCollection,
+  Geometry,
+  MultiPolygon,
+  Polygon,
+} from 'geojson';
 import * as L from 'leaflet';
 import 'leaflet-draw';
 import 'leaflet.sync';
@@ -74,7 +87,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   };
 
   planCreationOptions: PlanCreationOption[] = [
-    {value: 'draw-area', icon: 'edit', display: 'Draw an area'},
+    { value: 'draw-area', icon: 'edit', display: 'Draw an area' },
   ];
   selectedPlanCreationOption: PlanCreationOption | null = null;
   showCreatePlanButton: boolean = false;
@@ -92,10 +105,14 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   }
 
   static stadiaAlidadeTiles() {
-    return L.tileLayer('https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png', {
-      maxZoom: 19,
-      attribution: '&copy; <a href="https://stadiamaps.com/" target="_blank" rel="noreferrer">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/" target="_blank" rel="noreferrer">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org" target="_blank" rel="noreferrer">OpenStreetMap</a> contributors',
-    });
+    return L.tileLayer(
+      'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png',
+      {
+        maxZoom: 19,
+        attribution:
+          '&copy; <a href="https://stadiamaps.com/" target="_blank" rel="noreferrer">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/" target="_blank" rel="noreferrer">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org" target="_blank" rel="noreferrer">OpenStreetMap</a> contributors',
+      }
+    );
   }
 
   static dataLayerTiles() {
@@ -306,8 +323,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       showUsForestBoundaryLayer: false,
       showDataLayer: false,
       showDataLayerNormalized: false,
-    }
-  };
+    };
+  }
 
   /** Sync pan, zoom, etc. between all maps. */
   private syncAllMaps() {
@@ -325,29 +342,29 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     map.addLayer(this.drawingLayer);
 
     const drawOptions: L.Control.DrawConstructorOptions = {
-        position: 'bottomright',
-        draw: {
-            polygon: {
-              allowIntersection: false,
-              showArea: true,
-              metric: false, // Set measurement units to acres
-              shapeOptions: {
-                color: '#7b61ff',
-              },
-              drawError: {
-                  color: '#ff7b61',
-                  message: 'Can\'t draw polygons with intersections!',
-              },
-            }, // Set to false to disable each tool
-            polyline: false,
-            circle: false,
-            rectangle: false,
-            marker: false,
-            circlemarker: false,
-        },
-        edit: {
-            featureGroup: this.drawingLayer, // Required and declares which layer is editable
-        }
+      position: 'bottomright',
+      draw: {
+        polygon: {
+          allowIntersection: false,
+          showArea: true,
+          metric: false, // Set measurement units to acres
+          shapeOptions: {
+            color: '#7b61ff',
+          },
+          drawError: {
+            color: '#ff7b61',
+            message: "Can't draw polygons with intersections!",
+          },
+        }, // Set to false to disable each tool
+        polyline: false,
+        circle: false,
+        rectangle: false,
+        marker: false,
+        circlemarker: false,
+      },
+      edit: {
+        featureGroup: this.drawingLayer, // Required and declares which layer is editable
+      },
     };
 
     const drawControl = new L.Control.Draw(drawOptions);
@@ -372,27 +389,28 @@ export class MapComponent implements AfterViewInit, OnDestroy {
    */
   private convertToPlanningArea(): GeoJSON.GeoJSON {
     const drawnGeoJson = this.drawingLayer.toGeoJSON() as FeatureCollection;
-      // Case: Single polygon
-      if (drawnGeoJson.features.length <= 1) return drawnGeoJson;
+    // Case: Single polygon
+    if (drawnGeoJson.features.length <= 1) return drawnGeoJson;
 
-      // Case: Multipolygon
-      const newFeature: GeoJSON.Feature = {
-        type: 'Feature',
-        geometry: {
-          type: 'MultiPolygon',
-          coordinates: [],
-        },
-        properties: {},
-      };
-      drawnGeoJson.features.forEach((feature) => {
-        (newFeature.geometry as MultiPolygon).coordinates.push(
-            (feature.geometry as Polygon).coordinates)
-      });
+    // Case: Multipolygon
+    const newFeature: GeoJSON.Feature = {
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [],
+      },
+      properties: {},
+    };
+    drawnGeoJson.features.forEach((feature) => {
+      (newFeature.geometry as MultiPolygon).coordinates.push(
+        (feature.geometry as Polygon).coordinates
+      );
+    });
 
-      return {
-        "type": "FeatureCollection",
-        "features": [newFeature],
-      } as FeatureCollection;
+    return {
+      type: 'FeatureCollection',
+      features: [newFeature],
+    } as FeatureCollection;
   }
 
   /** Configures and opens the Create Plan dialog */
@@ -400,7 +418,10 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     const dialogConfig = new MatDialogConfig();
     dialogConfig.maxWidth = '560px';
 
-    const openedDialog = this.dialog.open(PlanCreateDialogComponent, dialogConfig);
+    const openedDialog = this.dialog.open(
+      PlanCreateDialogComponent,
+      dialogConfig
+    );
 
     openedDialog.afterClosed().subscribe((result) => {
       if (result) {
@@ -413,14 +434,16 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     this.selectedRegion$.subscribe((selectedRegion) => {
       if (!selectedRegion) return;
 
-      this.planService.createPlan({
-        name: name,
-        ownerId: 'tempUserId',
-        region: selectedRegion,
-        planningArea: shape,
-      }).subscribe(result => {
-        console.log(result);
-      });
+      this.planService
+        .createPlan({
+          name: name,
+          ownerId: 'tempUserId',
+          region: selectedRegion,
+          planningArea: shape,
+        })
+        .subscribe((result) => {
+          console.log(result);
+        });
     });
   }
 
@@ -430,18 +453,21 @@ export class MapComponent implements AfterViewInit, OnDestroy {
    */
   onPlanCreationOptionChange(option: PlanCreationOption) {
     if (option.value === 'draw-area') {
-      const polygonDrawer = new L.Draw.Polygon(this.maps[0].instance as L.DrawMap, {
-        allowIntersection: false,
-        showArea: true,
-        metric: false,
-        shapeOptions: {
-          color: '#7b61ff',
-        },
-        drawError: {
+      const polygonDrawer = new L.Draw.Polygon(
+        this.maps[0].instance as L.DrawMap,
+        {
+          allowIntersection: false,
+          showArea: true,
+          metric: false,
+          shapeOptions: {
+            color: '#7b61ff',
+          },
+          drawError: {
             color: '#ff7b61',
-            message: 'Can\'t draw polygons with intersections!',
-        },
-      });
+            message: "Can't draw polygons with intersections!",
+          },
+        }
+      );
       polygonDrawer.enable();
     }
   }
@@ -690,5 +716,44 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     setTimeout(() => {
       this.maps.forEach((map: Map) => map.instance?.invalidateSize());
     }, 0);
+  }
+
+  /** Whether the map at given index should be visible. */
+  isMapVisible(index: number): boolean {
+    if (index === this.selectedMapIndex) return true;
+
+    switch (this.mapCount) {
+      case 4:
+        return true;
+      case 1:
+        // Only 1 map is visible and this one is not selected
+        return false;
+      case 2:
+      default:
+        // In 2 map view, only the 1st and 2nd map are shown regardless of selection
+        if (index === 0 || index === 1) {
+          // TODO: 2 map view might go away or the logic here might change
+          return true;
+        }
+        return false;
+    }
+  }
+
+  /** Computes the height for the map row at given index (0%, 50%, or 100%). */
+  mapRowHeight(index: number): string {
+    switch (this.mapCount) {
+      case 4:
+        return '50%';
+      case 2:
+        // In 2 map view, only the 1st and 2nd map are shown regardless of selection
+        // TODO: 2 map view might go away or the logic here might change
+        return index === 0 ? '100%' : '0%';
+      case 1:
+      default:
+        if (Math.floor(this.selectedMapIndex / 2) === index) {
+          return '100%';
+        }
+        return '0%';
+    }
   }
 }


### PR DESCRIPTION
## Changes
- Previously, when the user switched to 1-map view, only Map 1 was visible. Now the visible map in 1-map view is the map the user had selected.
- Map controls for visible maps are active in the lefthand panel; map controls for hidden maps are greyed out.
- Unit tests updated.
- Ran formatter on affected files.

![image](https://user-images.githubusercontent.com/10444733/204401454-0b7b32a9-10f8-422b-ada2-15bd66e94b9e.png)
