### PR TITLE
Minor fixes to set priorities view

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -68,7 +68,7 @@ describe('SetPrioritiesComponent', () => {
     };
     const element = {
       conditionName: 'test_element_1',
-      filepath: 'test_element_1',
+      filepath: 'test_element_1_normalized',
       score: 0,
       children: [metric],
       level: 1,
@@ -76,7 +76,7 @@ describe('SetPrioritiesComponent', () => {
     };
     const pillar = {
       conditionName: 'test_pillar_1',
-      filepath: 'test_pillar_1',
+      filepath: 'test_pillar_1_normalized',
       score: 0,
       children: [element],
       level: 0,

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -64,7 +64,7 @@ export class SetPrioritiesComponent implements OnInit {
           conditionName: pillar.display_name
             ? pillar.display_name
             : pillar.pillar_name!,
-          filepath: pillar.filepath!,
+          filepath: pillar.filepath!.concat('_normalized'),
           score: 0,
           children: [],
           level: 0,
@@ -76,7 +76,7 @@ export class SetPrioritiesComponent implements OnInit {
             conditionName: element.display_name
               ? element.display_name
               : element.element_name!,
-            filepath: element.filepath!,
+            filepath: element.filepath!.concat('_normalized'),
             score: 0,
             children: [],
             level: 1,
@@ -129,6 +129,8 @@ export class SetPrioritiesComponent implements OnInit {
           priorityRow.visible = false;
         }
       });
+    } else {
+      this.changeConditionEvent.emit('');
     }
   }
 }

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -19,7 +19,7 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   map!: L.Map;
   drawingLayer: L.GeoJSON | undefined;
-  tileLayer: L.TileLayer.WMS | undefined;
+  tileLayer: L.TileLayer | undefined;
 
   constructor(private router: Router) {}
 
@@ -85,21 +85,19 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
     this.destroy$.complete();
   }
 
+  /** Display rendered tiles for the provided condition filepath (or, if the filepath
+   *  string is empty, remove rendered tiles). */
   setCondition(filepath: string): void {
-    if (filepath?.length === 0 || !filepath) return;
-    filepath = filepath.substring(filepath.lastIndexOf('/') + 1) + '.tif';
-
     this.tileLayer?.remove();
 
-    this.tileLayer = L.tileLayer.wms(
-      BackendConstants.END_POINT + '/conditions/wms',
+    if (filepath?.length === 0 || !filepath) return;
+
+    this.tileLayer = L.tileLayer(
+      BackendConstants.TILES_END_POINT + filepath + '/{z}/{x}/{y}.png',
       {
-        crs: L.CRS.EPSG4326,
         minZoom: 7,
-        maxZoom: 15,
-        format: 'image/png',
+        maxZoom: 13,
         opacity: 0.7,
-        layers: filepath,
       }
     );
 


### PR DESCRIPTION
- Deselecting a layer (by clicking the eye icon) removes it from the map view
- Show normalized rasters for pillar and element scores (since non-normalized aren't available)