### PR TITLE
Miscellaneous small map updates

### DIFF
--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
@@ -1,4 +1,4 @@
-<div class="map-nameplate" [ngClass]="{'selected': selected}">
+<div class="map-nameplate" [style.max-width]="widthInPx" [class.selected]="selected">
   <div class="map-name">{{ map?.name }}</div>
   <div class="map-config-string">{{ map?.config | stringifyMapConfig }}</div>
 </div>

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
@@ -1,4 +1,5 @@
-<div class="map-nameplate" [style.max-width]="widthInPx" [class.selected]="selected">
+<div class="map-nameplate" [style.max-width]="widthInPx" [class.selected]="selected"
+  [matTooltip]="map?.config | stringifyMapConfig" [matTooltipClass]="'map-nameplate-tooltip'">
   <div class="map-name">{{ map?.name }}</div>
   <div class="map-config-string">{{ map?.config | stringifyMapConfig }}</div>
 </div>

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.scss
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.scss
@@ -14,12 +14,13 @@
   align-items: center;
   background-color: #ffffff;
   bottom: 0px;
+  box-sizing: border-box;
   display: flex;
   height: 30px;
   min-width: 0;
   opacity: 50%;
+  padding-right: 16px;
   position: absolute;
-  width: 100%;
   z-index: 10;
 }
 

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.spec.ts
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.spec.ts
@@ -1,7 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { BehaviorSubject } from 'rxjs';
 
 import { StringifyMapConfigPipe } from './../../stringify-map-config.pipe';
-import { MapNameplateComponent } from './map-nameplate.component';
+import {
+  MapNameplateComponent,
+  NAMEPLATE_RIGHT_MARGIN,
+} from './map-nameplate.component';
 
 describe('MapNameplateComponent', () => {
   let component: MapNameplateComponent;
@@ -10,6 +15,7 @@ describe('MapNameplateComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [MapNameplateComponent, StringifyMapConfigPipe],
+      imports: [MatTooltipModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MapNameplateComponent);
@@ -19,5 +25,22 @@ describe('MapNameplateComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should calculate width in px', () => {
+    expect(component.widthInPx).toEqual('100%');
+
+    component.width$ = new BehaviorSubject<number | null>(
+      40 + NAMEPLATE_RIGHT_MARGIN
+    );
+    component.ngAfterViewInit();
+
+    (component.width$ as BehaviorSubject<number | null>).next(
+      40 + NAMEPLATE_RIGHT_MARGIN
+    );
+
+    setTimeout(() => {
+      expect(component.widthInPx).toEqual('40px');
+    }, 0);
   });
 });

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.ts
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.ts
@@ -1,12 +1,39 @@
-import { Component, Input } from '@angular/core';
+import { filter } from 'rxjs/operators';
+import { Observable, BehaviorSubject, of } from 'rxjs';
+import { Component, Input, OnInit, AfterViewInit, AfterContentInit, AfterContentChecked, ChangeDetectorRef } from '@angular/core';
 import { Map } from 'src/app/types';
+
+const NAMEPLATE_RIGHT_MARGIN = 16;
 
 @Component({
   selector: 'app-map-nameplate',
   templateUrl: './map-nameplate.component.html',
   styleUrls: ['./map-nameplate.component.scss'],
 })
-export class MapNameplateComponent {
-  @Input() map!: Map | null;
+export class MapNameplateComponent implements OnInit {
+  @Input() map: Map | null = null;
   @Input() selected: boolean = false;
+  @Input() width$: Observable<number | null> = of(null);
+
+  widthInPx: string = '100%';
+
+  ngOnInit() {
+    this.width$.pipe(filter(width => !!width)).subscribe(width => {
+      // Timeout is required to avoid triggering changes too quickly,
+      // which causes errors with Angular's change detection.
+      setTimeout(() => {
+        this.widthInPx = this.widthToPx(width);
+      }, 0);
+    });
+  }
+
+  /** Compute the maximum width of the nameplate, accounting for the Leaflet
+   *  attribution control.
+   */
+  private widthToPx(width: number | null): string {
+    if (width != null) {
+      return Number(width - NAMEPLATE_RIGHT_MARGIN).toString().concat('px');
+    }
+    return '100%';
+  }
 }

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.ts
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.ts
@@ -1,24 +1,24 @@
+import { AfterViewInit, Component, Input } from '@angular/core';
+import { Observable, of } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { Observable, BehaviorSubject, of } from 'rxjs';
-import { Component, Input, OnInit, AfterViewInit, AfterContentInit, AfterContentChecked, ChangeDetectorRef } from '@angular/core';
 import { Map } from 'src/app/types';
 
-const NAMEPLATE_RIGHT_MARGIN = 16;
+export const NAMEPLATE_RIGHT_MARGIN = 16;
 
 @Component({
   selector: 'app-map-nameplate',
   templateUrl: './map-nameplate.component.html',
   styleUrls: ['./map-nameplate.component.scss'],
 })
-export class MapNameplateComponent implements OnInit {
+export class MapNameplateComponent implements AfterViewInit {
   @Input() map: Map | null = null;
   @Input() selected: boolean = false;
   @Input() width$: Observable<number | null> = of(null);
 
   widthInPx: string = '100%';
 
-  ngOnInit() {
-    this.width$.pipe(filter(width => !!width)).subscribe(width => {
+  ngAfterViewInit() {
+    this.width$.pipe(filter((width) => !!width)).subscribe((width) => {
       // Timeout is required to avoid triggering changes too quickly,
       // which causes errors with Angular's change detection.
       setTimeout(() => {
@@ -32,7 +32,9 @@ export class MapNameplateComponent implements OnInit {
    */
   private widthToPx(width: number | null): string {
     if (width != null) {
-      return Number(width - NAMEPLATE_RIGHT_MARGIN).toString().concat('px');
+      return Number(width - NAMEPLATE_RIGHT_MARGIN)
+        .toString()
+        .concat('px');
     }
     return '100%';
   }

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -37,7 +37,7 @@
 
       <!-- Layer controls for each map, displayed in tabs -->
       <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true" [selectedIndex]="mapViewOptions.selectedMapIndex"
-        class="layer-controls-tab-group">
+        class="layer-controls-tab-group" (selectedIndexChange)="selectMap($event)">
         <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}" [disabled]="!isMapVisible(i)">
           <mat-accordion multi displayMode="flat">
 
@@ -212,24 +212,32 @@
     <div class="map-row" [ngStyle]="{'height': mapRowHeight(0)}">
       <div class="map-box" [ngClass]="{'selected': mapViewOptions.selectedMapIndex === 0}"
         [hidden]="!isMapVisible(0)" data-testid="map1">
-        <app-map-nameplate [map]="maps[0]" [selected]="mapViewOptions.selectedMapIndex === 0"></app-map-nameplate>
+        <app-map-nameplate [map]="maps[0]" [selected]="mapViewOptions.selectedMapIndex === 0"
+          [width$]="mapNameplateWidths[0]">
+        </app-map-nameplate>
         <div id="map1" class="map"></div>
       </div>
       <div class="map-box" [ngClass]="{'selected': mapViewOptions.selectedMapIndex === 1}"
         [hidden]="!isMapVisible(1)" data-testid="map2">
-        <app-map-nameplate [map]="maps[1]" [selected]="mapViewOptions.selectedMapIndex === 1"></app-map-nameplate>
+        <app-map-nameplate [map]="maps[1]" [selected]="mapViewOptions.selectedMapIndex === 1"
+        [width$]="mapNameplateWidths[1]">
+      </app-map-nameplate>
         <div id="map2" class="map"></div>
       </div>
     </div>
     <div class="map-row" [ngStyle]="{'height': mapRowHeight(1)}">
       <div class="map-box" [ngClass]="{'selected': mapViewOptions.selectedMapIndex === 2}"
         [hidden]="!isMapVisible(2)" data-testid="map3">
-        <app-map-nameplate [map]="maps[2]" [selected]="mapViewOptions.selectedMapIndex === 2"></app-map-nameplate>
+        <app-map-nameplate [map]="maps[2]" [selected]="mapViewOptions.selectedMapIndex === 2"
+        [width$]="mapNameplateWidths[2]">
+      </app-map-nameplate>
         <div id="map3" class="map"></div>
       </div>
       <div class="map-box" [ngClass]="{'selected': mapViewOptions.selectedMapIndex === 3}"
         [hidden]="!isMapVisible(3)" data-testid="map4">
-        <app-map-nameplate [map]="maps[3]" [selected]="mapViewOptions.selectedMapIndex === 3"></app-map-nameplate>
+        <app-map-nameplate [map]="maps[3]" [selected]="mapViewOptions.selectedMapIndex === 3"
+        [width$]="mapNameplateWidths[3]">
+      </app-map-nameplate>
         <div id="map4" class="map"></div>
       </div>
     </div>

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -408,7 +408,11 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   changeMapCount(mapCount: number) {
     this.mapViewOptions.numVisibleMaps = mapCount;
     setTimeout(() => {
-      this.maps.forEach((map: Map) => map.instance?.invalidateSize());
+      this.maps.forEach((map: Map) => {
+        map.instance?.invalidateSize();
+        // Recalculate the map nameplate size.
+        this.updateMapNameplateWidth(map);
+      });
     }, 0);
   }
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -61,6 +61,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     selectedMapIndex: 0,
     numVisibleMaps: 2,
   };
+  mapNameplateWidths: BehaviorSubject<number | null>[] = Array(4)
+    .fill(null)
+    .map((_) => new BehaviorSubject<number | null>(null));
 
   boundaryConfig$: Observable<BoundaryConfig[] | null>;
   conditionsConfig$: Observable<ConditionsConfig | null>;
@@ -269,27 +272,34 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       this.displayRegionBoundary(map, selectedRegion);
     });
 
-    // Mark the map as selected when the user clicks anywhere on it
-    // and updates which map can be drawn on.
+    // Mark the map as selected when the user clicks anywhere on it.
     map.instance?.addEventListener('click', () => {
-      const previousMapIndex = this.mapViewOptions.selectedMapIndex;
-      const currentMapIndex = this.maps.indexOf(map);
-
-      // Toggle the cloned layer on if the map is not the current selected map.
-      // Toggle on the drawing layer and control on the selected map.
-      if (previousMapIndex !== currentMapIndex) {
-        this.mapManager.removeDrawingControl(
-          this.maps[previousMapIndex].instance!
-        );
-        this.mapManager.showClonedDrawing(this.maps[previousMapIndex]);
-
-        this.mapViewOptions.selectedMapIndex = currentMapIndex;
-        this.sessionService.setMapViewOptions(this.mapViewOptions);
-
-        this.mapManager.addDrawingControl(this.maps[currentMapIndex].instance!);
-        this.mapManager.hideClonedDrawing(this.maps[currentMapIndex]);
-      }
+      this.selectMap(this.maps.indexOf(map));
     });
+
+    // Calculate the maximum width of the map nameplate.
+    this.updateMapNameplateWidth(map);
+  }
+
+  private updateMapNameplateWidth(map: Map) {
+    this.mapNameplateWidths[this.maps.indexOf(map)].next(
+      this.getMapNameplateWidth(map)
+    );
+  }
+
+  private getMapNameplateWidth(map: Map): number | null {
+    const mapElement = document.getElementById(map.id);
+    const attribution = mapElement
+      ?.getElementsByClassName('leaflet-control-attribution')
+      ?.item(0);
+    const mapWidth = !!mapElement ? mapElement.clientWidth : null;
+    const attributionWidth = !!attribution ? attribution.clientWidth : null;
+    // The maximum width of the nameplate is equal to the width of the map minus the width
+    // of Leaflet's attribution control. Additional padding/margins may be applied in the
+    // nameplate component, but are not considered for this width.
+    const nameplateWidth =
+      !!mapWidth && !!attributionWidth ? mapWidth - attributionWidth : null;
+    return nameplateWidth;
   }
 
   private startLoadingLayerCallback(layerName: string) {
@@ -370,6 +380,10 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   /** Toggles which base layer is shown. */
   changeBaseLayer(map: Map) {
     this.mapManager.changeBaseLayer(map);
+
+    // Changing the base layer may change the attribution, so the map nameplate
+    // width should be recalculated.
+    this.updateMapNameplateWidth(map);
   }
 
   /** Toggles which boundary layer is shown. */
@@ -396,6 +410,26 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     setTimeout(() => {
       this.maps.forEach((map: Map) => map.instance?.invalidateSize());
     }, 0);
+  }
+
+  /** Select a map and update which map contains the drawing layer. */
+  selectMap(mapIndex: number) {
+    const previousMapIndex = this.mapViewOptions.selectedMapIndex;
+
+    // Toggle the cloned layer on if the map is not the current selected map.
+    // Toggle on the drawing layer and control on the selected map.
+    if (previousMapIndex !== mapIndex) {
+      this.mapManager.removeDrawingControl(
+        this.maps[previousMapIndex].instance!
+      );
+      this.mapManager.showClonedDrawing(this.maps[previousMapIndex]);
+
+      this.mapViewOptions.selectedMapIndex = mapIndex;
+      this.sessionService.setMapViewOptions(this.mapViewOptions);
+
+      this.mapManager.addDrawingControl(this.maps[mapIndex].instance!);
+      this.mapManager.hideClonedDrawing(this.maps[mapIndex]);
+    }
   }
 
   /**

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -16,6 +16,7 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTreeModule } from '@angular/material/tree';
 
 
@@ -38,6 +39,7 @@ import { MatTreeModule } from '@angular/material/tree';
     MatSliderModule,
     MatTabsModule,
     MatToolbarModule,
+    MatTooltipModule,
     MatTreeModule,
   ]
 })

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -107,10 +107,5 @@ $planscape-frontend-theme: mat.define-light-theme((
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
-// Adjust the Leaflet attribution control to make room for the map nameplate.
-.leaflet-container .leaflet-control-attribution {
-  margin-bottom: 30px;
-}
-
 // Must manually import leaflet draw css. https://github.com/Leaflet/Leaflet.draw/issues/617
 @import "~leaflet-draw/dist/leaflet.draw.css";

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -107,5 +107,9 @@ $planscape-frontend-theme: mat.define-light-theme((
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
+.map-nameplate-tooltip {
+  font-size: 14px;
+}
+
 // Must manually import leaflet draw css. https://github.com/Leaflet/Leaflet.draw/issues/617
 @import "~leaflet-draw/dist/leaflet.draw.css";


### PR DESCRIPTION
## Changes
- Selecting a tab in the layer controls selects the map.
- Move Leaflet's attribution control back to its default position at the bottom of the map view.
- Map nameplate width is now dynamic and resizes to fit remaining space not allocated to Leaflet's attribution control.
- Add tooltip to map nameplate to show the full layer list (in case the nameplate is truncated).
 
![Screen Shot 2022-12-07 at 4 17 22 PM](https://user-images.githubusercontent.com/10444733/206325446-9d4b6b9c-1521-457c-a99a-3e3594c56808.png)