### PR TITLE
Load boundary layers from config + lazy loading

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -8,7 +8,7 @@ import {
 import * as L from 'leaflet';
 import 'leaflet-draw';
 import 'leaflet.sync';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, take } from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
 import { PopupService } from '../services';
@@ -23,6 +23,8 @@ export class MapManager {
   maps: Map[];
   popupService: PopupService;
 
+  boundaryGeoJsonCache = new Map<string, GeoJSON.GeoJSON>();
+
   drawingLayer = new L.FeatureGroup();
 
   constructor(maps: Map[], popupService: PopupService) {
@@ -34,12 +36,11 @@ export class MapManager {
   initLeafletMap(
     map: Map,
     mapId: string,
-    huc12BoundaryGeoJson$: BehaviorSubject<GeoJSON.GeoJSON | null>,
-    huc10BoundaryGeoJson$: BehaviorSubject<GeoJSON.GeoJSON | null>,
-    countyBoundaryGeoJson$: BehaviorSubject<GeoJSON.GeoJSON | null>,
-    usForestBoundaryGeoJson$: BehaviorSubject<GeoJSON.GeoJSON | null>,
     existingProjectsGeoJson$: BehaviorSubject<GeoJSON.GeoJSON | null>,
-    createDetailCardCallback: (feature: Feature<Geometry, any>) => any
+    createDetailCardCallback: (feature: Feature<Geometry, any>) => any,
+    getBoundaryLayerGeoJsonCallback: (
+      boundaryName: string
+    ) => Observable<GeoJSON.GeoJSON>
   ) {
     if (map.instance != undefined) map.instance.remove();
 
@@ -63,26 +64,7 @@ export class MapManager {
     zoomControl.addTo(map.instance);
 
     // Init layers, but only add them to the map instance if specified in the map config.
-    huc12BoundaryGeoJson$.subscribe((boundary: GeoJSON.GeoJSON | null) => {
-      if (boundary) {
-        this.initHuc12BoundaryLayer(map, boundary);
-      }
-    });
-    huc10BoundaryGeoJson$.subscribe((boundary: GeoJSON.GeoJSON | null) => {
-      if (boundary != null) {
-        this.initHUC10BoundaryLayer(map, boundary);
-      }
-    });
-    countyBoundaryGeoJson$.subscribe((boundary: GeoJSON.GeoJSON | null) => {
-      if (boundary) {
-        this.initCountyBoundaryLayer(map, boundary);
-      }
-    });
-    usForestBoundaryGeoJson$.subscribe((boundary: GeoJSON.GeoJSON | null) => {
-      if (boundary != null) {
-        this.initUSForestBoundaryLayer(map, boundary);
-      }
-    });
+    this.toggleBoundaryLayer(map, getBoundaryLayerGeoJsonCallback);
     existingProjectsGeoJson$.subscribe((projects: GeoJSON.GeoJSON | null) => {
       if (projects) {
         this.initCalMapperLayer(map, projects, createDetailCardCallback);
@@ -137,56 +119,6 @@ export class MapManager {
     if (map.config.showExistingProjectsLayer) {
       map.instance?.addLayer(map.existingProjectsLayerRef);
     }
-  }
-
-  /** Renders the HUC-12 boundaries in an optional layer. */
-  private initHuc12BoundaryLayer(map: Map, boundary: GeoJSON.GeoJSON) {
-    map.huc12BoundaryLayerRef = this.boundaryLayer(boundary);
-
-    if (map.config.showHuc12BoundaryLayer) {
-      map.instance?.addLayer(map.huc12BoundaryLayerRef);
-    }
-  }
-
-  private initHUC10BoundaryLayer(map: Map, boundary: GeoJSON.GeoJSON) {
-    map.huc10BoundaryLayerRef = this.boundaryLayer(boundary);
-
-    if (map.config.showHuc10BoundaryLayer) {
-      map.instance?.addLayer(map.huc10BoundaryLayerRef);
-    }
-  }
-
-  /** Renders the county boundaries in an optional layer. */
-  private initCountyBoundaryLayer(map: Map, boundary: GeoJSON.GeoJSON) {
-    map.countyBoundaryLayerRef = this.boundaryLayer(boundary);
-
-    if (map.config.showCountyBoundaryLayer) {
-      map.instance?.addLayer(map.countyBoundaryLayerRef);
-    }
-  }
-
-  private initUSForestBoundaryLayer(map: Map, boundary: GeoJSON.GeoJSON) {
-    map.usForestBoundaryLayerRef = this.boundaryLayer(boundary);
-
-    if (map.config.showUsForestBoundaryLayer) {
-      map.instance?.addLayer(map.usForestBoundaryLayerRef);
-    }
-  }
-
-  private boundaryLayer(boundary: GeoJSON.GeoJSON): L.Layer {
-    return L.geoJSON(boundary, {
-      style: (_) => ({
-        weight: 3,
-        opacity: 0.5,
-        color: '#0000ff',
-        fillOpacity: 0.2,
-        fillColor: '#6DB65B',
-      }),
-      onEachFeature: (feature, layer) =>
-        layer.bindTooltip(
-          this.popupService.makeDetailsPopup(feature.properties.shape_name)
-        ),
-    });
   }
 
   /**
@@ -350,48 +282,55 @@ export class MapManager {
     map.instance?.addLayer(map.baseLayerRef!);
   }
 
-  /** Toggles whether HUC-12 boundaries are shown. */
-  toggleHuc12BoundariesLayer(map: Map) {
+  /** Toggles which boundary layer is shown. */
+  toggleBoundaryLayer(
+    map: Map,
+    getBoundaryLayerGeoJsonCallback: (
+      boundaryName: string
+    ) => Observable<GeoJSON.GeoJSON>
+  ) {
     if (map.instance === undefined) return;
 
-    if (map.config.showHuc12BoundaryLayer) {
-      map.huc12BoundaryLayerRef?.addTo(map.instance);
-    } else {
-      map.huc12BoundaryLayerRef?.remove();
+    console.log(map.config.boundaryLayerName);
+
+    map.boundaryLayerRef?.remove();
+
+    const boundaryLayerName = map.config.boundaryLayerName;
+
+    if (boundaryLayerName !== null) {
+      if (this.boundaryGeoJsonCache.has(boundaryLayerName)) {
+        console.log('got from cache');
+        map.boundaryLayerRef = this.boundaryLayer(
+          this.boundaryGeoJsonCache.get(boundaryLayerName)!
+        );
+        map.boundaryLayerRef.addTo(map.instance);
+      } else {
+        getBoundaryLayerGeoJsonCallback(boundaryLayerName)
+          .pipe(take(1))
+          .subscribe((geojson) => {
+            console.log('loaded geojson');
+            this.boundaryGeoJsonCache.set(boundaryLayerName, geojson);
+            map.boundaryLayerRef = this.boundaryLayer(geojson);
+            map.boundaryLayerRef.addTo(map.instance!);
+          });
+      }
     }
   }
 
-  /** Toggles whether HUC-10 boundaries are shown. */
-  toggleHUC10BoundariesLayer(map: Map) {
-    if (map.instance === undefined) return;
-
-    if (map.config.showHuc10BoundaryLayer) {
-      map.huc10BoundaryLayerRef?.addTo(map.instance);
-    } else {
-      map.huc10BoundaryLayerRef?.remove();
-    }
-  }
-
-  /** Toggles whether county boundaries are shown. */
-  toggleCountyBoundariesLayer(map: Map) {
-    if (map.instance === undefined) return;
-
-    if (map.config.showCountyBoundaryLayer) {
-      map.countyBoundaryLayerRef?.addTo(map.instance);
-    } else {
-      map.countyBoundaryLayerRef?.remove();
-    }
-  }
-
-  /** Toggles whether US Forest boundaries are shown. */
-  toggleUSForestsBoundariesLayer(map: Map) {
-    if (map.instance == undefined) return;
-
-    if (map.config.showUsForestBoundaryLayer) {
-      map.usForestBoundaryLayerRef?.addTo(map.instance);
-    } else {
-      map.usForestBoundaryLayerRef?.remove();
-    }
+  private boundaryLayer(boundary: GeoJSON.GeoJSON): L.Layer {
+    return L.geoJSON(boundary, {
+      style: (_) => ({
+        weight: 3,
+        opacity: 0.5,
+        color: '#0000ff',
+        fillOpacity: 0.2,
+        fillColor: '#6DB65B',
+      }),
+      onEachFeature: (feature, layer) =>
+        layer.bindTooltip(
+          this.popupService.makeDetailsPopup(feature.properties.shape_name)
+        ),
+    });
   }
 
   /** Toggles whether existing projects from CalMapper are shown. */

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -80,6 +80,7 @@ export class MapManager {
         this.initCalMapperLayer(map, projects, createDetailCardCallback);
       }
     });
+    this.changeConditionsLayer(map);
   }
 
   /** Creates a basemap layer using the Hillshade tiles. */

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -303,9 +303,9 @@ export class MapManager {
 
     map.boundaryLayerRef?.remove();
 
-    const boundaryLayerName = map.config.boundaryLayerName;
+    const boundaryLayerName = map.config.boundaryLayerConfig.boundary_name;
 
-    if (boundaryLayerName !== null) {
+    if (boundaryLayerName !== '') {
       if (this.boundaryGeoJsonCache.has(boundaryLayerName)) {
         map.boundaryLayerRef = this.boundaryLayer(
           this.boundaryGeoJsonCache.get(boundaryLayerName)!

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -49,34 +49,23 @@
           </mat-radio-group>
 
           <h3>Boundaries</h3>
-          <div class="layer-control-container">
-            <mat-checkbox name="{{ map.id + '-huc12-toggle' }}" aria-label="Select or deselect" class="layer-checkbox"
-              [(ngModel)]="map.config.showHuc12BoundaryLayer" (change)="toggleHuc12BoundariesLayer(map)">
-              HUC-12
-            </mat-checkbox>
-            <mat-spinner [diameter]="24" *ngIf="!huc12BoundaryGeoJsonLoaded"></mat-spinner>
-          </div>
-          <div class="layer-control-container">
-            <mat-checkbox name="{{ map.id + '-huc10-toggle' }}" aria-label="Select or deselect" class="layer-checkbox"
-              [(ngModel)]="map.config.showHuc10BoundaryLayer" (change)="toggleHUC10BoundariesLayer(map)">
-              HUC-10
-            </mat-checkbox>
-            <mat-spinner [diameter]="24" *ngIf="!huc10BoundaryGeoJsonLoaded"></mat-spinner>
-          </div>
-          <div class="layer-control-container">
-            <mat-checkbox name="{{ map.id + '-county-toggle' }}" aria-label="Select or deselect" class="layer-checkbox"
-              [(ngModel)]="map.config.showCountyBoundaryLayer" (change)="toggleCountyBoundariesLayer(map)">
-              Counties
-            </mat-checkbox>
-            <mat-spinner [diameter]="24" *ngIf="!countyBoundaryGeoJsonLoaded"></mat-spinner>
-          </div>
-          <div class="layer-control-container">
+          <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
+            class="layer-radio-group"
+            [(ngModel)]="map.config.boundaryLayerName" (change)="toggleBoundaryLayer(map)">
+            <div *ngFor="let boundary of (boundaryConfig$ | async)">
+              <mat-radio-button class="layer-radio-button" [value]="boundary.boundary_name">
+                {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
+              </mat-radio-button>
+            </div>
+          </mat-radio-group>
+
+          <!-- <div class="layer-control-container">
             <mat-checkbox name="{{ map.id + '-usfs-toggle' }}" aria-label="Select or deselect" class="layer-checkbox"
               [(ngModel)]="map.config.showUsForestBoundaryLayer" (change)="toggleUSForestsBoundariesLayer(map)">
               US Forests
             </mat-checkbox>
             <mat-spinner [diameter]="24" *ngIf="!usForestBoundaryGeoJsonLoaded"></mat-spinner>
-          </div>
+          </div> -->
 
           <h3>Projects</h3>
           <div class="layer-control-container">

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -52,20 +52,13 @@
           <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
             class="layer-radio-group"
             [(ngModel)]="map.config.boundaryLayerName" (change)="toggleBoundaryLayer(map)">
-            <div *ngFor="let boundary of (boundaryConfig$ | async)">
+            <div *ngFor="let boundary of (boundaryConfig$ | async)" class="layer-control-container">
               <mat-radio-button class="layer-radio-button" [value]="boundary.boundary_name">
                 {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
               </mat-radio-button>
+              <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]"></mat-spinner>
             </div>
           </mat-radio-group>
-
-          <!-- <div class="layer-control-container">
-            <mat-checkbox name="{{ map.id + '-usfs-toggle' }}" aria-label="Select or deselect" class="layer-checkbox"
-              [(ngModel)]="map.config.showUsForestBoundaryLayer" (change)="toggleUSForestsBoundariesLayer(map)">
-              US Forests
-            </mat-checkbox>
-            <mat-spinner [diameter]="24" *ngIf="!usForestBoundaryGeoJsonLoaded"></mat-spinner>
-          </div> -->
 
           <h3>Projects</h3>
           <div class="layer-control-container">
@@ -74,7 +67,7 @@
               (change)="toggleExistingProjectsLayer(map)">
               Existing projects
             </mat-checkbox>
-            <mat-spinner [diameter]="24" *ngIf="!existingProjectsGeoJsonLoaded"></mat-spinner>
+            <mat-spinner [diameter]="24" *ngIf="!loadingIndicators['existing_projects']"></mat-spinner>
           </div>
 
           <h3>Conditions</h3>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -51,9 +51,9 @@
           <h3>Boundaries</h3>
           <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
             class="layer-radio-group"
-            [(ngModel)]="map.config.boundaryLayerName" (change)="toggleBoundaryLayer(map)">
+            [(ngModel)]="map.config.boundaryLayerConfig" (change)="toggleBoundaryLayer(map)">
             <div *ngFor="let boundary of (boundaryConfig$ | async)" class="layer-control-container">
-              <mat-radio-button class="layer-radio-button" [value]="boundary.boundary_name">
+              <mat-radio-button class="layer-radio-button" [value]="boundary">
                 {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
               </mat-radio-button>
               <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]"></mat-spinner>

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -522,7 +522,9 @@ describe('MapComponent', () => {
       const sessionServiceStub: SessionService =
         fixture.debugElement.injector.get(SessionService);
       const mapConfig = defaultMapConfig();
-      mapConfig.boundaryLayerName = 'huc-12';
+      mapConfig.boundaryLayerConfig = {
+        boundary_name: 'huc-12',
+      };
       const savedMapConfigs: MapConfig[] = Array(4).fill(mapConfig);
 
       sessionServiceStub.mapConfigs$.next(savedMapConfigs);

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -25,6 +25,7 @@ import {
   Region,
   defaultMapConfig,
   ConditionsConfig,
+  BoundaryConfig,
 } from './../types';
 import { MapComponent } from './map.component';
 import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dialog.component';
@@ -63,14 +64,16 @@ describe('MapComponent', () => {
     const fakeMapService = jasmine.createSpyObj<MapService>(
       'MapService',
       {
-        getHuc12BoundaryShapes: of(fakeGeoJson),
-        getHuc10BoundaryShapes: of(fakeGeoJson),
-        getCountyBoundaryShapes: of(fakeGeoJson),
-        getUsForestBoundaryShapes: of(fakeGeoJson),
         getExistingProjects: of(fakeGeoJson),
         getRegionBoundary: of(fakeGeoJson),
+        getBoundaryShapes: of(fakeGeoJson),
       },
       {
+        boundaryConfig$: new BehaviorSubject<BoundaryConfig[] | null>([
+          {
+            boundary_name: 'HUC-12',
+          },
+        ]),
         conditionsConfig$: new BehaviorSubject<ConditionsConfig | null>({
           pillars: [
             {
@@ -161,12 +164,6 @@ describe('MapComponent', () => {
       expect(mapServiceStub.getRegionBoundary).toHaveBeenCalledWith(
         Region.SIERRA_NEVADA
       );
-      expect(mapServiceStub.getHuc12BoundaryShapes).toHaveBeenCalledWith(
-        Region.SIERRA_NEVADA
-      );
-      expect(mapServiceStub.getCountyBoundaryShapes).toHaveBeenCalledWith(
-        Region.SIERRA_NEVADA
-      );
       expect(mapServiceStub.getExistingProjects).toHaveBeenCalled();
     });
   });
@@ -178,8 +175,6 @@ describe('MapComponent', () => {
       component.maps.forEach((map: Map) => {
         expect(map.instance).toBeDefined();
         expect(map.baseLayerRef).toBeDefined();
-        expect(map.huc12BoundaryLayerRef).toBeDefined();
-        expect(map.countyBoundaryLayerRef).toBeDefined();
         expect(map.existingProjectsLayerRef).toBeDefined();
       });
     });
@@ -365,60 +360,21 @@ describe('MapComponent', () => {
           expect(map.instance?.hasLayer(map.baseLayerRef!));
         });
 
-        it(`map-${testCase + 1} should toggle HUC-12 boundaries`, async () => {
+        it(`map-${testCase + 1} should toggle boundary layer`, async () => {
           let map = component.maps[testCase];
-          spyOn(component, 'toggleHuc12BoundariesLayer').and.callThrough();
-          const checkbox = await loader.getHarness(
-            MatCheckboxHarness.with({ name: `${map.id}-huc12-toggle` })
+          spyOn(component, 'toggleBoundaryLayer').and.callThrough();
+          const radioButtonGroup = await loader.getHarness(
+            MatRadioGroupHarness.with({ name: `${map.id}-boundaries-select` })
           );
-          expect(
-            map.instance?.hasLayer(map.huc12BoundaryLayerRef!)
-          ).toBeFalse();
+          expect(map.boundaryLayerRef).toBeUndefined();
 
-          // Act: check the HUC-12 checkbox
-          await checkbox.check();
-
-          // Assert: expect that the map does not contain the HUC-12 layer
-          expect(component.toggleHuc12BoundariesLayer).toHaveBeenCalled();
-          expect(map.instance?.hasLayer(map.huc12BoundaryLayerRef!)).toBeTrue();
-
-          // Act: uncheck the HUC-12 checkbox
-          await checkbox.uncheck();
+          // Act: select the HUC-12 boundary
+          await radioButtonGroup.checkRadioButton({ label: 'HUC-12' });
 
           // Assert: expect that the map contains the HUC-12 layer
-          expect(component.toggleHuc12BoundariesLayer).toHaveBeenCalled();
-          expect(
-            map.instance?.hasLayer(map.huc12BoundaryLayerRef!)
-          ).toBeFalse();
-        });
-
-        it(`map-${testCase + 1} should toggle county boundaries`, async () => {
-          let map = component.maps[testCase];
-          spyOn(component, 'toggleCountyBoundariesLayer').and.callThrough();
-          const checkbox = await loader.getHarness(
-            MatCheckboxHarness.with({ name: `${map.id}-county-toggle` })
-          );
-          expect(
-            map.instance?.hasLayer(map.countyBoundaryLayerRef!)
-          ).toBeFalse();
-
-          // Act: check the county checkbox
-          await checkbox.check();
-
-          // Assert: expect that the map does not contain the county layer
-          expect(component.toggleCountyBoundariesLayer).toHaveBeenCalled();
-          expect(
-            map.instance?.hasLayer(map.countyBoundaryLayerRef!)
-          ).toBeTrue();
-
-          // Act: check the county checkbox
-          await checkbox.uncheck();
-
-          // Assert: expect that the map contains the county layer
-          expect(component.toggleCountyBoundariesLayer).toHaveBeenCalled();
-          expect(
-            map.instance?.hasLayer(map.countyBoundaryLayerRef!)
-          ).toBeFalse();
+          expect(component.toggleBoundaryLayer).toHaveBeenCalled();
+          expect(map.boundaryLayerRef).toBeDefined();
+          expect(map.instance?.hasLayer(map.boundaryLayerRef!)).toBeTrue();
         });
 
         it(`map-${
@@ -566,7 +522,7 @@ describe('MapComponent', () => {
       const sessionServiceStub: SessionService =
         fixture.debugElement.injector.get(SessionService);
       const mapConfig = defaultMapConfig();
-      mapConfig.showCountyBoundaryLayer = true;
+      mapConfig.boundaryLayerName = 'huc-12';
       const savedMapConfigs: MapConfig[] = Array(4).fill(mapConfig);
 
       sessionServiceStub.mapConfigs$.next(savedMapConfigs);

--- a/src/interface/src/app/services/map.service.spec.ts
+++ b/src/interface/src/app/services/map.service.spec.ts
@@ -1,18 +1,22 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { BackendConstants } from '../backend-constants';
 import { MapService } from './map.service';
-import { Region } from '../types';
-import { ConditionsConfig } from '../types/data.types';
+import { BoundaryConfig, ConditionsConfig, Region } from '../types';
 
 describe('MapService', () => {
   let httpTestingController: HttpTestingController;
   let service: MapService;
   let fakeGeoJson: GeoJSON.GeoJSON;
 
+  const boundaryConfigs: BoundaryConfig[] = [];
+
   const conditionsConfig: ConditionsConfig = {
-    pillars: []
+    pillars: [],
   };
 
   beforeEach(() => {
@@ -22,46 +26,39 @@ describe('MapService', () => {
     };
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [MapService]
+      providers: [MapService],
     });
     service = TestBed.inject(MapService);
     httpTestingController = TestBed.inject(HttpTestingController);
 
-    // Must flush the request in the constructor for httpTestingController.verify()
+    // Must flush the requests in the constructor for httpTestingController.verify()
     // to pass in other tests.
-    const req = httpTestingController.expectOne(
-      BackendConstants.END_POINT + '/conditions/config/?region_name=sierra_cascade_inyo'
+    const req1 = httpTestingController.expectOne(
+      BackendConstants.END_POINT + '/boundary/boundary'
     );
-    req.flush(conditionsConfig);
+    req1.flush(conditionsConfig);
+    const req2 = httpTestingController.expectOne(
+      BackendConstants.END_POINT +
+        '/conditions/config/?region_name=sierra_cascade_inyo'
+    );
+    req2.flush(conditionsConfig);
   });
 
   it('can load instance', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('getHUC12BoundaryShapes', () => {
+  describe('getBoundaryShapes', () => {
     it('makes request to backend', () => {
-      service.getHuc12BoundaryShapes(Region.SIERRA_NEVADA).subscribe(res => {
-        expect(res).toEqual(fakeGeoJson);
-      });
+      service
+        .getBoundaryShapes('huc12', Region.SIERRA_NEVADA)
+        .subscribe((res) => {
+          expect(res).toEqual(fakeGeoJson);
+        });
 
       const req = httpTestingController.expectOne(
-        BackendConstants.END_POINT + '/boundary/boundary_details/?boundary_name=huc12&region_name=SierraNevada'
-      );
-      expect(req.request.method).toEqual('GET');
-      req.flush(fakeGeoJson);
-      httpTestingController.verify();
-    });
-  });
-
-  describe('getCountyBoundaryShapes', () => {
-    it('makes request to backend', () => {
-      service.getCountyBoundaryShapes(Region.NORTHERN_CALIFORNIA).subscribe(res => {
-        expect(res).toEqual(fakeGeoJson);
-      });
-
-      const req = httpTestingController.expectOne(
-        BackendConstants.END_POINT + '/boundary/boundary_details/?boundary_name=counties&region_name=NorthernCalifornia'
+        BackendConstants.END_POINT +
+          '/boundary/boundary_details/?boundary_name=huc12&region_name=SierraNevada'
       );
       expect(req.request.method).toEqual('GET');
       req.flush(fakeGeoJson);
@@ -73,7 +70,7 @@ describe('MapService', () => {
     it('makes request to endpoint', () => {
       const fakeGeoJsonText: string = JSON.stringify(fakeGeoJson);
 
-      service.getExistingProjects().subscribe(res => {
+      service.getExistingProjects().subscribe((res) => {
         expect(res).toEqual(fakeGeoJson);
       });
 
@@ -88,7 +85,7 @@ describe('MapService', () => {
 
   describe('getRegionBoundary', () => {
     it('uses the correct path to the corresponding geoJSON file', () => {
-      service.getRegionBoundary(Region.SIERRA_NEVADA).subscribe(res => {
+      service.getRegionBoundary(Region.SIERRA_NEVADA).subscribe((res) => {
         expect(res).toEqual(fakeGeoJson);
       });
 

--- a/src/interface/src/app/services/map.service.ts
+++ b/src/interface/src/app/services/map.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, EMPTY, map, Observable, take } from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
-import { ConditionsConfig, Region } from '../types';
+import { BoundaryConfig, ConditionsConfig, Region } from '../types';
 
 /** A map of Region to its corresponding geojson path. */
 const regionToGeojsonMap: Record<Region, string> = {
@@ -11,18 +11,28 @@ const regionToGeojsonMap: Record<Region, string> = {
   [Region.CENTRAL_COAST]: '',
   [Region.NORTHERN_CALIFORNIA]: '',
   [Region.SOUTHERN_CALIFORNIA]: '',
-}
+};
 
 @Injectable({
   providedIn: 'root',
 })
 export class MapService {
-  readonly conditionsConfig$ = new BehaviorSubject<ConditionsConfig | null>(null);
+  readonly boundaryConfig$ = new BehaviorSubject<BoundaryConfig[] | null>(null);
+  readonly conditionsConfig$ = new BehaviorSubject<ConditionsConfig | null>(
+    null
+  );
 
   constructor(private http: HttpClient) {
     this.http
+      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/boundary')
+      .pipe(take(1))
+      .subscribe((config: BoundaryConfig[]) => {
+        this.boundaryConfig$.next(config);
+      });
+    this.http
       .get<ConditionsConfig>(
-        BackendConstants.END_POINT + '/conditions/config/?region_name=sierra_cascade_inyo'
+        BackendConstants.END_POINT +
+          '/conditions/config/?region_name=sierra_cascade_inyo'
       )
       .pipe(take(1))
       .subscribe((config: ConditionsConfig) => {
@@ -47,7 +57,8 @@ export class MapService {
    * */
   getRegionBoundaries(): Observable<GeoJSON.GeoJSON> {
     return this.http.get<GeoJSON.GeoJSON>(
-      BackendConstants.END_POINT + '/boundary/boundary_details/?boundary_name=task_force_regions'
+      BackendConstants.END_POINT +
+        '/boundary/boundary_details/?boundary_name=task_force_regions'
     );
   }
 
@@ -64,52 +75,19 @@ export class MapService {
     }
   }
 
-  getHuc12BoundaryShapes(region: Region | null): Observable<GeoJSON.GeoJSON> {
-    // Get the shapes from the REST server.
-    var regionString: string = '';
-    if (region != null) {
-      regionString = '&region_name=' + this.regionToString(region);
-    }
-    return this.http.get<GeoJSON.GeoJSON>(
-      BackendConstants.END_POINT + '/boundary/boundary_details/?boundary_name=huc12' +
-        regionString
-    );
-  }
-
-  getHuc10BoundaryShapes(region: Region | null): Observable<GeoJSON.GeoJSON> {
-    // Get the shapes from the REST server.
-    var regionString: string = '';
-    if (region != null) {
-      regionString = '&region_name=' + this.regionToString(region);
-    }
-    return this.http.get<GeoJSON.GeoJSON>(
-      BackendConstants.END_POINT + '/boundary/boundary_details/?boundary_name=huc10' +
-        regionString
-    );
-  }
-
-  getCountyBoundaryShapes(region: Region | null): Observable<GeoJSON.GeoJSON> {
-    // Get the shapes from the REST server.
-    var regionString: string = '';
-    if (region != null) {
-      regionString = '&region_name=' + this.regionToString(region);
-    }
-    return this.http.get<GeoJSON.GeoJSON>(
-      BackendConstants.END_POINT + '/boundary/boundary_details/?boundary_name=counties' +
-        regionString
-    );
-  }
-
-  getUsForestBoundaryShapes(
+  /** Get shapes for a boundary from the REST server, within a region if region is non-null. */
+  getBoundaryShapes(
+    boundaryName: string,
     region: Region | null
   ): Observable<GeoJSON.GeoJSON> {
     // Get the shapes from the REST server.
     var regionString: string = '';
     if (region != null) {
-      regionString = '&region_name=' + this.regionToString(region);
+      regionString = `&region_name=${this.regionToString(region)}`;
     }
     return this.http.get<GeoJSON.GeoJSON>(
-      BackendConstants.END_POINT + '/boundary/boundary_details/?boundary_name=USFS' +
+      BackendConstants.END_POINT +
+        `/boundary/boundary_details/?boundary_name=${boundaryName}` +
         regionString
     );
   }

--- a/src/interface/src/app/services/session.service.ts
+++ b/src/interface/src/app/services/session.service.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject, interval, Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
-import { MapConfig, MapViewOptions, Region } from '../types';
+import { defaultMapConfig, MapConfig, MapViewOptions, Region } from '../types';
 
 /** How often the user's session should be saved to local storage (in ms). */
 const SESSION_SAVE_INTERVAL = 60000;
@@ -25,7 +25,7 @@ export class SessionService {
 
   constructor() {
     const storedMapConfigs = localStorage.getItem('mapConfigs');
-    if (storedMapConfigs) {
+    if (storedMapConfigs && this.validateSavedMapConfigs(storedMapConfigs)) {
       this.mapConfigs$.next(JSON.parse(storedMapConfigs));
     }
     const storedMapViewOptions = localStorage.getItem('mapViewOptions');
@@ -53,5 +53,17 @@ export class SessionService {
       localStorage.setItem('region', value);
       this.region$.next(value);
     }
+  }
+
+  /** Validates the map configs loaded from local storage to ensure all required fields
+   *  are present. */
+  private validateSavedMapConfigs(data: string): boolean {
+    const configs: any[] = JSON.parse(data);
+    return configs.every(val => this.instanceOfMapConfig(val));
+  }
+
+  private instanceOfMapConfig(data: any): boolean {
+    const mapConfigExample: MapConfig = defaultMapConfig();
+    return Object.keys(data).sort().join(',') === Object.keys(mapConfigExample).sort().join(',');
   }
 }

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -22,7 +22,10 @@ describe('StringifyMapConfigPipe', () => {
     it('should return formatted config string', () => {
       let mapConfig: MapConfig = {
         baseLayerType: BaseLayerType.Road,
-        boundaryLayerName: 'huc-12',
+        boundaryLayerConfig: {
+          display_name: 'HUC-12',
+          boundary_name: 'huc12'
+        },
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',
           metric_name: '',
@@ -33,7 +36,7 @@ describe('StringifyMapConfigPipe', () => {
         showExistingProjectsLayer: true,
       };
       let mapConfigStr =
-        'Habitat Connectivity (Normalized) | Existing Projects | huc-12';
+        'Habitat Connectivity (Normalized) | Existing Projects | HUC-12';
 
       let transformedStr = pipe.transform(mapConfig);
 

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -22,6 +22,7 @@ describe('StringifyMapConfigPipe', () => {
     it('should return formatted config string', () => {
       let mapConfig: MapConfig = {
         baseLayerType: BaseLayerType.Road,
+        boundaryLayerName: 'huc-12',
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',
           metric_name: '',
@@ -30,12 +31,9 @@ describe('StringifyMapConfigPipe', () => {
         showDataLayer: true,
         normalizeDataLayer: true,
         showExistingProjectsLayer: true,
-        showHuc12BoundaryLayer: true,
-        showHuc10BoundaryLayer: false,
-        showUsForestBoundaryLayer: false,
-        showCountyBoundaryLayer: false,
       };
-      let mapConfigStr = 'Habitat Connectivity (Normalized) | Existing Projects | HUC-12 Boundaries';
+      let mapConfigStr =
+        'Habitat Connectivity (Normalized) | Existing Projects | huc-12';
 
       let transformedStr = pipe.transform(mapConfig);
 

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -24,7 +24,7 @@ describe('StringifyMapConfigPipe', () => {
         baseLayerType: BaseLayerType.Road,
         boundaryLayerConfig: {
           display_name: 'HUC-12',
-          boundary_name: 'huc12'
+          boundary_name: 'huc12',
         },
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',

--- a/src/interface/src/app/stringify-map-config.pipe.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.ts
@@ -30,17 +30,8 @@ export class StringifyMapConfigPipe implements PipeTransform {
     if (mapConfig.showExistingProjectsLayer) {
       labels.push('Existing Projects');
     }
-    if (mapConfig.showHuc12BoundaryLayer) {
-      labels.push('HUC-12 Boundaries');
-    }
-    if (mapConfig.showHuc10BoundaryLayer) {
-      labels.push('HUC-10 Boundaries');
-    }
-    if (mapConfig.showCountyBoundaryLayer) {
-      labels.push('County Boundaries');
-    }
-    if (mapConfig.showUsForestBoundaryLayer) {
-      labels.push('US Forest Boundaries');
+    if (mapConfig.boundaryLayerName !== null) {
+      labels.push(mapConfig.boundaryLayerName);
     }
     labels.forEach((label, index) => {
       if (index > 0) {

--- a/src/interface/src/app/stringify-map-config.pipe.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.ts
@@ -30,8 +30,11 @@ export class StringifyMapConfigPipe implements PipeTransform {
     if (mapConfig.showExistingProjectsLayer) {
       labels.push('Existing Projects');
     }
-    if (mapConfig.boundaryLayerName !== null) {
-      labels.push(mapConfig.boundaryLayerName);
+    if (mapConfig.boundaryLayerConfig.boundary_name !== '') {
+      let boundaryLabel = mapConfig.boundaryLayerConfig.display_name
+        ? mapConfig.boundaryLayerConfig.display_name
+        : mapConfig.boundaryLayerConfig.boundary_name;
+      labels.push(boundaryLabel);
     }
     labels.forEach((label, index) => {
       if (index > 0) {

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -1,3 +1,8 @@
+export interface BoundaryConfig {
+  display_name?: string;
+  boundary_name: string;
+}
+
 export interface ConditionsConfig {
   display_name?: string;
   filepath?: string;

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -1,6 +1,6 @@
 import { BaseLayerType } from './layer.types';
 import * as L from 'leaflet';
-import { MetricConfig } from './data.types';
+import { BoundaryConfig, MetricConfig } from './data.types';
 
 export interface Map {
   id: string;
@@ -15,11 +15,11 @@ export interface Map {
 
 export interface MapConfig {
   baseLayerType: BaseLayerType;
+  boundaryLayerConfig: BoundaryConfig;
   dataLayerConfig: MetricConfig;
   showDataLayer: boolean;
   normalizeDataLayer: boolean;
   showExistingProjectsLayer: boolean;
-  boundaryLayerName: string | null;
 }
 
 
@@ -31,6 +31,9 @@ export interface MapViewOptions {
 export function defaultMapConfig(): MapConfig {
   return {
     baseLayerType: BaseLayerType.Road,
+    boundaryLayerConfig: {
+      boundary_name: '',
+    },
     dataLayerConfig: {
       metric_name: '',
       filepath: '',
@@ -38,6 +41,5 @@ export function defaultMapConfig(): MapConfig {
     showDataLayer: false,
     normalizeDataLayer: false,
     showExistingProjectsLayer: false,
-    boundaryLayerName: null,
   };
 }

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -8,10 +8,7 @@ export interface Map {
   config: MapConfig;
   instance?: L.Map | undefined;
   baseLayerRef?: L.Layer | undefined;
-  huc12BoundaryLayerRef?: L.Layer | undefined;
-  huc10BoundaryLayerRef?: L.Layer | undefined;
-  countyBoundaryLayerRef?: L.Layer | undefined;
-  usForestBoundaryLayerRef?: L.Layer | undefined;
+  boundaryLayerRef?: L.Layer | undefined;
   existingProjectsLayerRef?: L.Layer | undefined;
   dataLayerRef?: L.Layer | undefined;
 }
@@ -22,10 +19,7 @@ export interface MapConfig {
   showDataLayer: boolean;
   normalizeDataLayer: boolean;
   showExistingProjectsLayer: boolean;
-  showHuc12BoundaryLayer: boolean;
-  showHuc10BoundaryLayer: boolean;
-  showCountyBoundaryLayer: boolean;
-  showUsForestBoundaryLayer: boolean;
+  boundaryLayerName: string | null;
 }
 
 
@@ -44,9 +38,6 @@ export function defaultMapConfig(): MapConfig {
     showDataLayer: false,
     normalizeDataLayer: false,
     showExistingProjectsLayer: false,
-    showHuc12BoundaryLayer: false,
-    showHuc10BoundaryLayer: false,
-    showCountyBoundaryLayer: false,
-    showUsForestBoundaryLayer: false,
+    boundaryLayerName: null,
   };
 }


### PR DESCRIPTION
## Changes
- Fixes #134 by loading the available boundary layers from the `/boundary/boundary` endpoint.
- No longer necessary to load each boundary layer separately on the frontend.
- Implements lazy loading + caching for boundary layers. Each boundary layer will only have its GeoJSON loaded when the boundary is toggled on, and the GeoJSON will only be loaded once. This makes loading layers much faster (observable delay of no more than 1 second even to load the large HUC-12 boundary geojson).
- Continue to show loading indicators for layers that are currently retrieving geojson.
- Unit tests for all functionality.

<img width="1719" alt="image" src="https://user-images.githubusercontent.com/10444733/205410710-f3a4937c-8fd9-49e4-adc4-09d629711cdf.png">

## Todo
- Show display names for boundaries once #178 is merged.