### PR TITLE
Small tweak to app theme

### DIFF
--- a/src/interface/src/app/plan/plan-navigation-bar/plan-navigation-bar.component.html
+++ b/src/interface/src/app/plan/plan-navigation-bar/plan-navigation-bar.component.html
@@ -2,7 +2,7 @@
   <mat-divider></mat-divider>
   <div class="button-row">
     <button mat-icon-button (click)="backToOverviewEvent.emit()">
-      <mat-icon>arrow_back</mat-icon>
+      <mat-icon color="primary">arrow_back</mat-icon>
     </button>
     <span class="title">Back to Planning Overview</span>
   </div>

--- a/src/interface/src/app/top-bar/top-bar.component.scss
+++ b/src/interface/src/app/top-bar/top-bar.component.scss
@@ -17,6 +17,7 @@
 
 // Top-bar styling
 .mat-toolbar {
+  background-color: #494949;
   height: $toolbar-height;
   padding: 0 12px;
   position: relative;

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -81,7 +81,7 @@
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue. Available color palettes: https://material.io/design/color/
-$planscape-frontend-primary: mat.define-palette(mat.$gray-palette, 800);
+$planscape-frontend-primary: mat.define-palette(mat.$indigo-palette);
 $planscape-frontend-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);
 
 // The warn palette is optional (defaults to red).


### PR DESCRIPTION
Changes the primary theme palette from grey to indigo (while preserving the grey top bar). This isn't a final choice, but will make it easier to tell which buttons, icons, etc. should be colored. Once @ayee07 defines the theme palette in #465 , we can change `styles.scss` to match.

![image](https://user-images.githubusercontent.com/10444733/216208132-94641f60-ea27-4e16-897e-aa8731be4295.png)
