### PR TITLE
Frontend: save project constraints and priorities

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -8,7 +8,7 @@ import { Plan, Region } from 'src/app/types';
 import { PlanModule } from '../plan.module';
 import { CreateScenariosComponent } from './create-scenarios.component';
 
-fdescribe('CreateScenariosComponent', () => {
+describe('CreateScenariosComponent', () => {
   let component: CreateScenariosComponent;
   let fixture: ComponentFixture<CreateScenariosComponent>;
   let fakePlanService: PlanService;
@@ -82,7 +82,6 @@ fdescribe('CreateScenariosComponent', () => {
     component.formGroups[1].get('budgetForm.maxBudget')?.setValue(-1);
 
     expect(fakePlanService.updateProject).toHaveBeenCalledTimes(0);
-
   });
 
   it('emits drawShapes event when "identify project areas" form inputs change', () => {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -13,17 +13,20 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnInit,
   Output,
   ViewChild,
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, take } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { PlanService } from 'src/app/services';
 import {
   colorTransitionTrigger,
   opacityTransitionTrigger,
 } from 'src/app/shared/animations';
-import { Plan } from 'src/app/types';
+import { Plan, ProjectConfig } from 'src/app/types';
 
 import { PlanStep } from './../plan.component';
 
@@ -82,7 +85,7 @@ interface StepState {
     }),
   ],
 })
-export class CreateScenariosComponent {
+export class CreateScenariosComponent implements OnInit {
   @ViewChild(MatStepper) stepper: MatStepper | undefined;
 
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
@@ -92,10 +95,11 @@ export class CreateScenariosComponent {
   formGroups: FormGroup[];
   readonly PlanStep = PlanStep;
   panelExpanded: boolean = true;
+  projectId: number | undefined;
   stepStates: StepState[];
 
-  constructor(private fb: FormBuilder) {
-    // TODO: Get and populate saved scenario config
+  constructor(private fb: FormBuilder, private planService: PlanService) {
+    // TODO: Get and populate saved scenario config if applicable
 
     this.formGroups = [
       // Step 1: Select condition score
@@ -105,16 +109,16 @@ export class CreateScenariosComponent {
       // Step 2: Set constraints
       this.fb.group({
         budgetForm: this.fb.group({
-          maxBudget: [''],
+          maxBudget: ['', Validators.min(0)],
           optimizeBudget: [false, Validators.required],
         }),
         treatmentForm: this.fb.group({
-          maxArea: ['', Validators.required],
+          maxArea: ['', [Validators.required, Validators.min(0)]],
         }),
         excludeAreasByDegrees: [false],
         excludeAreasByDistance: [false],
-        excludeSlope: [''],
-        excludeDistance: [''],
+        excludeSlope: ['', Validators.min(0)],
+        excludeDistance: ['', Validators.min(0)],
       }),
       // Step 3: Select priorities
       this.fb.group({
@@ -130,16 +134,64 @@ export class CreateScenariosComponent {
       {},
       {},
     ];
+  }
 
-    this.formGroups.every((formGroup) => {
-      formGroup.valueChanges.subscribe((value) => {
-        // TODO: save new values to backend
-        console.log(value);
+  ngOnInit(): void {
+    // Create a new saved scenario config
+    this.plan$
+      .pipe(
+        filter((plan) => !!plan),
+        take(1)
+      )
+      .subscribe((plan) => {
+        this.planService
+          .createProjectInPlan(plan!.id)
+          .subscribe((projectId) => {
+            this.projectId = projectId;
+          });
+      });
+
+    this.formGroups.forEach((formGroup) => {
+      formGroup.valueChanges.subscribe((_) => {
+        // Update scenario config in backend
+        if (
+          this.projectId &&
+          this.formGroups.every(
+            (formGroup) => formGroup.valid || formGroup.pristine
+          )
+        ) {
+          this.planService
+            .updateProject(this.formValueToProjectConfig())
+            .subscribe();
+        }
       });
     });
   }
 
   selectedStepChanged(event: StepperSelectionEvent): void {
     this.stepStates[event.selectedIndex].opened = true;
+  }
+
+  formValueToProjectConfig(): ProjectConfig {
+    const maxBudget = this.formGroups[1].get('budgetForm.maxBudget');
+    const maxArea = this.formGroups[1].get('treatmentForm.maxArea');
+    const excludeDistance = this.formGroups[1].get('excludeDistance');
+    const excludeSlope = this.formGroups[1].get('excludeSlope');
+    const priorities = this.formGroups[2].get('priorities');
+
+    let projectConfig: ProjectConfig = {
+      id: this.projectId!,
+    };
+    if (maxBudget?.valid)
+      projectConfig.max_budget = parseFloat(maxBudget.value);
+    if (maxArea?.valid)
+      projectConfig.max_treatment_area_ratio = parseFloat(maxArea.value);
+    if (excludeDistance?.valid)
+      projectConfig.max_road_distance = parseFloat(excludeDistance.value);
+    if (excludeSlope?.valid)
+      projectConfig.max_slope = parseFloat(excludeSlope.value);
+    if (priorities?.valid) projectConfig.priorities = priorities.value;
+
+    return projectConfig;
   }
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -96,7 +96,7 @@ export class CreateScenariosComponent implements OnInit {
   formGroups: FormGroup[];
   readonly PlanStep = PlanStep;
   panelExpanded: boolean = true;
-  projectId: number | undefined;
+  projectId?: number;
   stepStates: StepState[];
 
   constructor(private fb: FormBuilder, private planService: PlanService) {

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -267,7 +267,7 @@ describe('SetPrioritiesComponent', () => {
     await checkboxHarnesses[1].check();
 
     expect(component.formGroup?.get('priorities')?.value).toEqual(
-      'test_pillar_1, test_element_1'
+      'test_pillar_1,test_element_1'
     );
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -196,7 +196,7 @@ export class SetPrioritiesComponent implements OnInit {
     const selectedPriorities: string[] = this.datasource.data
       .filter((row) => row.selected)
       .map((row) => row.conditionName);
-    this.formGroup?.get('priorities')?.setValue(selectedPriorities.join(', '));
+    this.formGroup?.get('priorities')?.setValue(selectedPriorities.join(','));
     console.log(this.formGroup?.value);
     console.log(this.formGroup?.valid);
   }

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -197,7 +197,5 @@ export class SetPrioritiesComponent implements OnInit {
       .filter((row) => row.selected)
       .map((row) => row.conditionName);
     this.formGroup?.get('priorities')?.setValue(selectedPriorities.join(','));
-    console.log(this.formGroup?.value);
-    console.log(this.formGroup?.valid);
   }
 }

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -6,7 +6,11 @@ import { TestBed } from '@angular/core/testing';
 
 import { BackendConstants } from '../backend-constants';
 import { BasePlan, Plan, Region } from '../types';
-import { PlanConditionScores, PlanPreview } from './../types/plan.types';
+import {
+  PlanConditionScores,
+  PlanPreview,
+  ProjectConfig,
+} from './../types/plan.types';
 import { BackendPlan, PlanService } from './plan.service';
 
 describe('PlanService', () => {
@@ -168,6 +172,43 @@ describe('PlanService', () => {
         BackendConstants.END_POINT.concat('/plan/scores/?id=1')
       );
       req.flush(expectedScores);
+      httpTestingController.verify();
+    });
+  });
+
+  describe('createProjectInPlan', () => {
+    it('should make HTTP request to backend', () => {
+      service.createProjectInPlan('1').subscribe((res) => {
+        expect(res).toEqual(1);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/create_project/')
+      );
+      expect(req.request.body).toEqual({ plan_id: 1 });
+      expect(req.request.method).toEqual('POST');
+      req.flush(1);
+      httpTestingController.verify();
+    });
+  });
+
+  describe('updateProject', () => {
+    it('should make HTTP request to backend', () => {
+      const projectConfig: ProjectConfig = {
+        id: 1,
+        max_budget: 200,
+      };
+
+      service.updateProject(projectConfig).subscribe((res) => {
+        expect(res).toEqual(1);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/update_project/')
+      );
+      expect(req.request.body).toEqual(projectConfig);
+      expect(req.request.method).toEqual('PUT');
+      req.flush(1);
       httpTestingController.verify();
     });
   });

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -1,18 +1,14 @@
-import { PlanPreview, PlanConditionScores } from './../types/plan.types';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BackendConstants } from '../backend-constants';
-import {
-  BehaviorSubject,
-  catchError,
-  map,
-  Observable,
-  of,
-  take,
-  tap,
-} from 'rxjs';
+import { BehaviorSubject, map, Observable, take, tap } from 'rxjs';
 
+import { BackendConstants } from '../backend-constants';
 import { BasePlan, Plan, Region } from '../types';
+import {
+  PlanConditionScores,
+  PlanPreview,
+  ProjectConfig,
+} from './../types/plan.types';
 
 export interface PlanState {
   all: {
@@ -57,7 +53,7 @@ export class PlanService {
       }),
       tap(({ result: createdPlan }) => {
         this.addPlanToState(createdPlan);
-      }),
+      })
     );
   }
 
@@ -124,6 +120,34 @@ export class PlanService {
       .pipe(take(1));
   }
 
+  /** Creates a project in a plan, and returns an ID which can be used to get or update the
+   *  project. */
+  createProjectInPlan(planId: string): Observable<number> {
+    let url = BackendConstants.END_POINT.concat('/plan/create_project/');
+    return this.http
+      .post<number>(
+        url,
+        {
+          plan_id: Number(planId),
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .pipe(take(1));
+  }
+
+  /** Updates a project with new parameters. */
+  updateProject(projectConfig: ProjectConfig): Observable<number> {
+    console.log(projectConfig);
+    let url = BackendConstants.END_POINT.concat('/plan/update_project/');
+    return this.http
+      .put<number>(url, projectConfig, {
+        withCredentials: true,
+      })
+      .pipe(take(1));
+  }
+
   private convertToPlan(plan: BackendPlan): Plan {
     return {
       id: String(plan.id),
@@ -131,7 +155,7 @@ export class PlanService {
       name: plan.name,
       region: plan.region_name,
       planningArea: plan.geometry,
-      savedScenarios: plan.scenarios?? 0,
+      savedScenarios: plan.scenarios ?? 0,
       createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
         plan.creation_timestamp
       ),

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -139,7 +139,6 @@ export class PlanService {
 
   /** Updates a project with new parameters. */
   updateProject(projectConfig: ProjectConfig): Observable<number> {
-    console.log(projectConfig);
     let url = BackendConstants.END_POINT.concat('/plan/update_project/');
     return this.http
       .put<number>(url, projectConfig, {

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -33,6 +33,15 @@ export interface Scenario {
   createdTimestamp: number; //in milliseconds since epoch
 }
 
+export interface ProjectConfig {
+  id: number;
+  max_budget?: number;
+  max_treatment_area_ratio?: number;
+  max_road_distance?: number;
+  max_slope?: number;
+  priorities?: string;
+}
+
 export interface PlanConditionScores {
   conditions: PlanConditionScore[];
 }

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -187,29 +187,29 @@ def list_plans_by_owner(request: HttpRequest) -> HttpResponse:
 def _save_project_parameters(body, project: Project):
     # Parse constraints
     max_budget = body.get('max_budget', None)
-    if max_budget is not None and not (isinstance(max_budget, float)):
-        raise ValueError("Max budget must be a float value")
+    if max_budget is not None and not (isinstance(max_budget, (int, float))):
+        raise ValueError("Max budget must be a number value")
 
     max_treatment_area_ratio = body.get('max_treatment_area_ratio', None)
     if (max_treatment_area_ratio is not None and
-            (not (isinstance(max_treatment_area_ratio, float)) or max_treatment_area_ratio < 0)):
+            (not (isinstance(max_treatment_area_ratio, (int, float))) or max_treatment_area_ratio < 0)):
         raise ValueError(
-            "Max treatment must be a float value >= 0.0")
+            "Max treatment must be a number value >= 0.0")
 
     max_road_distance = body.get('max_road_distance', None)
-    if max_road_distance is not None and not (isinstance(max_road_distance, float)):
-        raise ValueError("Max distance from road must be a float value")
+    if max_road_distance is not None and not (isinstance(max_road_distance, (int, float))):
+        raise ValueError("Max distance from road must be a number value")
 
     max_slope = body.get('max_slope', None)
     if (max_slope is not None and
-            (not (isinstance(max_slope, float)) or max_slope < 0)):
+            (not (isinstance(max_slope, (int, float))) or max_slope < 0)):
         raise ValueError(
-            "Max slope must be a float value >= 0.0")
+            "Max slope must be a number value >= 0.0")
 
-    project.max_budget = max_budget
-    project.max_treatment_area_ratio = max_treatment_area_ratio
-    project.max_road_distance = max_road_distance
-    project.max_slope = max_slope
+    project.max_budget = float(max_budget) if max_budget else None
+    project.max_treatment_area_ratio = float(max_treatment_area_ratio) if max_treatment_area_ratio else None
+    project.max_road_distance = float(max_road_distance) if max_road_distance else None
+    project.max_slope = float(max_slope) if max_slope else None
 
     # Parse priorities
     priorities = body.get('priorities', None)


### PR DESCRIPTION
## Changes
- Small change to `plan/views.py` in backend: accept float or int values for parameters, and cast to float before saving. This is necessary because Typescript doesn't have a float type, only a number type.
- When the user enters the scenario planning flow, frontend calls the `plan/create_project` API to create a new, empty project.
- When the user edits values in scenario planning (e.g. priorities), frontend calls the `plan/update_project` API to store the new parameters.
- Unit tests.
- Fixes #218 

## No UI change