### PR TITLE
add /get_project_areas endpoint

### DIFF
--- a/src/planscape/plan/serializers.py
+++ b/src/planscape/plan/serializers.py
@@ -2,7 +2,7 @@ from rest_framework.serializers import IntegerField
 from rest_framework import serializers
 from rest_framework_gis import serializers as gis_serializers
 
-from .models import Plan, Project
+from .models import Plan, Project, ProjectArea
 from conditions.models import Condition
 
 
@@ -30,3 +30,10 @@ class ProjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = Project
         fields = '__all__'
+
+
+class ProjectAreaSerializer(gis_serializers.GeoFeatureModelSerializer):
+    class Meta:
+        model = ProjectArea
+        fields = '__all__'
+        geo_field = "project_area"

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -524,3 +524,83 @@ class GetProjectTest(TransactionTestCase):
         self.assertEqual(response.json()['max_cost'], 100)
         self.assertEqual(response.json()['priorities'], [
                          self.condition1.pk, self.condition2.pk])
+
+
+class GetProjectAreaTest(TransactionTestCase):
+    def setUp(self):
+        self.geometry = {'type': 'MultiPolygon',
+                         'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
+        stored_geometry = GEOSGeometry(json.dumps(self.geometry))
+
+        self.base_condition = BaseCondition.objects.create(
+            condition_name="name", condition_level=ConditionLevel.ELEMENT)
+        self.condition1 = Condition.objects.create(
+            condition_dataset=self.base_condition, raster_name="name1")
+        self.condition2 = Condition.objects.create(
+            condition_dataset=self.base_condition, raster_name="name2")
+
+        self.plan_no_user = create_plan(None, 'ownerless', stored_geometry, [])
+        self.project_no_user = Project.objects.create(
+            owner=None, plan=self.plan_no_user, max_cost=100)
+        self.project_area_no_user = ProjectArea.objects.create(
+            owner=None, project=self.project_no_user, project_area=stored_geometry, estimated_area_treated=100)
+        self.project_area_no_user2 = ProjectArea.objects.create(
+            owner=None, project=self.project_no_user, project_area=stored_geometry)
+        self.project_no_user_no_projectareas = Project.objects.create(
+            owner=None, plan=self.plan_no_user, max_cost=200)
+
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+        self.plan_with_user = create_plan(
+            self.user, 'ownerless', stored_geometry, [])
+        self.project_with_user = Project.objects.create(
+            owner=self.user, plan=self.plan_with_user, max_cost=100)
+        self.project_area_with_user = ProjectArea.objects.create(
+            owner=self.user, project=self.project_with_user, project_area=stored_geometry, estimated_area_treated=200)
+
+    def test_get_projectareas_for_nonexistent_project(self):
+        response = self.client.get(reverse('plan:get_project_areas'), {'project_id': 10},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_projectareas_no_project_id(self):
+        response = self.client.get(reverse('plan:get_project_areas'), {},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_projectareas_no_results(self):
+        response = self.client.get(reverse('plan:get_project_areas'), {'project_id': self.project_no_user_no_projectareas.pk},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 0)
+
+    def test_get_projectareas_no_user(self):
+        response = self.client.get(reverse('plan:get_project_areas'), {'project_id': self.project_no_user.pk},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 2)
+        project_area_id = str(self.project_area_no_user.pk)
+        self.assertEqual(
+            response.json()[project_area_id]['properties']['owner'], None)
+        self.assertEqual(response.json()[
+                         project_area_id]['properties']['project'], self.project_no_user.pk)
+        self.assertEqual(
+            response.json()[project_area_id]['properties']['estimated_area_treated'], 100)
+        self.assertEqual(
+            response.json()[project_area_id]['geometry'], self.geometry)
+
+    def test_get_projectareas_with_user(self):
+        response = self.client.get(reverse('plan:get_project_areas'), {'project_id': self.project_with_user.pk},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        project_area_id = str(self.project_area_with_user.pk)
+        self.assertEqual(
+            response.json()[project_area_id]['properties']['owner'], self.user.pk)
+        self.assertEqual(response.json()[
+                         project_area_id]['properties']['project'], self.project_with_user.pk)
+        self.assertEqual(
+            response.json()[project_area_id]['properties']['estimated_area_treated'], 200)
+        self.assertEqual(
+            response.json()[project_area_id]['geometry'], self.geometry)

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -570,7 +570,8 @@ class GetProjectAreaTest(TransactionTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_get_projectareas_no_results(self):
-        response = self.client.get(reverse('plan:get_project_areas'), {'project_id': self.project_no_user_no_projectareas.pk},
+        response = self.client.get(reverse('plan:get_project_areas'),
+                                   {'project_id': self.project_no_user_no_projectareas.pk},
                                    content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 0)

--- a/src/planscape/plan/urls.py
+++ b/src/planscape/plan/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from plan.views import (create_plan, create_project, delete, get_plan,
-                        list_plans_by_owner, create_project_area, get_project)
+                        list_plans_by_owner, create_project_area, get_project, get_project_areas)
 
 app_name = 'plan'
 
@@ -14,4 +14,5 @@ urlpatterns = [
     path('create_project/', create_project, name='create_project'),
     path('get_project/', get_project, name='get_project'),
     path('create_project_area/', create_project_area, name='create_project_area'),
+    path('get_project_areas/', get_project_areas, name='get_project_areas'),
 ]

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -110,7 +110,7 @@ def delete(request: HttpRequest) -> HttpResponse:
 
 def get_plan_by_id(params: QueryDict):
     assert isinstance(params['id'], str)
-    plan_id = params.get('id', 0)
+    plan_id = params.get('id', "0")
     return (Plan.objects.filter(id=int(plan_id))
                         .annotate(projects=Count('project', distinct=True))
                         .annotate(scenarios=Count('project__scenario')))
@@ -204,7 +204,7 @@ def create_project(request: HttpRequest) -> HttpResponse:
 def get_project(request: HttpRequest) -> HttpResponse:
     try:
         assert isinstance(request.GET['id'], str)
-        project_id = request.GET.get('id', 0)
+        project_id = request.GET.get('id', "0")
         response = get_list_or_404(Project, id=project_id)
         return JsonResponse(ProjectSerializer(response[0]).data)
     except Exception as e:
@@ -259,7 +259,7 @@ def create_project_area(request: HttpRequest) -> HttpResponse:
 def get_project_areas(request: HttpRequest) -> HttpResponse:
     try:
         assert isinstance(request.GET['project_id'], str)
-        project_id = request.GET.get('project_id', 0)
+        project_id = request.GET.get('project_id', "0")
         project_exists = get_list_or_404(Project, id=project_id)
         project_areas = ProjectArea.objects.filter(project=project_id)
         response = {}

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -8,7 +8,7 @@ from django.db.models import Count
 from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
                          JsonResponse, QueryDict)
 from plan.models import Plan, Project, ProjectArea
-from plan.serializers import PlanSerializer, ProjectSerializer
+from plan.serializers import PlanSerializer, ProjectSerializer, ProjectAreaSerializer
 from planscape import settings
 from django.shortcuts import get_list_or_404
 
@@ -252,5 +252,20 @@ def create_project_area(request: HttpRequest) -> HttpResponse:
             owner=owner, project=project, project_area=geometry)
         project_area.save()
         return HttpResponse(str(project_area.pk))
+    except Exception as e:
+        return HttpResponseBadRequest("Ill-formed request: " + str(e))
+
+
+def get_project_areas(request: HttpRequest) -> HttpResponse:
+    try:
+        assert isinstance(request.GET['project_id'], str)
+        project_id = request.GET.get('project_id', 0)
+        project_exists = get_list_or_404(Project, id=project_id)
+        project_areas = ProjectArea.objects.filter(project=project_id)
+        response = {}
+        for area in project_areas:
+            data = ProjectAreaSerializer(area).data
+            response[data['id']] = data
+        return JsonResponse(response)
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))


### PR DESCRIPTION
1. Returns 400 error if the project_id isn't provided or doesn't exist
2. Returns an empty library if there are no project areas associated with the project.