### PR TITLE
Fix Angular tests

### DIFF
--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -376,7 +376,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
           planningArea: shape,
         })
         .subscribe((result) => {
-          console.log(result);
           this.router.navigate(['plan', result.result!.id]);
         });
     });

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
@@ -8,7 +8,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ConstraintsPanelComponent } from './constraints-panel.component';
 import { MaterialModule } from 'src/app/material/material.module';
 
-fdescribe('ConstraintsPanelComponent', () => {
+describe('ConstraintsPanelComponent', () => {
   let component: ConstraintsPanelComponent;
   let fixture: ComponentFixture<ConstraintsPanelComponent>;
   let loader: HarnessLoader;

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -90,7 +90,6 @@ export class ConstraintsPanelComponent implements OnInit {
   ngOnInit(): void {
     // TODO: Save constraints when plan-bottom-bar's "next" is clicked
     this.constraintsForm.valueChanges.subscribe((formValue) => {
-      console.log({formValue});
       const currentBudget = formValue.budgetForm?.optimizeBudget
         ? {
             useMostOptimizedOutcome: true,

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
@@ -1,9 +1,12 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
 import { colormapConfigToLegend } from 'src/app/types';
 
 import { MapService } from './../../../services/map.service';
+import { SharedModule } from './../../../shared/shared.module';
 import { ColormapConfig } from './../../../types/legend.types';
 import { CreateScenariosIntroComponent } from './create-scenarios-intro.component';
 
@@ -27,7 +30,12 @@ describe('CreateScenariosIntroComponent', () => {
       getColormap: of(fakeColormapConfig),
     });
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+        MaterialModule,
+        SharedModule,
+      ],
       declarations: [CreateScenariosIntroComponent],
       providers: [{ provide: MapService, useValue: fakeMapService }],
     }).compileComponents();

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -1,6 +1,8 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { PlanModule } from '../plan.module';
 import { CreateScenariosComponent } from './create-scenarios.component';
 
 describe('CreateScenariosComponent', () => {
@@ -9,7 +11,7 @@ describe('CreateScenariosComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule],
+      imports: [BrowserAnimationsModule, HttpClientTestingModule, PlanModule],
       declarations: [CreateScenariosComponent],
     }).compileComponents();
 

--- a/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.spec.ts
+++ b/src/interface/src/app/plan/plan-bottom-bar/plan-bottom-bar.component.spec.ts
@@ -1,3 +1,4 @@
+import { MaterialModule } from 'src/app/material/material.module';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PlanBottomBarComponent } from './plan-bottom-bar.component';
@@ -8,6 +9,7 @@ describe('BottomBarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [ MaterialModule ],
       declarations: [ PlanBottomBarComponent ]
     })
     .compileComponents();

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -1,3 +1,4 @@
+import { MaterialModule } from 'src/app/material/material.module';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SavedScenariosComponent } from './saved-scenarios.component';
@@ -8,6 +9,7 @@ describe('SavedScenariosComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [MaterialModule],
       declarations: [SavedScenariosComponent],
     }).compileComponents();
 

--- a/src/interface/src/app/plan/plan-summary/unsaved-scenarios/unsaved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/unsaved-scenarios/unsaved-scenarios.component.spec.ts
@@ -1,3 +1,4 @@
+import { MaterialModule } from 'src/app/material/material.module';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { UnsavedScenariosComponent } from './unsaved-scenarios.component';
@@ -8,6 +9,7 @@ describe('UnsavedScenariosComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [ MaterialModule ],
       declarations: [ UnsavedScenariosComponent ]
     })
     .compileComponents();

--- a/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
+++ b/src/interface/src/app/plan/plan-table/plan-table.component.spec.ts
@@ -1,9 +1,9 @@
-import { DeletePlanDialogComponent } from './delete-plan-dialog/delete-plan-dialog.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
@@ -11,6 +11,7 @@ import { MaterialModule } from 'src/app/material/material.module';
 import { PlanPreview, Region } from 'src/app/types';
 
 import { PlanService } from './../../services/plan.service';
+import { DeletePlanDialogComponent } from './delete-plan-dialog/delete-plan-dialog.component';
 import { PlanTableComponent } from './plan-table.component';
 
 describe('PlanTableComponent', () => {
@@ -33,7 +34,12 @@ describe('PlanTableComponent', () => {
     });
 
     await TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, MaterialModule],
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        MaterialModule,
+        ReactiveFormsModule,
+      ],
       declarations: [PlanTableComponent],
       providers: [
         { provide: PlanService, useValue: fakeService },

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -8,10 +8,12 @@ import { Plan, Region } from 'src/app/types';
 import { MaterialModule } from '../material/material.module';
 import { PlanService } from './../services/plan.service';
 import { PlanMapComponent } from './plan-map/plan-map.component';
+import { PlanOverviewComponent } from './plan-summary/plan-overview/plan-overview.component';
 import { PlanComponent } from './plan.component';
+import { PlanModule } from './plan.module';
 import { ProgressPanelComponent } from './progress-panel/progress-panel.component';
 
-fdescribe('PlanComponent', () => {
+describe('PlanComponent', () => {
   let component: PlanComponent;
   let fixture: ComponentFixture<PlanComponent>;
 
@@ -66,9 +68,15 @@ fdescribe('PlanComponent', () => {
       imports: [
         HttpClientTestingModule,
         MaterialModule,
+        PlanModule,
         RouterTestingModule.withRoutes([]),
       ],
-      declarations: [PlanComponent, PlanMapComponent, ProgressPanelComponent],
+      declarations: [
+        PlanComponent,
+        PlanMapComponent,
+        PlanOverviewComponent,
+        ProgressPanelComponent,
+      ],
       providers: [
         { provide: ActivatedRoute, useValue: fakeRoute },
         { provide: PlanService, useValue: fakeService },

--- a/src/interface/src/app/plan/progress-panel/progress-panel.component.ts
+++ b/src/interface/src/app/plan/progress-panel/progress-panel.component.ts
@@ -154,7 +154,6 @@ export class ProgressPanelComponent implements OnChanges, AfterViewInit {
 
   /** Sets the current task and renders the corresponding view. */
   goToStep(node: ProgressFlatNode) {
-    console.log('clicked ' + node.name);
     this.currentTaskId = node.id;
   }
 

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -83,7 +83,6 @@ export class AuthGuard implements CanActivate {
     return this.authService.refreshToken().pipe(
       map((response: any) => response.access),
       catchError(err => {
-        console.log(err);
         return of(false);
       })
     );

--- a/src/interface/src/app/services/map.service.spec.ts
+++ b/src/interface/src/app/services/map.service.spec.ts
@@ -95,7 +95,7 @@ describe('MapService', () => {
       });
 
       const req = httpTestingController.expectOne(
-        BackendConstants.END_POINT + '/projects'
+        BackendConstants.END_POINT + '/projects/calmapper'
       );
       expect(req.request.method).toEqual('GET');
       req.flush(fakeGeoJsonText);

--- a/src/interface/src/app/shared/file-uploader/file-uploader.component.spec.ts
+++ b/src/interface/src/app/shared/file-uploader/file-uploader.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { MaterialModule } from 'src/app/material/material.module';
 
 import { FileUploaderComponent } from './file-uploader.component';
 
@@ -9,9 +10,9 @@ describe('FileUploaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FileUploaderComponent ]
-    })
-    .compileComponents();
+      imports: [MaterialModule],
+      declarations: [FileUploaderComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(FileUploaderComponent);
     component = fixture.componentInstance;
@@ -21,14 +22,14 @@ describe('FileUploaderComponent', () => {
   it('should update the file model when a file is loaded', () => {
     const fileList = new DataTransfer();
     fileList.items.add(new File([''], 'test-file.zip'));
-    const inputDebugEl  = fixture.debugElement.query(By.css('input[type=file]'));
+    const inputDebugEl = fixture.debugElement.query(By.css('input[type=file]'));
     inputDebugEl.nativeElement.files = fileList.files;
 
     inputDebugEl.nativeElement.dispatchEvent(new InputEvent('change'));
     fixture.detectChanges();
 
-    expect(component.file).toBeTruthy()
-    expect(component.fileName).toBe('test-file.zip')
+    expect(component.file).toBeTruthy();
+    expect(component.fileName).toBe('test-file.zip');
   });
 
   it('file upload event should emit the file', () => {
@@ -42,5 +43,5 @@ describe('FileUploaderComponent', () => {
 
     expect(component.onFileUploaded).toHaveBeenCalled();
     expect(component.fileEvent.emit).toHaveBeenCalled();
-});
+  });
 });


### PR DESCRIPTION
Some frontend tests were mistakenly set to `fdescribe` instead of `describe` which caused the `ng test` command to skip all other tests, which was hiding test errors. This change fixes all outstanding test errors and warnings (mostly caused by missing test imports), and removes extraneous logs that were cluttering test output.

No change to non-test code except removing console output.