### PR TITLE
Update legend and add opacity controls for data layer

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -1,4 +1,7 @@
 import { MatSnackBar } from '@angular/material/snack-bar';
+import booleanIntersects from '@turf/boolean-intersects';
+import booleanWithin from '@turf/boolean-within';
+import { point } from '@turf/helpers';
 import {
   Feature,
   FeatureCollection,
@@ -8,9 +11,6 @@ import {
 } from 'geojson';
 import * as L from 'leaflet';
 import '@geoman-io/leaflet-geoman-free';
-import booleanIntersects from '@turf/boolean-intersects';
-import booleanWithin from '@turf/boolean-within';
-import { point } from '@turf/helpers';
 import 'leaflet.sync';
 import { BehaviorSubject, Observable, take } from 'rxjs';
 
@@ -687,10 +687,18 @@ export class MapManager {
       {
         minZoom: 7,
         maxZoom: 13,
-        opacity: 0.7,
+        opacity:
+          map.config.dataLayerConfig.opacity !== undefined
+            ? map.config.dataLayerConfig.opacity
+            : FrontendConstants.MAP_DATA_LAYER_OPACITY,
       }
     );
 
     map.dataLayerRef.addTo(map.instance);
+  }
+
+  /** Change the opacity of a map's data layer. */
+  changeOpacity(map: Map) {
+    map.dataLayerRef?.setOpacity(map.config.dataLayerConfig.opacity!);
   }
 }

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -3,14 +3,17 @@
   <!-- Map control panel -->
   <div id="controls" class="controls-container">
 
-    <div class="controls-header">
-      Highlighted map information
-    </div>
-
+    <ng-container *ngIf="mapHasDataLayer() | async">
       <!-- Legend for the currently shown map -->
       <app-legend [legend]="getSelectedLegend()"></app-legend>
 
-      <mat-divider class="layer-controls-divider"></mat-divider>
+      <!-- Opacity controls for the currently shown data layer -->
+      <app-opacity-slider (change)="changeOpacity($event)" [opacity]="getOpacityForSelectedMap() | async">
+      </app-opacity-slider>
+
+    </ng-container>
+
+    <mat-divider class="layer-controls-divider"></mat-divider>
 
       <!-- Controls for specifying how many maps should be shown -->
       <div class="map-count-button-row">

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -11,9 +11,9 @@
       <app-opacity-slider (change)="changeOpacity($event)" [opacity]="getOpacityForSelectedMap() | async">
       </app-opacity-slider>
 
-    </ng-container>
+      <mat-divider class="layer-controls-divider"></mat-divider>
 
-    <mat-divider class="layer-controls-divider"></mat-divider>
+    </ng-container>
 
       <!-- Controls for specifying how many maps should be shown -->
       <div class="map-count-button-row">

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -16,13 +16,6 @@
   width: 450px;
 }
 
-.controls-header {
-  font-size: 12px;
-  font-weight: 500;
-  padding: 16px;
-  text-align: center;
-}
-
 .layer-control-container {
   display: flex;
   flex-direction: row;

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  padding-top: 20px;
   width: 450px;
 }
 

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -10,14 +10,13 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatRadioGroupHarness } from '@angular/material/radio/testing';
 import { MatSelectModule } from '@angular/material/select';
-import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BehaviorSubject, of } from 'rxjs';
-import { featureCollection, point } from '@turf/helpers';
 import { Router } from '@angular/router';
+import { featureCollection, point } from '@turf/helpers';
 import * as L from 'leaflet';
+import { BehaviorSubject, of } from 'rxjs';
 import * as shp from 'shpjs';
 
 import {
@@ -40,13 +39,9 @@ import {
   Region,
 } from './../types';
 import { MapManager } from './map-manager';
-import { ConditionsNode, MapComponent } from './map.component';
+import { MapComponent } from './map.component';
 import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dialog.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
-
-interface ExtendedWindow extends Window {
-  FileReader: FileReader;
-}
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -886,6 +881,43 @@ describe('MapComponent', () => {
         node.children?.forEach((child) => {
           expect(child.styleDisabled).toBeFalse();
         });
+      });
+    });
+  });
+
+  describe('data layer opacity functions', () => {
+    it('changeOpacity changes opacity on the currently selected data layer', () => {
+      spyOn(mapManager, 'changeOpacity').and.returnValue();
+
+      component.changeOpacity(0.5);
+
+      expect(component.maps[0].config.dataLayerConfig.opacity).toEqual(0.5);
+      expect(mapManager.changeOpacity).toHaveBeenCalledOnceWith(
+        component.maps[0]
+      );
+    });
+
+    it('getOpacityForSelectedMap gets opacity for selected map', () => {
+      component.maps[0].config.dataLayerConfig.opacity = 0.5;
+
+      component.getOpacityForSelectedMap().subscribe((opacity) => {
+        expect(opacity).toEqual(0.5);
+      });
+    });
+
+    it('mapHasDataLayer returns true if map has data layer', () => {
+      component.maps[0].config.dataLayerConfig.filepath = 'test_metric_1';
+
+      component.mapHasDataLayer().subscribe((result) => {
+        expect(result).toBeTrue();
+      });
+    });
+
+    it('mapHasDataLayer returns false if map does not have data layer', () => {
+      component.maps[0].config.dataLayerConfig.filepath = '';
+
+      component.mapHasDataLayer().subscribe((result) => {
+        expect(result).toBeFalse();
       });
     });
   });

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -297,7 +297,10 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     });
 
     // Initialize the legend with colormap values.
-    this.updateLegendWithColormap(map, map.config.dataLayerConfig.colormap);
+    this.updateLegendWithColormap(map, map.config.dataLayerConfig.colormap, [
+      map.config.dataLayerConfig.min_value,
+      map.config.dataLayerConfig.max_value,
+    ]);
 
     // Calculate the maximum width of the map nameplate.
     this.updateMapNameplateWidth(map);
@@ -530,10 +533,17 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   /** Changes which condition scores layer (if any) is shown. */
   changeConditionsLayer(map: Map) {
     this.mapManager.changeConditionsLayer(map);
-    this.updateLegendWithColormap(map, map.config.dataLayerConfig.colormap);
+    this.updateLegendWithColormap(map, map.config.dataLayerConfig.colormap, [
+      map.config.dataLayerConfig.min_value,
+      map.config.dataLayerConfig.max_value,
+    ]);
   }
 
-  private updateLegendWithColormap(map: Map, colormap?: string) {
+  private updateLegendWithColormap(
+    map: Map,
+    colormap?: string,
+    minMaxValues?: (number | undefined)[]
+  ) {
     if (colormap == undefined) {
       colormap = DEFAULT_COLORMAP;
     } else if (colormap == NONE_COLORMAP) {
@@ -545,7 +555,12 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       .getColormap(colormap)
       .pipe(take(1))
       .subscribe((colormapConfig) => {
-        map.legend = colormapConfigToLegend(colormapConfig);
+        map.legend = colormapConfigToLegend(
+          colormapConfig,
+          minMaxValues?.every((val) => val !== undefined)
+            ? (minMaxValues as number[])
+            : undefined
+        );
       });
   }
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -13,7 +13,14 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTreeNestedDataSource } from '@angular/material/tree';
 import { Router } from '@angular/router';
 import { Feature, Geometry } from 'geojson';
-import { BehaviorSubject, Observable, Subject, take, takeUntil } from 'rxjs';
+import {
+  BehaviorSubject,
+  map,
+  Observable,
+  Subject,
+  take,
+  takeUntil,
+} from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
 import * as shp from 'shpjs';
 
@@ -80,6 +87,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
   conditionsConfig$: Observable<ConditionsConfig | null>;
   selectedRegion$: Observable<Region | null>;
   planState$: Observable<PlanState>;
+  selectedMap$: Observable<Map | undefined>;
 
   readonly noneBoundaryConfig = NONE_BOUNDARY_CONFIG;
 
@@ -173,6 +181,11 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
           config: defaultMapConfig(),
         };
       }
+    );
+
+    this.selectedMap$ = this.mapViewOptions$.pipe(
+      takeUntil(this.destroy$),
+      map((mapViewOptions) => this.maps[mapViewOptions.selectedMapIndex])
     );
 
     this.mapManager = new MapManager(
@@ -562,6 +575,27 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
             : undefined
         );
       });
+  }
+
+  /** Change the opacity of the currently shown data layer (if any). */
+  changeOpacity(opacity: number) {
+    const selectedMap = this.maps[this.mapViewOptions$.value.selectedMapIndex];
+    selectedMap.config.dataLayerConfig.opacity = opacity;
+    this.mapManager.changeOpacity(selectedMap);
+  }
+
+  /** Return the selected map's data layer opacity. */
+  getOpacityForSelectedMap(): Observable<number | undefined> {
+    return this.selectedMap$.pipe(
+      map((selectedMap) => selectedMap?.config.dataLayerConfig.opacity)
+    );
+  }
+
+  /** Whether the currently selected map has a data layer active. */
+  mapHasDataLayer(): Observable<boolean> {
+    return this.selectedMap$.pipe(
+      map((selectedMap) => !!selectedMap?.config.dataLayerConfig.filepath)
+    );
   }
 
   /** Change how many maps are displayed in the viewport. */

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
@@ -27,7 +27,7 @@
     </div>
     <div>
       <h4>Condition Score Scale</h4>
-      <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
+      <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true"></app-legend>
     </div>
 </div>
 <div class="row-div gap-60">
@@ -37,7 +37,7 @@
     </div>
     <div>
       <h4>Opportunity Score Scale</h4>
-      <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true" [hideOutline]="true"></app-legend>
+      <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true"></app-legend>
     </div>
   </div>
   <div class="row-div">

--- a/src/interface/src/app/shared/legend/legend.component.html
+++ b/src/interface/src/app/shared/legend/legend.component.html
@@ -1,11 +1,23 @@
 <div class="legend-wrapper" *ngIf="legend">
   <h1 *ngIf="!hideTitles">Legend</h1>
   <div class="legend" [class.vertical]="vertical" [class.no-border]="hideOutline">
-    <div class="colors" [class.vertical]="vertical">
+    <div class="gradient" [style.background-image]="gradient" *ngIf="!vertical"></div>
+    <div class="colors" [class.vertical]="vertical" *ngIf="vertical">
       <div class="colorbox" [class.vertical]="vertical" *ngFor="let color of legend?.colors" [ngStyle]="{'background-color': color}"></div>
     </div>
-    <div class="labels" [class.vertical]="vertical">
-      <div class="label" [class.vertical]="vertical" *ngFor="let label of legend?.labels">{{ label }}</div>
-    </div>
+
+    <!-- Raw value labels (e.g. "0 => 10") -->
+    <ng-container *ngIf="!vertical && legend.minMaxValues; else strLabels">
+      <div class="labels">
+        <div class="label" *ngFor="let value of legend.minMaxValues">{{ value | number}}</div>
+      </div>
+    </ng-container>
+
+    <!-- String labels (e.g. "Low => High") -->
+    <ng-template #strLabels>
+      <div class="labels" [class.vertical]="vertical">
+        <div class="label" [class.vertical]="vertical" *ngFor="let label of legend?.labels">{{ label }}</div>
+      </div>
+    </ng-template>
   </div>
 </div>

--- a/src/interface/src/app/shared/legend/legend.component.html
+++ b/src/interface/src/app/shared/legend/legend.component.html
@@ -1,9 +1,12 @@
 <div class="legend-wrapper" *ngIf="legend">
   <h1 *ngIf="!hideTitles">Legend</h1>
-  <div class="legend" [class.vertical]="vertical" [class.no-border]="hideOutline">
+  <div class="legend" [class.vertical]="vertical">
+    <!-- Gradient (if horizontal) -->
     <div class="gradient" [style.background-image]="gradient" *ngIf="!vertical"></div>
-    <div class="colors" [class.vertical]="vertical" *ngIf="vertical">
-      <div class="colorbox" [class.vertical]="vertical" *ngFor="let color of legend?.colors" [ngStyle]="{'background-color': color}"></div>
+
+    <!-- Colorboxes (if vertical) -->
+    <div class="colors" *ngIf="vertical">
+      <div class="colorbox" *ngFor="let color of legend?.colors" [ngStyle]="{'background-color': color}"></div>
     </div>
 
     <!-- Raw value labels (e.g. "0 => 10") -->

--- a/src/interface/src/app/shared/legend/legend.component.scss
+++ b/src/interface/src/app/shared/legend/legend.component.scss
@@ -6,27 +6,19 @@
 }
 
 h1 {
-  font-size: 12px;
-  font-weight: 500;
-  text-align: center;
-}
-
-h2 {
   font-size: 13px;
-  font-weight: 400;
+  font-weight: 500;
+  line-height: 15px;
   text-align: center;
 }
 
 .legend {
   align-items: center;
-  border: 1px solid #c4c4c4;
-  border-radius: 6px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   margin: 0px 48px 0px 48px;
-  padding: 12px;
 }
 
 .legend.vertical {
@@ -34,13 +26,7 @@ h2 {
   flex-direction: row;
   gap: 12px;
   justify-content: flex-start;
-}
-
-.legend.no-border {
-  border: none;
-  border-radius: 0px;
   margin: 0px;
-  padding: 0px;
 }
 
 .labels {
@@ -70,24 +56,14 @@ h2 {
 
 .colors {
   display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.colors.vertical {
   flex-direction: column;
+  flex-wrap: nowrap;
   gap: 8px;
-  width: unset;
 }
 
 .colorbox {
   flex: 1 1 auto;
   height: 24px;
-  min-width: 24px;
-}
-
-.colorbox.vertical {
   width: 36px;
 }
 

--- a/src/interface/src/app/shared/legend/legend.component.scss
+++ b/src/interface/src/app/shared/legend/legend.component.scss
@@ -59,14 +59,13 @@ h2 {
 .label {
   margin-top: 5px;
   min-width: 24px;
-  writing-mode: vertical-lr;
+  text-align: center;
 }
 
 .label.vertical {
   height: 24px;
   line-height: 24px;
   margin-top: 0px;
-  writing-mode: horizontal-tb;
 }
 
 .colors {
@@ -90,4 +89,9 @@ h2 {
 
 .colorbox.vertical {
   width: 36px;
+}
+
+.gradient {
+  height: 24px;
+  width: 100%;
 }

--- a/src/interface/src/app/shared/legend/legend.component.ts
+++ b/src/interface/src/app/shared/legend/legend.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { Legend } from 'src/app/types';
 
 @Component({
@@ -6,9 +6,17 @@ import { Legend } from 'src/app/types';
   templateUrl: './legend.component.html',
   styleUrls: ['./legend.component.scss'],
 })
-export class LegendComponent {
+export class LegendComponent implements OnChanges {
   @Input() legend?: Legend;
   @Input() vertical?: boolean;
   @Input() hideTitles?: boolean;
   @Input() hideOutline?: boolean;
+
+  gradient: string = '';
+
+  ngOnChanges(): void {
+    this.gradient = `linear-gradient(to right, ${this.legend?.colors?.join(
+      ', '
+    )})`;
+  }
 }

--- a/src/interface/src/app/shared/legend/legend.component.ts
+++ b/src/interface/src/app/shared/legend/legend.component.ts
@@ -10,7 +10,6 @@ export class LegendComponent implements OnChanges {
   @Input() legend?: Legend;
   @Input() vertical?: boolean;
   @Input() hideTitles?: boolean;
-  @Input() hideOutline?: boolean;
 
   gradient: string = '';
 

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.html
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.html
@@ -1,0 +1,11 @@
+<div class="root-container">
+  <h1>Heat Map Opacity</h1>
+
+  <div class="opacity-slider-wrapper">
+    0
+    <mat-slider class="opacity-slider" [min]="0" [max]="100" [thumbLabel]="true" [value]="opacityPercentage" (input)="onChange($event.value)">
+      <input matSliderThumb>
+    </mat-slider>
+    100
+  </div>
+</div>

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.scss
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.scss
@@ -1,0 +1,27 @@
+.root-container {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding: 0px 48px 0px 48px;
+  width: 100%;
+}
+
+.opacity-slider-wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: stretch;
+  width: 100%;
+}
+
+h1 {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 15px;
+  margin-bottom: 0px;
+  text-align: center;
+}
+
+.opacity-slider {
+  flex-grow: 1;
+  padding-top: 0px;
+}

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.spec.ts
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OpacitySliderComponent } from './opacity-slider.component';
+
+describe('OpacitySliderComponent', () => {
+  let component: OpacitySliderComponent;
+  let fixture: ComponentFixture<OpacitySliderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OpacitySliderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OpacitySliderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should convert decimal opacity to percentage', () => {
+    component.opacity = 0.6;
+    component.ngOnChanges();
+
+    expect(component.opacityPercentage).toEqual(60);
+  });
+
+  it('should emit event when opacity value changes', () => {
+    spyOn(component.change, 'emit');
+
+    component.onChange(35);
+
+    expect(component.change.emit).toHaveBeenCalledOnceWith(0.35);
+  });
+});

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.ts
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.ts
@@ -1,0 +1,30 @@
+import { FrontendConstants } from 'src/app/types';
+import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
+import { map, Observable, of } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-opacity-slider',
+  templateUrl: './opacity-slider.component.html',
+  styleUrls: ['./opacity-slider.component.scss'],
+})
+export class OpacitySliderComponent implements OnInit, OnChanges {
+  @Input() opacity: number | null | undefined = FrontendConstants.MAP_DATA_LAYER_OPACITY;
+  @Output() change = new EventEmitter<number>();
+
+  opacityPercentage: number = FrontendConstants.MAP_DATA_LAYER_OPACITY * 100;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  ngOnChanges(): void {
+    if (this.opacity !== undefined && this.opacity !== null) {
+      this.opacityPercentage = this.opacity * 100;
+    }
+  }
+
+  onChange(value: number | null): void {
+    if (value != null) this.change.emit(value / 100);
+  }
+}

--- a/src/interface/src/app/shared/shared.module.ts
+++ b/src/interface/src/app/shared/shared.module.ts
@@ -1,23 +1,19 @@
-import { NgModule } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
-import { LegendComponent } from './legend/legend.component';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MaterialModule } from 'src/app/material/material.module';
+
 import { FileUploaderComponent } from './file-uploader/file-uploader.component';
+import { LegendComponent } from './legend/legend.component';
+import { OpacitySliderComponent } from './opacity-slider/opacity-slider.component';
 
 @NgModule({
   declarations: [
     FileUploaderComponent,
-    LegendComponent
+    LegendComponent,
+    OpacitySliderComponent,
   ],
-  exports: [
-    FileUploaderComponent,
-    LegendComponent
-  ],
-  imports: [
-    CommonModule,
-    MatButtonModule,
-    MatIconModule,
-  ]
+  exports: [FileUploaderComponent, LegendComponent, OpacitySliderComponent],
+  imports: [CommonModule, FormsModule, MaterialModule, ReactiveFormsModule],
 })
-export class SharedModule { }
+export class SharedModule {}

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -26,6 +26,7 @@ export interface DataLayerConfig extends ConditionsMetadata {
   filepath?: string;
   colormap?: string;
   normalized?: boolean;
+  opacity?: number;
 }
 
 export interface ElementConfig extends DataLayerConfig {

--- a/src/interface/src/app/types/legend.types.ts
+++ b/src/interface/src/app/types/legend.types.ts
@@ -15,11 +15,13 @@ export interface ColormapValue {
 export interface Legend {
   colors?: string[];
   labels?: string[];
+  minMaxValues?: number[];
 }
 
 /** Convert a colormap to a legend object. */
 export function colormapConfigToLegend(
-  colormap: ColormapConfig
+  colormap: ColormapConfig,
+  minMaxValues?: number[]
 ): Legend | undefined {
   const sortedValues = colormap.values?.sort((valueA, valueB) => {
     if (valueA?.percentile != undefined && valueB?.percentile != undefined) {
@@ -30,5 +32,6 @@ export function colormapConfigToLegend(
   return {
     colors: sortedValues?.map((value) => (!!value.rgb ? value.rgb : '')),
     labels: sortedValues?.map((value) => (!!value.name ? value.name : '')),
+    minMaxValues: minMaxValues,
   };
 }

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -16,7 +16,7 @@ export interface Map {
   baseLayerRef?: L.Layer | undefined;
   boundaryLayerRef?: L.Layer | undefined;
   existingProjectsLayerRef?: L.Layer | undefined;
-  dataLayerRef?: L.Layer | undefined;
+  dataLayerRef?: L.TileLayer | undefined;
   clonedDrawingRef?: L.FeatureGroup | undefined;
   drawnPolygonLookup?: { [key: string]: L.Layer };
   legend?: Legend;
@@ -59,5 +59,6 @@ export const FrontendConstants = {
   MAP_CENTER: [38.646, -120.548],
   MAP_INITIAL_ZOOM: 9,
   MAP_MIN_ZOOM: 7,
-  MAP_MAX_ZOOM: 13
+  MAP_MAX_ZOOM: 13,
+  MAP_DATA_LAYER_OPACITY: 0.7,
 } as const;


### PR DESCRIPTION
## Changes
- Fixes #417 and #369 
- For raw data layers, show min/max values in legend instead of text labels
- Restyle legend (remove border and change text direction for labels)
- Remove "Highlighted map information" text
- Replace legend colorboxes with gradient using linear interpolation on RGB values (same as the heatmap tiles)
- Add opacity slider for the currently selected map (hidden if the map has no data layer)

## Legend and opacity slider
![image](https://user-images.githubusercontent.com/10444733/215891408-a1de04e9-4cca-4f68-97b2-c92e4d1381f4.png)

## No data layer (no legend or opacity slider)
![image](https://user-images.githubusercontent.com/10444733/215891483-ac8a988c-9b41-4fb1-97da-d05a3a76f166.png)
