### PR TITLE
Improve create a plan flow and ui

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -438,6 +438,16 @@ export class MapManager {
     map.pm.addControls(this.getGeomanDrawOptions());
   }
 
+  /** Clears all drawings and cloned drawings. */
+  clearAllDrawings() {
+    this.drawingLayer.clearLayers();
+    this.maps.forEach((currMap) => {
+      currMap.clonedDrawingRef!.clearLayers();
+      currMap.drawnPolygonLookup = {};
+    });
+    this.polygonsCreated$.next(false);
+  }
+
   /**
    * Converts drawingLayer to GeoJSON. If there are multiple polygons drawn,
    * creates and returns MultiPolygon type GeoJSON. Otherwise, returns a Polygon

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -214,7 +214,7 @@
       <button mat-flat-button
         class="draw-area-button"
         [class.is-hidden]="!showAreaCreationActionButtons"
-        [ngClass]="{selected: selectedAreaCreationAction==AreaCreationAction.DRAW}"
+        [ngClass]="{selected: selectedAreaCreationAction === AreaCreationAction.DRAW}"
         (click)="onAreaCreationActionChange(AreaCreationAction.DRAW)">
         <mat-icon>draw</mat-icon> Draw an area
       </button>
@@ -224,7 +224,7 @@
         <button mat-flat-button
           class="upload-area-button"
           [class.is-hidden]="!showAreaCreationActionButtons"
-          [ngClass]="{selected: selectedAreaCreationAction==AreaCreationAction.UPLOAD}"
+          [ngClass]="{selected: selectedAreaCreationAction === AreaCreationAction.UPLOAD}"
           (click)="onAreaCreationActionChange(AreaCreationAction.UPLOAD)">
           <mat-icon>upload</mat-icon> Upload an area
         </button>
@@ -236,7 +236,8 @@
       </div>
 
       <!-- Cancel button -->
-      <button *ngIf="selectedAreaCreationAction==AreaCreationAction.DRAW || selectedAreaCreationAction==AreaCreationAction.UPLOAD"
+      <button *ngIf="selectedAreaCreationAction === AreaCreationAction.DRAW ||
+        selectedAreaCreationAction === AreaCreationAction.UPLOAD"
         mat-button type="button"
         class="cancel-button"
         (click)="cancelAreaCreationAction()">

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -207,7 +207,7 @@
       <button mat-flat-button
           class="draw-area-button"
           (click)="onAreaCreationOptionChange(AreaCreationOption.DRAW)">
-          <mat-icon>edit</mat-icon> Draw an area
+          <mat-icon>draw</mat-icon> Draw an area
         </button>
 
       <!-- Upload a planning area -->
@@ -215,7 +215,7 @@
         <button mat-flat-button
           class="upload-area-button"
           (click)="onAreaCreationOptionChange(AreaCreationOption.UPLOAD)">
-          <mat-icon>upload_file</mat-icon> Upload an area
+          <mat-icon>upload</mat-icon> Upload an area
         </button>
         <file-uploader *ngIf="showUploader"
           class="file-uploader"
@@ -229,7 +229,7 @@
         mat-button type="button"
         class="create-plan-button"
         (click)="openCreatePlanDialog()">
-        <mat-icon>add</mat-icon>CREATE
+        <mat-icon>add_circle</mat-icon>Create plan
       </button>
     </div>
 

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -218,6 +218,7 @@
           <mat-icon>upload_file</mat-icon> Upload an area
         </button>
         <file-uploader *ngIf="showUploader"
+          class="file-uploader"
           requiredFileType="application/zip"
           (fileEvent)="loadArea($event)"
           ></file-uploader>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -202,19 +202,30 @@
   <!-- Display containers for leaflet maps (up to 4) -->
   <div class="maps-container">
     <!-- Actions bar above the maps -->
-    <div class="map-options-bar">
+    <div class="map-actions-bar">
+      <button mat-flat-button
+        class="create-plan-button"
+        (click)="showAreaCreationActionButtons=!showAreaCreationActionButtons">
+        Create a plan
+        <span class="arrow" [ngClass]="{right: !showAreaCreationActionButtons, left: showAreaCreationActionButtons}"></span>
+      </button>
+
       <!-- Draw a planning area -->
       <button mat-flat-button
-          class="draw-area-button"
-          (click)="onAreaCreationOptionChange(AreaCreationOption.DRAW)">
-          <mat-icon>draw</mat-icon> Draw an area
-        </button>
+        class="draw-area-button"
+        [class.is-hidden]="!showAreaCreationActionButtons"
+        [ngClass]="{selected: selectedAreaCreationAction==AreaCreationAction.DRAW}"
+        (click)="onAreaCreationActionChange(AreaCreationAction.DRAW)">
+        <mat-icon>draw</mat-icon> Draw an area
+      </button>
 
       <!-- Upload a planning area -->
       <div class="upload-wrapper">
         <button mat-flat-button
           class="upload-area-button"
-          (click)="onAreaCreationOptionChange(AreaCreationOption.UPLOAD)">
+          [class.is-hidden]="!showAreaCreationActionButtons"
+          [ngClass]="{selected: selectedAreaCreationAction==AreaCreationAction.UPLOAD}"
+          (click)="onAreaCreationActionChange(AreaCreationAction.UPLOAD)">
           <mat-icon>upload</mat-icon> Upload an area
         </button>
         <file-uploader *ngIf="showUploader"
@@ -224,12 +235,20 @@
           ></file-uploader>
       </div>
 
-      <!-- Create plan button -->
-      <button *ngIf="showCreatePlanButton$ | async"
+      <!-- Cancel button -->
+      <button *ngIf="selectedAreaCreationAction==AreaCreationAction.DRAW || selectedAreaCreationAction==AreaCreationAction.UPLOAD"
         mat-button type="button"
-        class="create-plan-button"
+        class="cancel-button"
+        (click)="cancelAreaCreationAction()">
+        <mat-icon>cancel</mat-icon>CANCEL
+      </button>
+
+      <!-- Done (confirm area) button -->
+      <button *ngIf="showConfirmAreaButton$ | async"
+        mat-button type="button"
+        class="confirm-area-button"
         (click)="openCreatePlanDialog()">
-        <mat-icon>add_circle</mat-icon>Create plan
+        <mat-icon>done</mat-icon>DONE
       </button>
     </div>
 

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -1,5 +1,4 @@
 @import "../shared/_variables.scss";
-@import "../shared/file-uploader/file-uploader.component.scss";
 
 .root-container {
   display: flex;

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -1,27 +1,5 @@
 @import "../shared/_variables.scss";
 
-.arrow {
-  position: relative;
-  width: 0;
-  height: 0;
-  border: solid #565656;
-  border-width: 0 3px 3px 0;
-  display: inline-block;
-  padding: 3px;
-  pointer-events: none;
-}
-
-.right {
-  transform: rotate(-45deg);
-  -webkit-transform: rotate(-45deg);
-}
-
-.left {
-  left: 5px;
-  transform: rotate(135deg);
-  -webkit-transform: rotate(135deg);
-}
-
 .root-container {
   display: flex;
   flex-direction: row;
@@ -154,8 +132,8 @@
 
 // Styling for the actions bar above the maps
 .map-actions-bar {
-  display: flex;
   background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
   flex-direction: row;
   height: $info-bar-height;
   position: absolute;
@@ -166,10 +144,32 @@
 .create-plan-button {
   align-items: center;
   background-color: #ffffff;
+  border-radius: 50px;
   font-weight: 500;
   height: 35px;
   margin: 8px 0px 0px 20px;
-  border-radius: 50px;
+}
+
+.arrow {
+  border: solid #565656;
+  border-width: 0 3px 3px 0;
+  display: inline-block;
+  height: 0;
+  padding: 3px;
+  pointer-events: none;
+  position: relative;
+  width: 0;
+}
+
+.right {
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+}
+
+.left {
+  left: 5px;
+  transform: rotate(135deg);
+  -webkit-transform: rotate(135deg);
 }
 
 .draw-area-button {
@@ -223,9 +223,9 @@
 .cancel-button {
   color: #ffffff;
   margin: 4px 20px 0px 20px;
+  margin-left: auto;
   pointer-events: auto;
   width: fit-content;
-  margin-left: auto;
 }
 
 .condition-tree-invisible {

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -1,4 +1,5 @@
 @import "../shared/_variables.scss";
+@import "../shared/file-uploader/file-uploader.component.scss";
 
 .root-container {
   display: flex;
@@ -163,6 +164,16 @@
 
   &:hover {
     background-color: #b9b9b9;
+  }
+}
+
+.upload-wrapper {
+  position: relative;
+
+  .file-uploader {
+    left: 0;
+    position: absolute;
+    top: 50px;
   }
 }
 

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -172,21 +172,7 @@
   -webkit-transform: rotate(135deg);
 }
 
-.draw-area-button {
-  background-color: #ffffff;
-  border-radius: 50px;
-  height: 35px;
-  margin: 0px 0px 0px 10px;
-  pointer-events: auto;
-  top: 8px;
-  width: fit-content;
-
-  &:hover {
-    background-color: #b9b9b9;
-  }
-}
-
-.upload-area-button {
+.draw-area-button, .upload-area-button {
   background-color: #ffffff;
   border-radius: 50px;
   height: 35px;

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -1,5 +1,27 @@
 @import "../shared/_variables.scss";
 
+.arrow {
+  position: relative;
+  width: 0;
+  height: 0;
+  border: solid #565656;
+  border-width: 0 3px 3px 0;
+  display: inline-block;
+  padding: 3px;
+  pointer-events: none;
+}
+
+.right {
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+}
+
+.left {
+  left: 5px;
+  transform: rotate(135deg);
+  -webkit-transform: rotate(135deg);
+}
+
 .root-container {
   display: flex;
   flex-direction: row;
@@ -131,7 +153,7 @@
 }
 
 // Styling for the actions bar above the maps
-.map-options-bar {
+.map-actions-bar {
   display: flex;
   background-color: rgba(0, 0, 0, 0.5);
   flex-direction: row;
@@ -141,10 +163,20 @@
   z-index: 2;
 }
 
+.create-plan-button {
+  align-items: center;
+  background-color: #ffffff;
+  font-weight: 500;
+  height: 35px;
+  margin: 8px 0px 0px 20px;
+  border-radius: 50px;
+}
+
 .draw-area-button {
   background-color: #ffffff;
+  border-radius: 50px;
   height: 35px;
-  margin: 0px 0px 0px 20px;
+  margin: 0px 0px 0px 10px;
   pointer-events: auto;
   top: 8px;
   width: fit-content;
@@ -156,6 +188,7 @@
 
 .upload-area-button {
   background-color: #ffffff;
+  border-radius: 50px;
   height: 35px;
   margin: 8px 0px 0px 10px;
   pointer-events: auto;
@@ -164,6 +197,10 @@
   &:hover {
     background-color: #b9b9b9;
   }
+}
+
+.selected {
+  background-color: #b9b9b9;
 }
 
 .upload-wrapper {
@@ -176,11 +213,19 @@
   }
 }
 
-.create-plan-button {
+.confirm-area-button {
   color: #ffffff;
-  margin: 4px 0px 0px 20px;
+  margin: 4px 20px 0px 0px;
   pointer-events: auto;
   width: fit-content;
+}
+
+.cancel-button {
+  color: #ffffff;
+  margin: 4px 20px 0px 20px;
+  pointer-events: auto;
+  width: fit-content;
+  margin-left: auto;
 }
 
 .condition-tree-invisible {

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -200,22 +200,6 @@ describe('MapComponent', () => {
       );
       expect(mapServiceStub.getExistingProjects).toHaveBeenCalled();
     });
-
-    it('sets up drawing', () => {
-      const selectedMap =
-        component.maps[component.mapViewOptions$.getValue().selectedMapIndex];
-
-      component.maps.forEach((map: Map) => {
-        expect(map.clonedDrawingRef).toBeDefined();
-        expect(map.drawnPolygonLookup).toEqual({});
-      });
-      expect(
-        selectedMap.instance?.hasLayer(selectedMap.clonedDrawingRef!)
-      ).toBeFalse();
-      expect(
-        selectedMap.instance?.hasLayer(mapManager.drawingLayer)
-      ).toBeTrue();
-    });
   });
 
   describe('ngAfterViewInit', () => {
@@ -371,8 +355,15 @@ describe('MapComponent', () => {
       });
     });
 
-    it('enables drawing on selected map and shows cloned layer on other maps', () => {
+    it('enables drawing on selected map and shows cloned layer on other maps', async () => {
       component.ngAfterViewInit();
+      spyOn(component, 'onAreaCreationActionChange').and.callThrough();
+      const button = await loader.getHarness(
+        MatButtonHarness.with({
+          selector: '.draw-area-button',
+        })
+      );
+      await button.click();
 
       component.maps[3].instance?.fireEvent('click');
 
@@ -514,8 +505,32 @@ describe('MapComponent', () => {
       component.ngAfterViewInit();
     });
 
+    it('sets up drawing', async () => {
+      spyOn(component, 'onAreaCreationActionChange').and.callThrough();
+      const button = await loader.getHarness(
+        MatButtonHarness.with({
+          selector: '.draw-area-button',
+        })
+      );
+
+      await button.click();
+      const selectedMap =
+        component.maps[component.mapViewOptions$.getValue().selectedMapIndex];
+
+      component.maps.forEach((map: Map) => {
+        expect(map.clonedDrawingRef).toBeDefined();
+        expect(map.drawnPolygonLookup).toEqual({});
+      });
+      expect(
+        selectedMap.instance?.hasLayer(selectedMap.clonedDrawingRef!)
+      ).toBeFalse();
+      expect(
+        selectedMap.instance?.hasLayer(mapManager.drawingLayer)
+      ).toBeTrue();
+    });
+
     it('enables polygon tool when drawing option is selected', async () => {
-      spyOn(component, 'onAreaCreationOptionChange').and.callThrough();
+      spyOn(component, 'onAreaCreationActionChange').and.callThrough();
       const button = await loader.getHarness(
         MatButtonHarness.with({
           selector: '.draw-area-button',
@@ -524,7 +539,7 @@ describe('MapComponent', () => {
 
       await button.click();
 
-      expect(component.onAreaCreationOptionChange).toHaveBeenCalled();
+      expect(component.onAreaCreationActionChange).toHaveBeenCalled();
       expect(
         component.maps[
           component.mapViewOptions$.getValue().selectedMapIndex
@@ -645,11 +660,11 @@ describe('MapComponent', () => {
         fixture.debugElement.injector.get(MatDialog);
       const planServiceStub: PlanService =
         fixture.debugElement.injector.get(PlanService);
-      fixture.componentInstance.showCreatePlanButton$ =
+      fixture.componentInstance.showConfirmAreaButton$ =
         new BehaviorSubject<boolean>(true);
       const button = await loader.getHarness(
         MatButtonHarness.with({
-          selector: '.create-plan-button',
+          selector: '.confirm-area-button',
         })
       );
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -518,21 +518,27 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   selectMap(mapIndex: number) {
     const mapViewOptions = this.mapViewOptions$.getValue();
     const previousMapIndex = mapViewOptions.selectedMapIndex;
+    mapViewOptions.selectedMapIndex = mapIndex;
+    this.mapViewOptions$.next(mapViewOptions);
+    this.sessionService.setMapViewOptions(mapViewOptions);
 
     // Toggle the cloned layer on if the map is not the current selected map.
     // Toggle on the drawing layer and control on the selected map.
-    if (previousMapIndex !== mapIndex) {
-      this.mapManager.removeDrawingControl(
-        this.maps[previousMapIndex].instance!
-      );
-      this.mapManager.showClonedDrawing(this.maps[previousMapIndex]);
-
-      mapViewOptions.selectedMapIndex = mapIndex;
-      this.mapViewOptions$.next(mapViewOptions);
-      this.sessionService.setMapViewOptions(mapViewOptions);
-
-      this.mapManager.addDrawingControl(this.maps[mapIndex].instance!);
-      this.mapManager.hideClonedDrawing(this.maps[mapIndex]);
+    if (
+      this.selectedAreaCreationAction === AreaCreationAction.DRAW ||
+      this.showConfirmAreaButton$
+    ) {
+      if (previousMapIndex !== mapIndex) {
+        this.mapManager.disablePolygonDrawingTool(
+          this.maps[previousMapIndex].instance!
+        );
+        this.mapManager.removeDrawingControl(
+          this.maps[previousMapIndex].instance!
+        );
+        this.mapManager.showClonedDrawing(this.maps[previousMapIndex]);
+        this.mapManager.addDrawingControl(this.maps[mapIndex].instance!);
+        this.mapManager.hideClonedDrawing(this.maps[mapIndex]);
+      }
     }
   }
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -269,9 +269,15 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     });
 
     this.showConfirmAreaButton$.subscribe((value: boolean) => {
-      if (!value && this.selectedAreaCreationAction === AreaCreationAction.UPLOAD) {
-        const selectedMapIndex = this.mapViewOptions$.getValue().selectedMapIndex;
-        this.mapManager.removeDrawingControl(this.maps[selectedMapIndex].instance!);
+      if (
+        !value &&
+        this.selectedAreaCreationAction === AreaCreationAction.UPLOAD
+      ) {
+        const selectedMapIndex =
+          this.mapViewOptions$.getValue().selectedMapIndex;
+        this.mapManager.removeDrawingControl(
+          this.maps[selectedMapIndex].instance!
+        );
         this.showUploader = true;
       }
     });
@@ -529,13 +535,17 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     const mapViewOptions = this.mapViewOptions$.getValue();
     const previousMapIndex = mapViewOptions.selectedMapIndex;
 
-    // Toggle the cloned layer on if the map is not the current selected map.
-    // Toggle on the drawing layer and control on the selected map.
-    if (
-      this.selectedAreaCreationAction === AreaCreationAction.DRAW ||
-      this.showConfirmAreaButton$.value
-    ) {
-      if (previousMapIndex !== mapIndex) {
+    if (previousMapIndex !== mapIndex) {
+      mapViewOptions.selectedMapIndex = mapIndex;
+      this.mapViewOptions$.next(mapViewOptions);
+      this.sessionService.setMapViewOptions(mapViewOptions);
+
+      // Toggle the cloned layer on if the map is not the current selected map.
+      // Toggle on the drawing layer and control on the selected map.
+      if (
+        this.selectedAreaCreationAction === AreaCreationAction.DRAW ||
+        this.showConfirmAreaButton$.value
+      ) {
         this.mapManager.disablePolygonDrawingTool(
           this.maps[previousMapIndex].instance!
         );
@@ -547,9 +557,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         this.mapManager.hideClonedDrawing(this.maps[mapIndex]);
       }
     }
-    mapViewOptions.selectedMapIndex = mapIndex;
-    this.mapViewOptions$.next(mapViewOptions);
-    this.sessionService.setMapViewOptions(mapViewOptions);
   }
 
   /**

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -383,7 +383,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       this.changeMapCount(1);
     }
     if (option === AreaCreationAction.UPLOAD) {
-      this.maps[selectedMapIndex].instance!.pm.removeControls();
+      if (!this.showConfirmAreaButton$.value) {
+        this.maps[selectedMapIndex].instance!.pm.removeControls();
+      }
       this.mapManager.disablePolygonDrawingTool(
         this.maps[selectedMapIndex].instance!
       );

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -375,7 +375,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       this.changeMapCount(1);
     }
     if (option === AreaCreationAction.UPLOAD) {
-      const selectedMapIndex = this.mapViewOptions$.getValue().selectedMapIndex;
       this.maps[selectedMapIndex].instance!.pm.removeControls();
       this.mapManager.disablePolygonDrawingTool(
         this.maps[selectedMapIndex].instance!

--- a/src/interface/src/app/shared/file-uploader/file-uploader.component.scss
+++ b/src/interface/src/app/shared/file-uploader/file-uploader.component.scss
@@ -10,8 +10,6 @@
   flex-direction: column;
   height: 120px;
   padding: 0px 20px 0px 20px;
-  position: relative;
-  top: 8px;
   z-index: 2;
 }
 

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -107,6 +107,10 @@ $planscape-frontend-theme: mat.define-light-theme((
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
+.is-hidden {
+  display: none !important;
+}
+
 .map-nameplate-tooltip {
   font-size: 14px;
 }


### PR DESCRIPTION
# Changes:
- Fix button shifting to the right when the file-upload component is open.
- Updated mat icons to match mocks
- Added toggle-able 'create a plan' button > shows 'draw an area' and 'upload an area' buttons
- Added 'done' and 'cancel' buttons
- Updated logic for new ui elements
- 'cancel' removes drawing controls and all drawn or uploaded areas
- 'done' only shows when there are polygons on the map
- Only have one entry point for starting drawing
- Disable drawing when not in drawing or area uploaded mode
- Enables drawing controls when an area is uploaded (to allow edits)

# UI Updates:
<img width="1109" alt="Screen Shot 2022-12-16 at 2 52 09 AM" src="https://user-images.githubusercontent.com/114368235/208140178-ada30be5-6241-4fcd-8b11-6c5755b8b609.png">

<img width="1107" alt="Screen Shot 2022-12-16 at 2 52 36 AM" src="https://user-images.githubusercontent.com/114368235/208140453-b21457f7-b628-444b-a944-ac422d08437f.png">

<img width="1104" alt="Screen Shot 2022-12-16 at 2 52 24 AM" src="https://user-images.githubusercontent.com/114368235/208140555-1877362b-f729-4960-9bfe-5d0acfaf0f66.png">

<img width="1435" alt="Screen Shot 2022-12-16 at 2 51 33 AM" src="https://user-images.githubusercontent.com/114368235/208140632-34c6f53a-8569-4a5f-b1e4-838ef8498028.png">


