### PR TITLE
Tweaks to /plan/{get_plan,list_plans_by_owner} for frontend

### DIFF
--- a/src/planscape/base/region_name.py
+++ b/src/planscape/base/region_name.py
@@ -17,7 +17,7 @@ class RegionName(str, enum.Enum):
     SOUTHERN_CALIFORNIA = 'southern_california'
 
 
-def region_to_display_name(region: RegionName) -> str:
+def region_to_display_name(region: RegionName) -> str | None:
     """
     Converts a backend RegionName to the display name.
     """
@@ -32,6 +32,9 @@ def region_to_display_name(region: RegionName) -> str:
             return 'Central Coast'
         case RegionName.SOUTHERN_CALIFORNIA:
             return 'Southern California'
+        case _:
+            # Necessary for region names that are now unknown.
+            return None
 
 
 def display_name_to_region(region: str) -> RegionName | None:

--- a/src/planscape/base/region_name.py
+++ b/src/planscape/base/region_name.py
@@ -4,6 +4,7 @@ Valid region names.
 
 import enum
 
+
 class RegionName(str, enum.Enum):
     """Valid Regions."""
     # Tahoe Central-Sierra Initiative
@@ -14,3 +15,39 @@ class RegionName(str, enum.Enum):
     NORTH_COAST_INLAND = 'north_coast_inland'
     COASTAL_INLAND = 'coastal_inland'
     SOUTHERN_CALIFORNIA = 'southern_california'
+
+
+def region_to_display_name(region: RegionName) -> str:
+    """
+    Converts a backend RegionName to the display name.
+    """
+    match region:
+        case RegionName.TCSI:
+            return 'TCSI'
+        case RegionName.SIERRA_CASCADE_INYO:
+            return 'Sierra Nevada'
+        case RegionName.NORTH_COAST_INLAND:
+            return 'Northern California'
+        case RegionName.COASTAL_INLAND:
+            return 'Central Coast'
+        case RegionName.SOUTHERN_CALIFORNIA:
+            return 'Southern California'
+
+
+def display_name_to_region(region: str) -> RegionName | None:
+    """
+    Converts a backend RegionName to the display name.
+    """
+    match region:
+        case 'TCSI':
+            return RegionName.TCSI
+        case 'Sierra Nevada':
+            return RegionName.SIERRA_CASCADE_INYO
+        case 'Northern California':
+            return RegionName.NORTH_COAST_INLAND
+        case 'Central Coast':
+            return RegionName.COASTAL_INLAND
+        case 'Southern California':
+            return RegionName.SOUTHERN_CALIFORNIA
+        case _:
+            return None

--- a/src/planscape/base/region_name_test.py
+++ b/src/planscape/base/region_name_test.py
@@ -1,0 +1,28 @@
+from base.region_name import (RegionName, display_name_to_region,
+                              region_to_display_name)
+from django.test import TestCase
+
+
+class RegionNameTest(TestCase):
+    def test_region_to_display_name(self):
+        self.assertEqual(region_to_display_name(RegionName.TCSI), 'TCSI')
+        self.assertEqual(region_to_display_name(
+            RegionName.SIERRA_CASCADE_INYO), 'Sierra Nevada')
+        self.assertEqual(region_to_display_name(
+            RegionName.SOUTHERN_CALIFORNIA), 'Southern California')
+        self.assertEqual(region_to_display_name(
+            RegionName.NORTH_COAST_INLAND), 'Northern California')
+        self.assertEqual(region_to_display_name(
+            RegionName.COASTAL_INLAND), 'Central Coast')
+
+    def test_display_name_to_region(self):
+        self.assertEqual(display_name_to_region('TCSI'), RegionName.TCSI)
+        self.assertEqual(display_name_to_region('Sierra Nevada'),
+                         RegionName.SIERRA_CASCADE_INYO)
+        self.assertEqual(display_name_to_region('Southern California'),
+                         RegionName.SOUTHERN_CALIFORNIA)
+        self.assertEqual(display_name_to_region('Northern California'),
+                         RegionName.NORTH_COAST_INLAND)
+        self.assertEqual(display_name_to_region('Central Coast'),
+                         RegionName.COASTAL_INLAND)
+        self.assertEqual(display_name_to_region('Unknown'), None)

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 
 from django.contrib.auth.models import User
@@ -76,7 +77,7 @@ class CreatePlanTest(TransactionTestCase):
                 {'geometry': {'type': 'Polygon', 'coordinates': [[[1, 2], [2, 3], [3, 4], [1, 2]]]}}]}},
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(Plan.objects.all()), 1)
+        self.assertEqual(Plan.objects.count(), 1)
 
     def test_good_multipolygon(self):
         self.client.force_login(self.user)
@@ -86,17 +87,31 @@ class CreatePlanTest(TransactionTestCase):
                 {'geometry': {'type': 'MultiPolygon', 'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}}]}},
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(Plan.objects.all()), 1)
+        self.assertEqual(Plan.objects.count(), 1)
 
-    def test_good_region_name(self):
+    def test_bad_region_name(self):
         self.client.force_login(self.user)
         response = self.client.post(
             reverse('plan:create'),
             {'name': 'plan', 'region_name': 'north_coast_inland', 'geometry': {'features': [
                 {'geometry': {'type': 'MultiPolygon', 'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}}]}},
             content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_good_region_name(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('plan:create'),
+            {'name': 'plan', 'region_name': 'Northern California', 'geometry': {'features': [
+                {'geometry': {'type': 'MultiPolygon', 'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}}]}},
+            content_type='application/json')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(Plan.objects.all()), 1)
+        plans = Plan.objects.all()
+        self.assertEqual(plans.count(), 1)
+        plan = plans.first()
+        assert plan is not None
+        self.assertEqual(plan.region_name, 'north_coast_inland')
+
 
 
 def create_plan(owner: User | None, name: str, geometry: GEOSGeometry | None, scenarios: list[int]):
@@ -129,9 +144,9 @@ class DeletePlanTest(TransactionTestCase):
             reverse('plan:delete'), {'id': self.plan2.pk},
             content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(len(Plan.objects.all()), 2)
-        self.assertEqual(len(Project.objects.all()), 2)
-        self.assertEqual(len(Scenario.objects.all()), 1)
+        self.assertEqual(Plan.objects.count(), 2)
+        self.assertEqual(Project.objects.all().count(), 2)
+        self.assertEqual(Scenario.objects.count(), 1)
 
     def test_user_logged_in_tries_to_delete_ownerless_plan(self):
         self.client.force_login(self.user)
@@ -139,9 +154,9 @@ class DeletePlanTest(TransactionTestCase):
             reverse('plan:delete'), {'id': self.plan1.pk},
             content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(len(Plan.objects.all()), 2)
-        self.assertEqual(len(Project.objects.all()), 2)
-        self.assertEqual(len(Scenario.objects.all()), 1)
+        self.assertEqual(Plan.objects.count(), 2)
+        self.assertEqual(Project.objects.count(), 2)
+        self.assertEqual(Scenario.objects.count(), 1)
 
     def test_delete_wrong_user(self):
         new_user = User.objects.create(username='newuser')
@@ -152,34 +167,34 @@ class DeletePlanTest(TransactionTestCase):
             reverse('plan:delete'), {'id': self.plan2.pk},
             content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(len(Plan.objects.all()), 2)
-        self.assertEqual(len(Project.objects.all()), 2)
-        self.assertEqual(len(Scenario.objects.all()), 1)
+        self.assertEqual(Plan.objects.count(), 2)
+        self.assertEqual(Project.objects.count(), 2)
+        self.assertEqual(Scenario.objects.count(), 1)
 
     def test_delete_ownerless_plan(self):
-        self.assertEqual(len(Plan.objects.all()), 2)
+        self.assertEqual(Plan.objects.count(), 2)
         plan1_id = self.plan1.pk
         response = self.client.post(
             reverse('plan:delete'), {'id': self.plan1.pk},
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, str(plan1_id).encode())
-        self.assertEqual(len(Plan.objects.all()), 1)
-        self.assertEqual(len(Project.objects.all()), 1)
-        self.assertEqual(len(Scenario.objects.all()), 1)
+        self.assertEqual(Plan.objects.count(), 1)
+        self.assertEqual(Project.objects.count(), 1)
+        self.assertEqual(Scenario.objects.count(), 1)
 
     def test_delete_owned_plan(self):
         self.client.force_login(self.user)
-        self.assertEqual(len(Plan.objects.all()), 2)
+        self.assertEqual(Plan.objects.count(), 2)
         plan2_id = self.plan2.pk
         response = self.client.post(
             reverse('plan:delete'), {'id': self.plan2.pk},
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, str(plan2_id).encode())
-        self.assertEqual(len(Plan.objects.all()), 1)
-        self.assertEqual(len(Project.objects.all()), 1)
-        self.assertEqual(len(Scenario.objects.all()), 0)
+        self.assertEqual(Plan.objects.count(), 1)
+        self.assertEqual(Project.objects.count(), 1)
+        self.assertEqual(Scenario.objects.count(), 0)
 
 
 class GetPlanTest(TransactionTestCase):
@@ -198,6 +213,7 @@ class GetPlanTest(TransactionTestCase):
                                    content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['name'], 'owned')
+        self.assertEqual(response.json()['region_name'], 'Sierra Nevada')
 
     def test_get_plan_no_user(self):
         response = self.client.get(reverse('plan:get_plan'), {'id': self.plan_no_user.pk},
@@ -205,6 +221,9 @@ class GetPlanTest(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['name'], 'ownerless')
         self.assertEqual(response.json()['geometry'], self.geometry)
+        self.assertLessEqual(
+            response.json()['creation_timestamp'], datetime.datetime.now().timestamp())
+        self.assertEqual(response.json()['region_name'], 'Sierra Nevada')
 
 
 class ListPlansTest(TransactionTestCase):
@@ -226,6 +245,8 @@ class ListPlansTest(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 2)
         for plan in response.json():
+            self.assertTrue('geometry' not in plan)
+            self.assertEqual(plan['region_name'], 'Sierra Nevada')
             if plan['name'] == 'plan1':
                 self.assertEqual(plan['projects'], 0)
                 self.assertEqual(plan['scenarios'], 0)
@@ -241,7 +262,8 @@ class ListPlansTest(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 2)
         for plan in response.json():
-            self.assertEqual(plan['geometry'], self.geometry)
+            self.assertTrue('geometry' not in plan)
+            self.assertEqual(plan['region_name'], 'Sierra Nevada')
             if plan['name'] == 'plan3':
                 self.assertEqual(plan['projects'], 1)
                 self.assertEqual(plan['scenarios'], 1)

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -225,6 +225,18 @@ class GetPlanTest(TransactionTestCase):
             response.json()['creation_timestamp'], datetime.datetime.now().timestamp())
         self.assertEqual(response.json()['region_name'], 'Sierra Nevada')
 
+    def test_get_plan_bad_stored_region(self):
+        plan = Plan.objects.create(
+            owner=self.user, name='badregion', region_name='Sierra Nevada', geometry=None)
+        plan.save()
+        response = self.client.get(reverse('plan:get_plan'), {'id': plan.pk},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['name'], 'badregion')
+        self.assertLessEqual(
+            response.json()['creation_timestamp'], datetime.datetime.now().timestamp())
+        self.assertEqual(response.json()['region_name'], None)
+       
 
 class ListPlansTest(TransactionTestCase):
     def setUp(self):

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -4,7 +4,7 @@ import json
 from base.region_name import (RegionName, display_name_to_region,
                               region_to_display_name)
 from django.contrib.gis.geos import GEOSGeometry
-from django.db.models import Count, F
+from django.db.models import Count
 from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
                          JsonResponse, QueryDict)
 from plan.models import Plan, Project

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -1,7 +1,10 @@
+import datetime
 import json
 
+from base.region_name import (RegionName, display_name_to_region,
+                              region_to_display_name)
 from django.contrib.gis.geos import GEOSGeometry
-from django.db.models import Count
+from django.db.models import Count, F
 from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
                          JsonResponse, QueryDict)
 from plan.models import Plan, Project
@@ -26,9 +29,10 @@ def create(request: HttpRequest) -> HttpResponse:
 
         # Get the region name
         # TODO Reconsider default of Sierra Nevada region.
-        region_name = body.get('region_name', None)
+        region_name_input = body.get('region_name', 'Sierra Nevada')
+        region_name = display_name_to_region(region_name_input)
         if region_name is None:
-            region_name = 'sierra_cascade_inyo'
+            raise ValueError("Unknown region_name: " + region_name_input)
 
         # Get the geometry of the plan.  Convert it to a MultiPolygon
         # if it is a simple Polygon, since the model column type is
@@ -102,25 +106,44 @@ def get_plans_by_owner(params: QueryDict):
             .annotate(scenarios=Count('project__scenario')))
 
 
-def _serialize_plan(plan: Plan):
+def _serialize_plan(plan: Plan, add_geometry: bool) -> dict:
+    """
+    Serializes a Plan into a dictionary.
+    1. Converts the Plan to a dictionary with fields 'id', 'geometry', and 'properties'
+       (the latter of which is a dictionary).
+    2. Creates the partial result from the properties and 'id' fields.
+    3. Replaces 'creation_time' with a Posix timestamp.
+    4. Adds the 'geometry' if requested.
+    5. Replaces the internal region_name with the display version.
+    """
     data = PlanSerializer(plan).data
     result = data['properties']
-    result.update({'id': data['id'], 'geometry': data['geometry']})
+    result['id'] = data['id']
+    if 'creation_time' in result:
+        result['creation_timestamp'] = datetime.datetime.fromisoformat(
+            result['creation_time'].replace('Z', '+00:00')).timestamp()
+        del result['creation_time']
+    if 'geometry' in data and add_geometry:
+        result['geometry'] = data['geometry']
+    if 'region_name' in result:
+        result['region_name'] = region_to_display_name(result['region_name'])
     return result
 
 
 def get_plan(request: HttpRequest) -> HttpResponse:
     try:
-        return JsonResponse(_serialize_plan(get_plan_by_id(request.GET)[0]))
+        return JsonResponse(_serialize_plan(get_plan_by_id(request.GET)[0], True))
     except Exception as e:
+        print(e)
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 
 def list_plans_by_owner(request: HttpRequest) -> HttpResponse:
     try:
         plans = get_plans_by_owner(request.GET)
-        return JsonResponse([_serialize_plan(plan) for plan in plans], safe=False)
+        return JsonResponse([_serialize_plan(plan, False) for plan in plans], safe=False)
     except Exception as e:
+        print(e)
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -134,7 +134,6 @@ def get_plan(request: HttpRequest) -> HttpResponse:
     try:
         return JsonResponse(_serialize_plan(get_plan_by_id(request.GET)[0], True))
     except Exception as e:
-        print(e)
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 
@@ -143,7 +142,6 @@ def list_plans_by_owner(request: HttpRequest) -> HttpResponse:
         plans = get_plans_by_owner(request.GET)
         return JsonResponse([_serialize_plan(plan, False) for plan in plans], safe=False)
     except Exception as e:
-        print(e)
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 


### PR DESCRIPTION
These are noted in #282:

1. For region_name, return the display name (e.g., 'Sierra Nevada') instead of the internal name (e.g., 'sierra_cascade_inyo')
2. Convert the creation_time to a creation_timestamp in the form of Posix, i.e., seconds since the epoch, and
3. Remove the geometry field in /plan/list_plans_by_owner

Also
1. Fix the "create" call to match, i.e., check for display names as input and convert to internal names.
2. Nit: use ".count()" instead of "len" to check the number of database rows in tests.
3. Make get_plan and list_plans_by_owner resilient to bad internal names in the database (which there are now).

