### PR TITLE
Add basic plan summary panel component

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { SharedModule } from './shared/shared.module';
 import { SignupComponent } from './signup/signup.component';
 import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
+import { SummaryPanelComponent } from './plan/summary-panel/summary-panel.component';
 
 @NgModule({
   declarations: [
@@ -54,6 +55,7 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     PlanCreateDialogComponent,
     LayerInfoCardComponent,
     PlanComponent,
+    SummaryPanelComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -1,6 +1,6 @@
 <div class="root-container">
   <div class="plan-summary-panel">
-    <h1>Plan summary</h1>
+    <summary-panel></summary-panel>
   </div>
   <mat-divider [vertical]="true"></mat-divider>
   <div class="plan-map-container">

--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -11,8 +11,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 20px;
-  width: 450px;
+  position: relative;
+  width: 300px;
 }
 
 .plan-map-container {

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.html
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.html
@@ -1,13 +1,14 @@
 <div class="summary-panel">
   <div class="summary-header">
-    <div class="summary-title">Shiba Inu</div>
-    <div class="summary-subtitle">Status: Cute</div>
+    <div class="summary-title">{{summaryInput?.type}} Summary</div>
+    <div *ngIf="summaryInput?.type === 'Plan'" class="summary-subtitle">Status: {{summaryInput?.status}}</div>
   </div>
   <div class="summary-content">
     <p>
-      The Shiba Inu is the smallest of the six original and distinct spitz breeds of dog from Japan.
-      A small, agile dog that copes very well with mountainous terrain, the Shiba Inu was originally
-      bred for hunting.
+      <span>Owner: {{summaryInput?.owner}}</span>
+      <br><span>Created: {{summaryInput?.createdTime}}</span>
+      <br><span>Last updated: {{summaryInput?.updatedTime}}</span>
+      <br><span>Region: {{summaryInput?.region}}</span>
     </p>
 
     <div class="grid-container">

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.html
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.html
@@ -1,7 +1,7 @@
 <div class="summary-panel">
   <div class="summary-header">
     <div class="summary-title">{{summaryInput?.type}} Summary</div>
-    <div *ngIf="summaryInput?.type === 'Plan'" class="summary-subtitle">Status: {{summaryInput?.status}}</div>
+    <div class="summary-subtitle">Status: {{summaryInput?.status}}</div>
   </div>
   <div class="summary-content">
     <p>
@@ -13,15 +13,15 @@
 
     <div class="grid-container">
       <div class="grid-item">
-        <span class="grid-title">Poor</span>
+        <span class="grid-title" [style.color]="conditionScoreColorMap[conditionScore]">{{conditionScore}}</span>
         <span class="grid-subtitle">current condition</span>
       </div>
       <div class="grid-item">
-        <span class="grid-title">Leaning Good</span>
+        <span class="grid-title" [style.color]="conditionScoreColorMap[futureConditionScore]">{{futureConditionScore}}</span>
         <span class="grid-subtitle">future condition</span>
       </div>
       <div class="grid-item">
-        <span class="grid-title">123456</span>
+        <span class="grid-title">{{acres}}</span>
         <span class="grid-subtitle">acres</span>
       </div>
       <div class="grid-item">

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.html
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.html
@@ -1,0 +1,38 @@
+<div class="summary-panel">
+  <div class="summary-header">
+    <div class="summary-title">Shiba Inu</div>
+    <div class="summary-subtitle">Status: Cute</div>
+  </div>
+  <div class="summary-content">
+    <p>
+      The Shiba Inu is the smallest of the six original and distinct spitz breeds of dog from Japan.
+      A small, agile dog that copes very well with mountainous terrain, the Shiba Inu was originally
+      bred for hunting.
+    </p>
+
+    <div class="grid-container">
+      <div class="grid-item">
+        <span class="grid-title">Poor</span>
+        <span class="grid-subtitle">current condition</span>
+      </div>
+      <div class="grid-item">
+        <span class="grid-title">Leaning Good</span>
+        <span class="grid-subtitle">future condition</span>
+      </div>
+      <div class="grid-item">
+        <span class="grid-title">123456</span>
+        <span class="grid-subtitle">acres</span>
+      </div>
+      <div class="grid-item">
+        <span class="grid-title">0</span>
+        <span class="grid-subtitle">scenarios</span>
+      </div>
+    </div>
+  </div>
+  <div class="summary-footer">
+    <div class="summary-actions">
+      <button mat-flat-button>Share</button>
+      <button mat-flat-button>Subscribe</button>
+    </div>
+  </div>
+</div>

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.scss
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.scss
@@ -43,7 +43,7 @@
 }
 
 .grid-title {
-  color: #F4511E;
+  color: #455a64;
   font-size: 20px;
 }
 

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.scss
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.scss
@@ -1,0 +1,52 @@
+.summary-panel {
+  background-color: white;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  height: 100%;
+  padding: 24px;
+  position: absolute;
+  width: 300px;
+}
+
+.summary-title {
+  font-family: "Google Sans";
+  font-size: 24px;
+  margin: 20px 0px 10px 0px;
+}
+
+.summary-subtitle {
+  color: #5F6368;
+  font-family: "Google Sans";
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.25px;
+  margin-bottom: 5px;
+}
+
+.summary-content {
+  color: #5F6368;
+  font-size: 12px;
+  letter-spacing: 0.3px;
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: 130px 130px;
+}
+
+.grid-item {
+  display: flex;
+  flex-direction: column;
+  margin: 10px;
+}
+
+.grid-title {
+  color: #F4511E;
+  font-size: 20px;
+}
+
+.summary-footer {
+  margin-top: auto;
+}

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.spec.ts
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SummaryPanelComponent } from './summary-panel.component';
+
+describe('SummaryPanelComponent', () => {
+  let component: SummaryPanelComponent;
+  let fixture: ComponentFixture<SummaryPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SummaryPanelComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SummaryPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.ts
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input, OnInit } from '@angular/core';
+import * as L from 'leaflet';
+
+import { Plan, Region } from '../../types';
+
+@Component({
+  selector: 'summary-panel',
+  templateUrl: './summary-panel.component.html',
+  styleUrls: ['./summary-panel.component.scss']
+})
+export class SummaryPanelComponent implements OnInit {
+  @Input() plan: Plan | null = null;
+
+  constructor() { }
+
+  ngOnInit(): void {
+    this.plan = {
+      id: 'fake',
+      name: 'placeholder plan name',
+      ownerId: 'fake',
+      region: Region.SIERRA_NEVADA,
+      planningArea: new L.Polygon([
+        new L.LatLng(38.715517043571914, -120.42857302225725),
+        new L.LatLng(38.47079787227401, -120.5164425608172),
+        new L.LatLng(38.52668443555346, -120.11828371421737),
+      ]).toGeoJSON(),
+    };
+  }
+
+}

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.ts
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.ts
@@ -3,19 +3,32 @@ import * as L from 'leaflet';
 
 import { Plan, Region } from '../../types';
 
+export interface SummaryInput {
+  id?: string;
+  type: string;
+  name: string;
+  owner: string;
+  region: Region;
+  area: GeoJSON.GeoJSON;
+  status?: string;
+  createdTime: string;
+  updatedTime: string;
+}
+
 @Component({
   selector: 'summary-panel',
   templateUrl: './summary-panel.component.html',
   styleUrls: ['./summary-panel.component.scss']
 })
 export class SummaryPanelComponent implements OnInit {
-  @Input() plan: Plan | null = null;
+  @Input() summaryInput: SummaryInput | null = null;
 
   constructor() { }
 
   ngOnInit(): void {
-    this.plan = {
-      id: 'fake',
+    // todo: pass the summaryInput from plan component
+    const plan = {
+      id: 'fakeId',
       name: 'placeholder plan name',
       ownerId: 'fake',
       region: Region.SIERRA_NEVADA,
@@ -25,6 +38,18 @@ export class SummaryPanelComponent implements OnInit {
         new L.LatLng(38.52668443555346, -120.11828371421737),
       ]).toGeoJSON(),
     };
+
+    this.summaryInput = {
+      id: plan.id,
+      type: 'Plan',
+      name: plan.name,
+      owner: 'Player 456',
+      region: plan.region,
+      area: plan.planningArea,
+      status: 'Draft',
+      createdTime: '10/20/2022',
+      updatedTime: '2 hours ago',
+    }
   }
 
 }

--- a/src/interface/src/app/plan/summary-panel/summary-panel.component.ts
+++ b/src/interface/src/app/plan/summary-panel/summary-panel.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import * as L from 'leaflet';
 
-import { Plan, Region } from '../../types';
+import { Region } from '../../types';
 
 export interface SummaryInput {
   id?: string;
@@ -15,6 +15,23 @@ export interface SummaryInput {
   updatedTime: string;
 }
 
+// todo: move this to shared types
+export enum ConditionName {
+  GOOD = 'Good',
+  LEANING_GOOD = 'Leaning good',
+  NEUTRAL = 'Neutral',
+  LEANING_POOR = 'Leaning poor',
+  POOR = 'Poor',
+}
+
+export const conditionScoreColorMap: Record<ConditionName, string> = {
+  [ConditionName.GOOD]: '#010108',
+  [ConditionName.LEANING_GOOD]: '#4c1761',
+  [ConditionName.NEUTRAL]: '#b1354c',
+  [ConditionName.LEANING_POOR]: '#F4511e',
+  [ConditionName.POOR]: '#fdd853',
+}
+
 @Component({
   selector: 'summary-panel',
   templateUrl: './summary-panel.component.html',
@@ -22,6 +39,12 @@ export interface SummaryInput {
 })
 export class SummaryPanelComponent implements OnInit {
   @Input() summaryInput: SummaryInput | null = null;
+  // todo: pass these in as inputs
+  conditionScore: ConditionName = ConditionName.POOR;
+  futureConditionScore: ConditionName = ConditionName.LEANING_GOOD;
+  acres = '123,456';
+
+  conditionScoreColorMap = conditionScoreColorMap;
 
   constructor() { }
 
@@ -51,5 +74,4 @@ export class SummaryPanelComponent implements OnInit {
       updatedTime: '2 hours ago',
     }
   }
-
 }


### PR DESCRIPTION
# Changes:
- Added summary-panel component (if other parts of plan needs a summary panel, this can be reused)
- Changes color of condition text based on condition score
- Displays only; no tests needed yet

# UI Updates:
<img width="1436" alt="Screen Shot 2022-12-16 at 5 39 36 PM" src="https://user-images.githubusercontent.com/114368235/208217565-296cd417-6fb6-4bd0-9181-9e2b28d57932.png">