### PR TITLE
Tweaks to condition selection UI

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -142,46 +142,63 @@
               </mat-expansion-panel-header>
 
               <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
-              [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
-                <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl" class="condition-tree">
+                [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionsLayer(map)">
+                <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl"
+                  class="condition-tree">
                   <!-- This is the tree node template for leaf nodes -->
                   <!-- There is inline padding applied to this node using styles.
                     This padding value depends on the mat-icon-button width. -->
                   <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-                    <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true" (mouseleave)="node.showInfoIcon = false">
-                      <mat-radio-button [value]="node">
-                        {{node.display_name}}
-                      </mat-radio-button>
-                      <button mat-icon-button [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
-                        [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
-                        (menuClosed)="node.infoMenuOpen = false">
-                        <mat-icon>info_outline</mat-icon>
-                      </button>
-                      <mat-menu #popoverMenu="matMenu">
-                        <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
-                      </mat-menu>
+                    <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
+                      (mouseleave)="node.showInfoIcon = false">
+                      <div [class.disabled]="node.styleDisabled">
+                        <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+                          (change)="onSelect(node)">
+                          {{node.display_name}}
+                        </mat-radio-button>
+                        <span *ngIf="node.disableSelect">
+                          {{node.display_name}}
+                        </span>
+                        <button mat-icon-button
+                          [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
+                          [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+                          (menuClosed)="node.infoMenuOpen = false">
+                          <mat-icon>info_outline</mat-icon>
+                        </button>
+                        <mat-menu #popoverMenu="matMenu">
+                          <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+                        </mat-menu>
+                      </div>
                     </div>
                   </mat-tree-node>
                   <!-- This is the tree node template for expandable nodes -->
                   <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-                    <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true" (mouseleave)="node.showInfoIcon = false">
-                      <mat-radio-button [value]="node">
-                        {{node.display_name}}
-                      </mat-radio-button>
-                      <button mat-icon-button [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
-                        [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
-                        (menuClosed)="node.infoMenuOpen = false">
-                        <mat-icon>info_outline</mat-icon>
-                      </button>
-                      <mat-menu #popoverMenu="matMenu">
-                        <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
-                      </mat-menu>
-                      <button mat-icon-button matTreeNodeToggle
-                              [attr.aria-label]="'Toggle ' + node.display_name">
-                        <mat-icon class="mat-icon-rtl-mirror">
-                          {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
-                        </mat-icon>
-                      </button>
+                    <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
+                      (mouseleave)="node.showInfoIcon = false">
+                      <div [class.disabled]="node.styleDisabled">
+                        <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+                          (change)="onSelect(node)">
+                          {{node.display_name}}
+                        </mat-radio-button>
+                        <span *ngIf="node.disableSelect">
+                          {{node.display_name}}
+                        </span>
+                        <button mat-icon-button
+                          [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
+                          [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+                          (menuClosed)="node.infoMenuOpen = false">
+                          <mat-icon>info_outline</mat-icon>
+                        </button>
+                        <mat-menu #popoverMenu="matMenu">
+                          <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+                        </mat-menu>
+                        <button mat-icon-button matTreeNodeToggle
+                                [attr.aria-label]="'Toggle ' + node.display_name">
+                          <mat-icon class="mat-icon-rtl-mirror">
+                            {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
+                          </mat-icon>
+                        </button>
+                      </div>
                     </div>
                     <!-- There is inline padding applied to this div using styles.
                         This padding value depends on the mat-icon-button width.  -->

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -229,7 +229,7 @@
  * This padding sets alignment of the nested nodes.
  */
 .condition-tree .mat-nested-tree-node div[role=group] {
-  padding-left: 40px;
+  padding-left: 20px;
 }
 
 /*
@@ -238,5 +238,9 @@
  * under the same parent.
  */
 .condition-tree div[role=group] > .mat-tree-node {
-  padding-left: 40px;
+  padding-left: 20px;
+}
+
+.mat-tree-node > .disabled {
+  opacity: 0.5;
 }

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -40,7 +40,7 @@ import {
   Region,
 } from './../types';
 import { MapManager } from './map-manager';
-import { MapComponent } from './map.component';
+import { ConditionsNode, MapComponent } from './map.component';
 import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dialog.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
 
@@ -787,6 +787,41 @@ describe('MapComponent', () => {
       });
 
       expect(applicationRef.attachView).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('condition tree', () => {
+    beforeEach(() => {
+      component.conditionDataSource.data = [
+        {
+          children: [{}, {}, {}],
+        },
+        {
+          children: [],
+        },
+      ];
+    });
+
+    it('styles children of a selected node and unstyles all other nodes', () => {
+      const nodeWithChildren = component.conditionDataSource.data[0];
+      const nodeWithoutChildren = component.conditionDataSource.data[1];
+
+      component.onSelect(nodeWithChildren);
+
+      nodeWithChildren.children?.forEach((child) => {
+        expect(child.styleDisabled).toBeTrue();
+      });
+      expect(nodeWithChildren.styleDisabled).toBeFalse();
+      expect(nodeWithoutChildren.styleDisabled).toBeFalse();
+
+      component.onSelect(nodeWithoutChildren);
+
+      component.conditionDataSource.data.forEach((node) => {
+        expect(node.styleDisabled).toBeFalse();
+        node.children?.forEach((child) => {
+          expect(child.styleDisabled).toBeFalse();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Changes
- Fixes #297 
- For the un-normalized condition tree ("Current metric conditions"), remove radio buttons for everything except the leaf nodes (metrics).
- For the normalized condition tree ("Current conditions (normalized)"), remove radio buttons for the top-level node ("Current conditions (normalized)"). When a non-leaf node (e.g. pillar or element) is selected, every radio button beneath it should be greyed out, but still selectable.
- Unit tests

![image](https://user-images.githubusercontent.com/10444733/211433618-08446001-3a16-4bae-b640-a664a1c29e33.png)

![image](https://user-images.githubusercontent.com/10444733/211433652-455e297a-0798-4357-ba4b-9f927dbc181c.png)
