### PR TITLE
Map layer panel- add info button, hover state behavior, and callout function

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { SignupComponent } from './signup/signup.component';
 import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
 import { PlanCreateDialogComponent } from './map/plan-create-dialog/plan-create-dialog.component';
+import { LayerInfoCardComponent } from './map/layer-info-card/layer-info-card.component';
 
 @NgModule({
   declarations: [
@@ -40,6 +41,7 @@ import { PlanCreateDialogComponent } from './map/plan-create-dialog/plan-create-
     StringifyMapConfigPipe,
     MapNameplateComponent,
     PlanCreateDialogComponent,
+    LayerInfoCardComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
@@ -1,0 +1,8 @@
+<div class="layer-info-card">
+  <h2>{{dataLayerConfig?.display_name}}</h2>
+
+  <p>Definition of what {{dataLayerConfig?.display_name}} means.</p>
+  <p>SOURCE: sourcename (link) date/year</p>
+
+  <button mat-button>Learn more</button>
+</div>

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.scss
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.scss
@@ -1,0 +1,3 @@
+.layer-info-card {
+  padding: 12px;
+}

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.spec.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LayerInfoCardComponent } from './layer-info-card.component';
+
+describe('LayerInfoCardComponent', () => {
+  let component: LayerInfoCardComponent;
+  let fixture: ComponentFixture<LayerInfoCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LayerInfoCardComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LayerInfoCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { DataLayerConfig } from 'src/app/types';
+
+@Component({
+  selector: 'app-layer-info-card',
+  templateUrl: './layer-info-card.component.html',
+  styleUrls: ['./layer-info-card.component.scss']
+})
+export class LayerInfoCardComponent {
+
+  @Input() dataLayerConfig!: DataLayerConfig | null;
+
+}

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -145,27 +145,35 @@
                   <!-- There is inline padding applied to this node using styles.
                     This padding value depends on the mat-icon-button width. -->
                   <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-                    <mat-radio-button [value]="node">
-                      {{node.display_name}}
-                    </mat-radio-button>
+                    <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true" (mouseleave)="node.showInfoIcon = false">
+                      <mat-radio-button [value]="node">
+                        {{node.display_name}}
+                      </mat-radio-button>
+                      <button mat-icon-button [style.visibility]="node.showInfoIcon ? 'visible': 'hidden'">
+                        <mat-icon>info_outline</mat-icon>
+                      </button>
+                    </div>
                   </mat-tree-node>
                   <!-- This is the tree node template for expandable nodes -->
                   <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-                      <div class="mat-tree-node">
-                        <mat-radio-button [value]="node">
-                          {{node.display_name}}
-                        </mat-radio-button>
-                        <button mat-icon-button matTreeNodeToggle
-                                [attr.aria-label]="'Toggle ' + node.display_name">
-                          <mat-icon class="mat-icon-rtl-mirror">
-                            {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
-                          </mat-icon>
-                        </button>
-                      </div>
-                      <!-- There is inline padding applied to this div using styles.
-                          This padding value depends on the mat-icon-button width.  -->
-                      <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
-                          role="group">
+                    <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true" (mouseleave)="node.showInfoIcon = false">
+                      <mat-radio-button [value]="node">
+                        {{node.display_name}}
+                      </mat-radio-button>
+                      <button mat-icon-button [style.visibility]="node.showInfoIcon ? 'visible': 'hidden'">
+                        <mat-icon>info_outline</mat-icon>
+                      </button>
+                      <button mat-icon-button matTreeNodeToggle
+                              [attr.aria-label]="'Toggle ' + node.display_name">
+                        <mat-icon class="mat-icon-rtl-mirror">
+                          {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
+                        </mat-icon>
+                      </button>
+                    </div>
+                    <!-- There is inline padding applied to this div using styles.
+                        This padding value depends on the mat-icon-button width.  -->
+                    <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
+                        role="group">
                         <ng-container matTreeNodeOutlet></ng-container>
                     </div>
                   </mat-nested-tree-node>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -149,9 +149,14 @@
                       <mat-radio-button [value]="node">
                         {{node.display_name}}
                       </mat-radio-button>
-                      <button mat-icon-button [style.visibility]="node.showInfoIcon ? 'visible': 'hidden'">
+                      <button mat-icon-button [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
+                        [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+                        (menuClosed)="node.infoMenuOpen = false">
                         <mat-icon>info_outline</mat-icon>
                       </button>
+                      <mat-menu #popoverMenu="matMenu">
+                        <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+                      </mat-menu>
                     </div>
                   </mat-tree-node>
                   <!-- This is the tree node template for expandable nodes -->
@@ -160,9 +165,14 @@
                       <mat-radio-button [value]="node">
                         {{node.display_name}}
                       </mat-radio-button>
-                      <button mat-icon-button [style.visibility]="node.showInfoIcon ? 'visible': 'hidden'">
+                      <button mat-icon-button [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
+                        [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+                        (menuClosed)="node.infoMenuOpen = false">
                         <mat-icon>info_outline</mat-icon>
                       </button>
+                      <mat-menu #popoverMenu="matMenu">
+                        <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+                      </mat-menu>
                       <button mat-icon-button matTreeNodeToggle
                               [attr.aria-label]="'Toggle ' + node.display_name">
                         <mat-icon class="mat-icon-rtl-mirror">

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -46,6 +46,7 @@ export interface PlanCreationOption {
 
 interface ConditionsNode extends DataLayerConfig {
   showInfoIcon?: boolean;
+  infoMenuOpen?: boolean;
   children?: ConditionsNode[];
 }
 
@@ -448,6 +449,10 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   /** Used to compute whether a node in the condition layer tree has children. */
   hasChild = (_: number, node: ConditionsNode) =>
     !!node.children && node.children.length > 0;
+
+  /** Used to compute whether to show the info button on a condition layer node. */
+  showInfoIcon = (node: ConditionsNode) =>
+    node.filepath?.length && (node.showInfoIcon || node.infoMenuOpen);
 
   private conditionsConfigToData(config: ConditionsConfig): ConditionsNode[] {
     return [

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -45,6 +45,7 @@ export interface PlanCreationOption {
 }
 
 interface ConditionsNode extends DataLayerConfig {
+  showInfoIcon?: boolean;
   children?: ConditionsNode[];
 }
 

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -9,6 +9,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
@@ -31,6 +32,7 @@ import { MatTreeModule } from '@angular/material/tree';
     MatIconModule,
     MatInputModule,
     MatListModule,
+    MatMenuModule,
     MatProgressSpinnerModule,
     MatRadioModule,
     MatSelectModule,


### PR DESCRIPTION
## Changes
- Fixes #195 
- Shows an info button when the user hovers over a condition score.
- Clicking the info button opens a popup menu containing information about the condition and a link to learn more (all of this is placeholder for now). Clicking anywhere outside the popup closes it.

![image](https://user-images.githubusercontent.com/10444733/206303051-0baae7e6-9fd5-4370-a540-06caaea04dcb.png)
