### PR TITLE
Plan table view

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import {
 import { createFeatureGuard } from './features/feature.guard';
 import { LoginComponent } from './login/login.component';
 import { MapComponent } from './map/map.component';
+import { PlanTableComponent } from './plan/plan-table/plan-table.component';
 import { PlanComponent } from './plan/plan.component';
 import { RegionSelectionComponent } from './region-selection/region-selection.component';
 import { SignupComponent } from './signup/signup.component';
@@ -38,8 +39,8 @@ const routes: Routes = [
         component: RegionSelectionComponent,
       },
       { path: 'map', title: 'Explore', component: MapComponent },
-      { path: 'plan/:id', title: 'Plan', component: PlanComponent },
-      { path: 'plan', title: 'Plan', component: PlanComponent },
+      { path: 'plan/:id', title: 'Plan Details', component: PlanComponent },
+      { path: 'plan', title: 'My Plans', component: PlanTableComponent },
     ],
   },
 ];

--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -10,12 +10,14 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -35,12 +37,14 @@ import { MatTreeModule } from '@angular/material/tree';
     MatInputModule,
     MatListModule,
     MatMenuModule,
+    MatPaginatorModule,
     MatProgressSpinnerModule,
     MatRadioModule,
     MatSelectModule,
     MatSidenavModule,
     MatSliderModule,
     MatSnackBarModule,
+    MatSortModule,
     MatTableModule,
     MatTabsModule,
     MatToolbarModule,

--- a/src/interface/src/app/navigation/navigation.component.ts
+++ b/src/interface/src/app/navigation/navigation.component.ts
@@ -30,7 +30,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
       icon: "explore",
     },
     {
-      text: "Plan",
+      text: "My Plans",
       href: "/plan",
       icon: "edit_document",
     },

--- a/src/interface/src/app/plan/plan-table/plan-table.component.html
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.html
@@ -1,0 +1,1 @@
+<p>plan-table works!</p>

--- a/src/interface/src/app/plan/plan-table/plan-table.component.html
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.html
@@ -1,1 +1,63 @@
-<p>plan-table works!</p>
+<div class="root-container">
+  <h1>My Plans</h1>
+
+  <mat-table [dataSource]="datasource" matSort>
+    <!-- Name Column -->
+    <ng-container matColumnDef="name">
+      <mat-header-cell *matHeaderCellDef mat-sort-header>
+        Name
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        <a href="/plan/{{ element.id }}">{{element.name}}</a>
+      </mat-cell>
+    </ng-container>
+
+    <!-- Timestamp Column -->
+    <ng-container matColumnDef="createdTimestamp">
+      <mat-header-cell *matHeaderCellDef mat-sort-header>
+        Date Created
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        {{element.createdTimestamp | date:'medium' }}
+      </mat-cell>
+    </ng-container>
+
+    <!-- Region Column -->
+    <ng-container matColumnDef="region">
+      <mat-header-cell *matHeaderCellDef mat-sort-header>
+        Region
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        {{element.region}}
+      </mat-cell>
+    </ng-container>
+
+    <!-- Saved Scenarios Column -->
+    <ng-container matColumnDef="savedScenarios">
+      <mat-header-cell *matHeaderCellDef mat-sort-header>
+        Saved Scenarios
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        {{element.savedScenarios}}
+      </mat-cell>
+    </ng-container>
+
+    <!-- Status Column -->
+    <ng-container matColumnDef="status">
+      <mat-header-cell *matHeaderCellDef mat-sort-header>
+        Status
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        {{element.status}}
+      </mat-cell>
+    </ng-container>
+
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+  </mat-table>
+
+  <mat-paginator [pageSizeOptions]="[10, 20, 30]"
+                 showFirstLastButtons
+                 aria-label="Select page of plans">
+  </mat-paginator>
+</div>

--- a/src/interface/src/app/plan/plan-table/plan-table.component.html
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.html
@@ -15,7 +15,7 @@
         Name
       </mat-header-cell>
       <mat-cell *matCellDef="let element">
-        <a href="/plan/{{ element.id }}">{{element.name}}</a>
+        <a href="/plan/{{element.id}}">{{element.name}}</a>
       </mat-cell>
     </ng-container>
 

--- a/src/interface/src/app/plan/plan-table/plan-table.component.html
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.html
@@ -1,6 +1,13 @@
 <div class="root-container">
   <h1>My Plans</h1>
 
+  <div class="button-row">
+    <button mat-raised-button color="primary" (click)="create()">
+      <mat-icon>add_box</mat-icon>
+      CREATE
+    </button>
+  </div>
+
   <mat-table [dataSource]="datasource" matSort>
     <!-- Name Column -->
     <ng-container matColumnDef="name">

--- a/src/interface/src/app/plan/plan-table/plan-table.component.scss
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.scss
@@ -1,0 +1,3 @@
+.root-container {
+  padding: 48px;
+}

--- a/src/interface/src/app/plan/plan-table/plan-table.component.scss
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.scss
@@ -1,3 +1,7 @@
 .root-container {
   padding: 48px;
 }
+
+.button-row {
+  padding-bottom: 12px;
+}

--- a/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlanTableComponent } from './plan-table.component';
+
+describe('PlanTableComponent', () => {
+  let component: PlanTableComponent;
+  let fixture: ComponentFixture<PlanTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PlanTableComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlanTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
@@ -1,7 +1,11 @@
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MaterialModule } from 'src/app/material/material.module';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
 import { of } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
 import { PlanPreview, Region } from 'src/app/types';
 
 import { PlanService } from './../../services/plan.service';
@@ -16,19 +20,25 @@ describe('PlanTableComponent', () => {
 
   let component: PlanTableComponent;
   let fixture: ComponentFixture<PlanTableComponent>;
+  let loader: HarnessLoader;
   let fakeService: PlanService = jasmine.createSpyObj('PlanService', {
     listPlansByUser: of([fakePlan]),
   });
+  let routerStub = () => ({ navigate: (array: string[]) => ({}) });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, MaterialModule],
       declarations: [PlanTableComponent],
-      providers: [{ provide: PlanService, useValue: fakeService }],
+      providers: [
+        { provide: PlanService, useValue: fakeService },
+        { provide: Router, useFactory: routerStub },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PlanTableComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 
@@ -39,5 +49,15 @@ describe('PlanTableComponent', () => {
   it('should fetch plans from the DB', () => {
     expect(fakeService.listPlansByUser).toHaveBeenCalled();
     expect(component.datasource.data).toEqual([fakePlan]);
+  });
+
+  it('create button should navigate to region selection', async () => {
+    const routerStub: Router = fixture.debugElement.injector.get(Router);
+    spyOn(routerStub, 'navigate').and.callThrough();
+    const button = await loader.getHarness(MatButtonHarness);
+
+    await button.click();
+
+    expect(routerStub.navigate).toHaveBeenCalledOnceWith(['region']);
   });
 });

--- a/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
@@ -1,16 +1,31 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MaterialModule } from 'src/app/material/material.module';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { PlanPreview, Region } from 'src/app/types';
 
+import { PlanService } from './../../services/plan.service';
 import { PlanTableComponent } from './plan-table.component';
 
 describe('PlanTableComponent', () => {
+  const fakePlan: PlanPreview = {
+    id: 'temp',
+    name: 'somePlan',
+    region: Region.SIERRA_NEVADA,
+  };
+
   let component: PlanTableComponent;
   let fixture: ComponentFixture<PlanTableComponent>;
+  let fakeService: PlanService = jasmine.createSpyObj('PlanService', {
+    listPlansByUser: of([fakePlan]),
+  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PlanTableComponent ]
-    })
-    .compileComponents();
+      imports: [BrowserAnimationsModule, MaterialModule],
+      declarations: [PlanTableComponent],
+      providers: [{ provide: PlanService, useValue: fakeService }],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PlanTableComponent);
     component = fixture.componentInstance;
@@ -19,5 +34,10 @@ describe('PlanTableComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should fetch plans from the DB', () => {
+    expect(fakeService.listPlansByUser).toHaveBeenCalled();
+    expect(component.datasource.data).toEqual([fakePlan]);
   });
 });

--- a/src/interface/src/app/plan/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-plan-table',
+  templateUrl: './plan-table.component.html',
+  styleUrls: ['./plan-table.component.scss']
+})
+export class PlanTableComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/interface/src/app/plan/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.ts
@@ -1,22 +1,22 @@
-import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { take } from 'rxjs';
-import { Plan } from 'src/app/types';
 
 import { PlanService } from './../../services/plan.service';
+import { PlanPreview } from './../../types/plan.types';
 
 @Component({
   selector: 'app-plan-table',
   templateUrl: './plan-table.component.html',
   styleUrls: ['./plan-table.component.scss'],
 })
-export class PlanTableComponent implements AfterViewInit {
+export class PlanTableComponent implements AfterViewInit, OnInit {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 
-  datasource = new MatTableDataSource<Plan>();
+  datasource = new MatTableDataSource<PlanPreview>();
   displayedColumns: string[] = [
     'name',
     'createdTimestamp',
@@ -25,17 +25,19 @@ export class PlanTableComponent implements AfterViewInit {
     'status',
   ];
 
-  constructor(private planService: PlanService) {
+  constructor(private planService: PlanService) {}
+
+  ngAfterViewInit(): void {
+    this.datasource.paginator = this.paginator;
+    this.datasource.sort = this.sort;
+  }
+
+  ngOnInit(): void {
     this.planService
       .listPlansByUser(null)
       .pipe(take(1))
       .subscribe((plans) => {
         this.datasource.data = plans;
       });
-  }
-
-  ngAfterViewInit(): void {
-    this.datasource.paginator = this.paginator;
-    this.datasource.sort = this.sort;
   }
 }

--- a/src/interface/src/app/plan/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.ts
@@ -1,15 +1,41 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { MatTableDataSource } from '@angular/material/table';
+import { take } from 'rxjs';
+import { Plan } from 'src/app/types';
+
+import { PlanService } from './../../services/plan.service';
 
 @Component({
   selector: 'app-plan-table',
   templateUrl: './plan-table.component.html',
-  styleUrls: ['./plan-table.component.scss']
+  styleUrls: ['./plan-table.component.scss'],
 })
-export class PlanTableComponent implements OnInit {
+export class PlanTableComponent implements AfterViewInit {
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
-  constructor() { }
+  datasource = new MatTableDataSource<Plan>();
+  displayedColumns: string[] = [
+    'name',
+    'createdTimestamp',
+    'region',
+    'savedScenarios',
+    'status',
+  ];
 
-  ngOnInit(): void {
+  constructor(private planService: PlanService) {
+    this.planService
+      .listPlansByUser(null)
+      .pipe(take(1))
+      .subscribe((plans) => {
+        this.datasource.data = plans;
+      });
   }
 
+  ngAfterViewInit(): void {
+    this.datasource.paginator = this.paginator;
+    this.datasource.sort = this.sort;
+  }
 }

--- a/src/interface/src/app/plan/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
+import { Router } from '@angular/router';
 import { take } from 'rxjs';
 
 import { PlanService } from './../../services/plan.service';
@@ -25,7 +26,7 @@ export class PlanTableComponent implements AfterViewInit, OnInit {
     'status',
   ];
 
-  constructor(private planService: PlanService) {}
+  constructor(private planService: PlanService, private router: Router) {}
 
   ngAfterViewInit(): void {
     this.datasource.paginator = this.paginator;
@@ -39,5 +40,9 @@ export class PlanTableComponent implements AfterViewInit, OnInit {
       .subscribe((plans) => {
         this.datasource.data = plans;
       });
+  }
+
+  create(): void {
+    this.router.navigate(['region']);
   }
 }

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -9,6 +9,7 @@ import { SavedScenariosComponent } from './saved-scenarios/saved-scenarios.compo
 import { SummaryPanelComponent } from './summary-panel/summary-panel.component';
 import { UnsavedScenariosComponent } from './unsaved-scenarios/unsaved-scenarios.component';
 import { PlanUnavailableComponent } from './plan-unavailable/plan-unavailable.component';
+import { PlanTableComponent } from './plan-table/plan-table.component';
 
 /** Components used in the plan flow. */
 @NgModule({
@@ -20,6 +21,7 @@ import { PlanUnavailableComponent } from './plan-unavailable/plan-unavailable.co
     SummaryPanelComponent,
     UnsavedScenariosComponent,
     PlanUnavailableComponent,
+    PlanTableComponent,
   ],
   imports: [CommonModule, MaterialModule],
 })

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -5,8 +5,9 @@ import {
 import { TestBed } from '@angular/core/testing';
 
 import { BackendConstants } from '../backend-constants';
-import { PlanService } from './plan.service';
 import { BasePlan, Plan, Region } from '../types';
+import { PlanPreview } from './../types/plan.types';
+import { BackendPlan, PlanService } from './plan.service';
 
 describe('PlanService', () => {
   let httpTestingController: HttpTestingController;
@@ -20,7 +21,7 @@ describe('PlanService', () => {
     };
     mockPlan = {
       name: 'tempName',
-      ownerId: 'tempUserId',
+      ownerId: '2',
       region: Region.SIERRA_NEVADA,
       planningArea: fakeGeoJson,
     };
@@ -51,6 +52,61 @@ describe('PlanService', () => {
       expect(service.planState$.value.all).toEqual({
         [expectedPlan.id]: expectedPlan,
       });
+    });
+  });
+
+  describe('getPlan', () => {
+    it('should make HTTP get request to DB', () => {
+      const expectedPlan: Plan = {
+        ...mockPlan,
+        id: '1',
+      };
+
+      const backendPlan: BackendPlan = {
+        id: 1,
+        name: expectedPlan.name,
+        owner: 2,
+        region: expectedPlan.region,
+        geometry: expectedPlan.planningArea,
+      };
+
+      service.getPlan('1').subscribe((res) => {
+        expect(res).toEqual(expectedPlan);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/get_plan/?id=1')
+      );
+      req.flush(backendPlan);
+      httpTestingController.verify();
+    });
+  });
+
+  describe('listPlansByUser', () => {
+    it('should make HTTP get request to DB', () => {
+      const expectedPlan: PlanPreview = {
+        id: '1',
+        name: mockPlan.name,
+        region: mockPlan.region,
+      };
+
+      const backendPlan: BackendPlan = {
+        id: 1,
+        name: expectedPlan.name,
+        owner: 2,
+        region: mockPlan.region,
+        geometry: mockPlan.planningArea,
+      };
+
+      service.listPlansByUser(null).subscribe((res) => {
+        expect(res).toEqual([expectedPlan]);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/list_plans_by_owner')
+      );
+      req.flush([backendPlan]);
+      httpTestingController.verify();
     });
   });
 });

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -78,6 +78,26 @@ export class PlanService {
       );
   }
 
+  /** Makes a request to the backend for a list of all plans owned by a user.
+   *  If the user is not provided, return all plans with owner=null.
+   */
+  listPlansByUser(userId: string | null): Observable<Plan[]> {
+    let url = BackendConstants.END_POINT.concat('/plan/list_plans_by_owner');
+    if (userId) {
+      url = url.concat('/?owner=', userId);
+    }
+    return this.http
+      .get<BackendPlan[]>(url, {
+        withCredentials: true,
+      })
+      .pipe(
+        take(1),
+        map((dbPlanList) =>
+          dbPlanList.map((dbPlan) => this.convertToPlan(dbPlan))
+        )
+      );
+  }
+
   private convertToPlan(plan: BackendPlan): Plan {
     return {
       id: String(plan.id),

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -1,3 +1,4 @@
+import { PlanPreview } from './../types/plan.types';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BackendConstants } from '../backend-constants';
@@ -81,7 +82,7 @@ export class PlanService {
   /** Makes a request to the backend for a list of all plans owned by a user.
    *  If the user is not provided, return all plans with owner=null.
    */
-  listPlansByUser(userId: string | null): Observable<Plan[]> {
+  listPlansByUser(userId: string | null): Observable<PlanPreview[]> {
     let url = BackendConstants.END_POINT.concat('/plan/list_plans_by_owner');
     if (userId) {
       url = url.concat('/?owner=', userId);
@@ -93,7 +94,7 @@ export class PlanService {
       .pipe(
         take(1),
         map((dbPlanList) =>
-          dbPlanList.map((dbPlan) => this.convertToPlan(dbPlan))
+          dbPlanList.map((dbPlan) => this.convertToPlanPreview(dbPlan))
         )
       );
   }
@@ -115,6 +116,14 @@ export class PlanService {
       region: plan.region,
       geometry: plan.planningArea,
     };
+  }
+
+  private convertToPlanPreview(plan: BackendPlan): PlanPreview {
+    return {
+      id: String(plan.id),
+      name: plan.name,
+      region: plan.region,
+    }
   }
 
   private addPlanToState(plan: Plan) {

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -16,6 +16,15 @@ export interface BasePlan {
   planningArea: GeoJSON.GeoJSON;
 }
 
+export interface PlanPreview {
+  id: string;
+  name: string;
+  createdTimestamp?: number;
+  region?: Region;
+  savedScenarios?: number;
+  status?: string;
+}
+
 export interface Scenario {
   id: string;
   createdTimestamp: number;


### PR DESCRIPTION
## Changes
- The url `/plan/` with no ID parameter now navigates to a table view of all the user's plans (currently all plans in the DB, since these all belong to user "null" at the moment).
- The table view is paginated and can be sorted by any of the headers. Only name is populated right now.
- Clicking on a plan name navigates to the detail page for that plan (`/plan/<plan ID>`).
- Clicking the "Create" button navigates to the region selection page.
- Unit tests.
- Fixes #215 with minimum functionality (see Todos).

## Current UI
![image](https://user-images.githubusercontent.com/10444733/210855379-b1689ef2-32b5-46af-9b8a-92a10d93fab4.png)

## Desired UI (from mocks)
![image](https://user-images.githubusercontent.com/10444733/210856099-aa0dd0ad-4c23-4469-9204-b03e8bfe1276.png)


## Todos
- The other columns in the table (e.g. Date Created, Saved Scenarios) aren't yet populated by the response from the DB. #282 is tracking this.
- Delete, refresh, and learn buttons should be added to the UI. #281 is tracking the delete button, refresh has no blockers, and the purpose of the learn button is unclear (needs UX/PM guidance).
- Styling tweaks to match mocks more closely.
