### PR TITLE
Create scenarios page

### DIFF
--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -6,6 +6,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
@@ -33,6 +34,7 @@ import { MatTreeModule } from '@angular/material/tree';
     MatDividerModule,
     MatExpansionModule,
     MatFormFieldModule,
+    MatGridListModule,
     MatIconModule,
     MatInputModule,
     MatListModule,

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,11 +1,11 @@
 <div class="create-scenarios-container">
   <div class="map-container">
   </div>
-  <div class="create-scenarios-panel" [class.collapsed]="!panelExpanded">
-    <div class="create-scenarios-panel-content" *ngIf="panelExpanded">
+  <div class="create-scenarios-panel" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
+    <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'expanded' : 'collapsed'">
       <h1>Create scenarios</h1>
     </div>
-    <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded">
+    <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'expanded': 'collapsed'">
       <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>
     </div>
   </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,0 +1,7 @@
+<div class="create-scenarios-container">
+  <div class="map-container">
+  </div>
+  <div class="create-scenarios-panel">
+    <h1>Create scenarios</h1>
+  </div>
+</div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,5 +1,5 @@
 <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
-  <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'expanded' : 'collapsed'">
+  <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
     <div>
       <h1>Create scenarios</h1>
       <p>{{ text1 }}</p>
@@ -57,7 +57,7 @@
       <div>{{ text5 }}</div>
     </div>
   </div>
-  <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'expanded': 'collapsed'">
+  <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'colorA': 'colorB'">
     <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>
   </div>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,7 +1,12 @@
 <div class="create-scenarios-container">
   <div class="map-container">
   </div>
-  <div class="create-scenarios-panel">
-    <h1>Create scenarios</h1>
+  <div class="create-scenarios-panel" [class.collapsed]="!panelExpanded">
+    <div class="create-scenarios-panel-content" *ngIf="panelExpanded">
+      <h1>Create scenarios</h1>
+    </div>
+    <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded">
+      <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>
+    </div>
   </div>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -4,7 +4,60 @@
   </div>
   <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
     <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'expanded' : 'collapsed'">
-      <h1>Create scenarios</h1>
+      <div>
+        <h1>Create scenarios</h1>
+        <p>{{ text1 }}</p>
+      </div>
+      <mat-grid-list cols="2" rowHeight="fit" gutterSize="64px" [style.flex]="'1 1 auto'">
+        <mat-grid-tile>
+          <div class="tile-content">
+            <mat-form-field appearance="fill">
+              <mat-label>
+                Generate scenarios using:
+              </mat-label>
+              <mat-select>
+                <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
+                <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="tile-content">
+            <p>
+              {{ text2 }}
+            </p>
+          </div>
+        </mat-grid-tile>
+      </mat-grid-list>
+      <mat-grid-list cols="3" rowHeight="fit" gutterSize="64px" [style.flex-grow]="2">
+        <mat-grid-tile colspan="2">
+          <div class="tile-content">
+            <h2>Current Conditions score</h2>
+            <p>{{ text3 }}</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="tile-content">
+            <h4>Condition Score Scale</h4>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile colspan="2">
+          <div class="tile-content">
+            <h2>Opportunity score (Coming soon)</h2>
+            <p>{{ text4 }}</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="tile-content">
+            <h4>Opportunity Score Scale</h4>
+          </div>
+        </mat-grid-tile>
+      </mat-grid-list>
+      <div class="row-div">
+        <button mat-icon-button><mat-icon class="material-symbols-outlined">info</mat-icon></button>
+        <div>{{ text5 }}</div>
+      </div>
     </div>
     <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'expanded': 'collapsed'">
       <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,68 +1,63 @@
-<div class="create-scenarios-container">
-  <div class="map-container">
-    <app-plan-map [plan]="plan$" [mapId]="'planning-map'"></app-plan-map>
+<div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
+  <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'expanded' : 'collapsed'">
+    <div>
+      <h1>Create scenarios</h1>
+      <p>{{ text1 }}</p>
+    </div>
+    <mat-grid-list cols="2" rowHeight="fit" gutterSize="64px" [style.flex]="'1 1 auto'">
+      <mat-grid-tile>
+        <div class="tile-content">
+          <mat-form-field appearance="fill">
+            <mat-label>
+              Generate scenarios using:
+            </mat-label>
+            <mat-select>
+              <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
+              <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </mat-grid-tile>
+      <mat-grid-tile>
+        <div class="tile-content">
+          <p>
+            {{ text2 }}
+          </p>
+        </div>
+      </mat-grid-tile>
+    </mat-grid-list>
+    <mat-grid-list cols="3" rowHeight="fit" gutterSize="64px" [style.flex-grow]="3">
+      <mat-grid-tile colspan="2">
+        <div class="tile-content">
+          <h2>Current Conditions score</h2>
+          <p>{{ text3 }}</p>
+        </div>
+      </mat-grid-tile>
+      <mat-grid-tile>
+        <div class="tile-content">
+          <h4>Condition Score Scale</h4>
+          <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
+        </div>
+      </mat-grid-tile>
+      <mat-grid-tile colspan="2">
+        <div class="tile-content">
+          <h2>Opportunity score (Coming soon)</h2>
+          <p>{{ text4 }}</p>
+        </div>
+      </mat-grid-tile>
+      <mat-grid-tile>
+        <div class="tile-content">
+          <h4>Opportunity Score Scale</h4>
+          <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
+        </div>
+      </mat-grid-tile>
+    </mat-grid-list>
+    <div class="row-div">
+      <button mat-icon-button><mat-icon class="material-symbols-outlined">info</mat-icon></button>
+      <div>{{ text5 }}</div>
+    </div>
   </div>
-  <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
-    <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'expanded' : 'collapsed'">
-      <div>
-        <h1>Create scenarios</h1>
-        <p>{{ text1 }}</p>
-      </div>
-      <mat-grid-list cols="2" rowHeight="fit" gutterSize="64px" [style.flex]="'1 1 auto'">
-        <mat-grid-tile>
-          <div class="tile-content">
-            <mat-form-field appearance="fill">
-              <mat-label>
-                Generate scenarios using:
-              </mat-label>
-              <mat-select>
-                <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
-                <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
-              </mat-select>
-            </mat-form-field>
-          </div>
-        </mat-grid-tile>
-        <mat-grid-tile>
-          <div class="tile-content">
-            <p>
-              {{ text2 }}
-            </p>
-          </div>
-        </mat-grid-tile>
-      </mat-grid-list>
-      <mat-grid-list cols="3" rowHeight="fit" gutterSize="64px" [style.flex-grow]="3">
-        <mat-grid-tile colspan="2">
-          <div class="tile-content">
-            <h2>Current Conditions score</h2>
-            <p>{{ text3 }}</p>
-          </div>
-        </mat-grid-tile>
-        <mat-grid-tile>
-          <div class="tile-content">
-            <h4>Condition Score Scale</h4>
-            <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
-          </div>
-        </mat-grid-tile>
-        <mat-grid-tile colspan="2">
-          <div class="tile-content">
-            <h2>Opportunity score (Coming soon)</h2>
-            <p>{{ text4 }}</p>
-          </div>
-        </mat-grid-tile>
-        <mat-grid-tile>
-          <div class="tile-content">
-            <h4>Opportunity Score Scale</h4>
-            <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
-          </div>
-        </mat-grid-tile>
-      </mat-grid-list>
-      <div class="row-div">
-        <button mat-icon-button><mat-icon class="material-symbols-outlined">info</mat-icon></button>
-        <div>{{ text5 }}</div>
-      </div>
-    </div>
-    <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'expanded': 'collapsed'">
-      <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>
-    </div>
+  <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'expanded': 'collapsed'">
+    <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>
   </div>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -30,7 +30,7 @@
           </div>
         </mat-grid-tile>
       </mat-grid-list>
-      <mat-grid-list cols="3" rowHeight="fit" gutterSize="64px" [style.flex-grow]="2">
+      <mat-grid-list cols="3" rowHeight="fit" gutterSize="64px" [style.flex-grow]="3">
         <mat-grid-tile colspan="2">
           <div class="tile-content">
             <h2>Current Conditions score</h2>
@@ -40,6 +40,7 @@
         <mat-grid-tile>
           <div class="tile-content">
             <h4>Condition Score Scale</h4>
+            <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
           </div>
         </mat-grid-tile>
         <mat-grid-tile colspan="2">
@@ -51,6 +52,7 @@
         <mat-grid-tile>
           <div class="tile-content">
             <h4>Opportunity Score Scale</h4>
+            <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
           </div>
         </mat-grid-tile>
       </mat-grid-list>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,6 +1,6 @@
 <div class="create-scenarios-container">
   <div class="map-container">
-    <app-plan-map [plan]="plan$"></app-plan-map>
+    <app-plan-map [plan]="plan$" [mapId]="'planning-map'"></app-plan-map>
   </div>
   <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
     <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'expanded' : 'collapsed'">

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,7 +1,8 @@
 <div class="create-scenarios-container">
   <div class="map-container">
+    <app-plan-map [plan]="plan$"></app-plan-map>
   </div>
-  <div class="create-scenarios-panel" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
+  <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
     <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'expanded' : 'collapsed'">
       <h1>Create scenarios</h1>
     </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -6,7 +6,6 @@
 }
 
 .map-container {
-  background-color: red;
   flex-grow: 1;
   height: 100%;
   width: 100%;

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -1,16 +1,3 @@
-.create-scenarios-container {
-  display: flex;
-  flex-grow: 1;
-  height: 100%;
-  position: relative;
-}
-
-.map-container {
-  flex-grow: 1;
-  height: 100%;
-  width: 100%;
-}
-
 .create-scenarios-panel {
   background-color: white;
   box-sizing: border-box;

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -21,3 +21,25 @@
   position: absolute;
   width: 700px;
 }
+
+.create-scenarios-panel.collapsed {
+  background-color: #ebebeb;
+  padding: 0px;
+  width: 36px;
+}
+
+.create-scenarios-panel-expand-button {
+  align-items: center;
+  background-color: white;
+  border-radius: 8px;
+  display: flex;
+  height: 64px;
+  position: absolute;
+  right: -24px;
+  top: 12px;
+}
+
+.create-scenarios-panel-expand-button.collapsed {
+  background-color: #ebebeb;
+  transform: rotate(180deg);
+}

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -22,12 +22,6 @@
   width: 700px;
 }
 
-.create-scenarios-panel.collapsed {
-  background-color: #ebebeb;
-  padding: 0px;
-  width: 36px;
-}
-
 .create-scenarios-panel-expand-button {
   align-items: center;
   background-color: white;
@@ -40,6 +34,5 @@
 }
 
 .create-scenarios-panel-expand-button.collapsed {
-  background-color: #ebebeb;
   transform: rotate(180deg);
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -1,0 +1,23 @@
+.create-scenarios-container {
+  display: flex;
+  flex-grow: 1;
+  height: 100%;
+  position: relative;
+}
+
+.map-container {
+  background-color: red;
+  flex-grow: 1;
+  height: 100%;
+  width: 100%;
+}
+
+.create-scenarios-panel {
+  background-color: white;
+  box-sizing: border-box;
+  height: 100%;
+  left: 0px;
+  padding: 32px;
+  position: absolute;
+  width: 700px;
+}

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -17,7 +17,7 @@
   box-sizing: border-box;
   height: 100%;
   left: 0px;
-  padding: 32px;
+  padding: 32px 56px 32px 32px;
   position: absolute;
   width: 700px;
   z-index: 2;
@@ -36,4 +36,21 @@
 
 .create-scenarios-panel-expand-button.collapsed {
   transform: rotate(180deg);
+}
+
+.create-scenarios-panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  height: 100%;
+}
+
+.tile-content {
+  height: 100%;
+  width: 100%;
+}
+
+.row-div {
+  display: flex;
+  flex-direction: row;
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -20,6 +20,7 @@
   padding: 32px;
   position: absolute;
   width: 700px;
+  z-index: 2;
 }
 
 .create-scenarios-panel-expand-button {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -18,10 +18,9 @@
   position: absolute;
   right: -24px;
   top: 12px;
-}
-
-.create-scenarios-panel-expand-button.collapsed {
-  transform: rotate(180deg);
+  &.collapsed {
+    transform: rotate(180deg);
+  }
 }
 
 .create-scenarios-panel-content {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -1,16 +1,36 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { colormapConfigToLegend } from 'src/app/types';
 
+import { MapService } from './../../services/map.service';
+import { ColormapConfig } from './../../types/legend.types';
 import { CreateScenariosComponent } from './create-scenarios.component';
 
 describe('CreateScenariosComponent', () => {
   let component: CreateScenariosComponent;
   let fixture: ComponentFixture<CreateScenariosComponent>;
+  let fakeMapService: MapService;
+
+  const fakeColormapConfig: ColormapConfig = {
+    name: 'fakecolormap',
+    values: [
+      {
+        rgb: '#000000',
+        name: 'fakelabel',
+      },
+    ],
+  };
 
   beforeEach(async () => {
+    fakeMapService = jasmine.createSpyObj('MapService', {
+      getColormap: of(fakeColormapConfig),
+    });
     await TestBed.configureTestingModule({
-      declarations: [ CreateScenariosComponent ]
-    })
-    .compileComponents();
+      imports: [BrowserAnimationsModule],
+      declarations: [CreateScenariosComponent],
+      providers: [{ provide: MapService, useValue: fakeMapService }],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CreateScenariosComponent);
     component = fixture.componentInstance;
@@ -19,5 +39,12 @@ describe('CreateScenariosComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should fetch colormap from service to create legend', () => {
+    expect(fakeMapService.getColormap).toHaveBeenCalledOnceWith('viridis');
+    expect(component.legend).toEqual(
+      colormapConfigToLegend(fakeColormapConfig)
+    );
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateScenariosComponent } from './create-scenarios.component';
+
+describe('CreateScenariosComponent', () => {
+  let component: CreateScenariosComponent;
+  let fixture: ComponentFixture<CreateScenariosComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CreateScenariosComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CreateScenariosComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -6,6 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./create-scenarios.component.scss']
 })
 export class CreateScenariosComponent implements OnInit {
+  panelExpanded: boolean = true;
 
   constructor() { }
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -22,7 +22,7 @@ import { Component, OnInit, Input } from '@angular/core';
         'expanded',
         style({
           backgroundColor: 'white',
-          padding: '32px',
+          padding: '*',
           width: '700px',
         })
       ),
@@ -30,7 +30,7 @@ import { Component, OnInit, Input } from '@angular/core';
         'collapsed',
         style({
           backgroundColor: '#ebebeb',
-          padding: '32px 0px',
+          padding: '0px',
           width: '36px',
         })
       ),
@@ -85,6 +85,34 @@ import { Component, OnInit, Input } from '@angular/core';
 })
 export class CreateScenariosComponent implements OnInit {
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
+
+  readonly text1: string = `
+    Scenarios consist of project areas identified by your priorities and constraints
+    within the planning area. You can draw or upload your own project areas when creating
+    scenarios or Planscape can recommend some project areas and scenarios within those
+    project areas.
+  `;
+
+  readonly text2: string = `
+    You can choose to use either Current Condition scores or Management Opportunity scores to
+    inform your selection of priorities.
+  `;
+
+  readonly text3: string = `
+    Define project areas based on choosing priorities based only on the current condition of
+    the defined planning area. Future modeling is not considered in this mode.
+  `;
+
+  readonly text4: string = `
+    Choose priorities using the Pillars of Resilience Framework. Priorities with higher
+    opportunity scores (-1 to +1 range) represent how management value is greatest in the near
+    term within the defined planning area. Future modeling is considered in this mode.
+  `;
+
+  readonly text5: string = `
+    To learn more about how priorities are defined and used within this tool, visit
+    linkaddresshere.
+  `;
 
   panelExpanded: boolean = true;
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,16 +1,90 @@
+import {
+  animate,
+  animateChild,
+  group,
+  query,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
 import { Component, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-create-scenarios',
   templateUrl: './create-scenarios.component.html',
-  styleUrls: ['./create-scenarios.component.scss']
+  styleUrls: ['./create-scenarios.component.scss'],
+  animations: [
+    trigger('expandCollapsePanel', [
+      state(
+        'expanded',
+        style({
+          backgroundColor: 'white',
+          padding: '32px',
+          width: '700px',
+        })
+      ),
+      state(
+        'collapsed',
+        style({
+          backgroundColor: '#ebebeb',
+          padding: '32px 0px',
+          width: '36px',
+        })
+      ),
+      transition('expanded => collapsed', [
+        group([
+          query('@expandCollapseButton', animateChild()),
+          query('@expandCollapsePanelContent', animateChild()),
+          animate('300ms 100ms ease-out'),
+        ]),
+      ]),
+      transition('collapsed => expanded', [
+        group([
+          query('@expandCollapseButton', animateChild()),
+          query('@expandCollapsePanelContent', animateChild()),
+          animate('250ms ease-out'),
+        ]),
+      ]),
+    ]),
+    trigger('expandCollapseButton', [
+      state(
+        'expanded',
+        style({
+          backgroundColor: 'white',
+        })
+      ),
+      state(
+        'collapsed',
+        style({
+          backgroundColor: '#ebebeb',
+        })
+      ),
+      transition('expanded => collapsed', [animate('300ms ease-out')]),
+      transition('collapsed => expanded', [animate('250ms ease-out')]),
+    ]),
+    trigger('expandCollapsePanelContent', [
+      state(
+        'expanded',
+        style({
+          opacity: 1,
+        })
+      ),
+      state(
+        'collapsed',
+        style({
+          opacity: 0,
+        })
+      ),
+      transition('expanded => collapsed', [animate('100ms ease-out')]),
+      transition('collapsed => expanded', [animate('100ms 250ms ease-out')]),
+    ]),
+  ],
 })
 export class CreateScenariosComponent implements OnInit {
   panelExpanded: boolean = true;
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,5 +1,3 @@
-import { Plan } from 'src/app/types';
-import { BehaviorSubject } from 'rxjs';
 import {
   animate,
   animateChild,
@@ -10,7 +8,11 @@ import {
   transition,
   trigger,
 } from '@angular/animations';
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { BehaviorSubject, take } from 'rxjs';
+import { colormapConfigToLegend, Legend, Plan } from 'src/app/types';
+
+import { MapService } from './../../services/map.service';
 
 @Component({
   selector: 'app-create-scenarios',
@@ -114,9 +116,17 @@ export class CreateScenariosComponent implements OnInit {
     linkaddresshere.
   `;
 
+  legend: Legend | undefined;
   panelExpanded: boolean = true;
 
-  constructor() {}
+  constructor(private mapService: MapService) {
+    this.mapService
+      .getColormap('viridis')
+      .pipe(take(1))
+      .subscribe((colormapConfig) => {
+        this.legend = colormapConfigToLegend(colormapConfig);
+      });
+  }
 
   ngOnInit(): void {}
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -10,6 +10,10 @@ import {
 } from '@angular/animations';
 import { Component, Input, OnInit } from '@angular/core';
 import { BehaviorSubject, take } from 'rxjs';
+import {
+  colorTransitionTrigger,
+  opacityTransitionTrigger,
+} from 'src/app/shared/animations';
 import { colormapConfigToLegend, Legend, Plan } from 'src/app/types';
 
 import { MapService } from './../../services/map.service';
@@ -51,38 +55,18 @@ import { MapService } from './../../services/map.service';
         ]),
       ]),
     ]),
-    trigger('expandCollapseButton', [
-      state(
-        'expanded',
-        style({
-          backgroundColor: 'white',
-        })
-      ),
-      state(
-        'collapsed',
-        style({
-          backgroundColor: '#ebebeb',
-        })
-      ),
-      transition('expanded => collapsed', [animate('300ms ease-out')]),
-      transition('collapsed => expanded', [animate('250ms ease-out')]),
-    ]),
-    trigger('expandCollapsePanelContent', [
-      state(
-        'expanded',
-        style({
-          opacity: 1,
-        })
-      ),
-      state(
-        'collapsed',
-        style({
-          opacity: 0,
-        })
-      ),
-      transition('expanded => collapsed', [animate('100ms ease-out')]),
-      transition('collapsed => expanded', [animate('100ms 250ms ease-out')]),
-    ]),
+    colorTransitionTrigger({
+      triggerName: 'expandCollapseButton',
+      colorA: 'white',
+      colorB: '#ebebeb',
+      timingA: '300ms ease-out',
+      timingB: '250ms ease-out',
+    }),
+    opacityTransitionTrigger({
+      triggerName: 'expandCollapsePanelContent',
+      timingA: '100ms ease-out',
+      timingB: '100ms 250ms ease-out',
+    }),
   ],
 })
 export class CreateScenariosComponent implements OnInit {
@@ -123,7 +107,7 @@ export class CreateScenariosComponent implements OnInit {
 
   ngOnInit(): void {
     this.mapService
-      .getColormap('viridis')
+      .getColormap('viridis') // TODO(leehana): replace once colormaps are finalized
       .pipe(take(1))
       .subscribe((colormapConfig) => {
         this.legend = colormapConfigToLegend(colormapConfig);

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -119,7 +119,9 @@ export class CreateScenariosComponent implements OnInit {
   legend: Legend | undefined;
   panelExpanded: boolean = true;
 
-  constructor(private mapService: MapService) {
+  constructor(private mapService: MapService) {}
+
+  ngOnInit(): void {
     this.mapService
       .getColormap('viridis')
       .pipe(take(1))
@@ -127,6 +129,4 @@ export class CreateScenariosComponent implements OnInit {
         this.legend = colormapConfigToLegend(colormapConfig);
       });
   }
-
-  ngOnInit(): void {}
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-create-scenarios',
+  templateUrl: './create-scenarios.component.html',
+  styleUrls: ['./create-scenarios.component.scss']
+})
+export class CreateScenariosComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,3 +1,5 @@
+import { Plan } from 'src/app/types';
+import { BehaviorSubject } from 'rxjs';
 import {
   animate,
   animateChild,
@@ -8,7 +10,7 @@ import {
   transition,
   trigger,
 } from '@angular/animations';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
   selector: 'app-create-scenarios',
@@ -82,6 +84,8 @@ import { Component, OnInit } from '@angular/core';
   ],
 })
 export class CreateScenariosComponent implements OnInit {
+  @Input() plan$ = new BehaviorSubject<Plan | null>(null);
+
   panelExpanded: boolean = true;
 
   constructor() {}

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.html
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.html
@@ -1,0 +1,7 @@
+<div class="bottom-bar-root">
+  <mat-divider></mat-divider>
+  <div class="button-row">
+    <button mat-button>RESET</button>
+    <button mat-button>NEXT</button>
+  </div>
+</div>

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.html
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.html
@@ -1,4 +1,4 @@
-<div class="bottom-bar-root">
+<div class="bottom-bar-root mat-elevation-z2">
   <mat-divider></mat-divider>
   <div class="button-row">
     <button mat-button>RESET</button>

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.scss
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.scss
@@ -1,0 +1,18 @@
+.bottom-bar-root {
+  align-items: stretch;
+  background-color: white;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 56px;
+  width: 100%;
+}
+
+.button-row {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 0px 48px;
+}

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.scss
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.scss
@@ -5,7 +5,9 @@
   display: flex;
   flex-direction: column;
   height: 56px;
+  position: relative;
   width: 100%;
+  z-index: 2;
 }
 
 .button-row {

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.spec.ts
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlanBottomBarComponent } from './plan-bottom-bar.component';
+
+describe('BottomBarComponent', () => {
+  let component: PlanBottomBarComponent;
+  let fixture: ComponentFixture<PlanBottomBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PlanBottomBarComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlanBottomBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.ts
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-plan-bottom-bar',
+  templateUrl: './plan-bottom-bar.component.html',
+  styleUrls: ['./plan-bottom-bar.component.scss']
+})
+export class PlanBottomBarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.ts
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.ts
@@ -1,15 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-plan-bottom-bar',
   templateUrl: './plan-bottom-bar.component.html',
-  styleUrls: ['./plan-bottom-bar.component.scss']
+  styleUrls: ['./plan-bottom-bar.component.scss'],
 })
-export class PlanBottomBarComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
-}
+export class PlanBottomBarComponent {}

--- a/src/interface/src/app/plan/plan-map/plan-map.component.html
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.html
@@ -1,2 +1,2 @@
-<div id="map" class="plan-map"></div>
+<div id="{{mapId ? mapId : 'map'}}" class="plan-map"></div>
 <button mat-raised-button class="expand-map-button" (click)="expandMap()">EXPAND MAP</button>

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -12,6 +12,7 @@ import { Plan } from 'src/app/types';
 })
 export class PlanMapComponent implements AfterViewInit, OnDestroy {
   @Input() plan = new BehaviorSubject<Plan | null>(null);
+  @Input() mapId?: string;
 
   private readonly destroy$ = new Subject<void>();
   map!: L.Map;
@@ -22,7 +23,7 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     if (this.map != undefined) this.map.remove();
 
-    this.map = L.map('map', {
+    this.map = L.map(this.mapId ? this.mapId : 'map', {
       center: [38.646, -120.548],
       zoom: 9,
       layers: [this.stadiaAlidadeTiles()],
@@ -39,6 +40,8 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
       .subscribe((plan) => {
         this.drawPlanningArea(plan!);
       });
+
+    setTimeout(() => this.map.invalidateSize(), 0);
   }
 
   // Add planning area to map and frame it in view

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
@@ -12,7 +12,7 @@
       </p>
       <button mat-raised-button color="primary" (click)="createScenario()">CREATE A NEW SCENARIO</button>
     </div>
-    <app-saved-scenarios [plan]="plan$ | async"></app-saved-scenarios>
+    <app-saved-scenarios [plan]="plan$ | async" (createScenarioEvent)="createScenario()"></app-saved-scenarios>
     <app-unsaved-scenarios [plan]="plan$ | async"></app-unsaved-scenarios>
   </div>
 </div>

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
@@ -1,0 +1,18 @@
+<div class="plan-overview-container">
+  <app-plan-map [plan]="plan$" class="plan-map-view"></app-plan-map>
+  <mat-divider></mat-divider>
+  <div class="plan-scenario-panel">
+    <h1>{{ (plan$ | async)?.name }}</h1>
+    <div class="plan-scenario-panel-content">
+      <p class="plan-scenario-panel-text">
+        Your planning area, priorities, and constraints are used to generate scenarios.
+        Using the Scenario Explorer, you can adjust the relative importance of priorities.
+        Saved scenarios are added to the Comparison table. Scenarios consist of Project Areas,
+        Treatment plans, Potential Outcomes, and Estimated costs.
+      </p>
+      <button mat-raised-button color="primary" (click)="createScenario()">CREATE A NEW SCENARIO</button>
+    </div>
+    <app-saved-scenarios [plan]="plan$ | async"></app-saved-scenarios>
+    <app-unsaved-scenarios [plan]="plan$ | async"></app-unsaved-scenarios>
+  </div>
+</div>

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.scss
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.scss
@@ -1,0 +1,32 @@
+.plan-overview-container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  height: 100%;
+}
+
+.plan-map-view {
+  background-color: #e9e9e9;
+  flex-grow: 2;
+  position: relative;
+}
+
+.plan-scenario-panel {
+  background-color: white;
+  flex-grow: 1;
+  padding: 20px;
+}
+
+.plan-scenario-panel-content {
+  align-items: flex-start;
+  display: flex;
+  width: 100%;
+}
+
+.plan-scenario-panel-text {
+  margin-right: 150px;
+}
+
+.mat-raised-button {
+  min-width: unset;
+}

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
@@ -1,0 +1,32 @@
+import { PlanModule } from './../../plan.module';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlanOverviewComponent } from './plan-overview.component';
+
+describe('PlanOverviewComponent', () => {
+  let component: PlanOverviewComponent;
+  let fixture: ComponentFixture<PlanOverviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PlanModule],
+      declarations: [PlanOverviewComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlanOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('createScenario should emit event', () => {
+    spyOn(component.createScenarioEvent, 'emit');
+
+    component.createScenario();
+
+    expect(component.createScenarioEvent.emit).toHaveBeenCalled();
+  });
+});

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.ts
@@ -1,0 +1,17 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Plan } from 'src/app/types';
+
+@Component({
+  selector: 'app-plan-overview',
+  templateUrl: './plan-overview.component.html',
+  styleUrls: ['./plan-overview.component.scss'],
+})
+export class PlanOverviewComponent {
+  @Input() plan$ = new BehaviorSubject<Plan | null>(null);
+  @Output() createScenarioEvent = new EventEmitter<void>();
+
+  createScenario(): void {
+    this.createScenarioEvent.emit();
+  }
+}

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -28,7 +28,7 @@
       <mat-icon>open_in_new</mat-icon>
       SEE ALL
     </button>
-    <button mat-raised-button color="primary">
+    <button mat-raised-button color="primary" (click)="createScenario()">
       <mat-icon>add_box</mat-icon>
       CREATE A NEW SCENARIO
     </button>

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -8,9 +8,8 @@ describe('SavedScenariosComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SavedScenariosComponent ]
-    })
-    .compileComponents();
+      declarations: [SavedScenariosComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SavedScenariosComponent);
     component = fixture.componentInstance;
@@ -19,5 +18,13 @@ describe('SavedScenariosComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('createScenario should emit event', () => {
+    spyOn(component.createScenarioEvent, 'emit');
+
+    component.createScenario();
+
+    expect(component.createScenarioEvent.emit).toHaveBeenCalled();
   });
 });

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { now } from 'moment';
 import { Plan, Scenario } from 'src/app/types';
 
@@ -9,6 +9,8 @@ import { Plan, Scenario } from 'src/app/types';
 })
 export class SavedScenariosComponent {
   @Input() plan: Plan | null = null;
+  @Output() createScenarioEvent = new EventEmitter<void>();
+
   scenarios: Scenario[];
   displayedColumns: string[] = ['id', 'createdTimestamp'];
 
@@ -20,5 +22,9 @@ export class SavedScenariosComponent {
         createdTimestamp: now(),
       },
     ];
+  }
+
+  createScenario(): void {
+    this.createScenarioEvent.emit();
   }
 }

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -11,7 +11,14 @@
     <div class="plan-content">
       <div class="plan-content-inner">
         <app-plan-overview [plan$]="currentPlan$" (createScenarioEvent)="currentPlanStep = 1" *ngIf="currentPlanStep === 0"></app-plan-overview>
-        <app-create-scenarios [plan$]="currentPlan$" *ngIf="currentPlanStep === 1"></app-create-scenarios>
+        <ng-container *ngIf="currentPlanStep > 0">
+          <div class="plan-map-container">
+            <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'"></app-plan-map>
+          </div>
+          <div class="plan-content-panel">
+            <app-create-scenarios [plan$]="currentPlan$" *ngIf="currentPlanStep === 1"></app-create-scenarios>
+          </div>
+        </ng-container>
       </div>
       <app-plan-bottom-bar *ngIf="currentPlanStep > 0"></app-plan-bottom-bar>
     </div>

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -9,7 +9,11 @@
     </div>
     <mat-divider [vertical]="true"></mat-divider>
     <div class="plan-content">
-      <app-plan-overview [plan$]="currentPlan$" (createScenarioEvent)="currentPlanStep = 1" *ngIf="currentPlanStep === 0"></app-plan-overview>
+      <div class="plan-content-inner">
+        <app-plan-overview [plan$]="currentPlan$" (createScenarioEvent)="currentPlanStep = 1" *ngIf="currentPlanStep === 0"></app-plan-overview>
+        <app-create-scenarios *ngIf="currentPlanStep === 1"></app-create-scenarios>
+      </div>
+      <app-plan-bottom-bar *ngIf="currentPlanStep > 0"></app-plan-bottom-bar>
     </div>
   </ng-container>
 </div>

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -1,30 +1,15 @@
 <div class="root-container">
   <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
   <ng-container *ngIf="!planNotFound && plan">
-    <div class="plan-summary-panel" *ngIf="!resumePlanning">
+    <div class="plan-summary-panel" *ngIf="currentPlanStep === 0">
       <summary-panel></summary-panel>
     </div>
-    <div class="plan-progress-panel" *ngIf="resumePlanning">
+    <div class="plan-progress-panel" *ngIf="currentPlanStep > 0">
       <progress-panel [plan]="currentPlan$ | async"></progress-panel>
     </div>
     <mat-divider [vertical]="true"></mat-divider>
-    <div class="plan-map-container">
-      <app-plan-map [plan]="currentPlan$" class="plan-map-view"></app-plan-map>
-      <mat-divider></mat-divider>
-      <div class="plan-scenario-panel">
-        <h1>{{ plan.name }}</h1>
-        <div class="plan-scenario-panel-content">
-          <p class="plan-scenario-panel-text">
-            Your planning area, priorities, and constraints are used to generate scenarios.
-            Using the Scenario Explorer, you can adjust the relative importance of priorities.
-            Saved scenarios are added to the Comparison table. Scenarios consist of Project Areas,
-            Treatment plans, Potential Outcomes, and Estimated costs.
-          </p>
-          <button mat-raised-button color="primary">CREATE A NEW SCENARIO</button>
-        </div>
-        <app-saved-scenarios [plan]="currentPlan$ | async"></app-saved-scenarios>
-        <app-unsaved-scenarios [plan]="currentPlan$ | async"></app-unsaved-scenarios>
-      </div>
+    <div class="plan-content">
+      <app-plan-overview [plan$]="currentPlan$" (createScenarioEvent)="currentPlanStep = 1" *ngIf="currentPlanStep === 0"></app-plan-overview>
     </div>
   </ng-container>
 </div>

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -11,7 +11,7 @@
     <div class="plan-content">
       <div class="plan-content-inner">
         <app-plan-overview [plan$]="currentPlan$" (createScenarioEvent)="currentPlanStep = 1" *ngIf="currentPlanStep === 0"></app-plan-overview>
-        <app-create-scenarios *ngIf="currentPlanStep === 1"></app-create-scenarios>
+        <app-create-scenarios [plan$]="currentPlan$" *ngIf="currentPlanStep === 1"></app-create-scenarios>
       </div>
       <app-plan-bottom-bar *ngIf="currentPlanStep > 0"></app-plan-bottom-bar>
     </div>

--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -35,4 +35,19 @@
 
 .plan-content-inner {
   flex: 1;
+  position: relative;
+}
+
+.plan-map-container {
+  height: 100%;
+  width: 100%;
+  z-index: 1;
+}
+
+.plan-content-panel {
+  left: 0;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  z-index: 2;
 }

--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -28,5 +28,11 @@
 }
 
 .plan-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.plan-content-inner {
   flex: 1;
 }

--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -9,8 +9,8 @@
   background-color: white;
   box-sizing: border-box;
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
-  flex-shrink: 0;
   height: 100%;
   position: relative;
   width: 300px;
@@ -20,42 +20,13 @@
   background-color: white;
   box-sizing: border-box;
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
-  flex-shrink: 0;
   height: 100%;
   position: relative;
   width: 300px;
 }
 
-.plan-map-container {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  height: 100%;
-}
-
-.plan-map-view {
-  background-color: #e9e9e9;
-  flex-grow: 2;
-  position: relative;
-}
-
-.plan-scenario-panel {
-  background-color: white;
-  flex-grow: 1;
-  padding: 20px;
-}
-
-.plan-scenario-panel-content {
-  align-items: flex-start;
-  display: flex;
-  width: 100%;
-}
-
-.plan-scenario-panel-text {
-  margin-right: 150px;
-}
-
-.mat-raised-button {
-  min-width: unset;
+.plan-content {
+  flex: 1;
 }

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -84,6 +84,10 @@ describe('PlanComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('currentPlanStep should be 0', () => {
+    expect(component.currentPlanStep).toBe(0);
+  });
+
   it('fetches plan from service using ID', () => {
     expect(component.planNotFound).toBeFalse();
     expect(component.plan).toEqual(fakePlan);

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -18,7 +18,7 @@ export enum PlanStep {
 export class PlanComponent {
   plan: Plan | undefined;
   currentPlan$ = new BehaviorSubject<Plan | null>(null);
-  currentPlanStep: PlanStep = PlanStep.Overview;
+  currentPlanStep: PlanStep = PlanStep.CreateScenarios;
   planNotFound: boolean = false;
 
   constructor(private planService: PlanService, private route: ActivatedRoute) {

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -5,6 +5,11 @@ import { BehaviorSubject, take } from 'rxjs';
 import { Plan } from '../types';
 import { PlanService } from './../services/plan.service';
 
+export enum PlanStep {
+  Overview,
+  CreateScenarios,
+}
+
 @Component({
   selector: 'app-plan',
   templateUrl: './plan.component.html',
@@ -13,7 +18,7 @@ import { PlanService } from './../services/plan.service';
 export class PlanComponent {
   plan: Plan | undefined;
   currentPlan$ = new BehaviorSubject<Plan | null>(null);
-  resumePlanning = true;
+  currentPlanStep: PlanStep = PlanStep.Overview;
   planNotFound: boolean = false;
 
   constructor(private planService: PlanService, private route: ActivatedRoute) {

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -18,7 +18,7 @@ export enum PlanStep {
 export class PlanComponent {
   plan: Plan | undefined;
   currentPlan$ = new BehaviorSubject<Plan | null>(null);
-  currentPlanStep: PlanStep = PlanStep.CreateScenarios;
+  currentPlanStep: PlanStep = PlanStep.Overview;
   planNotFound: boolean = false;
 
   constructor(private planService: PlanService, private route: ActivatedRoute) {

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { MaterialModule } from 'src/app/material/material.module';
 
 import { PlanMapComponent } from './plan-map/plan-map.component';
+import { PlanOverviewComponent } from './plan-summary/plan-overview/plan-overview.component';
 import { SavedScenariosComponent } from './plan-summary/saved-scenarios/saved-scenarios.component';
 import { SummaryPanelComponent } from './plan-summary/summary-panel/summary-panel.component';
 import { UnsavedScenariosComponent } from './plan-summary/unsaved-scenarios/unsaved-scenarios.component';
@@ -25,6 +26,7 @@ import { ProgressPanelComponent } from './progress-panel/progress-panel.componen
     PlanUnavailableComponent,
     PlanTableComponent,
     DeletePlanDialogComponent,
+    PlanOverviewComponent,
   ],
   imports: [CommonModule, FormsModule, MaterialModule],
 })

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MaterialModule } from 'src/app/material/material.module';
 
+import { SharedModule } from './../shared/shared.module';
 import { CreateScenariosComponent } from './create-scenarios/create-scenarios.component';
 import { PlanBottomBarComponent } from './plan-bottom-bar/plan-bottom-bar.component';
 import { PlanMapComponent } from './plan-map/plan-map.component';
@@ -32,6 +33,6 @@ import { ProgressPanelComponent } from './progress-panel/progress-panel.componen
     CreateScenariosComponent,
     PlanBottomBarComponent,
   ],
-  imports: [CommonModule, FormsModule, MaterialModule],
+  imports: [CommonModule, FormsModule, MaterialModule, SharedModule],
 })
 export class PlanModule {}

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -3,6 +3,8 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MaterialModule } from 'src/app/material/material.module';
 
+import { CreateScenariosComponent } from './create-scenarios/create-scenarios.component';
+import { PlanBottomBarComponent } from './plan-bottom-bar/plan-bottom-bar.component';
 import { PlanMapComponent } from './plan-map/plan-map.component';
 import { PlanOverviewComponent } from './plan-summary/plan-overview/plan-overview.component';
 import { SavedScenariosComponent } from './plan-summary/saved-scenarios/saved-scenarios.component';
@@ -27,6 +29,8 @@ import { ProgressPanelComponent } from './progress-panel/progress-panel.componen
     PlanTableComponent,
     DeletePlanDialogComponent,
     PlanOverviewComponent,
+    CreateScenariosComponent,
+    PlanBottomBarComponent,
   ],
   imports: [CommonModule, FormsModule, MaterialModule],
 })

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from 'src/app/material/material.module';
 
 import { SharedModule } from './../shared/shared.module';
@@ -33,6 +34,12 @@ import { ProgressPanelComponent } from './progress-panel/progress-panel.componen
     CreateScenariosComponent,
     PlanBottomBarComponent,
   ],
-  imports: [CommonModule, FormsModule, MaterialModule, SharedModule],
+  imports: [
+    BrowserAnimationsModule,
+    CommonModule,
+    FormsModule,
+    MaterialModule,
+    SharedModule,
+  ],
 })
 export class PlanModule {}

--- a/src/interface/src/app/shared/animations.ts
+++ b/src/interface/src/app/shared/animations.ts
@@ -1,0 +1,53 @@
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+
+export const colorTransitionTrigger = (params: {
+  triggerName: string;
+  colorA: string;
+  colorB: string;
+  timingA: string;
+  timingB: string;
+}) =>
+  trigger(params.triggerName, [
+    state(
+      'colorA',
+      style({
+        backgroundColor: params.colorA,
+      })
+    ),
+    state(
+      'colorB',
+      style({
+        backgroundColor: params.colorB,
+      })
+    ),
+    transition('colorA => colorB', [animate(params.timingA)]),
+    transition('colorB => colorA', [animate(params.timingB)]),
+  ]);
+
+export const opacityTransitionTrigger = (params: {
+  triggerName: string;
+  timingA: string;
+  timingB: string;
+}) =>
+  trigger(params.triggerName, [
+    state(
+      'opaque',
+      style({
+        opacity: 1,
+      })
+    ),
+    state(
+      'transparent',
+      style({
+        opacity: 0,
+      })
+    ),
+    transition('opaque => transparent', [animate(params.timingA)]),
+    transition('transparent => opaque', [animate(params.timingB)]),
+  ]);

--- a/src/interface/src/app/shared/legend/legend.component.html
+++ b/src/interface/src/app/shared/legend/legend.component.html
@@ -1,12 +1,12 @@
 <div class="legend-wrapper" *ngIf="legend">
-  <h1>Legend</h1>
-  <div class="legend">
-    <h2>Potential for impact</h2>
-    <div class="colors">
-      <div class="colorbox" *ngFor="let color of legend?.colors" [ngStyle]="{'background-color': color}"></div>
+  <h1 *ngIf="!hideTitles">Legend</h1>
+  <div class="legend" [class.vertical]="vertical" [class.no-border]="hideOutline">
+    <h2 *ngIf="!hideTitles">Potential for impact</h2>
+    <div class="colors" [class.vertical]="vertical">
+      <div class="colorbox" [class.vertical]="vertical" *ngFor="let color of legend?.colors" [ngStyle]="{'background-color': color}"></div>
     </div>
-    <div class="labels">
-      <div class="label" *ngFor="let label of legend?.labels">{{ label }}</div>
+    <div class="labels" [class.vertical]="vertical">
+      <div class="label" [class.vertical]="vertical" *ngFor="let label of legend?.labels">{{ label }}</div>
     </div>
   </div>
 </div>

--- a/src/interface/src/app/shared/legend/legend.component.scss
+++ b/src/interface/src/app/shared/legend/legend.component.scss
@@ -29,6 +29,20 @@ h2 {
   padding: 12px;
 }
 
+.legend.vertical {
+  align-items: flex-start;
+  flex-direction: row;
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+.legend.no-border {
+  border: none;
+  border-radius: 0px;
+  margin: 0px;
+  padding: 0px;
+}
+
 .labels {
   display: flex;
   flex-direction: row;
@@ -37,10 +51,22 @@ h2 {
   width: 100%;
 }
 
+.labels.vertical {
+  flex-direction: column;
+  gap: 8px;
+}
+
 .label {
   margin-top: 5px;
   min-width: 24px;
   writing-mode: vertical-lr;
+}
+
+.label.vertical {
+  height: 24px;
+  line-height: 24px;
+  margin-top: 0px;
+  writing-mode: horizontal-tb;
 }
 
 .colors {
@@ -50,8 +76,18 @@ h2 {
   width: 100%;
 }
 
+.colors.vertical {
+  flex-direction: column;
+  gap: 8px;
+  width: unset;
+}
+
 .colorbox {
   flex: 1 1 auto;
   height: 24px;
   min-width: 24px;
+}
+
+.colorbox.vertical {
+  width: 36px;
 }

--- a/src/interface/src/app/shared/legend/legend.component.ts
+++ b/src/interface/src/app/shared/legend/legend.component.ts
@@ -8,4 +8,7 @@ import { Legend } from 'src/app/types';
 })
 export class LegendComponent {
   @Input() legend?: Legend;
+  @Input() vertical?: boolean;
+  @Input() hideTitles?: boolean;
+  @Input() hideOutline?: boolean;
 }


### PR DESCRIPTION
## Changes
- Add "Create scenario" page containing expandable/collapsible panel, bottom bar, and map view
- Add "planningStep" variable to `PlanComponent` that tracks where the user is in their planning journey (replacing the `resumePlanning` boolean)
- "Create a scenario" button in the plan overview page now starts the scenario planning flow
- Add new configuration options to the shared legend component to render a vertical version
- Add an optional "mapId" param to the plan map component so it can be reused
- Fixes #308

## Expanded panel
![image](https://user-images.githubusercontent.com/10444733/212148536-5c067c6d-e8f5-4ab9-9803-1b1f0cf4a388.png)

## Collapsed panel
![image](https://user-images.githubusercontent.com/10444733/212158756-81a2331c-81e0-4cc4-91d4-57dbe52f4fa3.png)

## Score dropdown
![image](https://user-images.githubusercontent.com/10444733/212158967-76096a4c-a913-4fe5-95b4-5a4f07ee7f61.png)

## Todos
- Make expand/collapse animations reusable (so they can apply to the "Set priorities" and "Set constraints" panels)
- Add a URL parameter to track the current planning step instead of using a variable
- Update legends with values for the final colormap(s) we will be using