### PR TITLE
Disable expand map button

### DIFF
--- a/src/interface/src/app/plan/plan-map/plan-map.component.html
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.html
@@ -1,2 +1,2 @@
 <div id="{{mapId ? mapId : 'map'}}" class="plan-map"></div>
-<button mat-raised-button class="expand-map-button" (click)="expandMap()">EXPAND MAP</button>
+<button mat-raised-button class="expand-map-button" disabled (click)="expandMap()">EXPAND MAP</button>


### PR DESCRIPTION
Disabled until we implement going to the map with the planning area shown.

<img width="277" alt="Screenshot 2023-01-20 at 12 01 53 PM" src="https://user-images.githubusercontent.com/114368235/213794999-f1a71606-75fb-412d-8f43-23e78a0cb670.png">
