### PR TITLE
Add black overlay to saved scenario table

### DIFF
--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -1,36 +1,45 @@
-<mat-card [style.margin-top]="'24px'">
-  <mat-card-header>
-    <mat-card-title>Saved Scenarios</mat-card-title>
-    <mat-card-subtitle>{{ scenarios.length }}</mat-card-subtitle>
-  </mat-card-header>
+<div class="saved-scenarios-wrapper">
+  <mat-card [style.margin-top]="'24px'">
+    <mat-card-header>
+      <mat-card-title>Saved Scenarios</mat-card-title>
+      <mat-card-subtitle>{{ scenarios.length }}</mat-card-subtitle>
+    </mat-card-header>
 
-  <mat-card-content>
-    <mat-table [dataSource]="scenarios" >
-      <!-- ID Column -->
-      <ng-container matColumnDef="id">
-        <mat-header-cell *matHeaderCellDef> Scenario </mat-header-cell>
-        <mat-cell *matCellDef="let element"> {{element.id}} </mat-cell>
-      </ng-container>
+    <mat-card-content>
+      <mat-table [dataSource]="scenarios" >
+        <!-- ID Column -->
+        <ng-container matColumnDef="id">
+          <mat-header-cell *matHeaderCellDef> Scenario </mat-header-cell>
+          <mat-cell *matCellDef="let element"> {{element.id}} </mat-cell>
+        </ng-container>
 
-      <!-- Timestamp Column -->
-      <ng-container matColumnDef="createdTimestamp">
-        <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
-        <mat-cell *matCellDef="let element"> {{element.createdTimestamp | date:'medium' }} </mat-cell>
-      </ng-container>
+        <!-- Timestamp Column -->
+        <ng-container matColumnDef="createdTimestamp">
+          <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
+          <mat-cell *matCellDef="let element"> {{element.createdTimestamp | date:'medium' }} </mat-cell>
+        </ng-container>
 
-      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-    </mat-table>
-  </mat-card-content>
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+      </mat-table>
+    </mat-card-content>
 
-  <mat-card-actions align="end">
-    <button mat-raised-button>
-      <mat-icon>open_in_new</mat-icon>
-      SEE ALL
-    </button>
+    <mat-card-actions align="end">
+      <button mat-raised-button>
+        <mat-icon>open_in_new</mat-icon>
+        SEE ALL
+      </button>
+      <button mat-raised-button color="primary" (click)="createScenario()">
+        <mat-icon>add_box</mat-icon>
+        CREATE A NEW SCENARIO
+      </button>
+    </mat-card-actions>
+  </mat-card>
+
+  <div *ngIf="scenarios.length === 0" class="no-scenarios-overlay">
+    <p>Saved scenarios will appear here.</p>
     <button mat-raised-button color="primary" (click)="createScenario()">
-      <mat-icon>add_box</mat-icon>
       CREATE A NEW SCENARIO
     </button>
-  </mat-card-actions>
-</mat-card>
+  </div>
+</div>

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
@@ -1,0 +1,29 @@
+.saved-scenarios-wrapper {
+  position: relative;
+}
+
+.mat-card {
+  border-radius: 16px;
+}
+
+.no-scenarios-overlay {
+  align-items: center;
+  backdrop-filter: blur(2px);
+  background: rgba(79, 79, 79, 0.8);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+
+  p {
+    color: white;
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 24px;
+  }
+}

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -15,13 +15,8 @@ export class SavedScenariosComponent {
   displayedColumns: string[] = ['id', 'createdTimestamp'];
 
   constructor() {
-    // TODO (leehana): populate scenarios from plan object
-    this.scenarios = [
-      {
-        id: '1',
-        createdTimestamp: now(),
-      },
-    ];
+    // TODO (leehana): query scenarios from backend
+    this.scenarios = [];
   }
 
   createScenario(): void {


### PR DESCRIPTION
Updates the saved scenario table to have a semitransparent black overlay if there are zero saved scenarios, consistent with mocks. TODO: when #463 is closed, query saved scenarios from the backend. Part of #356 but doesn't close it.

## Demo screenshot
![image](https://user-images.githubusercontent.com/10444733/216206104-c7f5d7b8-bb30-4c8f-9b1d-7eeb5a89630e.png)

## UX mocks
![image](https://user-images.githubusercontent.com/10444733/216206138-775b156d-909e-4651-8a34-c2860b9bd8a3.png)
