### PR TITLE
Allow switching between maps using tabs in single map view

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -38,7 +38,7 @@
       <!-- Layer controls for each map, displayed in tabs -->
       <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true" [selectedIndex]="mapViewOptions.selectedMapIndex"
         class="layer-controls-tab-group" (selectedIndexChange)="selectMap($event)">
-        <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}" [disabled]="!isMapVisible(i)">
+        <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}">
           <mat-accordion multi displayMode="flat">
 
             <mat-expansion-panel expanded="true">


### PR DESCRIPTION
Enable all tabs in single map view so the user can switch to a different map by clicking on a tab. Fixes #188 