### PR TITLE
Make plan stepper linear and update step 1

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.html
@@ -3,13 +3,15 @@
 
   <h4>Prioritize by:</h4>
 
-  <mat-form-field appearance="fill" class="select-box" subscriptSizing="dynamic">
-    <mat-label>Make Selection</mat-label>
-    <mat-select>
-      <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
-      <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
-    </mat-select>
-  </mat-form-field>
+  <form [formGroup]="formGroup!">
+    <mat-form-field appearance="fill" class="select-box" subscriptSizing="dynamic">
+      <mat-label>Make Selection</mat-label>
+      <mat-select formControlName="scoreSelectCtrl">
+        <mat-option value="Current conditions scores">Current Conditions scores</mat-option>
+        <mat-option value="Management opportunity scores" disabled>Opportunity scores (Coming soon)</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
 
   <div class="row-div gap-60 shaded-box">
     <div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder, Validators } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
@@ -37,11 +38,20 @@ describe('CreateScenariosIntroComponent', () => {
         SharedModule,
       ],
       declarations: [CreateScenariosIntroComponent],
-      providers: [{ provide: MapService, useValue: fakeMapService }],
+      providers: [
+        FormBuilder,
+        { provide: MapService, useValue: fakeMapService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CreateScenariosIntroComponent);
     component = fixture.componentInstance;
+
+    const fb = fixture.componentRef.injector.get(FormBuilder);
+    component.formGroup = fb.group({
+      scoreSelectCtrl: ['', Validators.required],
+    });
+
     fixture.detectChanges();
   });
 
@@ -54,5 +64,14 @@ describe('CreateScenariosIntroComponent', () => {
     expect(component.legend).toEqual(
       colormapConfigToLegend(fakeColormapConfig)
     );
+  });
+
+  it('when form is valid, form complete event is emitted', () => {
+    spyOn(component.formCompleteEvent, 'emit');
+
+    // Fill out form to make it "valid"
+    component.formGroup?.get('scoreSelectCtrl')?.setValue('test');
+
+    expect(component.formCompleteEvent.emit).toHaveBeenCalledOnceWith();
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios-intro/create-scenarios-intro.component.ts
@@ -1,7 +1,8 @@
+import { FormGroup } from '@angular/forms';
 import { Legend, colormapConfigToLegend } from 'src/app/types';
 import { take } from 'rxjs';
 import { MapService } from './../../../services/map.service';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-create-scenarios-intro',
@@ -9,6 +10,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./create-scenarios-intro.component.scss'],
 })
 export class CreateScenariosIntroComponent implements OnInit {
+  @Input() formGroup: FormGroup | undefined;
+  @Output() formCompleteEvent = new EventEmitter<void>();
+
   readonly text1: string = `
   You can choose to use either the Current Condition scores or Management Opportunity scores
   to inform the identification and prioritization of project areas for treatment. Priorities
@@ -34,5 +38,11 @@ export class CreateScenariosIntroComponent implements OnInit {
       .subscribe((colormapConfig) => {
         this.legend = colormapConfigToLegend(colormapConfig);
       });
+
+    this.formGroup?.statusChanges.subscribe(status => {
+      if (status === 'VALID') {
+        this.formCompleteEvent.emit();
+      }
+    });
   }
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -3,17 +3,17 @@
   <div class="create-scenarios-panel-content"
     [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
 
-    <mat-stepper orientation="vertical" class="stepper"
+    <mat-stepper #stepper orientation="vertical" class="stepper" [linear]="true"
       (selectionChange)="selectedStepChanged($event)">
 
       <!-- Step 1: Select condition score -->
-      <mat-step #step1>
+      <mat-step #step1 [stepControl]="formGroups[0]">
         <ng-template matStepLabel>
           <div class="step-label-header">
             Select condition score
           </div>
         </ng-template>
-        <app-create-scenarios-intro></app-create-scenarios-intro>
+        <app-create-scenarios-intro [formGroup]="formGroups[0]" (formCompleteEvent)="stepper.next()"></app-create-scenarios-intro>
       </mat-step>
 
       <!-- Step 2: Set constraints -->

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -27,7 +27,7 @@
   display: flex;
   height: 100%;
   overflow-y: scroll;
-  padding: 32px 80px 32px 32px;
+  padding: 16px 80px 32px 32px;
 }
 
 /** Always show scrollbar. */

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -23,4 +23,20 @@ describe('CreateScenariosComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('stepper should begin on the first step', () => {
+    expect(component.stepper?.selectedIndex).toEqual(0);
+  });
+
+  it('advancing the stepper is blocked if the step form is invalid', () => {
+    component.stepper?.next();
+
+    expect(component.stepper?.selectedIndex).toEqual(0);
+  });
+
+  it('stepper advances automatically when step form is valid', () => {
+    component.formGroups[0].get('scoreSelectCtrl')?.setValue('test');
+
+    expect(component.stepper?.selectedIndex).toEqual(1);
+  });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -9,8 +9,15 @@ import {
   trigger,
 } from '@angular/animations';
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatStepper } from '@angular/material/stepper';
 import { BehaviorSubject } from 'rxjs';
 import {
   colorTransitionTrigger,
@@ -78,6 +85,8 @@ interface StepState {
   ],
 })
 export class CreateScenariosComponent {
+  @ViewChild(MatStepper) stepper: MatStepper | undefined;
+
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
   @Input() planningStep: PlanStep = PlanStep.CreateScenarios;
   @Output() changeConditionEvent = new EventEmitter<string>();

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/animations';
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
 import {
   colorTransitionTrigger,
@@ -83,11 +84,18 @@ export class CreateScenariosComponent {
   @Output() changeConstraintsEvent = new EventEmitter<Constraints>();
   @Output() changePrioritiesEvent = new EventEmitter<Priorities>();
 
+  formGroups: FormGroup[];
   readonly PlanStep = PlanStep;
   panelExpanded: boolean = true;
   stepStates: StepState[];
 
-  constructor() {
+  constructor(private fb: FormBuilder) {
+    this.formGroups = [
+      // Step 1: Select condition score
+      this.fb.group({
+        scoreSelectCtrl: ['', Validators.required],
+      }),
+    ];
     this.stepStates = [
       {
         opened: true,


### PR DESCRIPTION
## Changes
- Makes the plan stepper linear so user can't advance to the next step without completing the step's linked form group.
- Creates a form group for step 1 and passes as input.
- Automatically advance the stepper when the form is valid (since the mocks don't include submit buttons).

## Todo
- Link form groups for steps 2 and 3.

![image](https://user-images.githubusercontent.com/10444733/216154711-805fc78c-c93b-4333-9140-81a66cbf9d88.png)
