### PR TITLE
Changes to make CSRF checks work between Angular and Django

### DIFF
--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -86,7 +86,7 @@
             "development": {
               "browserTarget": "interface:build:development"
             }
-         },
+          },
           "defaultConfiguration": "development"
         },
         "extract-i18n": {

--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -76,6 +76,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "browserTarget": "interface:build:production"
@@ -83,7 +86,7 @@
             "development": {
               "browserTarget": "interface:build:development"
             }
-          },
+         },
           "defaultConfiguration": "development"
         },
         "extract-i18n": {

--- a/src/interface/proxy.conf.json
+++ b/src/interface/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/plan": {
+    "target": "http://127.0.0.1:8000/",
+    "secure": false,
+    "logLevel": "debug"
+  }
+}

--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { LayoutModule } from '@angular/cdk/layout';
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HttpClientXsrfModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
@@ -47,6 +47,10 @@ import { PlanCreateDialogComponent } from './map/plan-create-dialog/plan-create-
     CommonModule,
     FormsModule,
     HttpClientModule,
+    HttpClientXsrfModule.withOptions({
+      cookieName: 'csrftoken',
+      headerName: 'X-CSRFTOKEN'
+      }),
     LayoutModule,
     MaterialModule,
     SharedModule,

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -155,6 +155,11 @@ CORS_ALLOWED_HOSTS = [
     "http://localhost:4200",
 ]
 CORS_ALLOW_CREDENTIALS = True
+CSRF_USE_SESSIONS = False
+CSRF_COOKIE_HTTPONLY = False
+CSRF_TRUSTED_ORIGINS = [
+  "http://localhost:4200",
+]
 
 # REST Framework settings
 


### PR DESCRIPTION
Spent quite a bit of time getting this right.  Some references that helped:

- https://keepgrowing.in/angular/fix-invalid-csrf-token-error-add-the-xsrf-token-header-in-angular/
- https://stackoverflow.com/questions/57459150/send-angular-put-request-to-django-using-django-csrf
- https://www.stackhawk.com/blog/angular-csrf-protection-guide-examples-and-how-to-enable-it/
