### PR TITLE
in 2-map view, show row containing selected map

### DIFF
--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -353,6 +353,26 @@ describe('MapComponent', () => {
       });
     });
 
+    it('row containing selected map height is 100% in 2-map view', () => {
+      component.mapViewOptions$.getValue().numVisibleMaps = 2;
+
+      [0, 1].forEach((selectedMapIndex: number) => {
+        component.mapViewOptions$.getValue().selectedMapIndex =
+          selectedMapIndex;
+
+        expect(component.mapRowHeight(0)).toEqual('100%');
+        expect(component.mapRowHeight(1)).toEqual('0%');
+      });
+
+      [2, 3].forEach((selectedMapIndex: number) => {
+        component.mapViewOptions$.getValue().selectedMapIndex =
+          selectedMapIndex;
+
+        expect(component.mapRowHeight(0)).toEqual('0%');
+        expect(component.mapRowHeight(1)).toEqual('100%');
+      });
+    });
+
     it('all row heights are 50% in 4-map view', () => {
       component.mapViewOptions$.getValue().numVisibleMaps = 4;
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -581,9 +581,13 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         return false;
       case 2:
       default:
-        // In 2 map view, only the 1st and 2nd map are shown regardless of selection
-        if (index === 0 || index === 1) {
-          // TODO: 2 map view might go away or the logic here might change
+        // In 2 map view, if the 1st or 2nd map are selected, show maps 1 and 2
+        // Otherwise, show maps 3 and 4
+        // TODO: 2 map view might go away or the logic here might change
+        if (
+          Math.floor(this.mapViewOptions$.getValue().selectedMapIndex / 2) ===
+          Math.floor(index / 2)
+        ) {
           return true;
         }
         return false;
@@ -599,9 +603,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       case 4:
         return '50%';
       case 2:
-        // In 2 map view, only the 1st and 2nd map are shown regardless of selection
-        // TODO: 2 map view might go away or the logic here might change
-        return index === 0 ? '100%' : '0%';
       case 1:
       default:
         if (

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -584,13 +584,10 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         // In 2 map view, if the 1st or 2nd map are selected, show maps 1 and 2
         // Otherwise, show maps 3 and 4
         // TODO: 2 map view might go away or the logic here might change
-        if (
+        return (
           Math.floor(this.mapViewOptions$.getValue().selectedMapIndex / 2) ===
           Math.floor(index / 2)
-        ) {
-          return true;
-        }
-        return false;
+        );
     }
   }
 


### PR DESCRIPTION
Fixes #353 by showing the row containing the selected map in 2-map view.

- If map 1 or 2 is selected, maps 1 and 2 are shown.
- If map 3 or 4 is selected, maps 3 and 4 are shown.

This fixes the issue.

![image](https://user-images.githubusercontent.com/10444733/213533229-5c006470-5049-4365-ad54-360e8f9c4b77.png)
