### PR TITLE
Remove proxy.conf.json, and add production config for setting backend-constants correctly

### DIFF
--- a/src/interface/Dockerfile
+++ b/src/interface/Dockerfile
@@ -20,7 +20,7 @@ COPY . /src/interface
 RUN chmod -R 755 /src/interface/src/assets
 
 # Build app
-RUN npm run build -- --output-path=./dist/out
+RUN npm run build -- --configuration production --output-path=./dist/out
 
 # ---------------------------------
 # Multi-stage build 2: nginx Server

--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -76,9 +76,6 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
-          "options": {
-            "proxyConfig": "proxy.conf.json"
-          },
           "configurations": {
             "production": {
               "browserTarget": "interface:build:production"

--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -8,7 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
-    "build:prod": "ng build --prod",
+    "build:prod": "ng build --configuration production",
     "test:prod": "ng test --browsers=ChromeHeadless --watch=false --code-coverage"
   },
   "private": true,

--- a/src/interface/proxy.conf.json
+++ b/src/interface/proxy.conf.json
@@ -1,7 +1,0 @@
-{
-  "/plan": {
-    "target": "http://127.0.0.1:8000/",
-    "secure": false,
-    "logLevel": "debug"
-  }
-}

--- a/src/interface/src/app/backend-constants.ts
+++ b/src/interface/src/app/backend-constants.ts
@@ -1,3 +1,3 @@
 export const BackendConstants = {
-  END_POINT: 'http://127.0.0.1/planscape-backend',
+  END_POINT: 'http://localhost:8000/planscape-backend',
 } as const;

--- a/src/interface/src/app/backend-constants.ts
+++ b/src/interface/src/app/backend-constants.ts
@@ -1,3 +1,5 @@
+import { environment  } from "src/environments/environment";
+
 export const BackendConstants = {
-  END_POINT: 'http://localhost:8000/planscape-backend',
+  END_POINT: environment.backend_endpoint
 } as const;

--- a/src/interface/src/environments/environment.prod.ts
+++ b/src/interface/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  backend_endpoint: 'http://localhost/planscape-backend'
 };

--- a/src/interface/src/environments/environment.ts
+++ b/src/interface/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  backend_endpoint: 'http://localhost:8000/planscape-backend'
 };
 
 /*


### PR DESCRIPTION
proxy.conf.json seemed to be needed to fix CORS problems, but some testing suggested it's not necessary.

Tested in both local (non-production) builds and with Docker containers.