### PR TITLE
enables Google analytics

### DIFF
--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -27,6 +27,8 @@
     "moment": "^2.29.4",
     "ng-mocks": "^14.3.2",
     "ngx-cookie-service": "^14.0.1",
+    "ngx-google-analytics": "^14.0.1",
+    "package.json": "^2.0.1",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -28,7 +28,6 @@
     "ng-mocks": "^14.3.2",
     "ngx-cookie-service": "^14.0.1",
     "ngx-google-analytics": "^14.0.1",
-    "package.json": "^2.0.1",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CookieService } from 'ngx-cookie-service';
+import { NgxGoogleAnalyticsModule, NgxGoogleAnalyticsRouterModule } from 'ngx-google-analytics';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { AccountDialogComponent } from './account-dialog/account-dialog.component';
@@ -49,6 +50,8 @@ import { PlanCreateDialogComponent } from './map/plan-create-dialog/plan-create-
     HttpClientModule,
     LayoutModule,
     MaterialModule,
+    NgxGoogleAnalyticsModule,
+    NgxGoogleAnalyticsRouterModule,
     SharedModule,
     ReactiveFormsModule,
   ],


### PR DESCRIPTION
Enables Google analytics.

Additional set-up details in the "Setting up Git Repo for Production" section in the "Deployment Recipes" doc.

Seems to work --
![screenshot - google analytics](https://user-images.githubusercontent.com/3720361/206025730-5725e759-fa0d-4bb2-90d9-c40e63b68c2a.png)