### PR TITLE
Tweak style for boundary shapes

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -573,17 +573,13 @@ export class MapManager {
   private boundaryLayer(boundary: GeoJSON.GeoJSON): L.Layer {
     const normalStyle: L.PathOptions = {
       weight: 1,
-      opacity: 0.2,
       color: '#0000ff',
-      fillOpacity: 0.2,
-      fillColor: '#0000ff',
+      fillOpacity: 0,
     };
     const hoverStyle: L.PathOptions = {
-      weight: 3,
-      opacity: 0.5,
+      weight: 5,
       color: '#0000ff',
-      fillOpacity: 0.5,
-      fillColor: '#0000ff',
+      fillOpacity: 0,
     };
     return L.geoJSON(boundary, {
       style: normalStyle,
@@ -634,7 +630,7 @@ export class MapManager {
       {
         minZoom: 7,
         maxZoom: 13,
-        opacity: 0.7
+        opacity: 0.7,
       }
     );
 


### PR DESCRIPTION
Fix #310 by removing the polygon fill color and increasing the stroke width for the hover style.

![image](https://user-images.githubusercontent.com/10444733/213036062-70657aef-a8bb-4bde-9858-f28126751351.png)
