### PR TITLE
add ability to delete scenario configurations

### DIFF
--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
@@ -8,10 +8,10 @@
       <!-- Select Column -->
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>
-          <mat-checkbox></mat-checkbox>
+          <mat-checkbox (change)="selectAllConfigs($event)"></mat-checkbox>
         </mat-header-cell>
         <mat-cell *matCellDef="let element">
-          <mat-checkbox></mat-checkbox>
+          <mat-checkbox [(ngModel)]="element.selected"></mat-checkbox>
         </mat-cell>
       </ng-container>
 
@@ -60,12 +60,12 @@
   </mat-card-content>
 
   <mat-card-actions align="end">
-    <button mat-raised-button>
-      <mat-icon>open_in_new</mat-icon>
-      SEE ALL
+    <button mat-raised-button *ngIf="showDeleteButton()" (click)="deleteSelectedConfigs()">
+      <mat-icon>delete</mat-icon>
+      DELETE
     </button>
-    <button mat-raised-button color="primary">
-      OPEN
+    <button mat-raised-button *ngIf="showContinueButton()" color="primary">
+      CONTINUE PLANNING
     </button>
   </mat-card-actions>
 </mat-card>

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.spec.ts
@@ -1,42 +1,56 @@
-import { ProjectConfig } from 'src/app/types';
-import { of } from 'rxjs';
-import { PlanService } from 'src/app/services';
-import { MaterialModule } from 'src/app/material/material.module';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
+import { PlanService } from 'src/app/services';
+import { ProjectConfig } from 'src/app/types';
 
 import { ScenarioConfigurationsComponent } from './scenario-configurations.component';
 
 describe('UnsavedScenariosComponent', () => {
   let component: ScenarioConfigurationsComponent;
   let fixture: ComponentFixture<ScenarioConfigurationsComponent>;
+  let loader: HarnessLoader;
   let fakePlanService: PlanService;
 
-  const fakeConfig: ProjectConfig = {
-    id: 1
-  };
+  let fakeConfigs: ProjectConfig[];
 
   beforeEach(async () => {
+    fakeConfigs = [
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+    ];
+
     fakePlanService = jasmine.createSpyObj<PlanService>(
       'PlanService',
       {
-        getProjects: of([fakeConfig])
+        deleteProjects: of([1]),
+        getProjects: of(fakeConfigs),
       },
       {}
     );
 
     await TestBed.configureTestingModule({
-      imports: [ MaterialModule ],
-      declarations: [ ScenarioConfigurationsComponent ],
+      imports: [MaterialModule, NoopAnimationsModule],
+      declarations: [ScenarioConfigurationsComponent],
       providers: [
         {
-          provide: PlanService, useValue: fakePlanService
-        }
-      ]
-    })
-    .compileComponents();
+          provide: PlanService,
+          useValue: fakePlanService,
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ScenarioConfigurationsComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 
@@ -46,6 +60,36 @@ describe('UnsavedScenariosComponent', () => {
 
   it('should get a list of scenario configs', () => {
     expect(fakePlanService.getProjects).toHaveBeenCalled();
-    expect(component.configurations).toEqual([fakeConfig]);
+    expect(component.configurations).toEqual(fakeConfigs);
+  });
+
+  it('should show delete button if at least one config is selected', () => {
+    expect(component.showDeleteButton()).toBeFalse();
+
+    component.configurations[0].selected = true;
+
+    expect(component.showDeleteButton()).toBeTrue();
+  });
+
+  it('should show continue button if exactly one config is selected', () => {
+    expect(component.showContinueButton()).toBeFalse();
+
+    component.configurations[0].selected = true;
+
+    expect(component.showContinueButton()).toBeTrue();
+
+    component.configurations[1].selected = true;
+
+    expect(component.showContinueButton()).toBeFalse();
+  });
+
+  it('should call service when delete button is clicked', async () => {
+    component.configurations[0].selected = true;
+    component.configurations[1].selected = true;
+    let deleteButton = await loader.getHarness(MatButtonHarness);
+
+    await deleteButton.click();
+
+    expect(fakePlanService.deleteProjects).toHaveBeenCalledOnceWith([1, 2]);
   });
 });

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
@@ -1,6 +1,6 @@
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { Component, Input, OnInit } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { PlanService } from 'src/app/services';
 import { Plan, ProjectConfig } from 'src/app/types';
 
@@ -24,7 +24,10 @@ export class ScenarioConfigurationsComponent implements OnInit {
     'constraints',
   ];
 
-  constructor(private planService: PlanService, private snackbar: MatSnackBar) {}
+  constructor(
+    private planService: PlanService,
+    private snackbar: MatSnackBar
+  ) {}
 
   ngOnInit(): void {
     this.fetchProjects();
@@ -49,13 +52,24 @@ export class ScenarioConfigurationsComponent implements OnInit {
   }
 
   deleteSelectedConfigs(): void {
-    this.planService.deleteProjects(
-      this.configurations
-        .filter((config) => config.selected)
-        .map((config) => config.id)
-    ).subscribe((deletedIds) => {
-      this.snackbar.open(`Deleted ${deletedIds.length} configuration${deletedIds.length > 1 ? 's' : ''}`);
-      this.fetchProjects();
-    });
+    this.planService
+      .deleteProjects(
+        this.configurations
+          .filter((config) => config.selected)
+          .map((config) => config.id)
+      )
+      .subscribe({
+        next: (deletedIds) => {
+          this.snackbar.open(
+            `Deleted ${deletedIds.length} configuration${
+              deletedIds.length > 1 ? 's' : ''
+            }`
+          );
+          this.fetchProjects();
+        },
+        error: (err) => {
+          this.snackbar.open(`Error: ${err}`);
+        },
+      });
   }
 }

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
@@ -1,6 +1,12 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Component, Input, OnInit } from '@angular/core';
+import { MatCheckboxChange } from '@angular/material/checkbox';
 import { PlanService } from 'src/app/services';
 import { Plan, ProjectConfig } from 'src/app/types';
+
+interface ProjectConfigRow extends ProjectConfig {
+  selected?: boolean;
+}
 
 @Component({
   selector: 'app-scenario-configurations',
@@ -9,7 +15,7 @@ import { Plan, ProjectConfig } from 'src/app/types';
 })
 export class ScenarioConfigurationsComponent implements OnInit {
   @Input() plan: Plan | null = null;
-  configurations: ProjectConfig[] = [];
+  configurations: ProjectConfigRow[] = [];
   displayedColumns: string[] = [
     'select',
     'createdTimestamp',
@@ -18,11 +24,38 @@ export class ScenarioConfigurationsComponent implements OnInit {
     'constraints',
   ];
 
-  constructor(private planService: PlanService) {}
+  constructor(private planService: PlanService, private snackbar: MatSnackBar) {}
 
   ngOnInit(): void {
+    this.fetchProjects();
+  }
+
+  fetchProjects(): void {
     this.planService.getProjects(this.plan?.id!).subscribe((result) => {
       this.configurations = result;
+    });
+  }
+
+  selectAllConfigs(event: MatCheckboxChange): void {
+    this.configurations.forEach((config) => (config.selected = event.checked));
+  }
+
+  showDeleteButton(): boolean {
+    return this.configurations.filter((config) => config.selected).length > 0;
+  }
+
+  showContinueButton(): boolean {
+    return this.configurations.filter((config) => config.selected).length === 1;
+  }
+
+  deleteSelectedConfigs(): void {
+    this.planService.deleteProjects(
+      this.configurations
+        .filter((config) => config.selected)
+        .map((config) => config.id)
+    ).subscribe((deletedIds) => {
+      this.snackbar.open(`Deleted ${deletedIds.length} configuration${deletedIds.length > 1 ? 's' : ''}`);
+      this.fetchProjects();
     });
   }
 }

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -247,4 +247,24 @@ describe('PlanService', () => {
       httpTestingController.verify();
     });
   });
+
+  describe('deleteProjects', () => {
+    it('should make HTTP request to backend', () => {
+      const projectIds = [1, 2];
+
+      service.deleteProjects(projectIds).subscribe((res) => {
+        expect(res).toEqual(projectIds);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/delete_projects/')
+      );
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({
+        project_ids: projectIds,
+      });
+      req.flush(projectIds);
+      httpTestingController.verify();
+    });
+  });
 });

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -168,6 +168,19 @@ export class PlanService {
       );
   }
 
+  /** Deletes one or more projects from the backend. */
+  deleteProjects(projectIds: number[]): Observable<number[]> {
+    return this.http.post<number[]>(
+      BackendConstants.END_POINT.concat('/plan/delete_projects/'),
+      {
+        project_ids: projectIds,
+      },
+      {
+        withCredentials: true,
+      }
+    );
+  }
+
   private convertToPlan(plan: BackendPlan): Plan {
     return {
       id: String(plan.id),

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -845,7 +845,8 @@ class ListProjectsTest(TransactionTestCase):
             {'plan_id': self.plan_with_user.pk},
             content_type="application/json")
         print(response.content)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 0)
 
     def test_list_projects(self):
         self.client.force_login(self.user)

--- a/src/planscape/plan/tests.py
+++ b/src/planscape/plan/tests.py
@@ -620,7 +620,7 @@ class DeleteProjectsTest(TransactionTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(Project.objects.count(), 3)
 
-    def test_delete_multiple_plans(self):
+    def test_delete_multiple_projects(self):
         self.client.force_login(self.user)
         self.assertEqual(Project.objects.count(), 3)
         project_ids = [self.project_with_user.pk, self.project_with_user2.pk]

--- a/src/planscape/plan/urls.py
+++ b/src/planscape/plan/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
 from plan.views import (
     create_plan, create_project, delete, get_plan, get_project,
-    get_project_areas, get_scores, list_plans_by_owner, create_project_area, 
-    update_project, list_projects_for_plan)
+    get_project_areas, get_scores, list_plans_by_owner, delete_projects,
+    create_project_area, update_project, list_projects_for_plan)
 
 app_name = 'plan'
 
@@ -19,6 +19,7 @@ urlpatterns = [
     path('list_projects_for_plan/', list_projects_for_plan,
          name='list_projects_for_plan'),
     path('update_project/', update_project, name='update_project'),
+    path('delete_projects/', delete_projects, name='delete_projects'),
     path('create_project_area/', create_project_area, name='create_project_area'),
     path('get_project_areas/', get_project_areas, name='get_project_areas'),
 ]

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -287,6 +287,9 @@ def list_projects_for_plan(request: HttpRequest) -> HttpResponse:
 
         user = _get_user(request)
 
+        if Plan.objects.get(pk=plan_id) is None:
+            raise ValueError("Plan with id " + str(plan_id) + " does not exist")
+
         projects = Project.objects.filter(owner=user, plan=int(plan_id))
         
         projects = [ProjectSerializer(project).data for project in projects]


### PR DESCRIPTION
## Changes
- Adds `plan/delete_projects` API to delete one or more scenario configurations
- Modifies `plan/list_projects_for_plan` to not raise an error if a plan doesn't have any projects, but return an empty list instead
- Adds "Delete" button to list of scenario configurations in the frontend
- Show snackbar with "X configurations deleted" when configs are deleted successfully
- Unit tests in both frontend and backend
- Related to #484 

## Todo
- Update Backend API documentation

![image](https://user-images.githubusercontent.com/10444733/217678275-909d0205-fafd-4b67-bfa8-c9736001e76b.png)
