### PR TITLE
Remove leaflet box

### DIFF
--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -123,6 +123,7 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
   }
 }
 
+// Removes the box when a boundary is clicked. https://github.com/OurPlanscape/Planscape/issues/357
 * {
   outline: none;
 }

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -123,6 +123,10 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
   }
 }
 
+* {
+  outline: none;
+}
+
 // Geoman drawing vertex styling
 .marker-icon,
  .marker-icon:focus {


### PR DESCRIPTION
Removes the accessibility box that would show when a boundary was clicked. Thanks to Jon for finding the fix!

<img width="1107" alt="Screenshot 2023-01-27 at 10 07 50 AM" src="https://user-images.githubusercontent.com/114368235/215162050-5eab67d3-fd15-4804-9012-94f201569460.png">
