### PR TITLE
Display pillar in layer controls only if display flag is true

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -106,13 +106,15 @@
             class="layer-radio-group" *ngIf="map.config.showDataLayer"
             [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
             <div *ngFor="let pillar of (conditionsConfig$ | async)?.pillars">
-              <h4>{{ pillar.display_name }}</h4>
-              <div *ngFor="let element of pillar.elements">
-                <h5>{{ element.display_name }}</h5>
-                <div *ngFor="let metric of element.metrics">
-                  <mat-radio-button class="layer-radio-button" [value]="metric">
-                    {{ metric.display_name ? metric.display_name : metric.metric_name }}
-                  </mat-radio-button>
+              <div *ngIf="pillar.display">
+                <h4>{{ pillar.display_name }}</h4>
+                <div *ngFor="let element of pillar.elements">
+                  <h5>{{ element.display_name }}</h5>
+                  <div *ngFor="let metric of element.metrics">
+                    <mat-radio-button class="layer-radio-button" [value]="metric">
+                      {{ metric.display_name ? metric.display_name : metric.metric_name }}
+                    </mat-radio-button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -69,6 +69,7 @@ describe('MapComponent', () => {
         conditionsConfig$: new BehaviorSubject<ConditionsConfig | null>({
           pillars: [
             {
+              display: true,
               elements: [
                 {
                   metrics: [

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -20,6 +20,7 @@ export interface MetricConfig {
 
 export interface PillarConfig {
   display_name?: string;
+  display?: boolean;
   pillar_name?: string;
   filepath?: string;
   elements?: ElementConfig[];


### PR DESCRIPTION
* Hide pillars from layer controls if the display flag is false (meaning we don't have RRK data for that pillar yet).