### PR TITLE
populate layer info card

### DIFF
--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
@@ -14,9 +14,13 @@
     </span>
   </p>
 
-  <p *ngIf="hasDataProvider()">
-    DATA: <a [href]="dataLayerConfig?.data_download_link" target="_blank">Download from {{dataLayerConfig?.data_provider}}</a>
-  </p>
+  <div *ngIf="hasDataProvider()">
+    <p>
+      PROVIDER: {{dataLayerConfig?.data_provider}}
+    <p>
+      DATA: <a [href]="dataLayerConfig?.data_download_link" target="_blank">Download</a>
+    </p>
+  </div>
 
-  <a mat-button *ngIf="hasReferenceLink()" [href]="dataLayerConfig?.reference_link" target="_blank">Learn more</a>
+  <a mat-raised-button color="primary" *ngIf="hasReferenceLink()" [href]="dataLayerConfig?.reference_link" target="_blank">Learn more</a>
 </div>

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
@@ -1,8 +1,22 @@
 <div class="layer-info-card">
   <h2>{{dataLayerConfig?.display_name}}</h2>
 
-  <p>Definition of what {{dataLayerConfig?.display_name}} means.</p>
-  <p>SOURCE: sourcename (link) date/year</p>
+  <p *ngIf="hasMinMax()">
+    VALUE RANGE: {{computeMinMax()}}
+  </p>
 
-  <button mat-button>Learn more</button>
+  <p>
+    <span *ngIf="hasSource()">
+      SOURCE: <a [href]="dataLayerConfig?.source_link" target="_blank">{{dataLayerConfig?.source}}</a>
+    </span>
+    <span *ngIf="hasYear()">
+      ({{dataLayerConfig?.data_year}})
+    </span>
+  </p>
+
+  <p *ngIf="hasDataProvider()">
+    DATA: <a [href]="dataLayerConfig?.data_download_link" target="_blank">Download from {{dataLayerConfig?.data_provider}}</a>
+  </p>
+
+  <a mat-button *ngIf="hasReferenceLink()" [href]="dataLayerConfig?.reference_link" target="_blank">Learn more</a>
 </div>

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
@@ -4,10 +4,45 @@ import { DataLayerConfig } from 'src/app/types';
 @Component({
   selector: 'app-layer-info-card',
   templateUrl: './layer-info-card.component.html',
-  styleUrls: ['./layer-info-card.component.scss']
+  styleUrls: ['./layer-info-card.component.scss'],
 })
 export class LayerInfoCardComponent {
-
   @Input() dataLayerConfig!: DataLayerConfig | null;
 
+  hasDataProvider(): boolean {
+    return (
+      !!this.dataLayerConfig?.data_provider &&
+      !!this.dataLayerConfig.data_download_link
+    );
+  }
+
+  hasMinMax(): boolean {
+    return (
+      this.dataLayerConfig?.min_value != undefined &&
+      this.dataLayerConfig?.max_value != undefined
+    );
+  }
+
+  hasReferenceLink(): boolean {
+    return !!this.dataLayerConfig?.reference_link;
+  }
+
+  hasSource(): boolean {
+    return !!this.dataLayerConfig?.source && !!this.dataLayerConfig.source_link;
+  }
+
+  hasYear(): boolean {
+    return !!this.dataLayerConfig?.data_year;
+  }
+
+  computeMinMax(): number[] {
+    if (this.dataLayerConfig?.normalized) {
+      return [-1, 1];
+    } else {
+      return [
+        this.dataLayerConfig?.min_value!,
+        this.dataLayerConfig?.max_value!,
+      ];
+    }
+  }
 }

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -10,7 +10,18 @@ export interface ConditionsConfig extends DataLayerConfig {
   pillars?: PillarConfig[];
 }
 
-export interface DataLayerConfig {
+export interface ConditionsMetadata {
+  data_download_link?: string;
+  data_provider?: string;
+  data_year?: string;
+  reference_link?: string;
+  source?: string;
+  source_link?: string;
+  min_value?: number;
+  max_value?: number;
+}
+
+export interface DataLayerConfig extends ConditionsMetadata {
   display_name?: string;
   filepath?: string;
   colormap?: string;


### PR DESCRIPTION
Populates layer info card with currently available metadata for metrics. Metadata for elements and pillars is still missing (@riecke is working on this). Fixes #351 

![image](https://user-images.githubusercontent.com/10444733/213581977-78807047-3cbc-48f8-a9e0-c8802ae4775b.png)