### PR TITLE
Plan step 4: identify project areas

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -49,6 +49,9 @@
       <mat-step>
         <ng-template matStepLabel>
           <div class="step-label-header">Generate scenario(s)</div>
+          <div class="step-label-description" *ngIf="!stepStates[3].opened">
+            Identify project areas and prioritize treatments for optimized outcomes.
+          </div>
         </ng-template>
       </mat-step>
 
@@ -56,6 +59,9 @@
       <mat-step>
         <ng-template matStepLabel>
           <div class="step-label-header">View scenario(s)</div>
+          <div class="step-label-description" *ngIf="!stepStates[4].opened">
+            Weigh priorities to determine acreage of treatment and estimated impact on priorities.
+          </div>
         </ng-template>
       </mat-step>
     </mat-stepper>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -45,14 +45,18 @@
         </app-set-priorities>
       </mat-step>
 
-      <!-- Step 4: Generate scenario(s) -->
+      <!-- Step 4: Identify project areas -->
       <mat-step>
         <ng-template matStepLabel>
-          <div class="step-label-header">Generate scenario(s)</div>
+          <div class="step-label-header">Identify project areas</div>
           <div class="step-label-description" *ngIf="!stepStates[3].opened">
             Identify project areas and prioritize treatments for optimized outcomes.
           </div>
         </ng-template>
+        <app-identify-project-areas [formGroup]="formGroups[3]" (formNextEvent)="stepper.next()"
+          (formBackEvent)="stepper.previous()">
+
+        </app-identify-project-areas>
       </mat-step>
 
       <!-- Step 5: View scenario(s) -->

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -120,6 +120,11 @@ export class CreateScenariosComponent {
       this.fb.group({
         priorities: ['', Validators.required],
       }),
+      // Step 4: Identify project areas
+      this.fb.group({
+        generateAreas: ['', Validators.required],
+        uploadedArea: [''],
+      }),
     ];
     this.stepStates = [
       {

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
@@ -1,18 +1,28 @@
 <div>
   <form [formGroup]="formGroup!" class="form">
     Select one:
-      <mat-radio-group formControlName="generateAreas">
-        <mat-radio-button [value]="true">
-          I need project areas defined for me
-        </mat-radio-button>
-        <mat-radio-button [value]="false">
-          I need to upload shape files for my project areas
-          <button mat-stroked-button color="primary">
-            <mat-icon color="primary">upload</mat-icon>
-            UPLOAD
-          </button>
-        </mat-radio-button>
-      </mat-radio-group>
+    <mat-radio-group formControlName="generateAreas" (change)="validateFormRequirements()">
+      <mat-radio-button [value]="true">
+        I need project areas defined for me
+      </mat-radio-button>
+      <mat-radio-button [value]="false">
+        I need to upload shape files for my project areas
+        <button mat-stroked-button color="primary" (click)="showUploader = true">
+          <mat-icon color="primary">upload</mat-icon>
+          UPLOAD
+        </button>
+      </mat-radio-button>
+    </mat-radio-group>
+
+    <!-- File uploader -->
+    <file-uploader *ngIf="showUploader" class="file-uploader" requiredFileType="application/zip"
+      (fileEvent)="loadFile($event)"></file-uploader>
+
+    <mat-error *ngIf="showErrorText">[Error] Not a valid shapefile!</mat-error>
+    <div class="success-text" *ngIf="showSuccessText">
+      <mat-icon class="success-icon">check_circle</mat-icon>
+      {{ filename }} uploaded
+    </div>
   </form>
 
   <div class="flex-row">

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
@@ -1,0 +1,24 @@
+<div>
+  <form [formGroup]="formGroup!" class="form">
+    Select one:
+      <mat-radio-group formControlName="generateAreas">
+        <mat-radio-button [value]="true">
+          I need project areas defined for me
+        </mat-radio-button>
+        <mat-radio-button [value]="false">
+          I need to upload shape files for my project areas
+          <button mat-stroked-button color="primary">
+            <mat-icon color="primary">upload</mat-icon>
+            UPLOAD
+          </button>
+        </mat-radio-button>
+      </mat-radio-group>
+  </form>
+
+  <div class="flex-row">
+    <button mat-flat-button (click)="formNextEvent.emit()" [disabled]="formGroup?.invalid">
+      NEXT
+    </button>
+    <button mat-flat-button (click)="formBackEvent.emit()">BACK</button>
+  </div>
+</div>

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.scss
@@ -1,0 +1,18 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 4px;
+
+  mat-radio-group mat-radio-button {
+    margin-bottom: 28px;
+
+    button {
+      margin-left: 12px;
+    }
+  }
+}
+
+.flex-row {
+  display: flex;
+}

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
-  margin-bottom: 4px;
+  margin-bottom: 32px;
 
   mat-radio-group mat-radio-button {
     margin-bottom: 28px;
@@ -11,6 +11,23 @@
       margin-left: 12px;
     }
   }
+
+  mat-radio-group mat-radio-button:last-child {
+    margin-bottom: 0px;
+  }
+}
+
+.success-text {
+  align-items: center;
+  display: flex;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+}
+
+.success-icon {
+  color: #00C752;
+  margin-right: 4px;
 }
 
 .flex-row {

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.spec.ts
@@ -1,0 +1,88 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MaterialModule } from 'src/app/material/material.module';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import {
+  FormBuilder,
+  Validators,
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IdentifyProjectAreasComponent } from './identify-project-areas.component';
+
+fdescribe('IdentifyProjectAreasComponent', () => {
+  let component: IdentifyProjectAreasComponent;
+  let fixture: ComponentFixture<IdentifyProjectAreasComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        MaterialModule,
+        NoopAnimationsModule,
+      ],
+      declarations: [IdentifyProjectAreasComponent],
+      providers: [FormBuilder],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(IdentifyProjectAreasComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const fb = fixture.componentRef.injector.get(FormBuilder);
+    (component.formGroup = fb.group({
+      generateAreas: ['', Validators.required],
+      uploadedArea: [''],
+    })),
+      fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit event when next button is clicked and form is valid', async () => {
+    spyOn(component.formNextEvent, 'emit');
+    const nextButton: MatButtonHarness = await loader.getHarness(
+      MatButtonHarness.with({ text: 'NEXT' })
+    );
+    // Set form to valid state
+    component.formGroup?.get('generateAreas')?.setValue(true);
+
+    expect(component.formGroup?.valid).toBeTrue();
+    expect(await nextButton.isDisabled()).toBeFalse();
+
+    // Click next button
+    await nextButton.click();
+
+    expect(component.formNextEvent.emit).toHaveBeenCalledOnceWith();
+  });
+
+  it('should not emit event when next button is clicked and form is invalid', async () => {
+    spyOn(component.formNextEvent, 'emit');
+    const nextButton: MatButtonHarness = await loader.getHarness(
+      MatButtonHarness.with({ text: 'NEXT' })
+    );
+
+    // Click next button
+    await nextButton.click();
+
+    expect(component.formNextEvent.emit).toHaveBeenCalledTimes(0);
+  });
+
+  it('should emit event when previous button is clicked', async () => {
+    spyOn(component.formBackEvent, 'emit');
+    const backButton: MatButtonHarness = await loader.getHarness(
+      MatButtonHarness.with({ text: 'BACK' })
+    );
+    // Click back button
+    await backButton.click();
+
+    expect(component.formBackEvent.emit).toHaveBeenCalledOnceWith();
+  });
+});

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.ts
@@ -1,0 +1,19 @@
+import { FormGroup } from '@angular/forms';
+import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'app-identify-project-areas',
+  templateUrl: './identify-project-areas.component.html',
+  styleUrls: ['./identify-project-areas.component.scss']
+})
+export class IdentifyProjectAreasComponent implements OnInit {
+  @Input() formGroup: FormGroup | undefined;
+  @Output() formNextEvent = new EventEmitter<void>();
+  @Output() formBackEvent = new EventEmitter<void>();
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.ts
@@ -1,5 +1,7 @@
-import { FormGroup } from '@angular/forms';
+import { FormGroup, Validators } from '@angular/forms';
 import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+
+import * as shp from 'shpjs';
 
 @Component({
   selector: 'app-identify-project-areas',
@@ -11,9 +13,61 @@ export class IdentifyProjectAreasComponent implements OnInit {
   @Output() formNextEvent = new EventEmitter<void>();
   @Output() formBackEvent = new EventEmitter<void>();
 
+  filename: string = '';
+  showErrorText: boolean = false;
+  showSuccessText: boolean = false;
+  showUploader: boolean = false;
+
   constructor() { }
 
   ngOnInit(): void {
+  }
+
+  /** Updates validators for the form based on radio button selection.
+   *  If the "generate areas" radio button is selected, uploading an area isn't required.
+   *  If the "upload area" radio button is selected, uploading an area is required.
+   */
+  validateFormRequirements() {
+    const generateAreas = this.formGroup?.get('generateAreas');
+    const uploadedArea = this.formGroup?.get('uploadedArea');
+    if (generateAreas?.value) {
+      uploadedArea?.clearValidators();
+      uploadedArea?.updateValueAndValidity();
+    } else {
+      uploadedArea?.setValidators(Validators.required);
+      uploadedArea?.updateValueAndValidity();
+    }
+  }
+
+  /** Upload a shapefile and add it to the form. */
+  async loadFile(event: { type: string; value: File }) {
+    const file = event.value;
+    if (file) {
+      const reader = new FileReader();
+      const fileAsArrayBuffer: ArrayBuffer = await new Promise((resolve) => {
+        reader.onload = () => {
+          resolve(reader.result as ArrayBuffer);
+        };
+        reader.readAsArrayBuffer(file);
+      });
+      try {
+        const geojson = (await shp.parseZip(
+          fileAsArrayBuffer
+        )) as GeoJSON.GeoJSON;
+        if (geojson.type == 'FeatureCollection') {
+          this.formGroup?.get('uploadedArea')?.setValue(geojson);
+          this.showUploader = false;
+          this.showErrorText = false;
+          this.showSuccessText = true;
+          this.filename = file.name;
+          this.formGroup?.get('generateAreas')?.setValue(false);
+        } else {
+          this.showErrorText = true;
+        }
+      } catch (e) {
+        this.showErrorText = true;
+      }
+    }
   }
 
 }

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -8,6 +8,7 @@ import { SharedModule } from './../shared/shared.module';
 import { ConstraintsPanelComponent } from './create-scenarios/constraints-panel/constraints-panel.component';
 import { CreateScenariosIntroComponent } from './create-scenarios/create-scenarios-intro/create-scenarios-intro.component';
 import { CreateScenariosComponent } from './create-scenarios/create-scenarios.component';
+import { IdentifyProjectAreasComponent } from './create-scenarios/identify-project-areas/identify-project-areas.component';
 import { SetPrioritiesComponent } from './create-scenarios/set-priorities/set-priorities.component';
 import { PlanMapComponent } from './plan-map/plan-map.component';
 import { PlanNavigationBarComponent } from './plan-navigation-bar/plan-navigation-bar.component';
@@ -37,6 +38,7 @@ import { PlanComponent } from './plan.component';
     SetPrioritiesComponent,
     CreateScenariosIntroComponent,
     ConstraintsPanelComponent,
+    IdentifyProjectAreasComponent,
   ],
   imports: [
     BrowserAnimationsModule,


### PR DESCRIPTION
## Changes
- Adds preview text to steps 4 and 5
- Implements plan step 4 with options to either generate project areas, or upload a project area shapefile
- Reuses file uploader component (thanks @lattemilk !)
- Unit tests
- Addresses #423, but will keep open until shape is added to the map 

## Todo
- Add uploaded shape to the map

## Preview text
![image](https://user-images.githubusercontent.com/10444733/216485174-077fc7f2-8ddf-4cdf-a434-f8d5a65910e4.png)

## Step 4 form (untouched)
![image](https://user-images.githubusercontent.com/10444733/216485231-413cb88b-14f5-4027-bbed-9fd4723073f9.png)

## Uploader component open
![image](https://user-images.githubusercontent.com/10444733/216485287-0b0faedf-c275-475b-bd1b-abe9f2a94d67.png)

## Valid file uploaded
![image](https://user-images.githubusercontent.com/10444733/216485319-605f40c6-f85e-4b57-b1ff-e9f7b54216ee.png)

## Invalid file uploaded
![image](https://user-images.githubusercontent.com/10444733/216485416-3f89104a-2d40-43c9-a7e3-e0b4183da029.png)
