### PR TITLE
Set up simple memory cache for the boundary app

### DIFF
--- a/src/planscape/boundary/viewsets.py
+++ b/src/planscape/boundary/viewsets.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.contrib.gis.db.models.functions import Intersection
 from django.db.models import F, Subquery
 from django.utils.decorators import method_decorator
@@ -8,6 +6,9 @@ from rest_framework import viewsets
 
 from .models import Boundary, BoundaryDetails
 from .serializers import BoundaryDetailsSerializer, BoundarySerializer
+
+# Time to cache the boundary responses, in seconds.
+CACHE_TIME_IN_SECONDS = 60*60*2
 
 
 class BoundaryViewSet(viewsets.ReadOnlyModelViewSet):
@@ -56,7 +57,7 @@ class BoundaryDetailsViewSet(viewsets.ReadOnlyModelViewSet):
         return BoundaryDetails.objects.none()
 
     # The requests take O(10s) often to serialize, and boundaries don't change much.
-    # Cache the results for 60*60*2 seconds = 2 hours.
-    @method_decorator(cache_page(60*60*2))
+    # Cache the results for CACHE_TIME_IN_SECONDS seconds.
+    @method_decorator(cache_page(CACHE_TIME_IN_SECONDS))
     def list(self, request, *args, **kwargs):
         return super().list(self, request, *args, **kwargs)

--- a/src/planscape/conditions/views.py
+++ b/src/planscape/conditions/views.py
@@ -1,12 +1,12 @@
 from django.http import HttpRequest, HttpResponse, JsonResponse, QueryDict
 from django.db import connection
 
-from decouple import config
+from decouple import config as cfg
 from typing import cast
 
 import json, os
 
-PLANSCAPE_ROOT_DIRECTORY = cast(str, config('PLANSCAPE_ROOT_DIRECTORY'))
+PLANSCAPE_ROOT_DIRECTORY = cast(str, cfg('PLANSCAPE_ROOT_DIRECTORY'))
 
 # Name of the table and column from models.py.
 RASTER_TABLE = 'conditions_conditionraster'

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -178,3 +178,10 @@ SITE_ID = 1
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_LOGOUT_ON_GET = True
 
+# Caching; this improves loading times especially for the boundary app.
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'planscape-cache',
+    }
+}


### PR DESCRIPTION
This improves the loading of the HUC12, etc. boundaries greatly on the second load.

Also: ran "Sort imports" from VSCode.