### PR TITLE
adds pymemcache to django requirements.txt

### DIFF
--- a/src/planscape/requirements.txt
+++ b/src/planscape/requirements.txt
@@ -9,3 +9,4 @@ django-cors-headers
 django-allauth
 dj-rest-auth
 djangorestframework-simplejwt
+pymemcache


### PR DESCRIPTION
This enables memcached to be used in production (as a separate instance).
Set-up notes are in the "Setting up Git Repo for Production" section in the "Deployment Recipes" doc.