### PR TITLE
More popup fixes

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -183,6 +183,11 @@ export class MapManager {
     if (map.config.showExistingProjectsLayer) {
       map.instance?.addLayer(map.existingProjectsLayerRef);
     }
+
+    // When the existing projects layer is removed, close any popups.
+    map.existingProjectsLayerRef.addEventListener('remove', (_) => {
+      map.instance?.closePopup();
+    });
   }
 
   private setUpEventHandlers(

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -60,7 +60,10 @@ export class MapManager {
     map: Map,
     mapId: string,
     existingProjectsGeoJson$: BehaviorSubject<GeoJSON.GeoJSON | null>,
-    createDetailCardCallback: (features: Feature<Geometry, any>[]) => any,
+    createDetailCardCallback: (
+      features: Feature<Geometry, any>[],
+      onInitialized: () => void
+    ) => any,
     getBoundaryLayerGeoJsonCallback: (
       boundaryName: string
     ) => Observable<GeoJSON.GeoJSON>
@@ -192,7 +195,10 @@ export class MapManager {
 
   private setUpEventHandlers(
     map: Map,
-    createDetailCardCallback: (features: Feature<Geometry, any>[]) => any
+    createDetailCardCallback: (
+      features: Feature<Geometry, any>[],
+      onInitialized: () => void
+    ) => any
   ) {
     this.setUpDrawingHandlers(map.instance!);
     this.setUpClickHandler(map, createDetailCardCallback);
@@ -358,7 +364,10 @@ export class MapManager {
 
   private setUpClickHandler(
     map: Map,
-    createDetailCardCallback: (features: Feature<Geometry, any>[]) => any
+    createDetailCardCallback: (
+      features: Feature<Geometry, any>[],
+      onInitialized: () => void
+    ) => any
   ) {
     map.instance!.on('click', (e) => {
       if (!e.latlng) return;
@@ -392,16 +401,22 @@ export class MapManager {
       if (intersectingFeatureLayers.length === 0) return;
 
       // Open detail card with all the features present at the clicked point
-      map.instance!.openPopup(
-        createDetailCardCallback(
-          intersectingFeatureLayers
-            .map((featureLayer) => {
-              return (featureLayer as L.Polygon).feature;
-            })
-            .filter((feature) => !!feature) as Feature<Geometry, any>[]
-        ),
-        e.latlng
-      );
+      const popup: L.Popup = L.popup()
+        .setContent(
+          createDetailCardCallback(
+            intersectingFeatureLayers
+              .map((featureLayer) => {
+                return (featureLayer as L.Polygon).feature;
+              })
+              .filter((feature) => !!feature) as Feature<Geometry, any>[],
+            () => {
+              // After popup content is initialized, update its position and open it.
+              popup.update();
+              popup.openOn(map.instance!);
+            }
+          )
+        )
+        .setLatLng(e.latlng);
     });
   }
 

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -768,57 +768,70 @@ describe('MapComponent', () => {
       spyOn(applicationRef, 'attachView').and.callThrough;
 
       component.ngAfterViewInit();
+    });
 
-      // Add a polygon to map 3
-      const fakeGeometry: GeoJSON.Geometry = {
-        type: 'Polygon',
-        coordinates: [
-          [
-            [0, 0],
-            [1, 1],
+    describe('popup triggering', () => {
+      beforeEach(() => {
+        // Add a polygon to map 3
+        const fakeGeometry: GeoJSON.Geometry = {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 0],
+              [1, 1],
+            ],
           ],
-        ],
-      };
-      const feature: GeoJSON.Feature<GeoJSON.Polygon, any> = {
-        type: 'Feature',
-        geometry: fakeGeometry,
-        properties: {
-          PROJECT_NAME: 'test_project',
-        },
-      };
-      component.maps[3].existingProjectsLayerRef = L.geoJSON(feature);
-      component.maps[3].existingProjectsLayerRef.addTo(
-        component.maps[3].instance!
-      );
-    });
-
-    it('attaches popup when feature polygon is clicked', () => {
-      // Click on the polygon
-      component.maps[3].instance?.fireEvent('click', {
-        latlng: [0, 0],
+        };
+        const feature: GeoJSON.Feature<GeoJSON.Polygon, any> = {
+          type: 'Feature',
+          geometry: fakeGeometry,
+          properties: {
+            PROJECT_NAME: 'test_project',
+          },
+        };
+        component.maps[3].existingProjectsLayerRef = L.geoJSON(feature);
+        component.maps[3].existingProjectsLayerRef.addTo(
+          component.maps[3].instance!
+        );
       });
 
-      expect(applicationRef.attachView).toHaveBeenCalledTimes(1);
-    });
+      it('attaches popup when feature polygon is clicked', () => {
+        // Click on the polygon
+        component.maps[3].instance?.fireEvent('click', {
+          latlng: [0, 0],
+        });
 
-    it('does not attach popup when map is clicked outside the polygon', () => {
-      // Click outside the polygon
-      component.maps[3].instance?.fireEvent('click', {
-        latlng: [2, 2],
+        expect(applicationRef.attachView).toHaveBeenCalledTimes(1);
       });
 
-      expect(applicationRef.attachView).toHaveBeenCalledTimes(0);
-    });
+      it('does not attach popup when map is clicked outside the polygon', () => {
+        // Click outside the polygon
+        component.maps[3].instance?.fireEvent('click', {
+          latlng: [2, 2],
+        });
 
-    it('does not attach popup if drawing mode is active', () => {
-      component.mapManager.isInDrawingMode = true;
-
-      // Click on the polygon
-      component.maps[3].instance?.fireEvent('click', {
-        latlng: [0, 0],
+        expect(applicationRef.attachView).toHaveBeenCalledTimes(0);
       });
 
-      expect(applicationRef.attachView).toHaveBeenCalledTimes(0);
+      it('does not attach popup if drawing mode is active', () => {
+        component.mapManager.isInDrawingMode = true;
+
+        // Click on the polygon
+        component.maps[3].instance?.fireEvent('click', {
+          latlng: [0, 0],
+        });
+
+        expect(applicationRef.attachView).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    it('popup is removed when existing project layer is removed', () => {
+      spyOn(component.maps[3].instance!, 'closePopup');
+
+      component.maps[3].instance?.openPopup('test', [0, 0]);
+      component.maps[3].existingProjectsLayerRef?.fire('remove');
+
+      expect(component.maps[3].instance?.closePopup).toHaveBeenCalled();
     });
   });
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -324,10 +324,14 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     this.loadingIndicators[layerName] = false;
   }
 
-  private createDetailCardCallback(features: Feature<Geometry, any>[]): any {
+  private createDetailCardCallback(
+    features: Feature<Geometry, any>[],
+    onInitialized: () => void
+  ): any {
     let component = createComponent(ProjectCardComponent, {
       environmentInjector: this.environmentInjector,
     });
+    component.instance.initializedEvent.subscribe((_) => onInitialized());
     component.instance.features = features;
     this.applicationRef.attachView(component.hostView);
     return component.location.nativeElement;

--- a/src/interface/src/app/map/project-card/project-card.component.ts
+++ b/src/interface/src/app/map/project-card/project-card.component.ts
@@ -1,4 +1,11 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { Feature, Geometry } from 'geojson';
 
 interface Project {
@@ -25,13 +32,18 @@ interface Treatment {
   templateUrl: './project-card.component.html',
   styleUrls: ['./project-card.component.scss'],
 })
-export class ProjectCardComponent implements OnInit {
+export class ProjectCardComponent implements AfterViewInit, OnInit {
   @Input() features!: Feature<Geometry, any>[];
+  @Output() initializedEvent = new EventEmitter<void>();
 
   projects!: Project[];
 
   ngOnInit() {
     this.projects = this.getProjects();
+  }
+
+  ngAfterViewInit(): void {
+    this.initializedEvent.emit();
   }
 
   isProject(feature: Feature<Geometry, any>): boolean {


### PR DESCRIPTION
## Changes
- Fix #349 by updating popup size/position after the content has initialized, so Leaflet's autopan will pan the map to show the entire popup.
- Fix #350 by removing popups when the project layer is removed.

## Demo
(Can't see the behavior without a video, but I clicked on a project at the very top of the map pane and the map autopanned to show the entire popup. This is the positioning right after the click.)
![image](https://user-images.githubusercontent.com/10444733/213324695-3acf5b1e-73ec-4bd4-b3cb-3b480285b32b.png)
