### PR TITLE
Adjust drawing tool to multimaps

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -372,19 +372,9 @@ export class MapManager {
    * Enables the polygon drawing tool on a map.
    */
   enablePolygonDrawingTool(map: L.Map) {
-    const polygonDrawer = new L.Draw.Polygon(map as L.DrawMap, {
-      allowIntersection: false,
-      showArea: true,
-      metric: false,
-      shapeOptions: {
-        color: '#7b61ff',
-      },
-      drawError: {
-        color: '#ff7b61',
-        message: "Can't draw polygons with intersections!",
-      },
-    });
-    polygonDrawer.enable();
+    this.addDrawingControl(map);
+    const polygonButton = document.querySelector(".leaflet-draw-draw-polygon") as HTMLElement | null;
+    polygonButton?.click();
   }
 
   /** Sync pan, zoom, etc. between all maps. */

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -121,6 +121,9 @@ export class MapManager {
       }
     });
 
+    // Each map has its own cloned drawing layer because the same layer object cannot
+    // be added to multiple maps at the same time. Note this.drawingLayer is only added
+    // to one map at a time.
     map.clonedDrawingRef = new L.FeatureGroup();
     map.drawnPolygonLookup = {};
     this.setUpDrawingHandlers(map.instance!);
@@ -292,7 +295,7 @@ export class MapManager {
 
     map.on(L.Draw.Event.DELETED, (event) => {
       // sync deleted polygons to all maps
-      var layers = (event as L.DrawEvents.Deleted).layers;
+      const layers = (event as L.DrawEvents.Deleted).layers;
       layers.eachLayer((feature) => {
         this.maps.forEach((currMap) => {
           const originalPolygonKey = L.Util.stamp(feature);
@@ -310,7 +313,7 @@ export class MapManager {
 
     map.on(L.Draw.Event.EDITED, (event) => {
       // sync edited polygons to all maps
-      var layers = (event as L.DrawEvents.Edited).layers;
+      const layers = (event as L.DrawEvents.Edited).layers;
       layers.eachLayer((feature) => {
         this.maps.forEach((currMap) => {
           const originalPolygonKey = L.Util.stamp(feature);

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -146,7 +146,7 @@
       </button>
 
       <!-- Create plan button -->
-      <button *ngIf="showCreatePlanButton"
+      <button *ngIf="showCreatePlanButton$ | async"
         mat-button type="button"
         class="create-plan-button"
         (click)="openCreatePlanDialog()">

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -522,7 +522,7 @@ describe('MapComponent', () => {
     it('opens create plan dialog', async () => {
       const fakeMatDialog: MatDialog =
         fixture.debugElement.injector.get(MatDialog);
-      fixture.componentInstance.showCreatePlanButton = true;
+      fixture.componentInstance.showCreatePlanButton$ = new BehaviorSubject<boolean>(true);
       const button = await loader.getHarness(
         MatButtonHarness.with({
           selector: '.create-plan-button',

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -212,11 +212,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       const selectedMapIndex = this.mapViewOptions.selectedMapIndex;
       // Only add drawing controls to the selected map
       if (selectedMapIndex === this.maps.indexOf(map)) {
-        this.mapManager.addDrawingControl(
-          this.maps[selectedMapIndex].instance!,
-          this.onDrawCreatedCallback.bind(this),
-          this.onDrawDeletedCallback.bind(this)
-        );
+        this.mapManager.addDrawingControl(this.maps[selectedMapIndex].instance!);
       }
       else { // Show a copy of the drawing layer on the other maps
         this.mapManager.showClonedDrawing(map);
@@ -277,7 +273,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         component.instance.feature = feature;
         this.applicationRef.attachView(component.hostView);
         return component.location.nativeElement;
-      }
+      },
+      this.onDrawCreatedCallback.bind(this),
+      this.onDrawDeletedCallback.bind(this)
     );
 
     // Renders the selected region on the map.
@@ -298,12 +296,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         this.mapViewOptions.selectedMapIndex = currentMapIndex;
         this.sessionService.setMapViewOptions(this.mapViewOptions);
 
+        this.mapManager.addDrawingControl(this.maps[currentMapIndex].instance!);
         this.mapManager.hideClonedDrawing(this.maps[currentMapIndex]);
-        this.mapManager.addDrawingControl(
-          this.maps[currentMapIndex].instance!,
-          this.onDrawCreatedCallback.bind(this),
-          this.onDrawDeletedCallback.bind(this)
-        );
       }
     });
   }

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -97,7 +97,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     { value: 'draw-area', icon: 'edit', display: 'Draw an area' },
   ];
   selectedPlanCreationOption: PlanCreationOption | null = null;
-  showCreatePlanButton: boolean = false;
+  showCreatePlanButton$ = new BehaviorSubject(false);
 
   private readonly destroy$ = new Subject<void>();
 
@@ -191,6 +191,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     );
 
     this.mapManager = new MapManager(this.maps, popupService);
+    this.mapManager.polygonsCreated$.pipe(takeUntil(this.destroy$)).subscribe(this.showCreatePlanButton$);
   }
 
   ngOnInit(): void {
@@ -229,14 +230,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     this.destroy$.complete();
   }
 
-  private onDrawCreatedCallback() {
-    this.showCreatePlanButton = true;
-  }
-
-  private onDrawDeletedCallback() {
-    this.showCreatePlanButton = false;
-  }
-
   private restoreSession() {
     this.sessionService.mapViewOptions$
       .pipe(take(1))
@@ -273,9 +266,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         component.instance.feature = feature;
         this.applicationRef.attachView(component.hostView);
         return component.location.nativeElement;
-      },
-      this.onDrawCreatedCallback.bind(this),
-      this.onDrawDeletedCallback.bind(this)
+      }
     );
 
     // Renders the selected region on the map.

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -348,7 +348,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
    */
   onPlanCreationOptionChange(option: PlanCreationOption) {
     if (option.value === 'draw-area') {
-      this.mapManager.enablePolygonDrawingTool(this.maps[0].instance!);
+      this.mapManager.enablePolygonDrawingTool(this.maps[this.mapViewOptions.selectedMapIndex].instance!);
     }
   }
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -280,6 +280,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       const previousMapIndex = this.mapViewOptions.selectedMapIndex;
       const currentMapIndex = this.maps.indexOf(map);
 
+    // Toggle the cloned layer on if the map is not the current selected map.
+    // Toggle on the drawing layer and control on the selected map.
       if (previousMapIndex !== currentMapIndex) {
         this.mapManager.removeDrawingControl(this.maps[previousMapIndex].instance!);
         this.mapManager.showClonedDrawing(this.maps[previousMapIndex]);

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -343,6 +343,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   onPlanCreationOptionChange(option: PlanCreationOption) {
     if (option.value === 'draw-area') {
       this.mapManager.enablePolygonDrawingTool(this.maps[this.mapViewOptions.selectedMapIndex].instance!);
+      this.changeMapCount(1);
     }
   }
 
@@ -392,7 +393,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     this.mapManager.changeConditionsLayer(map);
   }
 
-  /* Change how many maps are displayed in the viewport. */
+  /** Change how many maps are displayed in the viewport. */
   changeMapCount(mapCount: number) {
     this.mapViewOptions.numVisibleMaps = mapCount;
     setTimeout(() => {
@@ -400,7 +401,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     }, 0);
   }
 
-  /** Whether the map at given index should be visible.
+  /**
+   * Whether the map at given index should be visible.
    *
    *  WARNING: This function is run constantly and shouldn't do any heavy lifting!
    */

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -210,12 +210,16 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     this.maps.forEach((map: Map) => {
       this.initMap(map, map.id);
       const selectedMapIndex = this.mapViewOptions.selectedMapIndex;
+      // Only add drawing controls to the selected map
       if (selectedMapIndex === this.maps.indexOf(map)) {
-        this.mapManager.addDrawing(
+        this.mapManager.addDrawingControl(
           this.maps[selectedMapIndex].instance!,
           this.onDrawCreatedCallback.bind(this),
           this.onDrawDeletedCallback.bind(this)
         );
+      }
+      else { // Show a copy of the drawing layer on the other maps
+        this.mapManager.showClonedDrawing(map);
       }
     });
 
@@ -281,18 +285,21 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       this.displayRegionBoundary(map, selectedRegion);
     });
 
-    // Mark the map as selected when the user clicks anywhere on it.
+    // Mark the map as selected when the user clicks anywhere on it
+    // and updates which map can be drawn on.
     map.instance?.addEventListener('click', () => {
       const previousMapIndex = this.mapViewOptions.selectedMapIndex;
       const currentMapIndex = this.maps.indexOf(map);
 
       if (previousMapIndex !== currentMapIndex) {
-        this.mapManager.removeDrawing(this.maps[previousMapIndex].instance!);
+        this.mapManager.removeDrawingControl(this.maps[previousMapIndex].instance!);
+        this.mapManager.showClonedDrawing(this.maps[previousMapIndex]);
 
         this.mapViewOptions.selectedMapIndex = currentMapIndex;
         this.sessionService.setMapViewOptions(this.mapViewOptions);
 
-        this.mapManager.addDrawing(
+        this.mapManager.hideClonedDrawing(this.maps[currentMapIndex]);
+        this.mapManager.addDrawingControl(
           this.maps[currentMapIndex].instance!,
           this.onDrawCreatedCallback.bind(this),
           this.onDrawDeletedCallback.bind(this)

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -209,14 +209,17 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   ngAfterViewInit(): void {
     this.maps.forEach((map: Map) => {
       this.initMap(map, map.id);
+      const selectedMapIndex = this.mapViewOptions.selectedMapIndex;
+      if (selectedMapIndex === this.maps.indexOf(map)) {
+        this.mapManager.addDrawing(
+          this.maps[selectedMapIndex].instance!,
+          this.onDrawCreatedCallback.bind(this),
+          this.onDrawDeletedCallback.bind(this)
+        );
+      }
     });
 
     this.mapManager.syncAllMaps();
-    this.mapManager.addDrawingControls(
-      this.maps[0].instance!,
-      this.onDrawCreatedCallback.bind(this),
-      this.onDrawDeletedCallback.bind(this)
-    );
   }
 
   ngOnDestroy(): void {
@@ -280,8 +283,21 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
 
     // Mark the map as selected when the user clicks anywhere on it.
     map.instance?.addEventListener('click', () => {
-      this.mapViewOptions.selectedMapIndex = this.maps.indexOf(map);
-      this.sessionService.setMapViewOptions(this.mapViewOptions);
+      const previousMapIndex = this.mapViewOptions.selectedMapIndex;
+      const currentMapIndex = this.maps.indexOf(map);
+
+      if (previousMapIndex !== currentMapIndex) {
+        this.mapManager.removeDrawing(this.maps[previousMapIndex].instance!);
+
+        this.mapViewOptions.selectedMapIndex = currentMapIndex;
+        this.sessionService.setMapViewOptions(this.mapViewOptions);
+
+        this.mapManager.addDrawing(
+          this.maps[currentMapIndex].instance!,
+          this.onDrawCreatedCallback.bind(this),
+          this.onDrawDeletedCallback.bind(this)
+        );
+      }
     });
   }
 

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -14,6 +14,7 @@ export interface Map {
   usForestBoundaryLayerRef?: L.Layer | undefined;
   existingProjectsLayerRef?: L.Layer | undefined;
   dataLayerRef?: L.Layer | undefined;
+  clonedDrawingRef?: L.FeatureGroup | undefined;
 }
 
 export interface MapConfig {

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -15,6 +15,7 @@ export interface Map {
   existingProjectsLayerRef?: L.Layer | undefined;
   dataLayerRef?: L.Layer | undefined;
   clonedDrawingRef?: L.FeatureGroup | undefined;
+  drawnPolygonLookup?: {[key: string]:L.Layer};
 }
 
 export interface MapConfig {


### PR DESCRIPTION
# Changes:
* Enable drawing tool on selected map (used to only be on map 1)
* Change to single map view when 'draw an area' is selected
* Update 'draw an area' button to draw on selected map
* Sync created polygons to all maps
* Sync deleted polygons to all maps
* Sync edited polygons to all maps
* Use observable instead of callbacks to show 'Create' button
* Fixed enabling the drawing tool when 'draw an area' is clicked (couldn't cancel drawing before)

* Note: The same layer object cannot be added to multiple maps at the same time, which is why each map has its own "copied drawing layer" that toggles on if it's not the selected map. The actual drawing layer used for drawing is shared between maps because only one map can be drawn on at a time. 

# UI Preview:
<img width="1436" alt="Screen Shot 2022-12-05 at 9 34 32 PM" src="https://user-images.githubusercontent.com/114368235/205973339-ce37d0ed-0bdc-4791-846f-263dd08d6150.png">

# Todo:
* Add unit tests