### PR TITLE
Plan step 4: draw uploaded project areas on map

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -39,4 +39,21 @@ describe('CreateScenariosComponent', () => {
 
     expect(component.stepper?.selectedIndex).toEqual(1);
   });
+
+  it('emits drawShapes event when "identify project areas" form inputs change', () => {
+    const generateAreas = component.formGroups[3].get('generateAreas');
+    const uploadedArea = component.formGroups[3].get('uploadedArea');
+    spyOn(component.drawShapesEvent, 'emit');
+
+    // Set "generate areas automatically" to true
+    generateAreas?.setValue(true);
+
+    expect(component.drawShapesEvent.emit).toHaveBeenCalledWith(null);
+
+    // Add an uploaded area and set "generate areas automatically" to false
+    generateAreas?.setValue(false);
+    uploadedArea?.setValue('testvalue');
+
+    expect(component.drawShapesEvent.emit).toHaveBeenCalledWith('testvalue');
+  });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -88,6 +88,7 @@ export class CreateScenariosComponent {
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
   @Input() planningStep: PlanStep = PlanStep.CreateScenarios;
   @Output() changeConditionEvent = new EventEmitter<string>();
+  @Output() drawShapesEvent = new EventEmitter<any>();
 
   formGroups: FormGroup[];
   readonly PlanStep = PlanStep;
@@ -137,10 +138,22 @@ export class CreateScenariosComponent {
     ];
 
     this.formGroups.forEach((formGroup) => {
-      formGroup.valueChanges.subscribe(_ => {
+      formGroup.valueChanges.subscribe((_) => {
         // TODO: save new values to backend
         console.log(formGroup.value);
       });
+    });
+
+    // When an area is uploaded, issue an event to draw it on the map.
+    // If the "generate areas" option is selected, remove any drawn areas.
+    this.formGroups[3].valueChanges.subscribe((_) => {
+      const generateAreas = this.formGroups[3].get('generateAreas');
+      const uploadedArea = this.formGroups[3].get('uploadedArea');
+      if (generateAreas?.value) {
+        this.drawShapesEvent.emit(null);
+      } else {
+        this.drawShapesEvent.emit(uploadedArea?.value);
+      }
     });
   }
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -136,10 +136,10 @@ export class CreateScenariosComponent {
       {},
     ];
 
-    this.formGroups.every((formGroup) => {
-      formGroup.valueChanges.subscribe((value) => {
+    this.formGroups.forEach((formGroup) => {
+      formGroup.valueChanges.subscribe(_ => {
         // TODO: save new values to backend
-        console.log(value);
+        console.log(formGroup.value);
       });
     });
   }

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -197,7 +197,5 @@ export class SetPrioritiesComponent implements OnInit {
       .filter((row) => row.selected)
       .map((row) => row.conditionName);
     this.formGroup?.get('priorities')?.setValue(selectedPriorities.join(', '));
-    console.log(this.formGroup?.value);
-    console.log(this.formGroup?.valid);
   }
 }

--- a/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
@@ -1,12 +1,13 @@
-import { BehaviorSubject } from 'rxjs';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { Router } from '@angular/router';
+import { featureCollection, point } from '@turf/helpers';
 import * as L from 'leaflet';
+import { BehaviorSubject } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
-import { Region, Plan } from 'src/app/types';
+import { Plan, Region } from 'src/app/types';
 
 import { PlanMapComponent } from './plan-map.component';
 
@@ -85,5 +86,26 @@ describe('PlanMapComponent', () => {
 
         expect(routerStub.navigate).toHaveBeenCalledOnceWith(['map']);
       };
+  });
+
+  describe('draw shapes on map', () => {
+    it('should draw project areas when drawShapes is called with geojson', () => {
+      const shapes = featureCollection([point([-75.343, 39.984])]);
+
+      component.drawShapes(shapes);
+
+      expect(component.projectAreasLayer).toBeDefined();
+      expect(component.map.hasLayer(component.projectAreasLayer!)).toBeTrue();
+    });
+
+    it('should remove project areas layer when drawShapes is called with null', () => {
+      const shapes = featureCollection([point([-75.343, 39.984])]);
+
+      component.drawShapes(shapes);
+      component.drawShapes(null);
+
+      expect(component.projectAreasLayer).toBeDefined();
+      expect(component.map.hasLayer(component.projectAreasLayer!)).toBeFalse();
+    });
   });
 });

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -21,6 +21,7 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   map!: L.Map;
   drawingLayer: L.GeoJSON | undefined;
+  projectAreasLayer: L.GeoJSON | undefined;
   tileLayer: L.TileLayer | undefined;
 
   constructor(private router: Router) {}
@@ -115,6 +116,22 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
     );
 
     this.map.addLayer(this.tileLayer);
+  }
+
+  /** Draw geojson shapes on the map, or erase currently drawn shapes. */
+  drawShapes(shapes: any): void {
+    this.projectAreasLayer?.remove();
+
+    if (!shapes) return;
+
+    this.projectAreasLayer = L.geoJSON(shapes, {
+      style: (_) => ({
+        color: '#ff4081',
+        fillColor: '#ff4081',
+        fillOpacity: 0.2,
+      })
+    });
+    this.projectAreasLayer.addTo(this.map);
   }
 
   expandMap() {

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -14,7 +14,9 @@
             <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'" [mapPadding]="[700, 0]"></app-plan-map>
           </div>
           <div class="plan-content-panel">
-            <app-create-scenarios [plan$]="currentPlan$" [planningStep]="currentPlanStep" (changeConditionEvent)="changeCondition($event)"></app-create-scenarios>
+            <app-create-scenarios [plan$]="currentPlan$" [planningStep]="currentPlanStep"
+              (changeConditionEvent)="changeCondition($event)" (drawShapesEvent)="drawShapes($event)">
+            </app-create-scenarios>
           </div>
         </ng-container>
       </div>

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -50,4 +50,8 @@ export class PlanComponent {
   changeCondition(filepath: string): void {
     this.map.setCondition(filepath);
   }
+
+  drawShapes(shapes: any): void {
+    this.map.drawShapes(shapes);
+  }
 }


### PR DESCRIPTION
When the user uploads a shapefile in planning step 4 ("Identify project areas"), draw it on the map. When the user selects "generate project areas" instead, remove the shapefile from the map. Fixes #423 

User uploaded a shapefile:
![image](https://user-images.githubusercontent.com/10444733/216698413-56d4e3f9-38f6-43a8-b8d0-34277c078784.png)

User uploaded shapefile, then changed their selection:
![image](https://user-images.githubusercontent.com/10444733/216698468-9ac4e0fa-6a2c-4339-abb8-103ab3594760.png)
