### PR TITLE
Revamp layer selection UI to match mocks

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -404,9 +404,6 @@ export class MapManager {
 
     let filepath = map.config.dataLayerConfig.filepath;
     if (filepath?.length === 0 || !filepath) return;
-    if (map.config.normalizeDataLayer) {
-      filepath = filepath.concat('_normalized');
-    }
     filepath = filepath.substring(filepath.lastIndexOf('/') + 1) + '.tif';
 
     let colormap = map.config.dataLayerConfig.colormap;
@@ -427,8 +424,6 @@ export class MapManager {
       }
     );
 
-    if (map.config.showDataLayer) {
-      map.dataLayerRef.addTo(map.instance);
-    }
+    map.dataLayerRef.addTo(map.instance);
   }
 }

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -39,69 +39,162 @@
       <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true" [selectedIndex]="mapViewOptions.selectedMapIndex"
         class="layer-controls-tab-group">
         <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}" [disabled]="!isMapVisible(i)">
-          <h3>Base layer</h3>
-          <mat-radio-group name="{{ map.id + '-base-layer-select' }}" aria-label="Select an option"
-            class="layer-radio-group" [(ngModel)]="map.config.baseLayerType" (change)="changeBaseLayer(map)">
-            <mat-radio-button *ngFor="let baseLayerType of baseLayerTypes" [value]="baseLayerType"
-              checked="{{ baseLayerType == map.config.baseLayerType }}" class="layer-radio-button">
-              {{ BaseLayerType[baseLayerType] }}
-            </mat-radio-button>
-          </mat-radio-group>
+          <mat-accordion multi displayMode="flat">
+            <mat-expansion-panel expanded="true">
+              <mat-expansion-panel-header>
+                Basemaps
+              </mat-expansion-panel-header>
+              <mat-radio-group name="{{ map.id + '-base-layer-select' }}" aria-label="Select an option"
+                class="layer-radio-group" [(ngModel)]="map.config.baseLayerType" (change)="changeBaseLayer(map)">
+                <mat-radio-button *ngFor="let baseLayerType of baseLayerTypes" [value]="baseLayerType"
+                  checked="{{ baseLayerType == map.config.baseLayerType }}" class="layer-radio-button">
+                  {{ BaseLayerType[baseLayerType] }}
+                </mat-radio-button>
+              </mat-radio-group>
+            </mat-expansion-panel>
 
-          <h3>Boundaries</h3>
-          <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
-            class="layer-radio-group"
-            [(ngModel)]="map.config.boundaryLayerConfig" (change)="toggleBoundaryLayer(map)">
-            <div *ngFor="let boundary of (boundaryConfig$ | async)" class="layer-control-container">
-              <mat-radio-button class="layer-radio-button" [value]="boundary">
-                {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
-              </mat-radio-button>
-              <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]"></mat-spinner>
-            </div>
-          </mat-radio-group>
+            <mat-expansion-panel expanded="false">
+              <mat-expansion-panel-header>
+                Boundaries
+              </mat-expansion-panel-header>
+              <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
+                class="layer-radio-group"
+                [(ngModel)]="map.config.boundaryLayerConfig" (change)="toggleBoundaryLayer(map)">
+                <div *ngFor="let boundary of (boundaryConfig$ | async)" class="layer-control-container">
+                  <mat-radio-button class="layer-radio-button" [value]="boundary">
+                    {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
+                  </mat-radio-button>
+                  <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]"></mat-spinner>
+                </div>
+              </mat-radio-group>
+            </mat-expansion-panel>
 
-          <h3>Projects</h3>
-          <div class="layer-control-container">
-            <mat-checkbox name="{{ map.id + '-existing-projects-toggle' }}" aria-label="Select or deselect"
-              class="layer-checkbox" [(ngModel)]="map.config.showExistingProjectsLayer"
-              (change)="toggleExistingProjectsLayer(map)">
-              Existing projects
-            </mat-checkbox>
-            <mat-spinner [diameter]="24" *ngIf="!loadingIndicators['existing_projects']"></mat-spinner>
-          </div>
+            <mat-expansion-panel disabled="true">
+              <mat-expansion-panel-header>
+                <mat-panel-title>
+                  Land types
+                </mat-panel-title>
+                <mat-panel-description>
+                  Coming soon!
+                </mat-panel-description>
+              </mat-expansion-panel-header>
+            </mat-expansion-panel>
 
-          <h3>Conditions</h3>
-          <mat-checkbox name="{{ map.id + '-conditions-toggle' }}" aria-label="Select or deselect"
-            class="layer-checkbox" [(ngModel)]="map.config.showDataLayer"
-            (change)="changeConditionsLayer(map)">
-            Show conditions
-          </mat-checkbox>
+            <mat-expansion-panel disabled="true">
+              <mat-expansion-panel-header>
+                <mat-panel-title>
+                  Operability
+                </mat-panel-title>
+                <mat-panel-description>
+                  Coming soon!
+                </mat-panel-description>
+              </mat-expansion-panel-header>
+            </mat-expansion-panel>
 
-          <mat-checkbox name="{{ map.id + '-normalized-conditions-toggle' }}"
-            aria-label="Select or deselect" class="layer-checkbox"
-            *ngIf="map.config.showDataLayer" [(ngModel)]="map.config.normalizeDataLayer"
-            (change)="changeConditionsLayer(map)">
-            Normalize conditions data
-          </mat-checkbox>
+            <mat-expansion-panel expanded="true">
+              <mat-expansion-panel-header>
+                Recent treatment areas
+              </mat-expansion-panel-header>
+              <div class="layer-control-container">
+                <mat-checkbox name="{{ map.id + '-existing-projects-toggle' }}" aria-label="Select or deselect"
+                  class="layer-checkbox" [(ngModel)]="map.config.showExistingProjectsLayer"
+                  (change)="toggleExistingProjectsLayer(map)">
+                  Existing projects
+                </mat-checkbox>
+                <mat-spinner [diameter]="24" *ngIf="!loadingIndicators['existing_projects']"></mat-spinner>
+              </div>
+            </mat-expansion-panel>
 
-          <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
-            class="layer-radio-group" *ngIf="map.config.showDataLayer"
-            [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
-            <div *ngFor="let pillar of (conditionsConfig$ | async)?.pillars">
-              <div *ngIf="pillar.display">
-                <h4>{{ pillar.display_name }}</h4>
-                <div *ngFor="let element of pillar.elements">
-                  <h5>{{ element.display_name }}</h5>
-                  <div *ngFor="let metric of element.metrics">
-                    <mat-radio-button class="layer-radio-button" [value]="metric">
-                      {{ metric.display_name ? metric.display_name : metric.metric_name }}
+            <mat-expansion-panel disabled="true">
+              <mat-expansion-panel-header>
+                <mat-panel-title>
+                  Disturbances
+                </mat-panel-title>
+                <mat-panel-description>
+                  Coming soon!
+                </mat-panel-description>
+              </mat-expansion-panel-header>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel disabled="true">
+              <mat-expansion-panel-header>
+                <mat-panel-title>
+                  HVRAs
+                </mat-panel-title>
+                <mat-panel-description>
+                  Coming soon!
+                </mat-panel-description>
+              </mat-expansion-panel-header>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel expanded="false">
+              <mat-expansion-panel-header>
+                Ecosystem scores
+              </mat-expansion-panel-header>
+
+              <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
+                [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
+                <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl" class="condition-tree">
+                  <!-- This is the tree node template for leaf nodes -->
+                  <!-- There is inline padding applied to this node using styles.
+                    This padding value depends on the mat-icon-button width. -->
+                  <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+                    <mat-radio-button [value]="node">
+                      {{node.display_name}}
                     </mat-radio-button>
+                  </mat-tree-node>
+                  <!-- This is the tree node template for expandable nodes -->
+                  <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+                      <div class="mat-tree-node">
+                        <mat-radio-button [value]="node">
+                          {{node.display_name}}
+                        </mat-radio-button>
+                        <button mat-icon-button matTreeNodeToggle
+                                [attr.aria-label]="'Toggle ' + node.display_name">
+                          <mat-icon class="mat-icon-rtl-mirror">
+                            {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
+                          </mat-icon>
+                        </button>
+                      </div>
+                      <!-- There is inline padding applied to this div using styles.
+                          This padding value depends on the mat-icon-button width.  -->
+                      <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
+                          role="group">
+                        <ng-container matTreeNodeOutlet></ng-container>
+                    </div>
+                  </mat-nested-tree-node>
+                </mat-tree>
+              </mat-radio-group>
+
+              <!-- <h3>Current condition</h3>
+
+              <mat-checkbox name="{{ map.id + '-normalized-conditions-toggle' }}"
+                aria-label="Select or deselect" class="layer-checkbox"
+                [(ngModel)]="map.config.normalizeDataLayer"
+                (change)="changeConditionsLayer(map)">
+                Normalize conditions data
+              </mat-checkbox>
+
+              <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
+                class="layer-radio-group"
+                [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
+                <div *ngFor="let pillar of (conditionsConfig$ | async)?.pillars">
+                  <div *ngIf="pillar.display">
+                    <h4>{{ pillar.display_name }}</h4>
+                    <div *ngFor="let element of pillar.elements">
+                      <h5>{{ element.display_name }}</h5>
+                      <div *ngFor="let metric of element.metrics">
+                        <mat-radio-button class="layer-radio-button" [value]="metric">
+                          {{ metric.display_name ? metric.display_name : metric.metric_name }}
+                        </mat-radio-button>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          </mat-radio-group>
+              </mat-radio-group> -->
+            </mat-expansion-panel>
 
+          </mat-accordion>
         </mat-tab>
       </mat-tab-group>
   </div>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -40,6 +40,7 @@
         class="layer-controls-tab-group">
         <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}" [disabled]="!isMapVisible(i)">
           <mat-accordion multi displayMode="flat">
+
             <mat-expansion-panel expanded="true">
               <mat-expansion-panel-header>
                 Basemaps
@@ -53,13 +54,18 @@
               </mat-radio-group>
             </mat-expansion-panel>
 
-            <mat-expansion-panel expanded="false">
+            <mat-expansion-panel expanded="true">
               <mat-expansion-panel-header>
                 Boundaries
               </mat-expansion-panel-header>
               <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
                 class="layer-radio-group"
                 [(ngModel)]="map.config.boundaryLayerConfig" (change)="toggleBoundaryLayer(map)">
+                <div class="layer-control-container">
+                  <mat-radio-button class="layer-radio-button" [value]="noneBoundaryConfig">
+                    None
+                  </mat-radio-button>
+                </div>
                 <div *ngFor="let boundary of (boundaryConfig$ | async)" class="layer-control-container">
                   <mat-radio-button class="layer-radio-button" [value]="boundary">
                     {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
@@ -91,7 +97,7 @@
               </mat-expansion-panel-header>
             </mat-expansion-panel>
 
-            <mat-expansion-panel expanded="true">
+            <mat-expansion-panel expanded="false">
               <mat-expansion-panel-header>
                 Recent treatment areas
               </mat-expansion-panel-header>
@@ -133,7 +139,7 @@
               </mat-expansion-panel-header>
 
               <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
-                [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
+              [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
                 <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl" class="condition-tree">
                   <!-- This is the tree node template for leaf nodes -->
                   <!-- There is inline padding applied to this node using styles.
@@ -165,33 +171,6 @@
                   </mat-nested-tree-node>
                 </mat-tree>
               </mat-radio-group>
-
-              <!-- <h3>Current condition</h3>
-
-              <mat-checkbox name="{{ map.id + '-normalized-conditions-toggle' }}"
-                aria-label="Select or deselect" class="layer-checkbox"
-                [(ngModel)]="map.config.normalizeDataLayer"
-                (change)="changeConditionsLayer(map)">
-                Normalize conditions data
-              </mat-checkbox>
-
-              <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
-                class="layer-radio-group"
-                [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
-                <div *ngFor="let pillar of (conditionsConfig$ | async)?.pillars">
-                  <div *ngIf="pillar.display">
-                    <h4>{{ pillar.display_name }}</h4>
-                    <div *ngFor="let element of pillar.elements">
-                      <h5>{{ element.display_name }}</h5>
-                      <div *ngFor="let metric of element.metrics">
-                        <mat-radio-button class="layer-radio-button" [value]="metric">
-                          {{ metric.display_name ? metric.display_name : metric.metric_name }}
-                        </mat-radio-button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </mat-radio-group> -->
             </mat-expansion-panel>
 
           </mat-accordion>

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -144,3 +144,30 @@
   pointer-events: auto;
   top: 10px;
 }
+
+.condition-tree-invisible {
+  display: none;
+}
+
+.condition-tree ul,
+.condition-tree li {
+  margin-top: 0;
+  margin-bottom: 0;
+  list-style-type: none;
+}
+
+/*
+ * This padding sets alignment of the nested nodes.
+ */
+.condition-tree .mat-nested-tree-node div[role=group] {
+  padding-left: 40px;
+}
+
+/*
+ * Padding for leaf nodes.
+ * Leaf nodes need to have padding so as to align with other non-leaf nodes
+ * under the same parent.
+ */
+.condition-tree div[role=group] > .mat-tree-node {
+  padding-left: 40px;
+}

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -410,19 +410,6 @@ describe('MapComponent', () => {
         it(`map-${testCase + 1} should change conditions layer`, async () => {
           let map = component.maps[testCase];
           spyOn(component, 'changeConditionsLayer').and.callThrough();
-          const showConditionsCheckbox = await loader.getHarness(
-            MatCheckboxHarness.with({
-              name: `${map.id}-conditions-toggle`,
-            })
-          );
-
-          // Act: toggle on conditions
-          await showConditionsCheckbox.check();
-
-          // Assert: expect that map config is updated but data layer ref is undefined
-          expect(component.changeConditionsLayer).toHaveBeenCalled();
-          expect(map.config.showDataLayer).toBeTrue();
-          expect(map.dataLayerRef).toBeUndefined();
 
           // Act: select test metric 1
           const radioButtonGroup = await loader.getHarness(

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -8,7 +8,9 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatRadioGroupHarness } from '@angular/material/radio/testing';
+import {
+  MatRadioGroupHarness,
+} from '@angular/material/radio/testing';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { By } from '@angular/platform-browser';
@@ -412,30 +414,12 @@ describe('MapComponent', () => {
           spyOn(component, 'changeConditionsLayer').and.callThrough();
 
           // Act: select test metric 1
-          const radioButtonGroup = await loader.getHarness(
-            MatRadioGroupHarness.with({ name: `${map.id}-conditions-select` })
-          );
-          await radioButtonGroup.checkRadioButton({ label: 'test_metric_1' });
+          // Radio button harnesses inside trees are buggy, so we manually
+          // change the value instead.
+          map.config.dataLayerConfig.filepath = 'test_metric_1';
+          component.changeConditionsLayer(map);
 
           // Assert: expect that the map contains test metric 1
-          expect(component.changeConditionsLayer).toHaveBeenCalled();
-          expect(map.config.dataLayerConfig.metric_name).toEqual(
-            'test_metric_1'
-          );
-          expect(map.dataLayerRef).toBeDefined();
-          expect(map.instance?.hasLayer(map.dataLayerRef!)).toBeTrue();
-
-          // Act: toggle on normalized data
-          const normalizeCheckbox = await loader.getHarness(
-            MatCheckboxHarness.with({
-              name: `${map.id}-normalized-conditions-toggle`,
-            })
-          );
-          await normalizeCheckbox.check();
-
-          // Assert: expect that the map contains the normalized data layer
-          expect(component.changeConditionsLayer).toHaveBeenCalled();
-          expect(map.config.normalizeDataLayer).toBeTrue;
           expect(map.dataLayerRef).toBeDefined();
           expect(map.instance?.hasLayer(map.dataLayerRef!)).toBeTrue();
         });

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -8,9 +8,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatRadioModule } from '@angular/material/radio';
-import {
-  MatRadioGroupHarness,
-} from '@angular/material/radio/testing';
+import { MatRadioGroupHarness } from '@angular/material/radio/testing';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { By } from '@angular/platform-browser';
@@ -449,7 +447,8 @@ describe('MapComponent', () => {
     it('opens create plan dialog', async () => {
       const fakeMatDialog: MatDialog =
         fixture.debugElement.injector.get(MatDialog);
-      fixture.componentInstance.showCreatePlanButton$ = new BehaviorSubject<boolean>(true);
+      fixture.componentInstance.showCreatePlanButton$ =
+        new BehaviorSubject<boolean>(true);
       const button = await loader.getHarness(
         MatButtonHarness.with({
           selector: '.create-plan-button',

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -1,3 +1,4 @@
+import { NestedTreeControl } from '@angular/cdk/tree';
 import {
   AfterViewInit,
   ApplicationRef,
@@ -8,8 +9,9 @@ import {
   OnInit,
 } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { MatTreeNestedDataSource } from '@angular/material/tree';
 import { BehaviorSubject, Observable, Subject, take, takeUntil } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { filter, switchMap } from 'rxjs/operators';
 
 import {
   MapService,
@@ -22,6 +24,7 @@ import {
   BaseLayerType,
   BoundaryConfig,
   ConditionsConfig,
+  DataLayerConfig,
   defaultMapConfig,
   Map,
   MapConfig,
@@ -37,6 +40,10 @@ export interface PlanCreationOption {
   value: string;
   display: string;
   icon: any;
+}
+
+interface ConditionsNode extends DataLayerConfig {
+  children?: ConditionsNode[];
 }
 
 @Component({
@@ -64,7 +71,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   existingProjectsGeoJson$ = new BehaviorSubject<GeoJSON.GeoJSON | null>(null);
 
   loadingIndicators: { [layerName: string]: boolean } = {
-    'existing_projects': true
+    existing_projects: true,
   };
 
   legend: Legend = {
@@ -95,6 +102,11 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   ];
   selectedPlanCreationOption: PlanCreationOption | null = null;
   showCreatePlanButton$ = new BehaviorSubject(false);
+
+  conditionTreeControl = new NestedTreeControl<ConditionsNode>(
+    (node) => node.children
+  );
+  conditionDataSource = new MatTreeNestedDataSource<ConditionsNode>();
 
   private readonly destroy$ = new Subject<void>();
 
@@ -144,7 +156,15 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       this.startLoadingLayerCallback.bind(this),
       this.doneLoadingLayerCallback.bind(this)
     );
-    this.mapManager.polygonsCreated$.pipe(takeUntil(this.destroy$)).subscribe(this.showCreatePlanButton$);
+    this.mapManager.polygonsCreated$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(this.showCreatePlanButton$);
+
+    this.conditionsConfig$
+      .pipe(filter((config) => !!config))
+      .subscribe((config) => {
+        this.conditionDataSource.data = this.conditionsConfigToData(config!);
+      });
   }
 
   ngOnInit(): void {
@@ -166,9 +186,11 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       const selectedMapIndex = this.mapViewOptions.selectedMapIndex;
       // Only add drawing controls to the selected map
       if (selectedMapIndex === this.maps.indexOf(map)) {
-        this.mapManager.addDrawingControl(this.maps[selectedMapIndex].instance!);
-      }
-      else { // Show a copy of the drawing layer on the other maps
+        this.mapManager.addDrawingControl(
+          this.maps[selectedMapIndex].instance!
+        );
+      } else {
+        // Show a copy of the drawing layer on the other maps
         this.mapManager.showClonedDrawing(map);
       }
     });
@@ -230,10 +252,12 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       const previousMapIndex = this.mapViewOptions.selectedMapIndex;
       const currentMapIndex = this.maps.indexOf(map);
 
-    // Toggle the cloned layer on if the map is not the current selected map.
-    // Toggle on the drawing layer and control on the selected map.
+      // Toggle the cloned layer on if the map is not the current selected map.
+      // Toggle on the drawing layer and control on the selected map.
       if (previousMapIndex !== currentMapIndex) {
-        this.mapManager.removeDrawingControl(this.maps[previousMapIndex].instance!);
+        this.mapManager.removeDrawingControl(
+          this.maps[previousMapIndex].instance!
+        );
         this.mapManager.showClonedDrawing(this.maps[previousMapIndex]);
 
         this.mapViewOptions.selectedMapIndex = currentMapIndex;
@@ -302,7 +326,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
    */
   onPlanCreationOptionChange(option: PlanCreationOption) {
     if (option.value === 'draw-area') {
-      this.mapManager.enablePolygonDrawingTool(this.maps[this.mapViewOptions.selectedMapIndex].instance!);
+      this.mapManager.enablePolygonDrawingTool(
+        this.maps[this.mapViewOptions.selectedMapIndex].instance!
+      );
       this.changeMapCount(1);
     }
   }
@@ -393,5 +419,60 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         }
         return '0%';
     }
+  }
+
+  /** Used to compute whether a node in the condition layer tree has children. */
+  hasChild = (_: number, node: ConditionsNode) =>
+    !!node.children && node.children.length > 0;
+
+  private conditionsConfigToData(config: ConditionsConfig): ConditionsNode[] {
+    return [
+      {
+        ...config,
+        display_name: 'Current condition',
+        children: config.pillars
+          ?.filter((pillar) => pillar.display)
+          .map((pillar): ConditionsNode => {
+            return {
+              ...pillar,
+              children: pillar.elements?.map((element): ConditionsNode => {
+                return {
+                  ...element,
+                  children: element.metrics,
+                };
+              }),
+            };
+          }),
+      },
+      {
+        display_name: 'Current condition (normalized)',
+        filepath: config.filepath?.concat('_normalized'),
+        colormap: config.colormap,
+        normalized: true,
+        children: config.pillars
+          ?.filter((pillar) => pillar.display)
+          .map((pillar): ConditionsNode => {
+            return {
+              ...pillar,
+              filepath: pillar.filepath?.concat('_normalized'),
+              normalized: true,
+              children: pillar.elements?.map((element): ConditionsNode => {
+                return {
+                  ...element,
+                  filepath: element.filepath?.concat('_normalized'),
+                  normalized: true,
+                  children: element.metrics?.map((metric): ConditionsNode => {
+                    return {
+                      ...metric,
+                      filepath: metric.filepath?.concat('_normalized'),
+                      normalized: true,
+                    };
+                  }),
+                };
+              }),
+            };
+          }),
+      },
+    ];
   }
 }

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -46,6 +46,15 @@ interface ConditionsNode extends DataLayerConfig {
   children?: ConditionsNode[];
 }
 
+const NONE_BOUNDARY_CONFIG: BoundaryConfig = {
+  boundary_name: '',
+};
+
+const NONE_CONDITIONS_NODE: ConditionsNode = {
+  display_name: 'None',
+  filepath: '',
+};
+
 @Component({
   selector: 'app-map',
   templateUrl: './map.component.html',
@@ -65,8 +74,13 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   selectedRegion$: Observable<Region | null>;
   planState$: Observable<PlanState>;
 
-  baseLayerTypes: number[] = [BaseLayerType.Road, BaseLayerType.Terrain];
-  BaseLayerType: typeof BaseLayerType = BaseLayerType;
+  readonly noneBoundaryConfig = NONE_BOUNDARY_CONFIG;
+
+  readonly baseLayerTypes: number[] = [
+    BaseLayerType.Road,
+    BaseLayerType.Terrain,
+  ];
+  readonly BaseLayerType: typeof BaseLayerType = BaseLayerType;
 
   existingProjectsGeoJson$ = new BehaviorSubject<GeoJSON.GeoJSON | null>(null);
 
@@ -160,6 +174,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       .pipe(takeUntil(this.destroy$))
       .subscribe(this.showCreatePlanButton$);
 
+    this.conditionDataSource.data = [NONE_CONDITIONS_NODE];
     this.conditionsConfig$
       .pipe(filter((config) => !!config))
       .subscribe((config) => {
@@ -427,6 +442,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
 
   private conditionsConfigToData(config: ConditionsConfig): ConditionsNode[] {
     return [
+      NONE_CONDITIONS_NODE,
       {
         ...config,
         display_name: 'Current condition',

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -29,6 +29,8 @@ import {
   Map,
   MapConfig,
   MapViewOptions,
+  NONE_BOUNDARY_CONFIG,
+  NONE_DATA_LAYER_CONFIG,
   Region,
 } from '../types';
 import { Legend } from './../shared/legend/legend.component';
@@ -45,15 +47,6 @@ export interface PlanCreationOption {
 interface ConditionsNode extends DataLayerConfig {
   children?: ConditionsNode[];
 }
-
-const NONE_BOUNDARY_CONFIG: BoundaryConfig = {
-  boundary_name: '',
-};
-
-const NONE_CONDITIONS_NODE: ConditionsNode = {
-  display_name: 'None',
-  filepath: '',
-};
 
 @Component({
   selector: 'app-map',
@@ -174,7 +167,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       .pipe(takeUntil(this.destroy$))
       .subscribe(this.showCreatePlanButton$);
 
-    this.conditionDataSource.data = [NONE_CONDITIONS_NODE];
+    this.conditionDataSource.data = [NONE_DATA_LAYER_CONFIG];
     this.conditionsConfig$
       .pipe(filter((config) => !!config))
       .subscribe((config) => {
@@ -236,6 +229,21 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
             this.maps[index].config = mapConfig;
           });
         }
+        this.boundaryConfig$
+          .pipe(filter((config) => !!config))
+          .subscribe((config) => {
+            // Ensure the radio button corresponding to the saved selection is selected.
+            this.maps.forEach((map) => {
+              const boundaryConfig = config?.find(
+                (boundary) =>
+                  boundary.boundary_name ===
+                  map.config.boundaryLayerConfig.boundary_name
+              );
+              if (!!boundaryConfig) {
+                map.config.boundaryLayerConfig = boundaryConfig;
+              }
+            });
+          });
       });
   }
 
@@ -442,7 +450,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
 
   private conditionsConfigToData(config: ConditionsConfig): ConditionsNode[] {
     return [
-      NONE_CONDITIONS_NODE,
+      NONE_DATA_LAYER_CONFIG,
       {
         ...config,
         display_name: 'Current condition',

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -4,6 +4,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -15,6 +16,7 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTreeModule } from '@angular/material/tree';
 
 
 @NgModule({
@@ -24,6 +26,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatCheckboxModule,
     MatDialogModule,
     MatDividerModule,
+    MatExpansionModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
@@ -35,6 +38,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatSliderModule,
     MatTabsModule,
     MatToolbarModule,
+    MatTreeModule,
   ]
 })
 export class MaterialModule { }

--- a/src/interface/src/app/services/map.service.spec.ts
+++ b/src/interface/src/app/services/map.service.spec.ts
@@ -58,7 +58,7 @@ describe('MapService', () => {
 
       const req = httpTestingController.expectOne(
         BackendConstants.END_POINT +
-          '/boundary/boundary_details/?boundary_name=huc12&region_name=SierraNevada'
+          '/boundary/boundary_details/?boundary_name=huc12&region_name=sierra_cascade_inyo'
       );
       expect(req.request.method).toEqual('GET');
       req.flush(fakeGeoJson);

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -28,10 +28,9 @@ describe('StringifyMapConfigPipe', () => {
         },
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',
-          metric_name: '',
-          filepath: '',
+          metric_name: 'habitat_connectivity',
+          filepath: 'habitat_connectivity',
         },
-        showDataLayer: true,
         normalizeDataLayer: true,
         showExistingProjectsLayer: true,
       };

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -28,10 +28,9 @@ describe('StringifyMapConfigPipe', () => {
         },
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',
-          metric_name: 'habitat_connectivity',
           filepath: 'habitat_connectivity',
+          normalized: true,
         },
-        normalizeDataLayer: true,
         showExistingProjectsLayer: true,
       };
       let mapConfigStr =

--- a/src/interface/src/app/stringify-map-config.pipe.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.ts
@@ -18,8 +18,13 @@ export class StringifyMapConfigPipe implements PipeTransform {
 
     let str: string = '';
     let labels: string[] = [];
-    if (!!mapConfig.dataLayerConfig.display_name) {
-      let dataLabel = mapConfig.dataLayerConfig.display_name;
+    if (
+      !!mapConfig.dataLayerConfig.filepath &&
+      mapConfig.dataLayerConfig.filepath.length > 0
+    ) {
+      let dataLabel = mapConfig.dataLayerConfig.display_name
+        ? mapConfig.dataLayerConfig.display_name
+        : mapConfig.dataLayerConfig.filepath;
       if (mapConfig.dataLayerConfig.normalized) {
         dataLabel = dataLabel.concat(' (Normalized)');
       }
@@ -28,7 +33,10 @@ export class StringifyMapConfigPipe implements PipeTransform {
     if (mapConfig.showExistingProjectsLayer) {
       labels.push('Existing Projects');
     }
-    if (mapConfig.boundaryLayerConfig.boundary_name !== '') {
+    if (
+      !!mapConfig.boundaryLayerConfig.boundary_name &&
+      mapConfig.boundaryLayerConfig.boundary_name.length > 0
+    ) {
       let boundaryLabel = mapConfig.boundaryLayerConfig.display_name
         ? mapConfig.boundaryLayerConfig.display_name
         : mapConfig.boundaryLayerConfig.boundary_name;

--- a/src/interface/src/app/stringify-map-config.pipe.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.ts
@@ -18,11 +18,9 @@ export class StringifyMapConfigPipe implements PipeTransform {
 
     let str: string = '';
     let labels: string[] = [];
-    if (mapConfig.showDataLayer) {
-      let dataLabel = mapConfig.dataLayerConfig.display_name
-        ? mapConfig.dataLayerConfig.display_name
-        : mapConfig.dataLayerConfig.metric_name;
-      if (mapConfig.normalizeDataLayer) {
+    if (!!mapConfig.dataLayerConfig.display_name) {
+      let dataLabel = mapConfig.dataLayerConfig.display_name;
+      if (mapConfig.dataLayerConfig.normalized) {
         dataLabel = dataLabel.concat(' (Normalized)');
       }
       labels.push(dataLabel);

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -29,3 +29,13 @@ export interface PillarConfig extends DataLayerConfig {
   pillar_name?: string;
   elements?: ElementConfig[];
 }
+
+export const NONE_BOUNDARY_CONFIG: BoundaryConfig = {
+  boundary_name: '',
+  display_name: 'None',
+};
+
+export const NONE_DATA_LAYER_CONFIG: DataLayerConfig = {
+  display_name: 'None',
+  filepath: '',
+};

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -3,34 +3,29 @@ export interface BoundaryConfig {
   boundary_name: string;
 }
 
-export interface ConditionsConfig {
-  display_name?: string;
-  filepath?: string;
+export interface ConditionsConfig extends DataLayerConfig {
   region_name?: string;
   pillars?: PillarConfig[];
-  colormap?: string;
 }
 
-export interface ElementConfig {
+export interface DataLayerConfig {
   display_name?: string;
-  element_name?: string;
   filepath?: string;
+  colormap?: string;
+  normalized?: boolean;
+}
+
+export interface ElementConfig extends DataLayerConfig {
+  element_name?: string;
   metrics?: MetricConfig[];
-  colormap?: string;
 }
 
-export interface MetricConfig {
+export interface MetricConfig extends DataLayerConfig {
   metric_name: string;
-  filepath: string;
-  display_name?: string;
-  colormap?: string;
 }
 
-export interface PillarConfig {
-  display_name?: string;
+export interface PillarConfig extends DataLayerConfig {
   display?: boolean;
   pillar_name?: string;
-  filepath?: string;
   elements?: ElementConfig[];
-  colormap?: string;
 }

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -1,6 +1,6 @@
 import { BaseLayerType } from './layer.types';
 import * as L from 'leaflet';
-import { BoundaryConfig, MetricConfig } from './data.types';
+import { BoundaryConfig, DataLayerConfig } from './data.types';
 
 export interface Map {
   id: string;
@@ -18,9 +18,7 @@ export interface Map {
 export interface MapConfig {
   baseLayerType: BaseLayerType;
   boundaryLayerConfig: BoundaryConfig;
-  dataLayerConfig: MetricConfig;
-  showDataLayer: boolean;
-  normalizeDataLayer: boolean;
+  dataLayerConfig: DataLayerConfig;
   showExistingProjectsLayer: boolean;
 }
 
@@ -37,11 +35,8 @@ export function defaultMapConfig(): MapConfig {
       boundary_name: '',
     },
     dataLayerConfig: {
-      metric_name: '',
       filepath: '',
     },
-    showDataLayer: false,
-    normalizeDataLayer: false,
     showExistingProjectsLayer: false,
   };
 }

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -35,6 +35,7 @@ export function defaultMapConfig(): MapConfig {
       boundary_name: '',
     },
     dataLayerConfig: {
+      display_name: 'None',
       filepath: '',
     },
     showExistingProjectsLayer: false,

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -1,6 +1,11 @@
 import { BaseLayerType } from './layer.types';
 import * as L from 'leaflet';
-import { BoundaryConfig, DataLayerConfig } from './data.types';
+import {
+  BoundaryConfig,
+  DataLayerConfig,
+  NONE_BOUNDARY_CONFIG,
+  NONE_DATA_LAYER_CONFIG,
+} from './data.types';
 
 export interface Map {
   id: string;
@@ -22,7 +27,6 @@ export interface MapConfig {
   showExistingProjectsLayer: boolean;
 }
 
-
 export interface MapViewOptions {
   selectedMapIndex: number;
   numVisibleMaps: number;
@@ -31,13 +35,8 @@ export interface MapViewOptions {
 export function defaultMapConfig(): MapConfig {
   return {
     baseLayerType: BaseLayerType.Road,
-    boundaryLayerConfig: {
-      boundary_name: '',
-    },
-    dataLayerConfig: {
-      display_name: 'None',
-      filepath: '',
-    },
+    boundaryLayerConfig: NONE_BOUNDARY_CONFIG,
+    dataLayerConfig: NONE_DATA_LAYER_CONFIG,
     showExistingProjectsLayer: false,
   };
 }


### PR DESCRIPTION
## Changes
- Add accordion w/ expansion panels for each layer type to the layer controls, including inactive (no data available yet) layer groups. The basemap and boundary panels are expanded by default; the rest are collapsed by default.
- Convert ecosystem score selection to tree format so pillar and element scores can be selected for display as well as metrics (fixes #175).
- Update unit tests. _Note: Material component harnesses don't seem to function well inside a tree, so the ecosystem score layer test manually changes config values now instead of mimicking UI interaction._
- Added "None" option to boundary and ecosystem score layer selection.

## Default view (basemap and boundary panels expanded, rest collapsed)
![image](https://user-images.githubusercontent.com/10444733/206051888-3096c067-6357-48fb-b598-2da349119fd2.png)

## Ecosystem score selection tree
![image](https://user-images.githubusercontent.com/10444733/206051971-4d5bd889-5ac9-46b5-9159-88c3e67bc888.png)

## Known issues / Todo
- Desired behavior: When a metric is selected, its pillar and element radio buttons should display as selected too. Current behavior: Only one radio button can be selected at a time.
- Desired behavior: When a pillar or element is selected, all of the elements/metrics it contains should be selected too. Current behavior: Only one radio button can be selected at a time.
- Desired behavior: When map config is loaded from local storage, the ecosystem score radio button corresponding to the saved selection should be checked. Current behavior: No radio buttons are checked.