### PR TITLE
Add /list_projects_for_plan endpoint

### DIFF
--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -730,6 +730,8 @@ class ListProjectsTest(TransactionTestCase):
 
         self.plan_with_user = create_plan(
             self.user, 'plan', stored_geometry, [])
+        self.plan_without_user = create_plan(
+            None, 'plan', stored_geometry, [])
 
     def test_list_no_plan_id(self):
         self.client.force_login(self.user)
@@ -739,14 +741,22 @@ class ListProjectsTest(TransactionTestCase):
             content_type="application/json")
         self.assertEqual(response.status_code, 400)
 
-    def test_list_no_projects(self):
+    def test_list_no_matching_plan(self):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse('plan:list_projects_for_plan'),
             {'plan_id': 4},
             content_type="application/json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()), 0)
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_no_projects(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('plan:list_projects_for_plan'),
+            {'plan_id': self.plan_with_user.pk},
+            content_type="application/json")
+        print(response.content)
+        self.assertEqual(response.status_code, 400)
 
     def test_list_projects(self):
         self.client.force_login(self.user)

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -718,6 +718,50 @@ class GetProjectTest(TransactionTestCase):
                          self.condition1.pk, self.condition2.pk])
 
 
+class ListProjectsTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+
+        self.geometry = {'type': 'MultiPolygon',
+                         'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
+        stored_geometry = GEOSGeometry(json.dumps(self.geometry))
+
+        self.plan_with_user = create_plan(
+            self.user, 'plan', stored_geometry, [])
+
+    def test_list_no_plan_id(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('plan:list_projects_for_plan'),
+            {},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_no_projects(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('plan:list_projects_for_plan'),
+            {'plan_id': 4},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 0)
+
+    def test_list_projects(self):
+        self.client.force_login(self.user)
+        self.project_with_user = Project.objects.create(
+            owner=self.user, plan=self.plan_with_user, max_budget=100)
+
+        response = self.client.get(
+            reverse('plan:list_projects_for_plan'),
+            {'plan_id': self.plan_with_user.pk},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]['id'], self.project_with_user.pk)
+
+
 class GetProjectAreaTest(TransactionTestCase):
     def setUp(self):
         self.geometry = {'type': 'MultiPolygon',

--- a/src/planscape/plan/urls.py
+++ b/src/planscape/plan/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from plan.views import (
     create_plan, create_project, delete, get_plan, get_project,
-    get_project_areas, get_scores, list_plans_by_owner, create_project_area, update_project)
+    get_project_areas, get_scores, list_plans_by_owner, create_project_area, update_project, list_projects_for_plan)
 
 app_name = 'plan'
 
@@ -15,6 +15,7 @@ urlpatterns = [
     # Projects
     path('create_project/', create_project, name='create_project'),
     path('get_project/', get_project, name='get_project'),
+    path('list_projects_for_plan/', list_projects_for_plan, name='list_projects_for_plan'),
     path('update_project/', update_project, name='update_project'),
     path('create_project_area/', create_project_area, name='create_project_area'),
     path('get_project_areas/', get_project_areas, name='get_project_areas'),

--- a/src/planscape/plan/urls.py
+++ b/src/planscape/plan/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 from plan.views import (
     create_plan, create_project, delete, get_plan, get_project,
-    get_project_areas, get_scores, list_plans_by_owner, create_project_area, update_project, list_projects_for_plan)
+    get_project_areas, get_scores, list_plans_by_owner, create_project_area, 
+    update_project, list_projects_for_plan)
 
 app_name = 'plan'
 
@@ -15,7 +16,8 @@ urlpatterns = [
     # Projects
     path('create_project/', create_project, name='create_project'),
     path('get_project/', get_project, name='get_project'),
-    path('list_projects_for_plan/', list_projects_for_plan, name='list_projects_for_plan'),
+    path('list_projects_for_plan/', list_projects_for_plan,
+         name='list_projects_for_plan'),
     path('update_project/', update_project, name='update_project'),
     path('create_project_area/', create_project_area, name='create_project_area'),
     path('get_project_areas/', get_project_areas, name='get_project_areas'),

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -278,6 +278,20 @@ def update_project(request: HttpRequest) -> HttpResponse:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 
+@csrf_exempt
+def list_projects_for_plan(request: HttpRequest) -> HttpResponse:
+    try:
+        assert isinstance(request.GET['plan_id'], str)
+        plan_id = request.GET.get('plan_id', "0")
+
+        user = _get_user(request)
+
+        projects = Project.objects.filter(owner=user, plan=plan_id)
+        return JsonResponse([ProjectSerializer(project).data for project in projects], safe=False)
+    except Exception as e:
+        return HttpResponseBadRequest("Ill-formed request: " + str(e))
+
+
 def get_project(request: HttpRequest) -> HttpResponse:
     try:
         assert isinstance(request.GET['id'], str)

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -13,6 +13,7 @@ from plan.models import Plan, Project, ProjectArea
 from plan.serializers import (PlanSerializer, ProjectAreaSerializer,
                               ProjectSerializer)
 from planscape import settings
+from django.shortcuts import get_list_or_404
 
 # TODO: remove csrf_exempt decorators when logged in users are required.
 
@@ -286,7 +287,7 @@ def list_projects_for_plan(request: HttpRequest) -> HttpResponse:
 
         user = _get_user(request)
 
-        projects = Project.objects.filter(owner=user, plan=int(plan_id))
+        projects = get_list_or_404(Project.objects.filter(owner=user, plan=int(plan_id)))
         return JsonResponse([ProjectSerializer(project).data for project in projects], safe=False)
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -286,7 +286,7 @@ def list_projects_for_plan(request: HttpRequest) -> HttpResponse:
 
         user = _get_user(request)
 
-        projects = Project.objects.filter(owner=user, plan=plan_id)
+        projects = Project.objects.filter(owner=user, plan=int(plan_id))
         return JsonResponse([ProjectSerializer(project).data for project in projects], safe=False)
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))


### PR DESCRIPTION
Returns a dictionary of Projects belonging to the owner with the given plan_id. May be empty if no Projects qualify.
Returns an error if the plan id does not exist in the database. 

Fixes #470 