### PR TITLE
Map condition name to condition display name in frontend

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -123,7 +123,7 @@ export class CreateScenariosComponent implements OnInit {
       }),
       // Step 3: Select priorities
       this.fb.group({
-        priorities: ['', Validators.required],
+        priorities: [[], [Validators.required, Validators.minLength(1)]],
       }),
       // Step 4: Identify project areas
       this.fb.group({

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -259,15 +259,16 @@ describe('SetPrioritiesComponent', () => {
     // Check the first priority (should be 'test_pillar_1')
     await checkboxHarnesses[0].check();
 
-    expect(component.formGroup?.get('priorities')?.value).toEqual(
-      'test_pillar_1'
-    );
+    expect(component.formGroup?.get('priorities')?.value).toEqual([
+      'test_pillar_1',
+    ]);
 
     // Check the second priority (should be 'test_element_1')
     await checkboxHarnesses[1].check();
 
-    expect(component.formGroup?.get('priorities')?.value).toEqual(
-      'test_pillar_1,test_element_1'
-    );
+    expect(component.formGroup?.get('priorities')?.value).toEqual([
+      'test_pillar_1',
+      'test_element_1',
+    ]);
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -196,6 +196,7 @@ export class SetPrioritiesComponent implements OnInit {
     const selectedPriorities: string[] = this.datasource.data
       .filter((row) => row.selected)
       .map((row) => row.conditionName);
-    this.formGroup?.get('priorities')?.setValue(selectedPriorities.join(','));
+    this.formGroup?.get('priorities')?.setValue(selectedPriorities);
+    this.formGroup?.get('priorities')?.markAsDirty();
   }
 }

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
@@ -30,7 +30,13 @@
       <!-- Priorities Column -->
       <ng-container matColumnDef="priorities">
         <mat-header-cell *matHeaderCellDef> Selected Priorities </mat-header-cell>
-        <mat-cell *matCellDef="let element"> {{element.priorities}} </mat-cell>
+        <mat-cell *matCellDef="let element">
+          <div>
+            <div *ngFor="let priority of displayPriorities(element.priorities)">
+              {{priority}}
+            </div>
+          </div>
+        </mat-cell>
       </ng-container>
 
       <!-- Constraints Column -->

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.spec.ts
@@ -1,21 +1,34 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ProjectConfig } from 'src/app/types';
-import { of } from 'rxjs';
-import { PlanService } from 'src/app/services';
+import { BehaviorSubject, of } from 'rxjs';
+import { MapService, PlanService } from 'src/app/services';
 import { MaterialModule } from 'src/app/material/material.module';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ScenarioConfigurationsComponent } from './scenario-configurations.component';
 
-describe('UnsavedScenariosComponent', () => {
+describe('ScenarioConfigurationsComponent', () => {
   let component: ScenarioConfigurationsComponent;
   let fixture: ComponentFixture<ScenarioConfigurationsComponent>;
+  let fakeMapService: MapService;
   let fakePlanService: PlanService;
 
   const fakeConfig: ProjectConfig = {
-    id: 1
+    id: 1,
+    priorities: ['fake_priority']
   };
 
   beforeEach(async () => {
+    let nameMap = new Map<string, string>();
+    nameMap.set('fake_priority', 'fake_display_priority');
+
+    fakeMapService = jasmine.createSpyObj<MapService>(
+      'MapService',
+      {},
+      {
+        conditionNameToDisplayNameMap$: new BehaviorSubject(nameMap)
+      }
+    );
     fakePlanService = jasmine.createSpyObj<PlanService>(
       'PlanService',
       {
@@ -28,6 +41,9 @@ describe('UnsavedScenariosComponent', () => {
       imports: [ MaterialModule ],
       declarations: [ ScenarioConfigurationsComponent ],
       providers: [
+        {
+          provide: MapService, useValue: fakeMapService
+        },
         {
           provide: PlanService, useValue: fakePlanService
         }
@@ -47,5 +63,9 @@ describe('UnsavedScenariosComponent', () => {
   it('should get a list of scenario configs', () => {
     expect(fakePlanService.getProjects).toHaveBeenCalled();
     expect(component.configurations).toEqual([fakeConfig]);
+  });
+
+  it('should map priorities to display names', () => {
+    expect(component.displayPriorities(fakeConfig.priorities!)).toEqual(['fake_display_priority']);
   });
 });

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
@@ -1,3 +1,4 @@
+import { MapService } from './../../../services/map.service';
 import { Component, Input, OnInit } from '@angular/core';
 import { PlanService } from 'src/app/services';
 import { Plan, ProjectConfig } from 'src/app/types';
@@ -18,11 +19,23 @@ export class ScenarioConfigurationsComponent implements OnInit {
     'constraints',
   ];
 
-  constructor(private planService: PlanService) {}
+  constructor(
+    private mapService: MapService,
+    private planService: PlanService
+  ) {}
 
   ngOnInit(): void {
     this.planService.getProjects(this.plan?.id!).subscribe((result) => {
       this.configurations = result;
     });
+  }
+
+  displayPriorities(priorities: string[]): string[] {
+    let nameMap = this.mapService.conditionNameToDisplayNameMap$.value;
+    return priorities
+      .map((priority) => {
+        if (nameMap.has(priority)) return nameMap.get(priority)!;
+        return priority;
+      });
   }
 }

--- a/src/interface/src/app/services/map.service.spec.ts
+++ b/src/interface/src/app/services/map.service.spec.ts
@@ -21,7 +21,12 @@ describe('MapService', () => {
   const boundaryConfigs: BoundaryConfig[] = [];
 
   const conditionsConfig: ConditionsConfig = {
-    pillars: [],
+    pillars: [
+      {
+        pillar_name: 'pillar',
+        display_name: 'pillar_display',
+      },
+    ],
   };
 
   beforeEach(() => {
@@ -53,6 +58,12 @@ describe('MapService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('populates condition display name map', () => {
+    const nameMap = new Map<string, string>([['pillar', 'pillar_display']]);
+
+    expect(service.conditionNameToDisplayNameMap$.value).toEqual(nameMap);
+  });
+
   describe('getBoundaryShapes', () => {
     it('gets shapes from the assets', () => {
       service
@@ -62,7 +73,7 @@ describe('MapService', () => {
         });
 
       const req = httpTestingController.expectOne(
-          'assets/geojson/sierra_cascade_inyo/huc12.geojson'
+        'assets/geojson/sierra_cascade_inyo/huc12.geojson'
       );
       expect(req.request.method).toEqual('GET');
       req.flush(fakeGeoJson);

--- a/src/interface/src/app/services/map.service.ts
+++ b/src/interface/src/app/services/map.service.ts
@@ -34,6 +34,7 @@ export class MapService {
   readonly conditionsConfig$ = new BehaviorSubject<ConditionsConfig | null>(
     null
   );
+  readonly conditionNameToDisplayNameMap$ = new BehaviorSubject<Map<string, string>>(new Map<string, string>());
 
   constructor(private http: HttpClient) {
     this.http
@@ -50,6 +51,7 @@ export class MapService {
       .pipe(take(1))
       .subscribe((config: ConditionsConfig) => {
         this.conditionsConfig$.next(config);
+        this.populateConditionNameMap(config);
       });
   }
 
@@ -125,5 +127,25 @@ export class MapService {
         `/conditions/colormap/?colormap=${colormap}`
       )
     );
+  }
+
+  private populateConditionNameMap(config: ConditionsConfig) {
+    let nameMap = this.conditionNameToDisplayNameMap$.value;
+    config.pillars?.forEach(pillar => {
+      if (!!pillar.pillar_name && !!pillar.display_name) {
+        nameMap.set(pillar.pillar_name, pillar.display_name);
+      }
+      pillar.elements?.forEach(element => {
+        if (!!element.element_name && !!element.display_name) {
+          nameMap.set(element.element_name, element.display_name);
+        }
+        element.metrics?.forEach(metric => {
+          if (!!metric.metric_name && !!metric.display_name) {
+            nameMap.set(metric.metric_name, metric.display_name);
+          }
+        });
+      });
+    });
+    this.conditionNameToDisplayNameMap$.next(nameMap);
   }
 }

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -40,7 +40,7 @@ export interface ProjectConfig {
   max_treatment_area_ratio?: number;
   max_road_distance?: number;
   max_slope?: number;
-  priorities?: string;
+  priorities?: string[];
 }
 
 export interface PlanConditionScores {

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -446,7 +446,7 @@ class CreateProjectTest(TransactionTestCase):
 
         response = self.client.post(
             reverse('plan:create_project'), {
-                'plan_id': self.plan_with_user.pk, 'priorities': 'condition1'},
+                'plan_id': self.plan_with_user.pk, 'priorities': ['condition1']},
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
@@ -459,7 +459,7 @@ class CreateProjectTest(TransactionTestCase):
 
         response = self.client.post(
             reverse('plan:create_project'), {
-                'plan_id': self.plan_with_user.pk, 'priorities': 'condition3'},
+                'plan_id': self.plan_with_user.pk, 'priorities': ['condition3']},
             content_type='application/json')
         self.assertEqual(response.status_code, 400)
 
@@ -536,7 +536,7 @@ class UpdateProjectTest(TransactionTestCase):
         self.client.force_login(self.user)
         response = self.client.put(
             reverse('plan:update_project'), {'id': self.project_with_user.pk,
-                                             'priorities': 'condition2'}, content_type='application/json')
+                                             'priorities': ['condition2']}, content_type='application/json')
         self.assertEqual(response.status_code, 200)
         project = Project.objects.get(id=self.project_with_user.pk)
         self.assertEqual(project.max_budget, None)
@@ -761,7 +761,7 @@ class ListProjectsTest(TransactionTestCase):
     def test_list_projects(self):
         self.client.force_login(self.user)
         base_condition = BaseCondition.objects.create(
-            condition_level=ConditionLevel.ELEMENT, display_name='test_condition')
+            condition_level=ConditionLevel.ELEMENT, condition_name='test_condition')
         self.condition = Condition.objects.create(condition_dataset=base_condition)
         self.project_with_user = Project.objects.create(
             owner=self.user, plan=self.plan_with_user, max_budget=100)

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -214,7 +214,7 @@ def _save_project_parameters(body, project: Project):
 
     # Parse priorities
     priorities = body.get('priorities', None)
-    priorities_list = [] if priorities is None else priorities.split(',')
+    priorities_list = [] if priorities is None else priorities
     for pri in priorities_list:
         base_condition = BaseCondition.objects.get(condition_name=pri)
         condition = Condition.objects.get(
@@ -292,7 +292,7 @@ def list_projects_for_plan(request: HttpRequest) -> HttpResponse:
         projects = [ProjectSerializer(project).data for project in projects]
 
         for project in projects:
-            project['priorities'] = [Condition.objects.get(pk=priority).condition_dataset.display_name for priority in project['priorities']]
+            project['priorities'] = [Condition.objects.get(pk=priority).condition_dataset.condition_name for priority in project['priorities']]
 
         return JsonResponse(projects, safe=False)
     except Exception as e:


### PR DESCRIPTION
## Changes
- There was a discrepancy between `plan/create_project` and `plan/list_projects_by_plan`; the first accepts priorities as a string, and the second outputs priorities as a list. I changed `plan/create_project` and `plan/update_project` to accept priorities as a list, so only one `ProjectConfig` type needs to exist in the frontend.
- Made the call that the backend should both accept and output `condition_name` instead of `display_name`, and frontend can maintain a mapping of condition names to display names. This map is generated from the config object retrieved from the `conditions/config` API.
- Fixed formatting for condition display names in the Plan Overview.
- Related to #463 and #484 

![image](https://user-images.githubusercontent.com/10444733/217668092-217ddf91-2cab-4607-a74c-71d10236f28e.png)
