### PR TITLE
updated UI for step 1

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
@@ -1,47 +1,36 @@
 <div class="panel-container">
-  <div>
-    <p>{{ text1 }}</p>
-  </div>
-  <div class="row-div gap-60">
-      <div>
-        <mat-form-field appearance="fill">
-          <mat-label>
-            Generate scenarios using:
-          </mat-label>
-          <mat-select>
-            <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
-            <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
-      <div>
-        <p>
-          {{ text2 }}
-        </p>
-      </div>
-  </div>
-  <div class="row-div gap-60">
+  <p class="secondary-text">{{ text1 }}</p>
+
+  <h4>Prioritize by:</h4>
+
+  <mat-form-field appearance="fill" class="select-box" subscriptSizing="dynamic">
+    <mat-label>Make Selection</mat-label>
+    <mat-select>
+      <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
+      <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <div class="row-div gap-60 shaded-box">
     <div>
-      <h2>Current Conditions score</h2>
+      <h4>Current Conditions score</h4>
       <p>{{ text3 }}</p>
     </div>
     <div>
-      <h4>Condition Score Scale</h4>
       <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true"></app-legend>
     </div>
 </div>
-<div class="row-div gap-60">
+<div class="row-div gap-60 shaded-box">
     <div>
-      <h2>Opportunity score (Coming soon)</h2>
+      <h4>Opportunity score</h4>
       <p>{{ text4 }}</p>
     </div>
     <div>
-      <h4>Opportunity Score Scale</h4>
       <app-legend [legend]="legend" [vertical]="true" [hideTitles]="true"></app-legend>
     </div>
   </div>
-  <div class="row-div">
+  <div class="row-div align-center">
     <button mat-icon-button><mat-icon class="material-symbols-outlined">info</mat-icon></button>
-    <div>{{ text5 }}</div>
+    <span><b><u>Learn more</u></b> about how data is used.</span>
   </div>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.scss
@@ -1,7 +1,7 @@
 .panel-container {
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 10px;
   height: 100%;
   width: 100%;
 }
@@ -13,4 +13,32 @@
 
 .gap-60 {
   gap: 60px;
+}
+
+.align-center {
+  align-items: center;
+}
+
+.secondary-text {
+  font-size: 13px;
+  opacity: 0.66;
+  line-height: 20px;
+}
+
+h4 {
+  color: #474747;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.select-box {
+  align-self: flex-start;
+}
+
+.shaded-box {
+  background-color: rgba(220, 228, 244, 0.39);
+  border-radius: 21px;
+  box-sizing: border-box;
+  padding: 20px;
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
@@ -50,7 +50,7 @@ describe('CreateScenariosIntroComponent', () => {
   });
 
   it('should fetch colormap from service to create legend', () => {
-    expect(fakeMapService.getColormap).toHaveBeenCalledOnceWith('viridis');
+    expect(fakeMapService.getColormap).toHaveBeenCalledOnceWith('turbo');
     expect(component.legend).toEqual(
       colormapConfigToLegend(fakeColormapConfig)
     );

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.ts
@@ -6,48 +6,33 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'app-create-scenarios-intro',
   templateUrl: './create-scenarios-intro.component.html',
-  styleUrls: ['./create-scenarios-intro.component.scss']
+  styleUrls: ['./create-scenarios-intro.component.scss'],
 })
 export class CreateScenariosIntroComponent implements OnInit {
   readonly text1: string = `
-    Scenarios consist of project areas identified by your priorities and constraints
-    within the planning area. You can draw or upload your own project areas when creating
-    scenarios or Planscape can recommend some project areas and scenarios within those
-    project areas.
-  `;
-
-  readonly text2: string = `
-    You can choose to use either Current Condition scores or Management Opportunity scores to
-    inform your selection of priorities.
+  You can choose to use either the Current Condition scores or Management Opportunity scores
+  to inform the identification and prioritization of project areas for treatment. Priorities
+  are based on the Pillars of Resilience Framework.
   `;
 
   readonly text3: string = `
-    Define project areas based on choosing priorities based only on the current condition of
-    the defined planning area. Future modeling is not considered in this mode.
+    Uses the current condition of the defined planning area. Future modeling is not considered.
   `;
 
   readonly text4: string = `
-    Choose priorities using the Pillars of Resilience Framework. Priorities with higher
-    opportunity scores (-1 to +1 range) represent how management value is greatest in the near
-    term within the defined planning area. Future modeling is considered in this mode.
-  `;
-
-  readonly text5: string = `
-    To learn more about how priorities are defined and used within this tool, visit
-    linkaddresshere.
+    Uses both current and future conditions of the defined planning area.
   `;
 
   legend: Legend | undefined;
 
-  constructor(private mapService: MapService) { }
+  constructor(private mapService: MapService) {}
 
   ngOnInit(): void {
     this.mapService
-      .getColormap('viridis') // TODO(leehana): replace once colormaps are finalized
+      .getColormap('turbo')
       .pipe(take(1))
       .subscribe((colormapConfig) => {
         this.legend = colormapConfigToLegend(colormapConfig);
       });
   }
-
 }


### PR DESCRIPTION
Tweak UI for Plan Step 1 to more closely match mocks. TODO: the blue background color for the active step is missing because the theme palette needs to be adjusted.

Closes #419 

![image](https://user-images.githubusercontent.com/10444733/215908817-79f8e52c-fda7-4146-8f34-c133bd752f69.png)
