### PR TITLE
Show avg condition scores for a planning area

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,7 +1,7 @@
 <div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
   <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
     <app-create-scenarios-intro *ngIf="planningStep === PlanStep.CreateScenarios"></app-create-scenarios-intro>
-    <app-set-priorities *ngIf="planningStep === PlanStep.SetPriorities" (changeConditionEvent)="changeConditionEvent.emit($event)"></app-set-priorities>
+    <app-set-priorities *ngIf="planningStep === PlanStep.SetPriorities" (changeConditionEvent)="changeConditionEvent.emit($event)" [plan$]="plan$"></app-set-priorities>
     <app-constraints-panel *ngIf="planningStep === PlanStep.SetConstraints" (changeConstraintsEvent)="changeConstraintsEvent.emit($event)"></app-constraints-panel>
   </div>
   <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded" [@expandCollapseButton]="panelExpanded ? 'colorA': 'colorB'">

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -43,14 +43,14 @@
       </mat-cell>
     </ng-container>
 
-    <ng-container matColumnDef="conditionName">
+    <ng-container matColumnDef="displayName">
       <mat-header-cell *matHeaderCellDef>
         Priorities
       </mat-header-cell>
       <mat-cell *matCellDef="let element">
         <span class="indent-level-{{ element.level }}"></span>
         <button mat-icon-button *ngIf="element.children.length" (click)="toggleExpand(element)"><mat-icon>expand_more</mat-icon></button>
-        {{ element.conditionName }}
+        {{ element.displayName ? element.displayName : element.conditionName }}
       </mat-cell>
     </ng-container>
 
@@ -59,7 +59,8 @@
         Condition score
       </mat-header-cell>
       <mat-cell *matCellDef="let element">
-        {{ element.score }}
+        <mat-spinner [diameter]="24" *ngIf="!conditionScores.has(element.conditionName)"></mat-spinner>
+        <div *ngIf="conditionScores.has(element.conditionName)">{{ conditionScores.get(element.conditionName) | number: '1.1-1' }}</div>
       </mat-cell>
     </ng-container>
 

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -60,7 +60,12 @@
       </mat-header-cell>
       <mat-cell *matCellDef="let element">
         <mat-spinner [diameter]="24" *ngIf="!conditionScores.has(element.conditionName)"></mat-spinner>
-        <div *ngIf="conditionScores.has(element.conditionName)">{{ conditionScores.get(element.conditionName) | number: '1.1-1' }}</div>
+        <ng-container *ngIf="conditionScores.has(element.conditionName)">
+          <div>
+            <div><b>{{ getScoreLabel(element.conditionName) }}</b></div>
+            <div class="score">{{  getScore(element.conditionName) | number: '1.1-1' }}</div>
+          </div>
+        </ng-container>
       </mat-cell>
     </ng-container>
 

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
@@ -62,3 +62,7 @@
   background-color: rgba(0,0,0,.5);
   border-radius: 4px;
 }
+
+.score {
+  font-size: 12px;
+}

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
@@ -24,7 +24,7 @@
   width: 48px;
 }
 
-.mat-column-conditionName {
+.mat-column-displayName {
   box-sizing: border-box;
   flex: 2 0 auto;
   padding-right: 24px;

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -8,7 +8,10 @@ import { Plan, Region } from 'src/app/types';
 import { MapService } from './../../../services/map.service';
 import { PlanService } from './../../../services/plan.service';
 import { ConditionsConfig } from './../../../types/data.types';
-import { SetPrioritiesComponent } from './set-priorities.component';
+import {
+  ScoreColumn,
+  SetPrioritiesComponent,
+} from './set-priorities.component';
 
 describe('SetPrioritiesComponent', () => {
   let component: SetPrioritiesComponent;
@@ -56,7 +59,7 @@ describe('SetPrioritiesComponent', () => {
             },
             {
               condition: 'test_element_1',
-              mean_score: 1.3,
+              mean_score: -0.7,
             },
             {
               condition: 'test_metric_1',
@@ -130,10 +133,28 @@ describe('SetPrioritiesComponent', () => {
       ownerId: '1',
       region: Region.SIERRA_NEVADA,
     };
-    const expectedMap = new Map<string, number>([
-      ['test_pillar_1', 0.1],
-      ['test_element_1', 1.3],
-      ['test_metric_1', 0.4],
+    const expectedMap = new Map<string, ScoreColumn>([
+      [
+        'test_pillar_1',
+        {
+          label: 'Medium',
+          score: 0.1,
+        },
+      ],
+      [
+        'test_element_1',
+        {
+          label: 'Lowest',
+          score: -0.7,
+        },
+      ],
+      [
+        'test_metric_1',
+        {
+          label: 'High',
+          score: 0.4,
+        },
+      ],
     ]);
 
     component.plan$.next(fakePlan);

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -9,6 +9,11 @@ import { PlanService } from './../../../services/plan.service';
 import { ConditionsConfig } from './../../../types/data.types';
 import { PlanConditionScores } from './../../../types/plan.types';
 
+export interface ScoreColumn {
+  label: string;
+  score: number;
+}
+
 interface PriorityRow {
   selected?: boolean;
   visible?: boolean; // Visible as raster data on map
@@ -36,7 +41,7 @@ export class SetPrioritiesComponent implements OnInit {
     the data.
   `;
 
-  conditionScores = new Map<string, number>();
+  conditionScores = new Map<string, ScoreColumn>();
   displayedColumns: string[] = ['selected', 'visible', 'displayName', 'score'];
   datasource = new MatTableDataSource<PriorityRow>();
 
@@ -111,12 +116,32 @@ export class SetPrioritiesComponent implements OnInit {
 
   private convertConditionScoresToDictionary(
     scores: PlanConditionScores
-  ): Map<string, number> {
-    let scoreMap = new Map<string, number>();
+  ): Map<string, ScoreColumn> {
+    let scoreMap = new Map<string, ScoreColumn>();
     scores.conditions.forEach((condition) => {
-      scoreMap.set(condition.condition, condition.mean_score);
+      scoreMap.set(condition.condition, {
+        label: this.scoreToLabel(condition.mean_score),
+        score: condition.mean_score,
+      });
     });
     return scoreMap;
+  }
+
+  private scoreToLabel(score: number): string {
+    // TEMPORARY: use 5 equal buckets for scores [-1, 1] (Lowest, Low, Medium, High, Highest)
+    if (score < -0.6) return 'Lowest';
+    if (score < -0.2) return 'Low';
+    if (score < 0.2) return 'Medium';
+    if (score < 0.6) return 'High';
+    return 'Highest';
+  }
+
+  getScoreLabel(conditionName: string): string | undefined {
+    return this.conditionScores.get(conditionName)?.label;
+  }
+
+  getScore(conditionName: string): number | undefined {
+    return this.conditionScores.get(conditionName)?.score;
   }
 
   /** Toggle whether a priority condition's children are expanded. */

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -1,10 +1,13 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
-import { take } from 'rxjs';
+import { BehaviorSubject, take } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { Plan } from 'src/app/types';
 
 import { MapService } from './../../../services/map.service';
+import { PlanService } from './../../../services/plan.service';
 import { ConditionsConfig } from './../../../types/data.types';
+import { PlanConditionScores } from './../../../types/plan.types';
 
 interface PriorityRow {
   selected?: boolean;
@@ -12,7 +15,7 @@ interface PriorityRow {
   expanded?: boolean; // Children in table are not hidden
   hidden?: boolean; // Row hidden from table (independent of "visible" attribute)
   conditionName: string;
-  score: number;
+  displayName?: string;
   filepath: string;
   children: PriorityRow[];
   level: number;
@@ -24,6 +27,7 @@ interface PriorityRow {
   styleUrls: ['./set-priorities.component.scss'],
 })
 export class SetPrioritiesComponent implements OnInit {
+  @Input() plan$ = new BehaviorSubject<Plan | null>(null);
   @Output() changeConditionEvent = new EventEmitter<string>();
 
   readonly text1: string = `
@@ -32,15 +36,14 @@ export class SetPrioritiesComponent implements OnInit {
     the data.
   `;
 
-  displayedColumns: string[] = [
-    'selected',
-    'visible',
-    'conditionName',
-    'score',
-  ];
+  conditionScores = new Map<string, number>();
+  displayedColumns: string[] = ['selected', 'visible', 'displayName', 'score'];
   datasource = new MatTableDataSource<PriorityRow>();
 
-  constructor(private mapService: MapService) {}
+  constructor(
+    private mapService: MapService,
+    private planService: PlanService
+  ) {}
 
   ngOnInit(): void {
     this.mapService.conditionsConfig$
@@ -53,19 +56,27 @@ export class SetPrioritiesComponent implements OnInit {
           conditionsConfig!
         );
       });
+    this.plan$.pipe(filter((plan) => !!plan)).subscribe((plan) => {
+      this.planService
+        .getConditionScoresForPlanningArea(plan!.id)
+        .subscribe((response) => {
+          this.conditionScores =
+            this.convertConditionScoresToDictionary(response);
+        });
+    });
   }
 
-  conditionsConfigToPriorityData(config: ConditionsConfig): PriorityRow[] {
+  private conditionsConfigToPriorityData(
+    config: ConditionsConfig
+  ): PriorityRow[] {
     let data: PriorityRow[] = [];
     config.pillars
       ?.filter((pillar) => pillar.display)
       .forEach((pillar) => {
         let pillarRow: PriorityRow = {
-          conditionName: pillar.display_name
-            ? pillar.display_name
-            : pillar.pillar_name!,
+          conditionName: pillar.pillar_name!,
+          displayName: pillar.display_name,
           filepath: pillar.filepath!.concat('_normalized'),
-          score: 0,
           children: [],
           level: 0,
           expanded: true,
@@ -73,11 +84,9 @@ export class SetPrioritiesComponent implements OnInit {
         data.push(pillarRow);
         pillar.elements?.forEach((element) => {
           let elementRow: PriorityRow = {
-            conditionName: element.display_name
-              ? element.display_name
-              : element.element_name!,
+            conditionName: element.element_name!,
+            displayName: element.display_name,
             filepath: element.filepath!.concat('_normalized'),
-            score: 0,
             children: [],
             level: 1,
             expanded: true,
@@ -86,11 +95,9 @@ export class SetPrioritiesComponent implements OnInit {
           pillarRow.children.push(elementRow);
           element.metrics?.forEach((metric) => {
             let metricRow: PriorityRow = {
-              conditionName: metric.display_name
-                ? metric.display_name
-                : metric.metric_name!,
+              conditionName: metric.metric_name!,
+              displayName: metric.display_name,
               filepath: metric.filepath!,
-              score: 0,
               children: [],
               level: 2,
             };
@@ -100,6 +107,16 @@ export class SetPrioritiesComponent implements OnInit {
         });
       });
     return data;
+  }
+
+  private convertConditionScoresToDictionary(
+    scores: PlanConditionScores
+  ): Map<string, number> {
+    let scoreMap = new Map<string, number>();
+    scores.conditions.forEach((condition) => {
+      scoreMap.set(condition.condition, condition.mean_score);
+    });
+    return scoreMap;
   }
 
   /** Toggle whether a priority condition's children are expanded. */

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -6,7 +6,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { BackendConstants } from '../backend-constants';
 import { BasePlan, Plan, Region } from '../types';
-import { PlanPreview } from './../types/plan.types';
+import { PlanConditionScores, PlanPreview } from './../types/plan.types';
 import { BackendPlan, PlanService } from './plan.service';
 
 describe('PlanService', () => {
@@ -142,6 +142,29 @@ describe('PlanService', () => {
         BackendConstants.END_POINT.concat('/plan/list_plans_by_owner')
       );
       req.flush([backendPlan]);
+      httpTestingController.verify();
+    });
+  });
+
+  describe('getConditionScoresForPlanningArea', () => {
+    it('should make HTTP request to backend', () => {
+      const expectedScores: PlanConditionScores = {
+        conditions: [
+          {
+            condition: 'fake_condition',
+            mean_score: 1.3,
+          },
+        ],
+      };
+
+      service.getConditionScoresForPlanningArea('1').subscribe((res) => {
+        expect(res).toEqual(expectedScores);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/scores/?id=1')
+      );
+      req.flush(expectedScores);
       httpTestingController.verify();
     });
   });

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -1,4 +1,4 @@
-import { PlanPreview } from './../types/plan.types';
+import { PlanPreview, PlanConditionScores } from './../types/plan.types';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BackendConstants } from '../backend-constants';
@@ -69,7 +69,10 @@ export class PlanService {
   /** Makes a request to the backend to delete a plan with the given ID. */
   deletePlan(planIds: string[]): Observable<string> {
     return this.http.post<string>(
-      BackendConstants.END_POINT.concat('/plan/delete/?id=', planIds.toString()),
+      BackendConstants.END_POINT.concat(
+        '/plan/delete/?id=',
+        planIds.toString()
+      ),
       {
         id: planIds,
       },
@@ -112,6 +115,18 @@ export class PlanService {
           dbPlanList.map((dbPlan) => this.convertToPlanPreview(dbPlan))
         )
       );
+  }
+
+  /** Makes a request to the backend for the average condition scores in a planning area. */
+  getConditionScoresForPlanningArea(
+    planId: string
+  ): Observable<PlanConditionScores> {
+    let url = BackendConstants.END_POINT.concat('/plan/scores/?id=', planId);
+    return this.http
+      .get<PlanConditionScores>(url, {
+        withCredentials: true,
+      })
+      .pipe(take(1));
   }
 
   private convertToPlan(plan: BackendPlan): Plan {

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -29,3 +29,12 @@ export interface Scenario {
   id: string;
   createdTimestamp: number; //in milliseconds since epoch
 }
+
+export interface PlanConditionScores {
+  conditions: PlanConditionScore[];
+}
+
+export interface PlanConditionScore {
+  condition: string;
+  mean_score: number;
+}


### PR DESCRIPTION
## Changes
- Fixes #380 
- Fetches the mean condition scores for the planning area from the DB and renders them in the "set priorities" panel.
- Buckets scores into five equal buckets (Lowest, Low, Medium, High, Highest) and renders labels.
- While scores are loading, show a loading indicator in the "Score" column.
- Unit tests.
![image](https://user-images.githubusercontent.com/10444733/214453760-5fbfce71-698c-46f1-99c1-8e134a5106e5.png)
