### PR TITLE
Set priorities page (first pass)

### DIFF
--- a/src/interface/src/app/material/material.module.ts
+++ b/src/interface/src/app/material/material.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -30,6 +31,7 @@ import { MatTreeModule } from '@angular/material/tree';
     MatButtonModule,
     MatCardModule,
     MatCheckboxModule,
+    MatChipsModule,
     MatDialogModule,
     MatDividerModule,
     MatExpansionModule,

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
@@ -1,0 +1,58 @@
+<div class="panel-container">
+  <div>
+    <h1>Create scenarios</h1>
+    <p>{{ text1 }}</p>
+  </div>
+  <mat-grid-list cols="2" rowHeight="fit" gutterSize="64px" [style.flex]="'1 1 auto'">
+    <mat-grid-tile>
+      <div class="tile-content">
+        <mat-form-field appearance="fill">
+          <mat-label>
+            Generate scenarios using:
+          </mat-label>
+          <mat-select>
+            <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
+            <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+    </mat-grid-tile>
+    <mat-grid-tile>
+      <div class="tile-content">
+        <p>
+          {{ text2 }}
+        </p>
+      </div>
+    </mat-grid-tile>
+  </mat-grid-list>
+  <mat-grid-list cols="3" rowHeight="fit" gutterSize="64px" [style.flex-grow]="3">
+    <mat-grid-tile colspan="2">
+      <div class="tile-content">
+        <h2>Current Conditions score</h2>
+        <p>{{ text3 }}</p>
+      </div>
+    </mat-grid-tile>
+    <mat-grid-tile>
+      <div class="tile-content">
+        <h4>Condition Score Scale</h4>
+        <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
+      </div>
+    </mat-grid-tile>
+    <mat-grid-tile colspan="2">
+      <div class="tile-content">
+        <h2>Opportunity score (Coming soon)</h2>
+        <p>{{ text4 }}</p>
+      </div>
+    </mat-grid-tile>
+    <mat-grid-tile>
+      <div class="tile-content">
+        <h4>Opportunity Score Scale</h4>
+        <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
+      </div>
+    </mat-grid-tile>
+  </mat-grid-list>
+  <div class="row-div">
+    <button mat-icon-button><mat-icon class="material-symbols-outlined">info</mat-icon></button>
+    <div>{{ text5 }}</div>
+  </div>
+</div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.scss
@@ -1,0 +1,16 @@
+.panel-container {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  height: 100%;
+}
+
+.tile-content {
+  height: 100%;
+  width: 100%;
+}
+
+.row-div {
+  display: flex;
+  flex-direction: row;
+}

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
@@ -1,16 +1,36 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { colormapConfigToLegend } from 'src/app/types';
 
+import { MapService } from './../../../services/map.service';
+import { ColormapConfig } from './../../../types/legend.types';
 import { CreateScenariosIntroComponent } from './create-scenarios-intro.component';
 
 describe('CreateScenariosIntroComponent', () => {
   let component: CreateScenariosIntroComponent;
   let fixture: ComponentFixture<CreateScenariosIntroComponent>;
+  let fakeMapService: MapService;
+
+  const fakeColormapConfig: ColormapConfig = {
+    name: 'fakecolormap',
+    values: [
+      {
+        rgb: '#000000',
+        name: 'fakelabel',
+      },
+    ],
+  };
 
   beforeEach(async () => {
+    fakeMapService = jasmine.createSpyObj('MapService', {
+      getColormap: of(fakeColormapConfig),
+    });
     await TestBed.configureTestingModule({
-      declarations: [ CreateScenariosIntroComponent ]
-    })
-    .compileComponents();
+      imports: [HttpClientTestingModule],
+      declarations: [CreateScenariosIntroComponent],
+      providers: [{ provide: MapService, useValue: fakeMapService }],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CreateScenariosIntroComponent);
     component = fixture.componentInstance;
@@ -19,5 +39,12 @@ describe('CreateScenariosIntroComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should fetch colormap from service to create legend', () => {
+    expect(fakeMapService.getColormap).toHaveBeenCalledOnceWith('viridis');
+    expect(component.legend).toEqual(
+      colormapConfigToLegend(fakeColormapConfig)
+    );
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateScenariosIntroComponent } from './create-scenarios-intro.component';
+
+describe('CreateScenariosIntroComponent', () => {
+  let component: CreateScenariosIntroComponent;
+  let fixture: ComponentFixture<CreateScenariosIntroComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CreateScenariosIntroComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CreateScenariosIntroComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.ts
@@ -1,0 +1,53 @@
+import { Legend, colormapConfigToLegend } from 'src/app/types';
+import { take } from 'rxjs';
+import { MapService } from './../../../services/map.service';
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-create-scenarios-intro',
+  templateUrl: './create-scenarios-intro.component.html',
+  styleUrls: ['./create-scenarios-intro.component.scss']
+})
+export class CreateScenariosIntroComponent implements OnInit {
+  readonly text1: string = `
+    Scenarios consist of project areas identified by your priorities and constraints
+    within the planning area. You can draw or upload your own project areas when creating
+    scenarios or Planscape can recommend some project areas and scenarios within those
+    project areas.
+  `;
+
+  readonly text2: string = `
+    You can choose to use either Current Condition scores or Management Opportunity scores to
+    inform your selection of priorities.
+  `;
+
+  readonly text3: string = `
+    Define project areas based on choosing priorities based only on the current condition of
+    the defined planning area. Future modeling is not considered in this mode.
+  `;
+
+  readonly text4: string = `
+    Choose priorities using the Pillars of Resilience Framework. Priorities with higher
+    opportunity scores (-1 to +1 range) represent how management value is greatest in the near
+    term within the defined planning area. Future modeling is considered in this mode.
+  `;
+
+  readonly text5: string = `
+    To learn more about how priorities are defined and used within this tool, visit
+    linkaddresshere.
+  `;
+
+  legend: Legend | undefined;
+
+  constructor(private mapService: MapService) { }
+
+  ngOnInit(): void {
+    this.mapService
+      .getColormap('viridis') // TODO(leehana): replace once colormaps are finalized
+      .pipe(take(1))
+      .subscribe((colormapConfig) => {
+        this.legend = colormapConfigToLegend(colormapConfig);
+      });
+  }
+
+}

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,7 +1,7 @@
 <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
   <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
     <app-create-scenarios-intro *ngIf="planningStep === 1"></app-create-scenarios-intro>
-    <app-set-priorities *ngIf="planningStep === 2"></app-set-priorities>
+    <app-set-priorities *ngIf="planningStep === 2" (changeConditionEvent)="changeConditionEvent.emit($event)"></app-set-priorities>
   </div>
   <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'colorA': 'colorB'">
     <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,61 +1,7 @@
 <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
   <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
-    <div>
-      <h1>Create scenarios</h1>
-      <p>{{ text1 }}</p>
-    </div>
-    <mat-grid-list cols="2" rowHeight="fit" gutterSize="64px" [style.flex]="'1 1 auto'">
-      <mat-grid-tile>
-        <div class="tile-content">
-          <mat-form-field appearance="fill">
-            <mat-label>
-              Generate scenarios using:
-            </mat-label>
-            <mat-select>
-              <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
-              <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-      </mat-grid-tile>
-      <mat-grid-tile>
-        <div class="tile-content">
-          <p>
-            {{ text2 }}
-          </p>
-        </div>
-      </mat-grid-tile>
-    </mat-grid-list>
-    <mat-grid-list cols="3" rowHeight="fit" gutterSize="64px" [style.flex-grow]="3">
-      <mat-grid-tile colspan="2">
-        <div class="tile-content">
-          <h2>Current Conditions score</h2>
-          <p>{{ text3 }}</p>
-        </div>
-      </mat-grid-tile>
-      <mat-grid-tile>
-        <div class="tile-content">
-          <h4>Condition Score Scale</h4>
-          <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
-        </div>
-      </mat-grid-tile>
-      <mat-grid-tile colspan="2">
-        <div class="tile-content">
-          <h2>Opportunity score (Coming soon)</h2>
-          <p>{{ text4 }}</p>
-        </div>
-      </mat-grid-tile>
-      <mat-grid-tile>
-        <div class="tile-content">
-          <h4>Opportunity Score Scale</h4>
-          <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
-        </div>
-      </mat-grid-tile>
-    </mat-grid-list>
-    <div class="row-div">
-      <button mat-icon-button><mat-icon class="material-symbols-outlined">info</mat-icon></button>
-      <div>{{ text5 }}</div>
-    </div>
+    <app-create-scenarios-intro *ngIf="planningStep === 1"></app-create-scenarios-intro>
+    <app-set-priorities *ngIf="planningStep === 2"></app-set-priorities>
   </div>
   <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'colorA': 'colorB'">
     <button mat-icon-button (click)="panelExpanded = !panelExpanded"><mat-icon>chevron_left</mat-icon></button>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -25,17 +25,5 @@
 
 .create-scenarios-panel-content {
   display: flex;
-  flex-direction: column;
-  gap: 48px;
   height: 100%;
-}
-
-.tile-content {
-  height: 100%;
-  width: 100%;
-}
-
-.row-div {
-  display: flex;
-  flex-direction: row;
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -1,35 +1,16 @@
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { of } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { colormapConfigToLegend } from 'src/app/types';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { MapService } from './../../services/map.service';
-import { ColormapConfig } from './../../types/legend.types';
 import { CreateScenariosComponent } from './create-scenarios.component';
 
 describe('CreateScenariosComponent', () => {
   let component: CreateScenariosComponent;
   let fixture: ComponentFixture<CreateScenariosComponent>;
-  let fakeMapService: MapService;
-
-  const fakeColormapConfig: ColormapConfig = {
-    name: 'fakecolormap',
-    values: [
-      {
-        rgb: '#000000',
-        name: 'fakelabel',
-      },
-    ],
-  };
 
   beforeEach(async () => {
-    fakeMapService = jasmine.createSpyObj('MapService', {
-      getColormap: of(fakeColormapConfig),
-    });
     await TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule],
       declarations: [CreateScenariosComponent],
-      providers: [{ provide: MapService, useValue: fakeMapService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CreateScenariosComponent);
@@ -39,12 +20,5 @@ describe('CreateScenariosComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should fetch colormap from service to create legend', () => {
-    expect(fakeMapService.getColormap).toHaveBeenCalledOnceWith('viridis');
-    expect(component.legend).toEqual(
-      colormapConfigToLegend(fakeColormapConfig)
-    );
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -8,15 +8,13 @@ import {
   transition,
   trigger,
 } from '@angular/animations';
-import { Component, Input, OnInit } from '@angular/core';
-import { BehaviorSubject, take } from 'rxjs';
+import { Component, Input } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 import {
   colorTransitionTrigger,
   opacityTransitionTrigger,
 } from 'src/app/shared/animations';
-import { colormapConfigToLegend, Legend, Plan } from 'src/app/types';
-
-import { MapService } from './../../services/map.service';
+import { Plan } from 'src/app/types';
 
 @Component({
   selector: 'app-create-scenarios',
@@ -69,48 +67,9 @@ import { MapService } from './../../services/map.service';
     }),
   ],
 })
-export class CreateScenariosComponent implements OnInit {
+export class CreateScenariosComponent {
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
+  @Input() planningStep: number = 1;
 
-  readonly text1: string = `
-    Scenarios consist of project areas identified by your priorities and constraints
-    within the planning area. You can draw or upload your own project areas when creating
-    scenarios or Planscape can recommend some project areas and scenarios within those
-    project areas.
-  `;
-
-  readonly text2: string = `
-    You can choose to use either Current Condition scores or Management Opportunity scores to
-    inform your selection of priorities.
-  `;
-
-  readonly text3: string = `
-    Define project areas based on choosing priorities based only on the current condition of
-    the defined planning area. Future modeling is not considered in this mode.
-  `;
-
-  readonly text4: string = `
-    Choose priorities using the Pillars of Resilience Framework. Priorities with higher
-    opportunity scores (-1 to +1 range) represent how management value is greatest in the near
-    term within the defined planning area. Future modeling is considered in this mode.
-  `;
-
-  readonly text5: string = `
-    To learn more about how priorities are defined and used within this tool, visit
-    linkaddresshere.
-  `;
-
-  legend: Legend | undefined;
   panelExpanded: boolean = true;
-
-  constructor(private mapService: MapService) {}
-
-  ngOnInit(): void {
-    this.mapService
-      .getColormap('viridis') // TODO(leehana): replace once colormaps are finalized
-      .pipe(take(1))
-      .subscribe((colormapConfig) => {
-        this.legend = colormapConfigToLegend(colormapConfig);
-      });
-  }
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -8,7 +8,7 @@ import {
   transition,
   trigger,
 } from '@angular/animations';
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import {
   colorTransitionTrigger,
@@ -70,6 +70,7 @@ import { Plan } from 'src/app/types';
 export class CreateScenariosComponent {
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
   @Input() planningStep: number = 1;
+  @Output() changeConditionEvent = new EventEmitter<string>();
 
   panelExpanded: boolean = true;
 }

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -48,6 +48,8 @@
         Priorities
       </mat-header-cell>
       <mat-cell *matCellDef="let element">
+        <span class="indent-level-{{ element.level }}"></span>
+        <button mat-icon-button *ngIf="element.children.length" (click)="toggleExpand(element)"><mat-icon>expand_more</mat-icon></button>
         {{ element.conditionName }}
       </mat-cell>
     </ng-container>
@@ -62,6 +64,6 @@
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;" [class.hide-row]="row.hidden"></mat-row>
   </mat-table>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -1,1 +1,57 @@
-<p>set-priorities works!</p>
+<div class="panel-container">
+  <h1>Set priorities</h1>
+  <div>
+    <mat-form-field appearance="fill">
+      <mat-label>
+        Generate scenarios using:
+      </mat-label>
+      <mat-select>
+        <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
+        <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+  <p>{{ text1 }}</p>
+  <mat-table [dataSource]="datasource" class="priority-table">
+    <ng-container matColumnDef="selected">
+      <mat-header-cell *matHeaderCellDef>
+        Select
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        <mat-checkbox name="${element.conditionName}-selected" [(ngModel)]="element.selected"></mat-checkbox>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="visible">
+      <mat-header-cell *matHeaderCellDef></mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        <button mat-icon-button>
+          <mat-icon class="material-symbols-outlined" (click)="element.visible = !element.visible">
+            {{ element.visible ? 'visibility' : 'visibility_off' }}
+          </mat-icon>
+        </button>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="conditionName">
+      <mat-header-cell *matHeaderCellDef>
+        Priorities
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        {{ element.conditionName }}
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="score">
+      <mat-header-cell *matHeaderCellDef>
+        Condition score
+      </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        {{ element.score }}
+      </mat-cell>
+    </ng-container>
+
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+  </mat-table>
+</div>

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -26,7 +26,7 @@
       <mat-header-cell *matHeaderCellDef></mat-header-cell>
       <mat-cell *matCellDef="let element">
         <button mat-icon-button>
-          <mat-icon class="material-symbols-outlined" (click)="element.visible = !element.visible">
+          <mat-icon class="material-symbols-outlined" (click)="toggleVisibility(element)">
             {{ element.visible ? 'visibility' : 'visibility_off' }}
           </mat-icon>
         </button>

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -1,0 +1,1 @@
+<p>set-priorities works!</p>

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -1,5 +1,15 @@
 <div class="panel-container">
-  <h1>Set priorities</h1>
+  <div class="flex-row-space-between">
+    <h1>Set priorities</h1>
+    <mat-chip-list>
+      <mat-chip>
+        <mat-chip-avatar>
+          <mat-icon class="material-symbols-outlined">info</mat-icon>
+        </mat-chip-avatar>
+        Required
+      </mat-chip>
+    </mat-chip-list>
+  </div>
   <div>
     <mat-form-field appearance="fill">
       <mat-label>

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
@@ -5,6 +5,11 @@
   height: 100%;
 }
 
+.flex-row-space-between {
+  display: flex;
+  justify-content: space-between;
+}
+
 .priority-table {
   overflow-y: auto;
 }

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
@@ -1,0 +1,29 @@
+.panel-container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  height: 100%;
+}
+
+.priority-table {
+  overflow-y: auto;
+}
+
+.mat-column-selected {
+  flex: 0 0 auto;
+  width: 36px;
+}
+
+.mat-column-visible {
+  flex: 0 0 auto;
+  width: 48px;
+}
+
+.mat-column-conditionName {
+  flex: 2 0 auto;
+}
+
+.mat-column-score {
+  flex: 0 0 auto;
+  width: 120px;
+}

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
@@ -25,10 +25,27 @@
 }
 
 .mat-column-conditionName {
+  box-sizing: border-box;
   flex: 2 0 auto;
+  padding-right: 24px;
+  width: 344px;
 }
 
 .mat-column-score {
   flex: 0 0 auto;
   width: 120px;
+}
+
+.indent-level-1 {
+  flex: 0 0 auto;
+  width: 24px;
+}
+
+.indent-level-2 {
+  flex: 0 0 auto;
+  width: 88px;
+}
+
+.hide-row {
+  display: none;
 }

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -1,16 +1,53 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
 
+import { MapService } from './../../../services/map.service';
+import { ConditionsConfig } from './../../../types/data.types';
 import { SetPrioritiesComponent } from './set-priorities.component';
 
 describe('SetPrioritiesComponent', () => {
   let component: SetPrioritiesComponent;
   let fixture: ComponentFixture<SetPrioritiesComponent>;
 
+  let fakeMapService: MapService;
+
   beforeEach(async () => {
+    fakeMapService = jasmine.createSpyObj<MapService>(
+      'MapService',
+      {},
+      {
+        conditionsConfig$: new BehaviorSubject<ConditionsConfig | null>({
+          pillars: [
+            {
+              pillar_name: 'test_pillar_1',
+              filepath: 'test_pillar_1',
+              display: true,
+              elements: [
+                {
+                  element_name: 'test_element_1',
+                  filepath: 'test_element_1',
+                  metrics: [
+                    {
+                      metric_name: 'test_metric_1',
+                      filepath: 'test_metric_1',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      }
+    );
     await TestBed.configureTestingModule({
-      declarations: [ SetPrioritiesComponent ]
-    })
-    .compileComponents();
+      declarations: [SetPrioritiesComponent],
+      providers: [
+        {
+          provide: MapService,
+          useValue: fakeMapService,
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SetPrioritiesComponent);
     component = fixture.componentInstance;
@@ -19,5 +56,83 @@ describe('SetPrioritiesComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should populate datasource', () => {
+    const metric = {
+      conditionName: 'test_metric_1',
+      filepath: 'test_metric_1',
+      score: 0,
+      children: [],
+      level: 2,
+    };
+    const element = {
+      conditionName: 'test_element_1',
+      filepath: 'test_element_1',
+      score: 0,
+      children: [metric],
+      level: 1,
+      expanded: true,
+    };
+    const pillar = {
+      conditionName: 'test_pillar_1',
+      filepath: 'test_pillar_1',
+      score: 0,
+      children: [element],
+      level: 0,
+      expanded: true,
+    };
+    expect(component.datasource.data).toEqual([pillar, element, metric]);
+  });
+
+  it('should only have 1 condition visible at a time', () => {
+    expect(
+      component.datasource.data.find((element) => element.visible)
+    ).toBeUndefined();
+
+    component.toggleVisibility(component.datasource.data[1]);
+
+    expect(component.datasource.data[1].visible).toBeTrue();
+    expect(
+      component.datasource.data.filter((element) => element.visible).length
+    ).toEqual(1);
+
+    component.toggleVisibility(component.datasource.data[2]);
+
+    expect(component.datasource.data[2].visible).toBeTrue();
+    expect(
+      component.datasource.data.filter((element) => element.visible).length
+    ).toEqual(1);
+  });
+
+  it('no rows should be hidden at first', () => {
+    expect(
+      component.datasource.data.find((element) => element.hidden)
+    ).toBeUndefined();
+  });
+
+  it('collapsing a row should hide all of its descendants', () => {
+    component.toggleExpand(component.datasource.data[0]);
+
+    expect(component.datasource.data[0].expanded).toBeFalse();
+    component.datasource.data[0].children.forEach((child) => {
+      expect(child.hidden).toBeTrue();
+      child.children.forEach((grandchild) => {
+        expect(grandchild.hidden).toBeTrue();
+      });
+    });
+  });
+
+  it('expanding a row should unhide its immediate children', () => {
+    component.toggleExpand(component.datasource.data[0]);
+    component.toggleExpand(component.datasource.data[0]);
+
+    expect(component.datasource.data[0].expanded).toBeTrue();
+    component.datasource.data[0].children.forEach((child) => {
+      expect(child.hidden).toBeFalse();
+      child.children.forEach((grandchild) => {
+        expect(grandchild.hidden).toBeTrue();
+      });
+    });
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SetPrioritiesComponent } from './set-priorities.component';
+
+describe('SetPrioritiesComponent', () => {
+  let component: SetPrioritiesComponent;
+  let fixture: ComponentFixture<SetPrioritiesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SetPrioritiesComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SetPrioritiesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -57,46 +57,48 @@ export class SetPrioritiesComponent implements OnInit {
 
   conditionsConfigToPriorityData(config: ConditionsConfig): PriorityRow[] {
     let data: PriorityRow[] = [];
-    config.pillars?.forEach((pillar) => {
-      let pillarRow: PriorityRow = {
-        conditionName: pillar.display_name
-          ? pillar.display_name
-          : pillar.pillar_name!,
-        filepath: pillar.filepath!,
-        score: 0,
-        children: [],
-        level: 0,
-        expanded: true,
-      };
-      data.push(pillarRow);
-      pillar.elements?.forEach((element) => {
-        let elementRow: PriorityRow = {
-          conditionName: element.display_name
-            ? element.display_name
-            : element.element_name!,
-          filepath: element.filepath!,
+    config.pillars
+      ?.filter((pillar) => pillar.display)
+      .forEach((pillar) => {
+        let pillarRow: PriorityRow = {
+          conditionName: pillar.display_name
+            ? pillar.display_name
+            : pillar.pillar_name!,
+          filepath: pillar.filepath!,
           score: 0,
           children: [],
-          level: 1,
+          level: 0,
           expanded: true,
         };
-        data.push(elementRow);
-        pillarRow.children.push(elementRow);
-        element.metrics?.forEach((metric) => {
-          let metricRow: PriorityRow = {
-            conditionName: metric.display_name
-              ? metric.display_name
-              : metric.metric_name!,
-            filepath: metric.filepath!,
+        data.push(pillarRow);
+        pillar.elements?.forEach((element) => {
+          let elementRow: PriorityRow = {
+            conditionName: element.display_name
+              ? element.display_name
+              : element.element_name!,
+            filepath: element.filepath!,
             score: 0,
             children: [],
-            level: 2,
+            level: 1,
+            expanded: true,
           };
-          data.push(metricRow);
-          elementRow.children.push(metricRow);
+          data.push(elementRow);
+          pillarRow.children.push(elementRow);
+          element.metrics?.forEach((metric) => {
+            let metricRow: PriorityRow = {
+              conditionName: metric.display_name
+                ? metric.display_name
+                : metric.metric_name!,
+              filepath: metric.filepath!,
+              score: 0,
+              children: [],
+              level: 2,
+            };
+            data.push(metricRow);
+            elementRow.children.push(metricRow);
+          });
         });
       });
-    });
     return data;
   }
 

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -1,15 +1,82 @@
+import { filter } from 'rxjs/operators';
+import { MatTableDataSource } from '@angular/material/table';
+import { take } from 'rxjs';
+import { ConditionsConfig } from './../../../types/data.types';
+import { MapService } from './../../../services/map.service';
 import { Component, OnInit } from '@angular/core';
+
+interface PriorityRow {
+  selected?: boolean;
+  visible?: boolean;
+  conditionName: string;
+  score: number;
+  children: PriorityRow[];
+}
 
 @Component({
   selector: 'app-set-priorities',
   templateUrl: './set-priorities.component.html',
-  styleUrls: ['./set-priorities.component.scss']
+  styleUrls: ['./set-priorities.component.scss'],
 })
 export class SetPrioritiesComponent implements OnInit {
+  readonly text1: string = `
+    Condition scores represent the condition of each priority within the defined planning area.
+    Select at least one priority to create scenarios. Note: Choosing more than 5 may dilute
+    the data.
+  `;
 
-  constructor() { }
+  displayedColumns: string[] = [
+    'selected',
+    'visible',
+    'conditionName',
+    'score'
+  ];
+  datasource = new MatTableDataSource<PriorityRow>();
+
+  constructor(private mapService: MapService) {}
 
   ngOnInit(): void {
+    this.mapService.conditionsConfig$
+      .pipe(
+        filter((result) => !!result),
+        take(1)
+      )
+      .subscribe((conditionsConfig) => {
+        this.datasource.data = this.conditionsConfigToPriorityData(
+          conditionsConfig!
+        );
+      });
   }
 
+  conditionsConfigToPriorityData(config: ConditionsConfig): PriorityRow[] {
+    let data: PriorityRow[] = [];
+    config.pillars?.forEach((pillar) => {
+      data.push({
+        conditionName: pillar.display_name
+          ? pillar.display_name
+          : pillar.pillar_name!,
+        score: 0,
+        children: [],
+      });
+      pillar.elements?.forEach((element) => {
+        data.push({
+          conditionName: element.display_name
+            ? element.display_name
+            : element.element_name!,
+          score: 0,
+          children: [],
+        });
+        element.metrics?.forEach((metric) => {
+          data.push({
+            conditionName: metric.display_name
+              ? metric.display_name
+              : metric.metric_name!,
+            score: 0,
+            children: [],
+          });
+        });
+      });
+    });
+    return data;
+  }
 }

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-set-priorities',
+  templateUrl: './set-priorities.component.html',
+  styleUrls: ['./set-priorities.component.scss']
+})
+export class SetPrioritiesComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.html
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.html
@@ -2,6 +2,7 @@
   <mat-divider></mat-divider>
   <div class="button-row">
     <button mat-button>RESET</button>
-    <button mat-button>NEXT</button>
+    <button mat-button (click)="previousEvent.emit()">PREVIOUS</button>
+    <button mat-button color="primary" (click)="nextEvent.emit()">NEXT</button>
   </div>
 </div>

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.ts
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.ts
@@ -1,8 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-plan-bottom-bar',
   templateUrl: './plan-bottom-bar.component.html',
   styleUrls: ['./plan-bottom-bar.component.scss'],
 })
-export class PlanBottomBarComponent {}
+export class PlanBottomBarComponent {
+  @Output() nextEvent = new EventEmitter<void>();
+  @Output() previousEvent = new EventEmitter<void>();
+}

--- a/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
@@ -64,6 +64,14 @@ describe('PlanMapComponent', () => {
     expect(foundPlanningAreaLayer).toBeTrue();
   });
 
+  it('should add tile layer to map', () => {
+    expect(component.tileLayer).toBeUndefined();
+
+    component.setCondition('filepath');
+
+    expect(component.tileLayer).toBeDefined();
+  });
+
   describe('expand map button', () => {
     it('should navigate to map view when clicked'),
       async () => {

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -5,6 +5,8 @@ import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { Plan } from 'src/app/types';
 
+import { BackendConstants } from './../../backend-constants';
+
 @Component({
   selector: 'app-plan-map',
   templateUrl: './plan-map.component.html',
@@ -17,6 +19,7 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   map!: L.Map;
   drawingLayer: L.GeoJSON | undefined;
+  tileLayer: L.TileLayer.WMS | undefined;
 
   constructor(private router: Router) {}
 
@@ -80,6 +83,27 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
     this.map.remove();
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  setCondition(filepath: string): void {
+    if (filepath?.length === 0 || !filepath) return;
+    filepath = filepath.substring(filepath.lastIndexOf('/') + 1) + '.tif';
+
+    this.tileLayer?.remove();
+
+    this.tileLayer = L.tileLayer.wms(
+      BackendConstants.END_POINT + '/conditions/wms',
+      {
+        crs: L.CRS.EPSG4326,
+        minZoom: 7,
+        maxZoom: 15,
+        format: 'image/png',
+        opacity: 0.7,
+        layers: filepath,
+      }
+    );
+
+    this.map.addLayer(this.tileLayer);
   }
 
   expandMap() {

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -16,11 +16,11 @@
             <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'"></app-plan-map>
           </div>
           <div class="plan-content-panel">
-            <app-create-scenarios [plan$]="currentPlan$" *ngIf="currentPlanStep === 1"></app-create-scenarios>
+            <app-create-scenarios [plan$]="currentPlan$" [planningStep]="currentPlanStep"></app-create-scenarios>
           </div>
         </ng-container>
       </div>
-      <app-plan-bottom-bar (nextEvent)="nextStep()" *ngIf="currentPlanStep > 0"></app-plan-bottom-bar>
+      <app-plan-bottom-bar (nextEvent)="nextStep()" (previousEvent)="previousStep()" *ngIf="currentPlanStep > 0"></app-plan-bottom-bar>
     </div>
   </ng-container>
 </div>

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -16,7 +16,7 @@
             <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'"></app-plan-map>
           </div>
           <div class="plan-content-panel">
-            <app-create-scenarios [plan$]="currentPlan$" [planningStep]="currentPlanStep"></app-create-scenarios>
+            <app-create-scenarios [plan$]="currentPlan$" [planningStep]="currentPlanStep" (changeConditionEvent)="changeCondition($event)"></app-create-scenarios>
           </div>
         </ng-container>
       </div>

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -20,7 +20,7 @@
           </div>
         </ng-container>
       </div>
-      <app-plan-bottom-bar *ngIf="currentPlanStep > 0"></app-plan-bottom-bar>
+      <app-plan-bottom-bar (nextEvent)="nextStep()" *ngIf="currentPlanStep > 0"></app-plan-bottom-bar>
     </div>
   </ng-container>
 </div>

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -88,6 +88,20 @@ describe('PlanComponent', () => {
     expect(component.currentPlanStep).toBe(0);
   });
 
+  it('nextStep should increment currentPlanStep', () => {
+    component.nextStep();
+
+    expect(component.currentPlanStep).toBe(1);
+  });
+
+  it('previousStep should decrement currentPlanStep', () => {
+    component.nextStep();
+    component.nextStep();
+    component.previousStep();
+
+    expect(component.currentPlanStep).toBe(1);
+  });
+
   it('fetches plan from service using ID', () => {
     expect(component.planNotFound).toBeFalse();
     expect(component.plan).toEqual(fakePlan);

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -22,7 +22,7 @@ export class PlanComponent {
 
   plan: Plan | undefined;
   currentPlan$ = new BehaviorSubject<Plan | null>(null);
-  currentPlanStep: PlanStep = PlanStep.SetPriorities;
+  currentPlanStep: PlanStep = PlanStep.Overview;
   planNotFound: boolean = false;
 
   constructor(private planService: PlanService, private route: ActivatedRoute) {

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { BehaviorSubject, take } from 'rxjs';
 
 import { Plan } from '../types';
 import { PlanService } from './../services/plan.service';
+import { PlanMapComponent } from './plan-map/plan-map.component';
 
 export enum PlanStep {
   Overview,
@@ -17,9 +18,11 @@ export enum PlanStep {
   styleUrls: ['./plan.component.scss'],
 })
 export class PlanComponent {
+  @ViewChild(PlanMapComponent) map!: PlanMapComponent;
+
   plan: Plan | undefined;
   currentPlan$ = new BehaviorSubject<Plan | null>(null);
-  currentPlanStep: PlanStep = PlanStep.Overview;
+  currentPlanStep: PlanStep = PlanStep.SetPriorities;
   planNotFound: boolean = false;
 
   constructor(private planService: PlanService, private route: ActivatedRoute) {
@@ -50,5 +53,9 @@ export class PlanComponent {
 
   previousStep(): void {
     this.currentPlanStep -= 1;
+  }
+
+  changeCondition(filepath: string): void {
+    this.map.setCondition(filepath);
   }
 }

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -8,6 +8,7 @@ import { PlanService } from './../services/plan.service';
 export enum PlanStep {
   Overview,
   CreateScenarios,
+  SetPriorities,
 }
 
 @Component({
@@ -41,5 +42,13 @@ export class PlanComponent {
           this.planNotFound = true;
         }
       );
+  }
+
+  nextStep(): void {
+    this.currentPlanStep += 1;
+  }
+
+  previousStep(): void {
+    this.currentPlanStep -= 1;
   }
 }

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -5,7 +5,9 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from 'src/app/material/material.module';
 
 import { SharedModule } from './../shared/shared.module';
+import { CreateScenariosIntroComponent } from './create-scenarios/create-scenarios-intro/create-scenarios-intro.component';
 import { CreateScenariosComponent } from './create-scenarios/create-scenarios.component';
+import { SetPrioritiesComponent } from './create-scenarios/set-priorities/set-priorities.component';
 import { PlanBottomBarComponent } from './plan-bottom-bar/plan-bottom-bar.component';
 import { PlanMapComponent } from './plan-map/plan-map.component';
 import { PlanOverviewComponent } from './plan-summary/plan-overview/plan-overview.component';
@@ -33,6 +35,8 @@ import { ProgressPanelComponent } from './progress-panel/progress-panel.componen
     PlanOverviewComponent,
     CreateScenariosComponent,
     PlanBottomBarComponent,
+    SetPrioritiesComponent,
+    CreateScenariosIntroComponent,
   ],
   imports: [
     BrowserAnimationsModule,


### PR DESCRIPTION
## Changes
- "Set priorities" panel as step 2 in the planning flow
- This panel (and the new create scenarios intro panel from #316 ) are now rendered within the expand/collapse panel, so that animation doesn't have to be applied individually to each screen.
- Toggling on visibility for a condition score renders the raster on the map view
- Condition scores can be selected, although this doesn't do anything yet
- In general, UI elements are non-functional and do not send anything to the backend, although the data displayed is *fetched* from the backend
- Fixes #216 and #259 and #227 (for now)
- Unit tests

![image](https://user-images.githubusercontent.com/10444733/212440207-8d998193-3ada-4198-8938-1fea97fac09e.png)

## Todos
- Selecting a pillar or element should deselect all of its descendants, and vice versa.
- Descendants of a selected row should be greyed out (but still selectable).
- Condition scores for the planning area should populate from the backend (blocked on #315 )
- Plan progress panel (far left) should update as the user progresses through screens
- The user should be prevented from proceeding ("NEXT" button is disabled) until they've chosen at least one priority