### PR TITLE
make tooltips follow the cursor

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -169,7 +169,10 @@ export class MapManager {
       style: normalStyle,
       onEachFeature: (feature: Feature<Geometry, any>, layer: L.Layer) => {
         layer.bindTooltip(
-          this.popupService.makeDetailsPopup(feature.properties.PROJECT_NAME)
+          this.popupService.makeDetailsPopup(feature.properties.PROJECT_NAME),
+          {
+            sticky: true,
+          }
         );
         // Exact type of layer (polygon or line) is not known
         if ((layer as any).setStyle) {
@@ -612,7 +615,10 @@ export class MapManager {
       style: normalStyle,
       onEachFeature: (feature, layer) => {
         layer.bindTooltip(
-          this.popupService.makeDetailsPopup(feature.properties.shape_name)
+          this.popupService.makeDetailsPopup(feature.properties.shape_name),
+          {
+            sticky: true,
+          }
         );
         // Exact type of layer (polygon or line) is not known
         if ((layer as any).setStyle) {


### PR DESCRIPTION
Fixes #368 by making tooltips sticky, so they follow the cursor as it moves over the map.

![image](https://user-images.githubusercontent.com/10444733/213587963-38353768-27d8-4dcc-9345-a11804579d34.png)
