### PR TITLE
center planning area in visible portion of map

### DIFF
--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -15,6 +15,8 @@ import { BackendConstants } from './../../backend-constants';
 export class PlanMapComponent implements AfterViewInit, OnDestroy {
   @Input() plan = new BehaviorSubject<Plan | null>(null);
   @Input() mapId?: string;
+  /** The amount of padding in the top left corner when the map fits the plan boundaries. */
+  @Input() mapPadding: L.PointTuple = [0, 0]; // [left, top]
 
   private readonly destroy$ = new Subject<void>();
   map!: L.Map;
@@ -37,7 +39,7 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
     this.map.attributionControl.setPosition('topright');
 
     // Add zoom controls to bottom right corner
-     const zoomControl = L.control.zoom({
+    const zoomControl = L.control.zoom({
       position: 'bottomright',
     });
     zoomControl.addTo(this.map);
@@ -71,7 +73,9 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
         weight: 3,
       },
     }).addTo(this.map);
-    this.map.fitBounds(this.drawingLayer.getBounds());
+    this.map.fitBounds(this.drawingLayer.getBounds(), {
+      paddingTopLeft: this.mapPadding,
+    });
   }
 
   /** Creates a basemap layer using the Stadia.AlidadeSmooth tiles. */

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -13,7 +13,7 @@
         <app-plan-overview [plan$]="currentPlan$" (createScenarioEvent)="currentPlanStep = 1" *ngIf="currentPlanStep === 0"></app-plan-overview>
         <ng-container *ngIf="currentPlanStep > 0">
           <div class="plan-map-container">
-            <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'"></app-plan-map>
+            <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'" [mapPadding]="[700, 0]"></app-plan-map>
           </div>
           <div class="plan-content-panel">
             <app-create-scenarios [plan$]="currentPlan$" [planningStep]="currentPlanStep" (changeConditionEvent)="changeCondition($event)"></app-create-scenarios>


### PR DESCRIPTION
Fixes #378 by applying padding to the `fitBounds` call in the plan map.

![image](https://user-images.githubusercontent.com/10444733/213586820-a7b1082c-7eb4-43a4-a007-98d416fea347.png)
