### PR TITLE
Fix CI test to fetch R binary, use environment variables instead of .env file

### DIFF
--- a/.github/workflows/django.yaml
+++ b/.github/workflows/django.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Dependencies
       run: |
         cd src/planscape
-        sudo apt-get install gdal-bin libgdal-dev
+        sudo apt-get install gdal-bin libgdal-dev r-base-core
         python -m pip install --upgrade pip
         pip install -r requirements.txt 
     - name: Set up PostGIS

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -7,11 +7,13 @@ services:
     volumes:
       - ./planscape/:/usr/src/planscape/
       - ./socket:/var/run/planscape
+    # Expose port 5432 to get access to the PostGIS database
     expose:
-      - 8000
       - 5432
-    env_file:
-      - ./planscape/planscape/.env
+    environment:
+      - PLANSCAPE_DATABASE_HOST=host.docker.internal
+      - PLANSCAPE_CORS_ALLOWED_HOSTS='http://127.0.0.1'
+      - PLANSCAPE_CORS_ALLOWED_ORIGINS='http://127.0.0.1'
     depends_on:
       - frontend
 


### PR DESCRIPTION
	modified:   .github/workflows/django.yaml