### PR TITLE
Update plan step 2 ("set constraints")

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -1,114 +1,74 @@
 <div class="constraints-panel">
   <!-- Form -->
   <div class="constraints-content">
-    <form class="constraints-form" [formGroup]="constraintsForm">
-      <!-- Budget -->
-      <div formGroupName="budgetForm" required>
-        <label class="form-label required">Budget</label>
-        <mat-radio-group formControlName="optimizeBudget" required>
-          <!-- Custom Budget -->
-            <mat-radio-button [value]="false">
-              <!-- Min -->
-              <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-                <mat-label>min</mat-label>
-                <span matTextPrefix>$ &nbsp;</span>
-                <input [required]="!constraintsForm.controls.budgetForm.controls.optimizeBudget.value" formControlName="minBudget" matInput type="number">
-              </mat-form-field>
+    <form class="constraints-form" [formGroup]="constraintsForm!">
+      <div class="flex-row">
+        <!-- Budget -->
+        <div formGroupName="budgetForm" required>
+          <label class="form-label required">Budget</label>
+          <mat-radio-group formControlName="optimizeBudget" required>
+            <!-- Custom Budget -->
+              <mat-radio-button [value]="false">
 
-              <!-- Max -->
-              <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-                <mat-label>max</mat-label>
-                <span matTextPrefix>$ &nbsp;</span>
-                <input [required]="!constraintsForm.controls.budgetForm.controls.optimizeBudget.value" formControlName="maxBudget" matInput type="number">
-              </mat-form-field>
-            </mat-radio-button>
+                <!-- Max -->
+                <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+                  <mat-label>Max</mat-label>
+                  <span matTextPrefix>$ &nbsp;</span>
+                  <input [required]="!constraintsForm?.get('budgetForm.optimizeBudget')?.value" formControlName="maxBudget" matInput type="number">
+                </mat-form-field>
+              </mat-radio-button>
 
-          <!-- Optimized Budget -->
+            <!-- Optimized Budget -->
             <mat-radio-button [value]="true">
-              Show estimated cost based on most optimized outcome
+              Show estimated cost range
             </mat-radio-button>
-          <mat-error *ngIf="constraintsForm.get('optimizeBudget')?.touched">Required</mat-error>
-        </mat-radio-group>
-      </div>
+          </mat-radio-group>
+        </div>
 
-      <div formGroupName="treatmentForm">
-        <!-- Treatment Percentage -->
-        <label class="form-label required">Treatment percentage of total planning area</label>
-        <div class="input-wrapper">
-          <!-- Min -->
-          <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-            <mat-label>min</mat-label>
-            <input formControlName="minArea" matInput type="number">
-            <span matSuffix>% &nbsp;</span>
-          </mat-form-field>
+        <div formGroupName="treatmentForm">
+          <!-- Treatment Percentage -->
+          <label class="form-label required">Max treatment percentage of total planning area</label>
 
           <!-- Max -->
           <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-            <mat-label>max</mat-label>
+            <mat-label>Max</mat-label>
             <input formControlName="maxArea" matInput type="number">
             <span matSuffix>% &nbsp;</span>
+            <mat-hint class="subtext">Cannot exceed 90%</mat-hint>
           </mat-form-field>
-          <div class="subtext">Cannot exceed 90%</div>
         </div>
       </div>
 
-      <div formGroupName="projectForm">
-        <!-- Project Size -->
-        <label class="form-label required">Project size</label>
-        <div class="input-wrapper">
-          <!-- Min -->
-          <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-              <mat-label>min</mat-label>
-              <input formControlName="minAcres" matInput type="number">
-              <span matSuffix>ac</span>
-            </mat-form-field>
-
-            <!-- Max -->
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-              <mat-label>max</mat-label>
-              <input formControlName="maxAcres" matInput type="number">
-              <span matSuffix>ac</span>
-            </mat-form-field>
-          </div>
-        </div>
-      </div>
-
-      <!-- Treatment type-->
-      <div class="form-section-treatment-type">
-        <label class="form-label">Treatment type</label>
-        <mat-form-field class="select-field" appearance="outline">
-          <mat-select multiple formControlName="treatmentType" placeholder="None" (selectionChange)="handleTreatmentTypeSelected($event)">
-            <mat-select-trigger>{{ treatmentTypeSelectTriggerText }}</mat-select-trigger>
-            <mat-option *ngFor="let treatment of treatmentTypes" [value]="treatment">{{treatment}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
-
-      <!-- Land ownership-->
-      <div class="form-section-land-ownership">
-        <label class="form-label">Land ownership</label>
-        <mat-form-field class="select-field" appearance="outline">
-          <mat-select multiple formControlName="landOwnership" placeholder="None" (selectionChange)="handleOwnershipSelected($event)">
-            <mat-select-trigger>{{ landOwnershipSelectTriggerText }}</mat-select-trigger>
-            <mat-option *ngFor="let owner of landOwnerships" [value]="owner">{{owner}}</mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
+      <mat-error *ngIf="constraintsForm?.get('budgetForm.optimizeBudget')?.touched">One required</mat-error>
 
       <!-- Other Constraints-->
       <div>
         <label class="form-label">Other Constraints</label>
-          <mat-checkbox formControlName="excludeAreasByDegrees">Exclude areas that are >40 degrees</mat-checkbox>
-          <mat-checkbox formControlName="excludeAreasByDistance" (change)="toggleRequiredExcludeDistance()">Exclude areas off a road by</mat-checkbox>
-        <div>
-          <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-            <mat-label>distance</mat-label>
-            <input formControlName="excludeDistance" matInput type="number">
-            <span matSuffix>ft.</span>
-          </mat-form-field>
+        <div class="flex-row">
+          <div>
+            <mat-checkbox formControlName="excludeAreasByDistance" (change)="toggleRequiredExcludeDistance()">Exclude areas off a road by</mat-checkbox>
+            <mat-form-field class="input-field margin-left" appearance="outline" floatLabel="always">
+              <mat-label>Distance</mat-label>
+              <input formControlName="excludeDistance" matInput type="number">
+              <span matSuffix>ft.</span>
+            </mat-form-field>
+          </div>
+          <div>
+            <mat-checkbox formControlName="excludeAreasByDegrees">Exclude areas that are over</mat-checkbox>
+            <mat-form-field class="input-field margin-left" appearance="outline" floatLabel="always">
+              <mat-label>Slope</mat-label>
+              <input formControlName="excludeSlope" matInput type="number">
+              <span matSuffix>degrees</span>
+            </mat-form-field>
+          </div>
         </div>
         <div class="error-text">*Required</div>
+      </div>
+
+      <!-- Next and Back -->
+      <div>
+        <button mat-flat-button [disabled]="constraintsForm?.invalid" (click)="formNextEvent.emit()">NEXT</button>
+        <button mat-flat-button (click)="formBackEvent.emit()">BACK</button>
       </div>
     </form>
   </div>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
@@ -26,24 +26,18 @@ label.required:after {
   color: red;
 }
 
-.input-wrapper {
-  margin-left: 30px;
-}
-
 .input-field {
     padding-top: 18px;
-    width: 100px;
+    width: 170px;
 
-    &:not(:last-child) {
-      margin-right: 20px;
-    }
+  &.margin-left {
+    margin-left: 28px;
+  }
 }
 
 .subtext {
   color: #5F6368;
   font-size: 12px;
-  margin-right: 98px;
-  text-align: right;
 }
 
 .select-field {
@@ -65,4 +59,8 @@ label.required:after {
   -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
   background-color: rgba(0,0,0,.5);
   border-radius: 4px;
+}
+
+.flex-row {
+  display: flex;
 }

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -1,168 +1,22 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
-import { FormBuilder, Validators } from '@angular/forms';
-import { MatSelectChange } from '@angular/material/select';
-
-interface BudgetOptimized {
-  useMostOptimizedOutcome: true;
-}
-
-interface BudgetCustom {
-  minUsd: number;
-  maxUsd: number;
-  useMostOptimizedOutcome: false;
-}
-
-type Budget = BudgetCustom | BudgetOptimized;
-
-// Temporary Constraints type
-export interface Constraints {
-  budget: Budget;
-  treatmentAreaPercentage: {
-    min: number;
-    max: number;
-  };
-  projectSize: {
-    minAcres: number;
-    maxAcres: number;
-  };
-  treatmentType: string[];
-  landOwnership: string[];
-  other: {
-    excludeAreasByDegrees: boolean;
-    excludeAreasByDistance: boolean;
-    excludeDistance: number;
-  };
-}
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'app-constraints-panel',
   templateUrl: './constraints-panel.component.html',
   styleUrls: ['./constraints-panel.component.scss'],
 })
-export class ConstraintsPanelComponent implements OnInit {
-  // TODO: Get and populate previously saved constraints
-
-  @Output()
-  changeConstraintsEvent = new EventEmitter<Constraints>();
-
-  treatmentTypes: string[] = [
-    'Mechanical Thinning',
-    'Prescribed Fire',
-    'Broadcast Burn',
-    'Fuel Reduction',
-    'Fuel Break',
-    'Road Way Clearance',
-  ];
-  landOwnerships: string[] = [
-    'Federal',
-    'State',
-    'Local',
-    'Private',
-    'Other'
-  ];
-
-  constraintsForm = this.fb.group({
-    budgetForm: this.fb.group({
-      minBudget: [''],
-      maxBudget: [''],
-      optimizeBudget: [false, Validators.required],
-    }),
-    treatmentForm: this.fb.group({
-      minArea: ['', Validators.required],
-      maxArea: ['', Validators.required],
-    }),
-    projectForm: this.fb.group({
-      minAcres: ['', Validators.required],
-      maxAcres: ['', Validators.required],
-    }),
-    treatmentType: [[...this.treatmentTypes]],
-    landOwnership: [[...this.landOwnerships]],
-    excludeAreasByDegrees: [false],
-    excludeAreasByDistance: [false],
-    excludeDistance: [''],
-  });
-
-  treatmentTypeSelectTriggerText = 'All treatment types selected';
-  landOwnershipSelectTriggerText = 'All ownerships selected';
-
-  constructor(private fb: FormBuilder) {}
-
-  ngOnInit(): void {
-    // TODO: Save constraints when plan-bottom-bar's "next" is clicked
-    this.constraintsForm.valueChanges.subscribe((formValue) => {
-      const currentBudget = formValue.budgetForm?.optimizeBudget
-        ? {
-            useMostOptimizedOutcome: true,
-          }
-        : {
-            useMostOptimizedOutcome: false,
-            minUsd: formValue.budgetForm?.minBudget,
-            maxUsd: formValue.budgetForm?.maxBudget,
-          };
-
-      const currentConstraints = {
-        budget: currentBudget,
-        treatmentAreaPercentage: {
-          min: formValue.treatmentForm?.minArea,
-          max: formValue.treatmentForm?.maxArea,
-        },
-        projectSize: {
-          minAcres: formValue.projectForm?.minAcres,
-          maxAcres: formValue.projectForm?.maxAcres,
-        },
-        treatmentType: formValue.treatmentType,
-        landOwnership: formValue.landOwnership,
-        other: {
-          excludeAreasByDegrees: formValue.excludeAreasByDegrees,
-          excludeAreasByDistance: formValue.excludeAreasByDistance,
-          excludeDistance: formValue.excludeDistance,
-        },
-      };
-      this.changeConstraintsEvent.emit(currentConstraints as any);
-    });
-  }
-
-  /** Displays the text shown in the mat-select depending on the selections.  */
-  handleTreatmentTypeSelected(matSelectChange: MatSelectChange) {
-    const allOptions = Array.from(matSelectChange.source.options);
-    const allOptionsSelected = allOptions.every((option) => option.selected);
-    const someOptionsSelected = allOptions.some((option) => option.selected);
-
-    if (allOptionsSelected) {
-      this.treatmentTypeSelectTriggerText = 'All treatment types selected';
-    } else if (someOptionsSelected) {
-      const selectedOptions = allOptions.filter((option) => option.selected);
-      const firstSelectedOption = selectedOptions[0].value;
-      if (selectedOptions.length > 1) {
-        this.treatmentTypeSelectTriggerText = `${firstSelectedOption} (+ ${selectedOptions.length - 1} more)`;
-      } else {
-        this.treatmentTypeSelectTriggerText = `${firstSelectedOption}`;
-      }
-    }
-  }
-
-  /** Displays the text shown in the mat-select depending on the selections.  */
-  handleOwnershipSelected(matSelectChange: MatSelectChange) {
-    const allOptions = Array.from(matSelectChange.source.options);
-    const allOptionsSelected = allOptions.every((option) => option.selected);
-    const someOptionsSelected = allOptions.some((option) => option.selected);
-
-    if (allOptionsSelected) {
-      this.landOwnershipSelectTriggerText = 'All ownership types selected';
-    } else if (someOptionsSelected) {
-      const selectedOptions = allOptions.filter((option) => option.selected);
-      const firstSelectedOption = selectedOptions[0].value;
-      if (selectedOptions.length > 1) {
-        this.landOwnershipSelectTriggerText = `${firstSelectedOption} (+ ${selectedOptions.length - 1} more)`;
-      } else {
-        this.landOwnershipSelectTriggerText = `${firstSelectedOption}`;
-      }
-    }
-  }
+export class ConstraintsPanelComponent {
+  @Input() constraintsForm: FormGroup | undefined;
+  @Output() formNextEvent = new EventEmitter<void>();
+  @Output() formBackEvent = new EventEmitter<void>();
 
   toggleRequiredExcludeDistance() {
-    this.constraintsForm.controls.excludeDistance.setValidators(
-        this.constraintsForm.controls.excludeAreasByDistance.value ? [Validators.required] : null);
-    this.constraintsForm.controls.excludeDistance.updateValueAndValidity();
+    this.constraintsForm!.controls['excludeDistance'].setValidators(
+      this.constraintsForm!.controls['excludeDistance'].value
+        ? [Validators.required]
+        : null
+    );
+    this.constraintsForm!.controls['excludeDistance'].updateValueAndValidity();
   }
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -17,14 +17,14 @@
       </mat-step>
 
       <!-- Step 2: Set constraints -->
-      <mat-step #step2>
+      <mat-step #step2 [stepControl]="formGroups[1]">
         <ng-template matStepLabel>
           <div class="step-label-header">Set constraints</div>
           <div class="step-label-description" *ngIf="!stepStates[1].opened">
             Constraints will be used to inform project areas and scenario options.
           </div>
         </ng-template>
-        <app-constraints-panel (changeConstraintsEvent)="changeConstraintsEvent.emit($event)">
+        <app-constraints-panel [constraintsForm]="formGroups[1]" (formNextEvent)="stepper.next()" (formBackEvent)="stepper.previous()">
         </app-constraints-panel>
       </mat-step>
 
@@ -39,8 +39,7 @@
             XX priorities selected
           </div>
         </ng-template>
-        <app-set-priorities (changeConditionEvent)="changeConditionEvent.emit($event)"
-          (changePrioritiesEvent)="changePrioritiesEvent.emit($event)" [plan$]="plan$">
+        <app-set-priorities [plan$]="plan$">
         </app-set-priorities>
       </mat-step>
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -34,7 +34,7 @@ describe('CreateScenariosComponent', () => {
     expect(component.stepper?.selectedIndex).toEqual(0);
   });
 
-  it('stepper advances automatically when step form is valid', () => {
+  it('stepper advances automatically when step 1 form is valid', () => {
     component.formGroups[0].get('scoreSelectCtrl')?.setValue('test');
 
     expect(component.stepper?.selectedIndex).toEqual(1);

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -26,8 +26,6 @@ import {
 import { Plan } from 'src/app/types';
 
 import { PlanStep } from './../plan.component';
-import { Constraints } from './constraints-panel/constraints-panel.component';
-import { Priorities } from './set-priorities/set-priorities.component';
 
 interface StepState {
   complete?: boolean;
@@ -90,8 +88,6 @@ export class CreateScenariosComponent {
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
   @Input() planningStep: PlanStep = PlanStep.CreateScenarios;
   @Output() changeConditionEvent = new EventEmitter<string>();
-  @Output() changeConstraintsEvent = new EventEmitter<Constraints>();
-  @Output() changePrioritiesEvent = new EventEmitter<Priorities>();
 
   formGroups: FormGroup[];
   readonly PlanStep = PlanStep;
@@ -99,10 +95,26 @@ export class CreateScenariosComponent {
   stepStates: StepState[];
 
   constructor(private fb: FormBuilder) {
+    // TODO: Get and populate saved scenario config
+
     this.formGroups = [
       // Step 1: Select condition score
       this.fb.group({
         scoreSelectCtrl: ['', Validators.required],
+      }),
+      // Step 2: Set constraints
+      this.fb.group({
+        budgetForm: this.fb.group({
+          maxBudget: [''],
+          optimizeBudget: [false, Validators.required],
+        }),
+        treatmentForm: this.fb.group({
+          maxArea: ['', Validators.required],
+        }),
+        excludeAreasByDegrees: [false],
+        excludeAreasByDistance: [false],
+        excludeSlope: [''],
+        excludeDistance: [''],
       }),
     ];
     this.stepStates = [
@@ -114,6 +126,13 @@ export class CreateScenariosComponent {
       {},
       {},
     ];
+
+    this.formGroups.every((formGroup) => {
+      formGroup.valueChanges.subscribe((value) => {
+        // TODO: save new values to backend
+        console.log(value);
+      });
+    });
   }
 
   selectedStepChanged(event: StepperSelectionEvent): void {


### PR DESCRIPTION
## Changes
- Simplified down the constraints form to just the fields present in latest mocks (budget, max treatment percentage, other constraints)
- Linked the constraints form to the overall stepper so advancing is blocked until form is valid
- Added next/back buttons to constraint form
- Tweaked CSS to match mocks more closely
- Unit tests
- Closes #420 

## Todo
- Link form for step 3
- Save form values to backend when form value changes

## Demo screenshot
![image](https://user-images.githubusercontent.com/10444733/216182021-390d8934-e7b9-41ca-8538-81f9e94ed29a.png)

## Mocks
![image](https://user-images.githubusercontent.com/10444733/216182269-cae27cd6-79e7-4e4c-968d-a2fff29e9fb9.png)

