### PR TITLE
Updates to frontend authentication logic

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -1,1 +1,1 @@
-<p>You are logged in as {{ (user$ | async)?.username }}.</p>
+<p>You are logged in as {{ (user$ | async) ? (user$ | async)!.username : 'Guest' }}.</p>

--- a/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
@@ -1,28 +1,27 @@
-import { of, BehaviorSubject, Subject } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
+
 import { AuthService } from '../services';
+import { User } from './../services/auth.service';
 import { AccountDialogComponent } from './account-dialog.component';
 
 describe('AccountDialogComponent', () => {
   let component: AccountDialogComponent;
   let fixture: ComponentFixture<AccountDialogComponent>;
-  let fakeLoggedInStatus: Subject<boolean>;
 
   beforeEach(() => {
     const fakeAuthService = jasmine.createSpyObj<AuthService>(
       'AuthService',
-      {
-        getLoggedInUser: of({ username: 'username' }),
-      },
       {},
+      {
+        loggedInUser$: new BehaviorSubject<User | null>(null),
+      }
     );
-    fakeLoggedInStatus = new BehaviorSubject(true);
-    fakeAuthService.isLoggedIn$ = fakeLoggedInStatus;
     TestBed.configureTestingModule({
-      schemas: [NO_ERRORS_SCHEMA],
+      imports: [MaterialModule],
       declarations: [AccountDialogComponent],
-      providers: [{ provide: AuthService, useValue: fakeAuthService }]
+      providers: [{ provide: AuthService, useValue: fakeAuthService }],
     });
     fixture = TestBed.createComponent(AccountDialogComponent);
     component = fixture.componentInstance;
@@ -31,21 +30,5 @@ describe('AccountDialogComponent', () => {
 
   it('can load instance', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('updates user observable when logged in status changes to false', (done) => {
-    fakeLoggedInStatus.next(false);
-    component.user$.subscribe(user => {
-      expect(user).toEqual({ username: 'Guest' });
-      done();
-    });
-  });
-
-  it('updates user observable when logged in status changes to true', (done) => {
-    fakeLoggedInStatus.next(true);
-    component.user$.subscribe(user => {
-      expect(user).toEqual({ username: 'username' });
-      done();
-    });
   });
 });

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -1,30 +1,19 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { concatMap, Observable, of, Subscription } from 'rxjs';
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { AuthService, User } from '../services';
 
 @Component({
   selector: 'app-account-dialog',
   templateUrl: './account-dialog.component.html',
-  styleUrls: ['./account-dialog.component.scss']
+  styleUrls: ['./account-dialog.component.scss'],
 })
-export class AccountDialogComponent implements OnInit, OnDestroy {
+export class AccountDialogComponent implements OnInit {
+  user$!: Observable<User | null>;
 
-  user$!: Observable<User>;
-
-  private isLoggedInSubscription!: Subscription;
-
-  constructor(private authService: AuthService) { }
+  constructor(private authService: AuthService) {}
 
   ngOnInit(): void {
-    this.isLoggedInSubscription = this.authService.isLoggedIn$.subscribe();
-    this.user$ = this.authService.isLoggedIn$.pipe(concatMap(loggedIn => {
-      return loggedIn ? this.authService.getLoggedInUser() : of({ username: 'Guest' });
-    }));
+    this.user$ = this.authService.loggedInUser$;
   }
-
-  ngOnDestroy(): void {
-    this.isLoggedInSubscription.unsubscribe();
-  }
-
 }

--- a/src/interface/src/app/app.component.spec.ts
+++ b/src/interface/src/app/app.component.spec.ts
@@ -15,22 +15,17 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     const fakeAuthService = jasmine.createSpyObj<AuthService>(
       'AuthService',
-      { refreshToken: of({ access: true }) },
-      {},
+      { refreshLoggedInUser: of({ username: 'username' }) },
+      {}
     );
     await TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule,
-        RouterTestingModule,
-      ],
+      imports: [HttpClientTestingModule, RouterTestingModule],
       declarations: [
         AppComponent,
         MockComponent(NavigationComponent),
         MockComponent(TopBarComponent),
       ],
-      providers: [
-        { provide: AuthService, useValue: fakeAuthService },
-      ],
+      providers: [{ provide: AuthService, useValue: fakeAuthService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AppComponent);
@@ -44,10 +39,9 @@ describe('AppComponent', () => {
 
   describe('ngOnInit', () => {
     it('should refresh user token', () => {
-      const authServiceStub: AuthService = fixture.debugElement.injector.get(
-        AuthService
-      );
-      expect(authServiceStub.refreshToken).toHaveBeenCalled();
-    })
+      const authServiceStub: AuthService =
+        fixture.debugElement.injector.get(AuthService);
+      expect(authServiceStub.refreshLoggedInUser).toHaveBeenCalled();
+    });
   });
 });

--- a/src/interface/src/app/app.component.ts
+++ b/src/interface/src/app/app.component.ts
@@ -19,7 +19,7 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     // Refresh the user's logged in status when the app initializes.
-    this.authService.refreshToken().pipe(take(1)).subscribe();
+    this.authService.refreshLoggedInUser().pipe(take(1)).subscribe();
   }
 
 }

--- a/src/interface/src/app/navigation/navigation.component.scss
+++ b/src/interface/src/app/navigation/navigation.component.scss
@@ -20,6 +20,7 @@
 
 .nav-link {
   align-items: center;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   height: auto;

--- a/src/interface/src/app/navigation/navigation.component.spec.ts
+++ b/src/interface/src/app/navigation/navigation.component.spec.ts
@@ -1,7 +1,8 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BehaviorSubject, of, Subject } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
 
 import { AuthService } from '../services';
 import { NavigationComponent } from './navigation.component';
@@ -15,17 +16,16 @@ describe('NavigationComponent', () => {
     const fakeAuthService = jasmine.createSpyObj<AuthService>(
       'AuthService',
       {
-        logout: of({}),
+        logout: of({ detail: '' }),
       },
-      {},
+      {}
     );
     fakeLoggedInStatus = new BehaviorSubject(true);
     fakeAuthService.isLoggedIn$ = fakeLoggedInStatus;
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      schemas: [NO_ERRORS_SCHEMA],
+      imports: [BrowserAnimationsModule, MaterialModule, RouterTestingModule],
       declarations: [NavigationComponent],
-      providers: [{ provide: AuthService, useValue: fakeAuthService }]
+      providers: [{ provide: AuthService, useValue: fakeAuthService }],
     });
     fixture = TestBed.createComponent(NavigationComponent);
     component = fixture.componentInstance;
@@ -41,17 +41,15 @@ describe('NavigationComponent', () => {
   });
 
   it(`isLoggedIn$ has default value`, () => {
-    const authServiceStub: AuthService = fixture.debugElement.injector.get(
-      AuthService
-    );
+    const authServiceStub: AuthService =
+      fixture.debugElement.injector.get(AuthService);
     expect(component.isLoggedIn$).toEqual(authServiceStub.isLoggedIn$);
   });
 
   describe('logout', () => {
     it('makes expected calls', () => {
-      const authServiceStub: AuthService = fixture.debugElement.injector.get(
-        AuthService
-      );
+      const authServiceStub: AuthService =
+        fixture.debugElement.injector.get(AuthService);
       component.logout();
       expect(authServiceStub.logout).toHaveBeenCalled();
     });

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -1,25 +1,42 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { CookieService } from 'ngx-cookie-service';
 import { of, throwError } from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
 import { AuthGuard, AuthService } from './auth.service';
 
-describe('AuthService', () => {
+fdescribe('AuthService', () => {
+  let httpTestingController: HttpTestingController;
   let service: AuthService;
 
   beforeEach(() => {
     const cookieServiceStub = () => ({ get: (string: string) => ({}) });
+    const snackbarSpy = jasmine.createSpyObj<MatSnackBar>(
+      'MatSnackBar',
+      {
+        open: undefined,
+      },
+      {}
+    );
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
         AuthService,
-        { provide: CookieService, useFactory: cookieServiceStub }
-      ]
+        { provide: CookieService, useFactory: cookieServiceStub },
+        {
+          provide: MatSnackBar,
+          useValue: snackbarSpy,
+        },
+      ],
     });
     service = TestBed.inject(AuthService);
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
   it('can load instance', () => {
@@ -31,150 +48,281 @@ describe('AuthService', () => {
   });
 
   describe('login', () => {
-    it('makes request to backend', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
+    it('makes request to backend /login endpoint', () => {
       const mockResponse = {
-        accessToken: 'test'
+        accessToken: 'test',
       };
 
-      service.login('username', 'password').subscribe(res => {
+      service.login('username', 'password').subscribe((res) => {
         expect(res).toEqual(mockResponse);
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/login/');
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/login/'
+      );
       expect(req.request.method).toEqual('POST');
       req.flush(mockResponse);
+      httpTestingController
+        .expectOne(BackendConstants.END_POINT + '/dj-rest-auth/user/')
+        .flush({ username: 'username' });
       httpTestingController.verify();
     });
 
-    it('updates logged in status to true', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
-      spyOn(service.loggedInStatus$, 'next').and.callThrough();
+    it('if successful, updates logged in status to true', () => {
       const mockResponse = {
-        accessToken: 'test'
+        accessToken: 'test',
       };
 
-      service.login('username', 'password').subscribe(_ => {
-        expect(service.loggedInStatus$.next).toHaveBeenCalledOnceWith(true);
+      service.login('username', 'password').subscribe((_) => {
+        expect(service.loggedInStatus$.value).toBeTrue();
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/login/');
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/login/'
+      );
       req.flush(mockResponse);
+    });
+
+    it('if unsuccessful, does not update logged in status', () => {
+      service.login('username', 'password').subscribe(
+        (_) => {},
+        (_) => {
+          expect(service.loggedInStatus$.value).toBeFalse();
+        }
+      );
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/login/'
+      );
+      req.flush('Unsuccessful', { status: 400, statusText: 'Bad request' });
+    });
+
+    it('if successful, makes request to backend /user endpoint', () => {
+      const mockResponse = {
+        accessToken: 'test',
+      };
+      const mockUser = {
+        username: 'username',
+      };
+
+      service.login('username', 'password').subscribe();
+
+      const req1 = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/login/'
+      );
+      req1.flush(mockResponse);
+
+      const req2 = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/user/'
+      );
+      req2.flush(mockUser);
+    });
+
+    it('if unsuccessful, does not make request to backend /user endpoint', () => {
+      service.login('username', 'password').subscribe(
+        (_) => {
+          expect(service.loggedInStatus$.value).toBeFalse();
+        },
+        (_) => {}
+      );
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/login/'
+      );
+      req.flush('Unsuccessful', { status: 400, statusText: 'Bad request' });
+      httpTestingController.verify();
     });
   });
 
   describe('signup', () => {
-    it('makes request to backend', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
+    it('makes request to /registration backend endpoint', () => {
       const mockResponse = {
-        accessToken: 'test'
+        accessToken: 'test',
       };
 
-      service.signup('username', 'email', 'password1', 'password2').subscribe(res => {
-        expect(res).toEqual(mockResponse);
-      });
+      service
+        .signup('username', 'email', 'password1', 'password2')
+        .subscribe((res) => {
+          expect(res).toEqual(mockResponse);
+        });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/registration/');
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
+      );
       expect(req.request.method).toEqual('POST');
       req.flush(mockResponse);
+      httpTestingController
+        .expectOne(BackendConstants.END_POINT + '/dj-rest-auth/user/')
+        .flush({ username: 'username' });
+      httpTestingController.verify();
+    });
+
+    it('if successful, updates logged in status to true', () => {
+      const mockResponse = {
+        accessToken: 'test',
+      };
+
+      service
+        .signup('username', 'email', 'password1', 'password2')
+        .subscribe((_) => {
+          expect(service.loggedInStatus$.value).toBeTrue();
+        });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
+      );
+      req.flush(mockResponse);
+    });
+
+    it('if unsuccessful, does not update logged in status', () => {
+      service.signup('username', 'email', 'password1', 'password2').subscribe(
+        (_) => {},
+        (_) => {
+          expect(service.loggedInStatus$.value).toBeFalse();
+        }
+      );
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
+      );
+      req.flush('Unsuccessful', { status: 400, statusText: 'Bad request' });
+    });
+
+    it('if successful, makes request to backend /user endpoint', () => {
+      const mockResponse = {
+        accessToken: 'test',
+      };
+      const mockUser = {
+        username: 'username',
+      };
+
+      service.signup('username', 'email', 'password1', 'password2').subscribe();
+
+      const req1 = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
+      );
+      req1.flush(mockResponse);
+
+      const req2 = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/user/'
+      );
+      req2.flush(mockUser);
+    });
+
+    it('if unsuccessful, does not make request to backend /user endpoint', () => {
+      service.signup('username', 'email', 'password1', 'password2').subscribe(
+        (_) => {},
+        (_) => {
+          expect(service.loggedInStatus$.value).toBeFalse();
+        }
+      );
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
+      );
+      req.flush('Unsuccessful', { status: 400, statusText: 'Bad request' });
       httpTestingController.verify();
     });
   });
 
   describe('logout', () => {
     it('makes request to backend', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
       const mockResponse = {
-        detail: 'Successfully logged out'
+        detail: 'Successfully logged out',
       };
 
-      service.logout().subscribe(res => {
+      service.logout().subscribe((res) => {
         expect(res).toEqual(mockResponse);
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/logout/');
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/logout/'
+      );
       expect(req.request.method).toEqual('GET');
       req.flush(mockResponse);
       httpTestingController.verify();
     });
 
-    it('updates logged in status to false', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
+    it('updates logged in status to false and logged in user to be null', () => {
       const mockResponse = {
-        detail: 'Successfully logged out'
+        detail: 'Successfully logged out',
       };
 
-      spyOn(service.loggedInStatus$, 'next').and.callThrough();
-      service.logout().subscribe(_ => {
-        expect(service.loggedInStatus$.next).toHaveBeenCalledOnceWith(false);
+      service.logout().subscribe((_) => {
+        expect(service.loggedInStatus$.value).toBeFalse();
+        expect(service.loggedInUser$.value).toBeNull();
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/logout/');
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/logout/'
+      );
       req.flush(mockResponse);
     });
   });
 
-  describe('refreshToken', () => {
-    it('makes request to backend', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
+  describe('refreshLoggedInUser', () => {
+    it('makes request to backend for access token and user', () => {
       const cookieServiceStub: CookieService = TestBed.inject(CookieService);
       spyOn(cookieServiceStub, 'get').and.callThrough();
       const mockResponse = { access: true };
+      const mockUser = {
+        username: 'username',
+      };
 
-      service.refreshToken().subscribe(res => {
-        expect(res).toEqual(mockResponse);
+      service.refreshLoggedInUser().subscribe((res) => {
+        expect(res).toEqual(mockUser);
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/token/refresh/');
-      expect(req.request.method).toEqual('POST');
+      const req1 = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/token/refresh/'
+      );
+      expect(req1.request.method).toEqual('POST');
       expect(cookieServiceStub.get).toHaveBeenCalled();
-      req.flush(mockResponse);
+      req1.flush(mockResponse);
+
+      const req2 = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/dj-rest-auth/user/'
+      );
+      expect(req2.request.method).toEqual('GET');
+      req2.flush(mockUser);
+
       httpTestingController.verify();
     });
 
     it('updates loggedInStatus to true when token is refreshed', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
       const mockResponse = { access: true };
-      spyOn(service.loggedInStatus$, 'next').and.callThrough();
+      const mockUser = {
+        username: 'username',
+      };
 
-      service.refreshToken().subscribe(_ => {
-        expect(service.loggedInStatus$.next).toHaveBeenCalledOnceWith(true);
+      service.refreshLoggedInUser().subscribe((_) => {
+        expect(service.loggedInStatus$.value).toBeTrue();
+        expect(service.loggedInUser$.value).toEqual(mockUser);
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/token/refresh/');
-      req.flush(mockResponse);
+      httpTestingController
+        .expectOne(BackendConstants.END_POINT + '/dj-rest-auth/token/refresh/')
+        .flush(mockResponse);
+      httpTestingController
+        .expectOne(BackendConstants.END_POINT + '/dj-rest-auth/user/')
+        .flush(mockUser);
     });
 
     it('updates loggedInStatus to false when token cannot be refreshed', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
       const errorResponse = new HttpErrorResponse({
         error: 'test 404 error',
-        status: 404, statusText: 'Not Found'
-      });
-      spyOn(service.loggedInStatus$, 'next').and.callThrough();
-
-      service.refreshToken().subscribe(_ => {
-        expect(service.loggedInStatus$.next).toHaveBeenCalledOnceWith(false);
+        status: 404,
+        statusText: 'Not Found',
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/token/refresh/');
-      req.flush(errorResponse);
-    });
-  });
-
-  describe('getLoggedInUser', () => {
-    it('makes request to backend', () => {
-      const httpTestingController = TestBed.inject(HttpTestingController);
-      const mockResponse = { username: 'username' };
-
-      service.getLoggedInUser().subscribe(res => {
-        expect(res).toEqual(mockResponse);
+      service.refreshLoggedInUser().subscribe((_) => {
+        expect(service.loggedInStatus$.value).toBeFalse();
+        expect(service.loggedInUser$.value).toBeNull();
       });
 
-      const req = httpTestingController.expectOne(BackendConstants.END_POINT + '/dj-rest-auth/user/');
-      expect(req.request.method).toEqual('GET');
-      req.flush(mockResponse);
-      httpTestingController.verify();
+      httpTestingController
+        .expectOne(BackendConstants.END_POINT + '/dj-rest-auth/token/refresh/')
+        .flush(errorResponse);
     });
   });
 });
@@ -185,12 +333,12 @@ describe('AuthGuard', () => {
   beforeEach(() => {
     const cookieServiceStub = () => ({ get: (string: string) => ({}) });
     TestBed.configureTestingModule({
-      imports: [ HttpClientTestingModule ],
+      imports: [HttpClientTestingModule],
       providers: [
         AuthService,
         AuthGuard,
-        { provide: CookieService, useFactory: cookieServiceStub }
-      ]
+        { provide: CookieService, useFactory: cookieServiceStub },
+      ],
     });
     service = TestBed.inject(AuthGuard);
   });
@@ -202,20 +350,24 @@ describe('AuthGuard', () => {
   describe('canActivate', () => {
     it('returns true if refreshToken succeeds', () => {
       const authServiceStub: AuthService = TestBed.inject(AuthService);
-      spyOn(authServiceStub, 'refreshToken').and.returnValue(of({access: true}));
+      spyOn(authServiceStub, 'refreshLoggedInUser').and.returnValue(
+        of({ username: 'username' })
+      );
 
-      service.canActivate().subscribe(result => {
+      service.canActivate().subscribe((result) => {
         expect(result).toBeTrue();
       });
     });
 
     it('returns false if refreshToken fails', () => {
       const authServiceStub: AuthService = TestBed.inject(AuthService);
-      spyOn(authServiceStub, 'refreshToken').and.returnValue(throwError(() => new Error()));
+      spyOn(authServiceStub, 'refreshLoggedInUser').and.returnValue(
+        throwError(() => new Error())
+      );
 
-      service.canActivate().subscribe(result => {
+      service.canActivate().subscribe((result) => {
         expect(result).toBeFalse();
       });
     });
-  })
+  });
 });

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -1,10 +1,15 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { CanActivate } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
-import { BehaviorSubject, catchError, map, Observable, of, Subject, tap } from 'rxjs';
+import { BehaviorSubject, catchError, map, Observable, of, Subject, tap, concatMap, take } from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
+
+interface LogoutResponse {
+  detail: string;
+}
 
 export interface User {
   username: string,
@@ -15,14 +20,16 @@ export interface User {
 })
 export class AuthService {
 
-  loggedInStatus$: Subject<boolean> = new BehaviorSubject(false);
+  loggedInStatus$ = new BehaviorSubject(false);
   isLoggedIn$: Observable<boolean> = this.loggedInStatus$;
+  loggedInUser$ = new BehaviorSubject<User | null>(null);
 
   private readonly API_ROOT = BackendConstants.END_POINT + '/dj-rest-auth/';
 
   constructor(
     private http: HttpClient,
-    private cookieService: CookieService) { }
+    private cookieService: CookieService,
+    private snackbar: MatSnackBar) { }
 
   login(username: string, password: string) {
     return this.http.post(
@@ -30,7 +37,13 @@ export class AuthService {
       { username, password },
       { withCredentials: true }
     ).pipe(
-      tap(_ => this.loggedInStatus$.next(true))
+      tap(_ => {
+        this.loggedInStatus$.next(true);
+        this.getLoggedInUser().pipe(take(1)).subscribe(user => {
+          this.loggedInUser$.next(user);
+        });
+      }),
+
     );
   }
 
@@ -38,19 +51,28 @@ export class AuthService {
     return this.http.post(
       this.API_ROOT.concat('registration/'),
       { username, password1, password2, email }
+    ).pipe(
+      tap(_ => {
+        this.loggedInStatus$.next(true);
+        this.getLoggedInUser().pipe(take(1)).subscribe();
+      })
     );
   }
 
   logout() {
-    return this.http.get(
+    return this.http.get<LogoutResponse>(
       this.API_ROOT.concat('logout/'),
       { withCredentials: true }
     ).pipe(
-      tap(_ => this.loggedInStatus$.next(false))
+      tap(response => {
+        this.loggedInStatus$.next(false);
+        this.loggedInUser$.next(null);
+        this.snackbar.open(response.detail);
+      })
     );
   }
 
-  refreshToken() {
+  private refreshToken() {
     return this.http.post(
       this.API_ROOT.concat('token/refresh/'),
       { refresh: this.cookieService.get('my-refresh-token') },
@@ -60,7 +82,15 @@ export class AuthService {
     }));
   }
 
-  getLoggedInUser(): Observable<User> {
+  /** Fetch the currently logged in user from the backend. */
+  refreshLoggedInUser(): Observable<User> {
+    // Must refresh the auth cookie to retrieve user
+    return this.refreshToken().pipe(concatMap(_ => {
+      return this.getLoggedInUser();
+    }));
+  }
+
+  private getLoggedInUser(): Observable<User> {
     return this.http.get(
       this.API_ROOT.concat('user/'),
       { withCredentials: true }
@@ -68,6 +98,7 @@ export class AuthService {
       const user: User = {
         username: response.username
       }
+      this.loggedInUser$.next(user);
       return user;
     }));
   }
@@ -80,11 +111,9 @@ export class AuthGuard implements CanActivate {
   constructor(private authService: AuthService) { }
 
   canActivate(): Observable<boolean> {
-    return this.authService.refreshToken().pipe(
-      map((response: any) => response.access),
-      catchError(err => {
-        return of(false);
-      })
+    return this.authService.refreshLoggedInUser().pipe(
+      map(_ => true),
+      catchError(_ => of(false))
     );
 
   }


### PR DESCRIPTION
## Changes
- Should fix #324
- Store the currently logged in user in a global BehaviorSubject 
- Simplify `AccountDialogComponent` to use the global user subject
- Update methods in `AuthService` to properly store and track login status and currently logged in user 
- Removes NO_ERRORS_SCHEMA from some unit tests and actually fixes errors (by importing missing modules)
- Change cursor to pointer when login button is hovered (to make it obvious that it's clickable)
- Show a snackbar when logout is successful (previously there was no feedback)
- Unit tests