### PR TITLE
Add Leaflet map to plan view

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { SharedModule } from './shared/shared.module';
 import { SignupComponent } from './signup/signup.component';
 import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
+import { PlanMapComponent } from './plan/plan-map/plan-map.component';
 
 @NgModule({
   declarations: [
@@ -54,6 +55,7 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     PlanCreateDialogComponent,
     LayerInfoCardComponent,
     PlanComponent,
+    PlanMapComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/interface/src/app/plan/plan-map/plan-map.component.html
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.html
@@ -1,0 +1,4 @@
+<div class="plan-map-view">
+  <div id="map" class="plan-map"></div>
+  <button mat-raised-button class="expand-map-button" (click)="expandMap()">EXPAND MAP</button>
+</div>

--- a/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
@@ -1,0 +1,68 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { Router } from '@angular/router';
+import * as L from 'leaflet';
+import { MaterialModule } from 'src/app/material/material.module';
+
+import { PlanMapComponent } from './plan-map.component';
+
+describe('PlanMapComponent', () => {
+  let component: PlanMapComponent;
+  let fixture: ComponentFixture<PlanMapComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    const routerStub = () => ({ navigate: (array: string[]) => ({}) });
+
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [PlanMapComponent],
+      providers: [{ provide: Router, useFactory: routerStub }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlanMapComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should add planning area to map', () => {
+    component.ngAfterViewInit();
+
+    let foundPlanningAreaLayer = false;
+
+    component.map.eachLayer((layer) => {
+      if (layer instanceof L.GeoJSON) {
+        if (
+          (layer as L.GeoJSON).toGeoJSON().bbox ===
+          component.plan?.planningArea.bbox
+        ) {
+          foundPlanningAreaLayer = true;
+        }
+      }
+    });
+
+    expect(foundPlanningAreaLayer).toBeTrue();
+  });
+
+  describe('expand map button', () => {
+    it('should navigate to map view when clicked'),
+      async () => {
+        const routerStub: Router = fixture.debugElement.injector.get(Router);
+        spyOn(routerStub, 'navigate').and.callThrough();
+        const button = await loader.getHarness(
+          MatButtonHarness.with({ text: 'EXPAND MAP' })
+        );
+
+        await button.click();
+
+        expect(routerStub.navigate).toHaveBeenCalledOnceWith(['map']);
+      };
+  });
+});

--- a/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
@@ -5,6 +5,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { Router } from '@angular/router';
 import * as L from 'leaflet';
 import { MaterialModule } from 'src/app/material/material.module';
+import { Region } from 'src/app/types';
 
 import { PlanMapComponent } from './plan-map.component';
 
@@ -33,6 +34,17 @@ describe('PlanMapComponent', () => {
   });
 
   it('should add planning area to map', () => {
+    component.plan = {
+      id: 'fake',
+      name: 'fake',
+      ownerId: 'fake',
+      region: Region.SIERRA_NEVADA,
+      planningArea: new L.Polygon([
+        new L.LatLng(38.715517043571914, -120.42857302225725),
+        new L.LatLng(38.47079787227401, -120.5164425608172),
+        new L.LatLng(38.52668443555346, -120.11828371421737),
+      ]).toGeoJSON(),
+    };
     component.ngAfterViewInit();
 
     let foundPlanningAreaLayer = false;

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -1,0 +1,64 @@
+import { AfterViewInit, Component, Input, OnDestroy } from '@angular/core';
+import { Router } from '@angular/router';
+import * as L from 'leaflet';
+import { Plan } from 'src/app/types';
+
+@Component({
+  selector: 'app-plan-map',
+  templateUrl: './plan-map.component.html',
+  styleUrls: ['./plan-map.component.scss'],
+})
+export class PlanMapComponent implements AfterViewInit, OnDestroy {
+  @Input() plan: Plan | undefined;
+
+  map!: L.Map;
+
+  constructor(private router: Router) {}
+
+  ngAfterViewInit(): void {
+    if (this.map != undefined) this.map.remove();
+
+    this.map = L.map('map', {
+      center: [38.646, -120.548],
+      zoom: 9,
+      layers: [this.stadiaAlidadeTiles()],
+      zoomControl: false,
+      pmIgnore: false,
+    });
+    this.map.attributionControl.setPosition('topright');
+
+    // Add planning area to map and frame it in view
+    if (!!this.plan) {
+      const planningArea = L.geoJSON(this.plan.planningArea, {
+        pane: 'overlayPane',
+        style: {
+          color: '#7b61ff',
+          fillColor: '#7b61ff',
+          fillOpacity: 0.2,
+          weight: 3,
+        },
+      }).addTo(this.map);
+      this.map.fitBounds(planningArea.getBounds());
+    }
+  }
+
+  /** Creates a basemap layer using the Stadia.AlidadeSmooth tiles. */
+  private stadiaAlidadeTiles() {
+    return L.tileLayer(
+      'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png',
+      {
+        maxZoom: 19,
+        attribution:
+          '&copy; <a href="https://stadiamaps.com/" target="_blank" rel="noreferrer">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/" target="_blank" rel="noreferrer">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org" target="_blank" rel="noreferrer">OpenStreetMap</a> contributors',
+      }
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.map.remove();
+  }
+
+  expandMap() {
+    this.router.navigate(['map']);
+  }
+}

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -5,7 +5,7 @@
   <mat-divider [vertical]="true"></mat-divider>
   <div class="plan-map-container">
     <div class="plan-map-view">
-      <p>Here is a map view</p>
+      <div id="map" class="plan-map"></div>
       <button mat-raised-button class="expand-map-button" (click)="expandMap()">EXPAND MAP</button>
     </div>
     <mat-divider></mat-divider>

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -4,10 +4,7 @@
   </div>
   <mat-divider [vertical]="true"></mat-divider>
   <div class="plan-map-container">
-    <div class="plan-map-view">
-      <div id="map" class="plan-map"></div>
-      <button mat-raised-button class="expand-map-button" (click)="expandMap()">EXPAND MAP</button>
-    </div>
+    <app-plan-map [plan]="plan"></app-plan-map>
     <mat-divider></mat-divider>
     <div class="plan-scenario-panel">
       <h1>Scenario comparison</h1>

--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -22,25 +22,6 @@
   height: 100%;
 }
 
-.plan-map-view {
-  background-color: #e9e9e9;
-  flex-grow: 2;
-  position: relative;
-}
-
-.plan-map {
-  height: 100%;
-  width: 100%;
-  z-index: 1;
-}
-
-.expand-map-button {
-  bottom: 12px;
-  position: absolute;
-  right: 12px;
-  z-index: 2;
-}
-
 .plan-scenario-panel {
   background-color: white;
   display: flex;

--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -23,19 +23,22 @@
 }
 
 .plan-map-view {
-  align-items: center;
   background-color: #e9e9e9;
-  display: flex;
   flex-grow: 2;
-  justify-content: center;
   position: relative;
-  text-align: center;
+}
+
+.plan-map {
+  height: 100%;
+  width: 100%;
+  z-index: 1;
 }
 
 .expand-map-button {
   bottom: 12px;
   position: absolute;
   right: 12px;
+  z-index: 2;
 }
 
 .plan-scenario-panel {

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MaterialModule } from '../material/material.module';
+import { PlanMapComponent } from './plan-map/plan-map.component';
 import { PlanComponent } from './plan.component';
 
 describe('PlanComponent', () => {
@@ -10,7 +11,7 @@ describe('PlanComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MaterialModule],
-      declarations: [PlanComponent],
+      declarations: [PlanComponent, PlanMapComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PlanComponent);

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -6,6 +6,9 @@ import { Router } from '@angular/router';
 
 import { PlanComponent } from './plan.component';
 
+import * as L from 'leaflet';
+import { MaterialModule } from '../material/material.module';
+
 describe('PlanComponent', () => {
   let component: PlanComponent;
   let fixture: ComponentFixture<PlanComponent>;
@@ -15,6 +18,7 @@ describe('PlanComponent', () => {
     const routerStub = () => ({ navigate: (array: string[]) => ({}) });
 
     await TestBed.configureTestingModule({
+      imports: [MaterialModule],
       declarations: [PlanComponent],
       providers: [{ provide: Router, useFactory: routerStub }],
     }).compileComponents();
@@ -27,6 +31,25 @@ describe('PlanComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should add planning area to map', () => {
+    component.ngAfterViewInit();
+
+    let foundPlanningAreaLayer = false;
+
+    component.map.eachLayer((layer) => {
+      if (layer instanceof L.GeoJSON) {
+        if (
+          (layer as L.GeoJSON).toGeoJSON().bbox ===
+          component.plan?.planningArea.bbox
+        ) {
+          foundPlanningAreaLayer = true;
+        }
+      }
+    });
+
+    expect(foundPlanningAreaLayer).toBeTrue();
   });
 
   describe('expand map button', () => {

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -1,69 +1,24 @@
-import { HarnessLoader } from '@angular/cdk/testing';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatButtonHarness } from '@angular/material/button/testing';
-import { Router } from '@angular/router';
 
-import { PlanComponent } from './plan.component';
-
-import * as L from 'leaflet';
 import { MaterialModule } from '../material/material.module';
+import { PlanComponent } from './plan.component';
 
 describe('PlanComponent', () => {
   let component: PlanComponent;
   let fixture: ComponentFixture<PlanComponent>;
-  let loader: HarnessLoader;
 
   beforeEach(async () => {
-    const routerStub = () => ({ navigate: (array: string[]) => ({}) });
-
     await TestBed.configureTestingModule({
       imports: [MaterialModule],
       declarations: [PlanComponent],
-      providers: [{ provide: Router, useFactory: routerStub }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PlanComponent);
     component = fixture.componentInstance;
-    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should add planning area to map', () => {
-    component.ngAfterViewInit();
-
-    let foundPlanningAreaLayer = false;
-
-    component.map.eachLayer((layer) => {
-      if (layer instanceof L.GeoJSON) {
-        if (
-          (layer as L.GeoJSON).toGeoJSON().bbox ===
-          component.plan?.planningArea.bbox
-        ) {
-          foundPlanningAreaLayer = true;
-        }
-      }
-    });
-
-    expect(foundPlanningAreaLayer).toBeTrue();
-  });
-
-  describe('expand map button', () => {
-    it('should navigate to map view when clicked'),
-      async () => {
-        const routerStub: Router = fixture.debugElement.injector.get(Router);
-        spyOn(routerStub, 'navigate').and.callThrough();
-        const button = await loader.getHarness(
-          MatButtonHarness.with({ text: 'EXPAND MAP' })
-        );
-
-        await button.click();
-
-        expect(routerStub.navigate).toHaveBeenCalledOnceWith(['map']);
-      };
   });
 });

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -1,5 +1,4 @@
-import { AfterViewInit, Component, OnDestroy } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component } from '@angular/core';
 import * as L from 'leaflet';
 
 import { Plan, Region } from '../types';
@@ -9,11 +8,10 @@ import { Plan, Region } from '../types';
   templateUrl: './plan.component.html',
   styleUrls: ['./plan.component.scss'],
 })
-export class PlanComponent implements AfterViewInit, OnDestroy {
-  map!: L.Map;
-  plan: Plan | null = null;
+export class PlanComponent {
+  plan: Plan | undefined;
 
-  constructor(private router: Router) {
+  constructor() {
     // TODO(leehana): Use a fake plan until we can query plans from the DB
     this.plan = {
       id: 'fake',
@@ -26,52 +24,5 @@ export class PlanComponent implements AfterViewInit, OnDestroy {
         new L.LatLng(38.52668443555346, -120.11828371421737),
       ]).toGeoJSON(),
     };
-  }
-
-  ngAfterViewInit(): void {
-    if (this.map != undefined) this.map.remove();
-
-    this.map = L.map('map', {
-      center: [38.646, -120.548],
-      zoom: 9,
-      layers: [this.stadiaAlidadeTiles()],
-      zoomControl: false,
-      pmIgnore: false,
-    });
-    this.map.attributionControl.setPosition('topright');
-
-    // Add planning area to map and frame it in view
-    if (!!this.plan) {
-      const planningArea = L.geoJSON(this.plan.planningArea, {
-        pane: 'overlayPane',
-        style: {
-          color: '#7b61ff',
-          fillColor: '#7b61ff',
-          fillOpacity: 0.2,
-          weight: 3,
-        },
-      }).addTo(this.map);
-      this.map.fitBounds(planningArea.getBounds());
-    }
-  }
-
-  /** Creates a basemap layer using the Stadia.AlidadeSmooth tiles. */
-  private stadiaAlidadeTiles() {
-    return L.tileLayer(
-      'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png',
-      {
-        maxZoom: 19,
-        attribution:
-          '&copy; <a href="https://stadiamaps.com/" target="_blank" rel="noreferrer">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/" target="_blank" rel="noreferrer">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org" target="_blank" rel="noreferrer">OpenStreetMap</a> contributors',
-      }
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.map.remove();
-  }
-
-  expandMap() {
-    this.router.navigate(['map']);
   }
 }

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -1,7 +1,8 @@
-import { Component, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Component } from '@angular/core';
 import { Router } from '@angular/router';
-
 import * as L from 'leaflet';
+
+import { Plan, Region } from '../types';
 
 @Component({
   selector: 'app-plan',
@@ -10,8 +11,22 @@ import * as L from 'leaflet';
 })
 export class PlanComponent implements AfterViewInit {
   private map!: L.Map;
+  private plan: Plan | null = null;
 
-  constructor(private router: Router) {}
+  constructor(private router: Router) {
+    // TODO(leehana): Use a fake plan until we can query plans from the DB
+    this.plan = {
+      id: 'fake',
+      name: 'fake',
+      ownerId: 'fake',
+      region: Region.SIERRA_NEVADA,
+      planningArea: new L.Polygon([
+        new L.LatLng(38.715517043571914, -120.42857302225725),
+        new L.LatLng(38.47079787227401, -120.5164425608172),
+        new L.LatLng(38.52668443555346, -120.11828371421737),
+      ]).toGeoJSON(),
+    };
+  }
 
   ngAfterViewInit(): void {
     this.map = L.map('map', {
@@ -22,6 +37,20 @@ export class PlanComponent implements AfterViewInit {
       pmIgnore: false,
     });
     this.map.attributionControl.setPosition('topright');
+
+    // Add planning area to map and frame it in view
+    if (!!this.plan) {
+      const planningArea = L.geoJSON(this.plan.planningArea, {
+        pane: 'overlayPane',
+        style: {
+          color: '#7b61ff',
+          fillColor: '#7b61ff',
+          fillOpacity: 0.2,
+          weight: 3,
+        },
+      }).addTo(this.map);
+      this.map.fitBounds(planningArea.getBounds());
+    }
   }
 
   /** Creates a basemap layer using the Stadia.AlidadeSmooth tiles. */

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import * as L from 'leaflet';
 
@@ -9,9 +9,9 @@ import { Plan, Region } from '../types';
   templateUrl: './plan.component.html',
   styleUrls: ['./plan.component.scss'],
 })
-export class PlanComponent implements AfterViewInit {
-  private map!: L.Map;
-  private plan: Plan | null = null;
+export class PlanComponent implements AfterViewInit, OnDestroy {
+  map!: L.Map;
+  plan: Plan | null = null;
 
   constructor(private router: Router) {
     // TODO(leehana): Use a fake plan until we can query plans from the DB
@@ -29,6 +29,8 @@ export class PlanComponent implements AfterViewInit {
   }
 
   ngAfterViewInit(): void {
+    if (this.map != undefined) this.map.remove();
+
     this.map = L.map('map', {
       center: [38.646, -120.548],
       zoom: 9,
@@ -63,6 +65,10 @@ export class PlanComponent implements AfterViewInit {
           '&copy; <a href="https://stadiamaps.com/" target="_blank" rel="noreferrer">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/" target="_blank" rel="noreferrer">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org" target="_blank" rel="noreferrer">OpenStreetMap</a> contributors',
       }
     );
+  }
+
+  ngOnDestroy(): void {
+    this.map.remove();
   }
 
   expandMap() {

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -1,13 +1,40 @@
-import { Component } from '@angular/core';
+import { Component, AfterViewInit } from '@angular/core';
 import { Router } from '@angular/router';
+
+import * as L from 'leaflet';
 
 @Component({
   selector: 'app-plan',
   templateUrl: './plan.component.html',
   styleUrls: ['./plan.component.scss'],
 })
-export class PlanComponent {
+export class PlanComponent implements AfterViewInit {
+  private map!: L.Map;
+
   constructor(private router: Router) {}
+
+  ngAfterViewInit(): void {
+    this.map = L.map('map', {
+      center: [38.646, -120.548],
+      zoom: 9,
+      layers: [this.stadiaAlidadeTiles()],
+      zoomControl: false,
+      pmIgnore: false,
+    });
+    this.map.attributionControl.setPosition('topright');
+  }
+
+  /** Creates a basemap layer using the Stadia.AlidadeSmooth tiles. */
+  private stadiaAlidadeTiles() {
+    return L.tileLayer(
+      'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png',
+      {
+        maxZoom: 19,
+        attribution:
+          '&copy; <a href="https://stadiamaps.com/" target="_blank" rel="noreferrer">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/" target="_blank" rel="noreferrer">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org" target="_blank" rel="noreferrer">OpenStreetMap</a> contributors',
+      }
+    );
+  }
 
   expandMap() {
     this.router.navigate(['map']);


### PR DESCRIPTION
## Changes
- Add temporary plan object with fake data to PlanComponent
- Add Leaflet map to planning view
- When planning view is initialized, render the planning area on the map and zoom/pan to fit its bounds
- Unit tests
- Fixes #226 

![image](https://user-images.githubusercontent.com/10444733/207992797-dc3e4dcd-072e-40fd-a5fb-5a4caf2496cf.png)
