### PR TITLE
Route to plan using plan ID

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -38,6 +38,7 @@ const routes: Routes = [
         component: RegionSelectionComponent,
       },
       { path: 'map', title: 'Explore', component: MapComponent },
+      { path: 'plan/:id', title: 'Plan', component: PlanComponent },
       { path: 'plan', title: 'Plan', component: PlanComponent },
     ],
   },

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -20,7 +20,13 @@ import { Router } from '@angular/router';
 import * as L from 'leaflet';
 import * as shp from 'shpjs';
 
-import { MapService, PlanService, PlanState, PopupService, SessionService } from '../services';
+import {
+  MapService,
+  PlanService,
+  PlanState,
+  PopupService,
+  SessionService,
+} from '../services';
 import {
   BaseLayerType,
   BoundaryConfig,
@@ -78,8 +84,8 @@ describe('MapComponent', () => {
       name: 'somePlan',
       ownerId: 'owner',
       region: Region.SIERRA_NEVADA,
-      planningArea: fakeGeoJson
-    }
+      planningArea: fakeGeoJson,
+    };
     const fakeMapService = jasmine.createSpyObj<MapService>(
       'MapService',
       {
@@ -114,7 +120,7 @@ describe('MapComponent', () => {
     );
     const fakePlanService = jasmine.createSpyObj<PlanService>(
       'PlanService',
-      {createPlan: of({ success:true, fakePlan}) },
+      { createPlan: of({ success: true, result: fakePlan }) },
       {
         planState$: new BehaviorSubject<PlanState>({
           all: {}, // All plans indexed by id
@@ -693,7 +699,7 @@ describe('MapComponent', () => {
 
       expect(createPlanSpy).toHaveBeenCalledWith('test name', emptyGeoJson);
       expect(planServiceStub.createPlan).toHaveBeenCalled();
-      expect(routerStub.navigate).toHaveBeenCalledOnceWith(['plan']);
+      expect(routerStub.navigate).toHaveBeenCalledOnceWith(['plan', 'temp']);
     });
   });
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -371,7 +371,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         })
         .subscribe((result) => {
           console.log(result);
-          this.router.navigate(['plan']);
+          this.router.navigate(['plan', result.result!.id]);
         });
     });
   }

--- a/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
@@ -1,3 +1,4 @@
+import { BehaviorSubject } from 'rxjs';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -5,7 +6,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { Router } from '@angular/router';
 import * as L from 'leaflet';
 import { MaterialModule } from 'src/app/material/material.module';
-import { Region } from 'src/app/types';
+import { Region, Plan } from 'src/app/types';
 
 import { PlanMapComponent } from './plan-map.component';
 
@@ -34,7 +35,7 @@ describe('PlanMapComponent', () => {
   });
 
   it('should add planning area to map', () => {
-    component.plan = {
+    component.plan = new BehaviorSubject<Plan | null>({
       id: 'fake',
       name: 'fake',
       ownerId: 'fake',
@@ -44,7 +45,7 @@ describe('PlanMapComponent', () => {
         new L.LatLng(38.47079787227401, -120.5164425608172),
         new L.LatLng(38.52668443555346, -120.11828371421737),
       ]).toGeoJSON(),
-    };
+    });
     component.ngAfterViewInit();
 
     let foundPlanningAreaLayer = false;
@@ -53,7 +54,7 @@ describe('PlanMapComponent', () => {
       if (layer instanceof L.GeoJSON) {
         if (
           (layer as L.GeoJSON).toGeoJSON().bbox ===
-          component.plan?.planningArea.bbox
+          component.plan.value?.planningArea.bbox
         ) {
           foundPlanningAreaLayer = true;
         }

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -11,7 +11,7 @@ import { Plan } from 'src/app/types';
   styleUrls: ['./plan-map.component.scss'],
 })
 export class PlanMapComponent implements AfterViewInit, OnDestroy {
-  @Input() plan!: BehaviorSubject<Plan | null>;
+  @Input() plan = new BehaviorSubject<Plan | null>(null);
 
   private readonly destroy$ = new Subject<void>();
   map!: L.Map;

--- a/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.html
+++ b/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.html
@@ -1,0 +1,4 @@
+<div class="root-container">
+  <h1>Plan not found</h1>
+  <p>Sorry! Either the plan you're trying to access doesn't exist, or you don't have permission to see it.</p>
+</div>

--- a/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.scss
+++ b/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.scss
@@ -1,0 +1,6 @@
+.root-container {
+  box-sizing: border-box;
+  height: 100%;
+  padding: 24px;
+  width: 100%;
+}

--- a/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.spec.ts
+++ b/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlanUnavailableComponent } from './plan-unavailable.component';
+
+describe('PlanUnavailableComponent', () => {
+  let component: PlanUnavailableComponent;
+  let fixture: ComponentFixture<PlanUnavailableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PlanUnavailableComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlanUnavailableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.ts
+++ b/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-plan-unavailable',
+  templateUrl: './plan-unavailable.component.html',
+  styleUrls: ['./plan-unavailable.component.scss'],
+})
+export class PlanUnavailableComponent {}

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -1,27 +1,30 @@
 <div class="root-container">
-  <div class="plan-summary-panel" *ngIf="!resumePlanning">
-    <summary-panel></summary-panel>
-  </div>
-  <div class="plan-progress-panel" *ngIf="resumePlanning">
-    <progress-panel [plan]="currentPlan$ | async"></progress-panel>
-  </div>
-  <mat-divider [vertical]="true"></mat-divider>
-  <div class="plan-map-container">
-    <app-plan-map [plan]="plan" class="plan-map-view"></app-plan-map>
-    <mat-divider></mat-divider>
-    <div class="plan-scenario-panel">
-      <h1>Plan name</h1>
-      <div class="plan-scenario-panel-content">
-        <p class="plan-scenario-panel-text">
-          Your planning area, priorities, and constraints are used to generate scenarios.
-          Using the Scenario Explorer, you can adjust the relative importance of priorities.
-          Saved scenarios are added to the Comparison table. Scenarios consist of Project Areas,
-          Treatment plans, Potential Outcomes, and Estimated costs.
-        </p>
-        <button mat-raised-button color="primary">CREATE A NEW SCENARIO</button>
-      </div>
-      <app-saved-scenarios [plan]="plan"></app-saved-scenarios>
-      <app-unsaved-scenarios [plan]="plan"></app-unsaved-scenarios>
+  <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
+  <ng-container *ngIf="!planNotFound && plan">
+    <div class="plan-summary-panel" *ngIf="!resumePlanning">
+      <summary-panel></summary-panel>
     </div>
-  </div>
+    <div class="plan-progress-panel" *ngIf="resumePlanning">
+      <progress-panel [plan]="currentPlan$ | async"></progress-panel>
+    </div>
+    <mat-divider [vertical]="true"></mat-divider>
+    <div class="plan-map-container">
+      <app-plan-map [plan]="currentPlan$" class="plan-map-view"></app-plan-map>
+      <mat-divider></mat-divider>
+      <div class="plan-scenario-panel">
+        <h1>{{ plan.name }}</h1>
+        <div class="plan-scenario-panel-content">
+          <p class="plan-scenario-panel-text">
+            Your planning area, priorities, and constraints are used to generate scenarios.
+            Using the Scenario Explorer, you can adjust the relative importance of priorities.
+            Saved scenarios are added to the Comparison table. Scenarios consist of Project Areas,
+            Treatment plans, Potential Outcomes, and Estimated costs.
+          </p>
+          <button mat-raised-button color="primary">CREATE A NEW SCENARIO</button>
+        </div>
+        <app-saved-scenarios [plan]="currentPlan$ | async"></app-saved-scenarios>
+        <app-unsaved-scenarios [plan]="currentPlan$ | async"></app-unsaved-scenarios>
+      </div>
+    </div>
+  </ng-container>
 </div>

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -1,8 +1,12 @@
-import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { Plan, Region } from 'src/app/types';
 
 import { MaterialModule } from '../material/material.module';
+import { PlanService } from './../services/plan.service';
 import { PlanMapComponent } from './plan-map/plan-map.component';
 import { PlanComponent } from './plan.component';
 import { ProgressPanelComponent } from './progress-panel/progress-panel.component';
@@ -11,10 +15,64 @@ describe('PlanComponent', () => {
   let component: PlanComponent;
   let fixture: ComponentFixture<PlanComponent>;
 
+  const fakeGeoJson: GeoJSON.GeoJSON = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'MultiPolygon',
+          coordinates: [
+            [
+              [
+                [10, 20],
+                [10, 30],
+                [15, 15],
+              ],
+            ],
+          ],
+        },
+        properties: {
+          shape_name: 'Test',
+        },
+      },
+    ],
+  };
+
+  const fakePlan: Plan = {
+    id: 'temp',
+    name: 'somePlan',
+    ownerId: 'owner',
+    region: Region.SIERRA_NEVADA,
+    planningArea: fakeGeoJson,
+  };
+
   beforeEach(async () => {
+    const fakeRoute = jasmine.createSpyObj(
+      'ActivatedRoute',
+      {},
+      {
+        snapshot: {
+          paramMap: convertToParamMap({ id: '24' }),
+        },
+      }
+    );
+
+    const fakeService = jasmine.createSpyObj('PlanService', {
+      getPlan: of(fakePlan),
+    });
+
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MaterialModule, RouterTestingModule],
+      imports: [
+        HttpClientTestingModule,
+        MaterialModule,
+        RouterTestingModule.withRoutes([]),
+      ],
       declarations: [PlanComponent, PlanMapComponent, ProgressPanelComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: fakeRoute },
+        { provide: PlanService, useValue: fakeService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PlanComponent);
@@ -24,5 +82,10 @@ describe('PlanComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('fetches plan from service using ID', () => {
+    expect(component.planNotFound).toBeFalse();
+    expect(component.plan).toEqual(fakePlan);
   });
 });

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -1,3 +1,5 @@
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MaterialModule } from '../material/material.module';
@@ -11,7 +13,7 @@ describe('PlanComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MaterialModule],
+      imports: [HttpClientTestingModule, MaterialModule, RouterTestingModule],
       declarations: [PlanComponent, PlanMapComponent, ProgressPanelComponent],
     }).compileComponents();
 

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -8,6 +8,7 @@ import { ProgressPanelComponent } from './progress-panel/progress-panel.componen
 import { SavedScenariosComponent } from './saved-scenarios/saved-scenarios.component';
 import { SummaryPanelComponent } from './summary-panel/summary-panel.component';
 import { UnsavedScenariosComponent } from './unsaved-scenarios/unsaved-scenarios.component';
+import { PlanUnavailableComponent } from './plan-unavailable/plan-unavailable.component';
 
 /** Components used in the plan flow. */
 @NgModule({
@@ -18,6 +19,7 @@ import { UnsavedScenariosComponent } from './unsaved-scenarios/unsaved-scenarios
     SavedScenariosComponent,
     SummaryPanelComponent,
     UnsavedScenariosComponent,
+    PlanUnavailableComponent,
   ],
   imports: [CommonModule, MaterialModule],
 })

--- a/src/interface/src/app/plan/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/saved-scenarios/saved-scenarios.component.ts
@@ -8,7 +8,7 @@ import { Plan, Scenario } from 'src/app/types';
   styleUrls: ['./saved-scenarios.component.scss'],
 })
 export class SavedScenariosComponent {
-  @Input() plan: Plan | undefined;
+  @Input() plan: Plan | null = null;
   scenarios: Scenario[];
   displayedColumns: string[] = ['id', 'createdTimestamp'];
 

--- a/src/interface/src/app/plan/unsaved-scenarios/unsaved-scenarios.component.ts
+++ b/src/interface/src/app/plan/unsaved-scenarios/unsaved-scenarios.component.ts
@@ -8,7 +8,7 @@ import { Plan, Scenario } from 'src/app/types';
   styleUrls: ['./unsaved-scenarios.component.scss'],
 })
 export class UnsavedScenariosComponent {
-  @Input() plan: Plan | undefined;
+  @Input() plan: Plan | null = null;
   scenarios: Scenario[];
   displayedColumns: string[] = ['id', 'createdTimestamp'];
 

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -63,6 +63,31 @@ export class PlanService {
     );
   }
 
+  /** Makes a request to the backend to fetch a plan with the given ID. */
+  getPlan(planId: string): Observable<Plan> {
+    return this.http
+      .get<BackendPlan>(
+        BackendConstants.END_POINT.concat('/plan/get_plan/?id=', planId),
+        {
+          withCredentials: true,
+        }
+      )
+      .pipe(
+        take(1),
+        map((dbPlan) => this.convertToPlan(dbPlan))
+      );
+  }
+
+  private convertToPlan(plan: BackendPlan): Plan {
+    return {
+      id: String(plan.id),
+      ownerId: String(plan.owner),
+      name: plan.name,
+      region: plan.region,
+      planningArea: plan.geometry,
+    };
+  }
+
   private convertToDbPlan(plan: BasePlan): BackendPlan {
     return {
       owner: Number(plan.ownerId),
@@ -92,11 +117,14 @@ export class PlanService {
       .post(BackendConstants.END_POINT + '/plan/create/', createPlanRequest, {
         withCredentials: true,
       })
-      .pipe(take(1), map((result) => {
-        return {
-          ...plan,
-          id: result.toString(),
-        };
-      }));
+      .pipe(
+        take(1),
+        map((result) => {
+          return {
+            ...plan,
+            id: result.toString(),
+          };
+        })
+      );
   }
 }


### PR DESCRIPTION
## Changes
- Fixes #254 
- Adds id parameter to `/plan` route
- When `PlanComponent` is initialized, use the id parameter to look up the plan in the DB
- Update map in plan view when the plan changes
- Show "Plan not found" view when the plan ID doesn't exist

## Plan fetched from ID in URL
![image](https://user-images.githubusercontent.com/10444733/210465331-f56fa224-0e5e-4e67-ab7e-81f0febce61e.png)

## Plan not found
![image](https://user-images.githubusercontent.com/10444733/210465347-428c34ed-0808-43b8-a583-2c6bbbec8a67.png)

## Known bug
- Planning area doesn't show up on the map because of a backend error (planning area geometry is not saved properly). Fix in progress by @riecke 