### PR TITLE
find and select layer options based on restored session

### DIFF
--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -191,6 +191,12 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       .pipe(filter((config) => !!config))
       .subscribe((config) => {
         this.conditionDataSource.data = this.conditionsConfigToData(config!);
+        this.maps.forEach((map) => {
+          // Ensure the radio button corresponding to the saved selection is selected.
+          map.config.dataLayerConfig = this.findAndRevealNodeWithFilepath(
+            map.config.dataLayerConfig.filepath
+          );
+        });
       });
   }
 
@@ -247,9 +253,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
                   boundary.boundary_name ===
                   map.config.boundaryLayerConfig.boundary_name
               );
-              if (!!boundaryConfig) {
-                map.config.boundaryLayerConfig = boundaryConfig;
-              }
+              map.config.boundaryLayerConfig = boundaryConfig
+                ? boundaryConfig
+                : NONE_BOUNDARY_CONFIG;
             });
           });
       });
@@ -709,5 +715,46 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
           }),
       },
     ];
+  }
+
+  /** Find the node matching the given filepath in the condition tree (if any), and expand its ancestors
+   *  so it becomes visible.
+   */
+  private findAndRevealNodeWithFilepath(
+    filepath: string | undefined
+  ): ConditionsNode {
+    if (!filepath || filepath === NONE_DATA_LAYER_CONFIG.filepath)
+      return NONE_DATA_LAYER_CONFIG;
+    for (let tree of this.conditionDataSource.data) {
+      if (tree.filepath === filepath) return tree;
+      if (tree.children) {
+        for (let pillar of tree.children) {
+          if (pillar.filepath === filepath) {
+            this.conditionTreeControl.expand(tree);
+            return pillar;
+          }
+          if (pillar.children) {
+            for (let element of pillar.children) {
+              if (element.filepath === filepath) {
+                this.conditionTreeControl.expand(tree);
+                this.conditionTreeControl.expand(pillar);
+                return element;
+              }
+              if (element.children) {
+                for (let metric of element.children) {
+                  if (metric.filepath === filepath) {
+                    this.conditionTreeControl.expand(tree);
+                    this.conditionTreeControl.expand(pillar);
+                    this.conditionTreeControl.expand(element);
+                    return metric;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return NONE_DATA_LAYER_CONFIG;
   }
 }


### PR DESCRIPTION
Fixes #400 by finding and selecting the appropriate layer radio buttons based on restored session data. (Note that the original bug is only reproducible when the user's previous map config has been saved to localStorage and restored.)

Added QOL tweak: the condition tree automatically expands to reveal the selected node retrieved from storage.

![image](https://user-images.githubusercontent.com/10444733/214181129-f7f2f112-bd7e-44c6-afb9-48c17a776822.png)
