### PR TITLE
Fix loading indicator for projects

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -110,7 +110,7 @@
                   (change)="toggleExistingProjectsLayer(map)">
                   Existing projects
                 </mat-checkbox>
-                <mat-spinner [diameter]="24" *ngIf="!loadingIndicators['existing_projects']"></mat-spinner>
+                <mat-spinner [diameter]="24" *ngIf="loadingIndicators['existing_projects']"></mat-spinner>
               </div>
             </mat-expansion-panel>
 


### PR DESCRIPTION
Loading indicator for projects had faulty logic (the loading indicator was present when projects were fully loaded in and missing when they were still loading). This PR fixes that.