### PR TITLE
Plan Step 5 (UI only)

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -55,18 +55,18 @@
         </ng-template>
         <app-identify-project-areas [formGroup]="formGroups[3]" (formNextEvent)="stepper.next()"
           (formBackEvent)="stepper.previous()">
-
         </app-identify-project-areas>
       </mat-step>
 
-      <!-- Step 5: View scenario(s) -->
+      <!-- Step 5: Generate scenarios -->
       <mat-step>
         <ng-template matStepLabel>
-          <div class="step-label-header">View scenario(s)</div>
+          <div class="step-label-header">Generate scenarios</div>
           <div class="step-label-description" *ngIf="!stepStates[4].opened">
             Weigh priorities to determine acreage of treatment and estimated impact on priorities.
           </div>
         </ng-template>
+        <app-generate-scenarios [formGroup]="formGroups[4]" (formBackEvent)="stepper.previous()"></app-generate-scenarios>
       </mat-step>
     </mat-stepper>
   </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject, of } from 'rxjs';
 import { PlanService } from 'src/app/services';
@@ -78,10 +79,14 @@ describe('CreateScenariosComponent', () => {
   });
 
   it('should not update project if form is invalid', () => {
+    component.formGroups[0].get('scoreSelectCtrl')?.setValue('test');
+    expect(fakePlanService.updateProject).toHaveBeenCalledTimes(1);
+
     component.formGroups[1].markAsDirty();
     component.formGroups[1].get('budgetForm.maxBudget')?.setValue(-1);
+    component.stepper?.previous();
 
-    expect(fakePlanService.updateProject).toHaveBeenCalledTimes(0);
+    expect(fakePlanService.updateProject).toHaveBeenCalledTimes(1);
   });
 
   it('emits drawShapes event when "identify project areas" form inputs change', () => {
@@ -99,5 +104,19 @@ describe('CreateScenariosComponent', () => {
     uploadedArea?.setValue('testvalue');
 
     expect(component.drawShapesEvent.emit).toHaveBeenCalledWith('testvalue');
+  });
+
+  it('adds a priority weight form control for each priority', () => {
+    component.formGroups[2]
+      .get('priorities')
+      ?.setValue(['priority1', 'priority2']);
+    const priorityWeightsForm = component.formGroups[4].get(
+      'priorityWeightsForm'
+    ) as FormGroup;
+
+    expect(priorityWeightsForm.value).toEqual({
+      priority1: 1,
+      priority2: 1,
+    });
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -130,6 +130,14 @@ export class CreateScenariosComponent implements OnInit {
         generateAreas: ['', Validators.required],
         uploadedArea: [''],
       }),
+      // Step 5: Generate scenarios
+      this.fb.group({
+        priorityWeightsForm: this.fb.group({}),
+        areaPercent: [
+          10,
+          [Validators.required, Validators.min(10), Validators.max(40)],
+        ],
+      }),
     ];
     this.stepStates = [
       {
@@ -157,22 +165,6 @@ export class CreateScenariosComponent implements OnInit {
           });
       });
 
-    this.formGroups.forEach((formGroup) => {
-      formGroup.valueChanges.subscribe((_) => {
-        // Update scenario config in backend
-        if (
-          this.projectId &&
-          this.formGroups.every(
-            (formGroup) => formGroup.valid || formGroup.pristine
-          )
-        ) {
-          this.planService
-            .updateProject(this.formValueToProjectConfig())
-            .subscribe();
-        }
-      });
-    });
-
     // When an area is uploaded, issue an event to draw it on the map.
     // If the "generate areas" option is selected, remove any drawn areas.
     this.formGroups[3].valueChanges.subscribe((_) => {
@@ -184,10 +176,26 @@ export class CreateScenariosComponent implements OnInit {
         this.drawShapesEvent.emit(uploadedArea?.value);
       }
     });
+
+    // When priorities are chosen, update the form controls for step 5.
+    this.formGroups[2].get('priorities')?.valueChanges.subscribe((_) => {
+      this.updatePriorityWeightsFormControls();
+    });
   }
 
   selectedStepChanged(event: StepperSelectionEvent): void {
     this.stepStates[event.selectedIndex].opened = true;
+    // Update scenario config in backend
+    if (
+      this.projectId &&
+      this.formGroups.every(
+        (formGroup) => formGroup.valid || formGroup.pristine
+      )
+    ) {
+      this.planService
+        .updateProject(this.formValueToProjectConfig())
+        .subscribe();
+    }
   }
 
   formValueToProjectConfig(): ProjectConfig {
@@ -211,5 +219,21 @@ export class CreateScenariosComponent implements OnInit {
     if (priorities?.valid) projectConfig.priorities = priorities.value;
 
     return projectConfig;
+  }
+
+  updatePriorityWeightsFormControls(): void {
+    const priorities: string[] = this.formGroups[2].get('priorities')?.value;
+    const priorityWeightsForm: FormGroup = this.formGroups[4].get(
+      'priorityWeightsForm'
+    ) as FormGroup;
+    priorityWeightsForm.controls = {};
+    priorities.forEach((priority) => {
+      const priorityControl = this.fb.control(1, [
+        Validators.required,
+        Validators.min(1),
+        Validators.max(5),
+      ]);
+      priorityWeightsForm.addControl(priority, priorityControl);
+    });
   }
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -221,7 +221,7 @@ export class CreateScenariosComponent implements OnInit {
     return projectConfig;
   }
 
-  updatePriorityWeightsFormControls(): void {
+  private updatePriorityWeightsFormControls(): void {
     const priorities: string[] = this.formGroups[2].get('priorities')?.value;
     const priorityWeightsForm: FormGroup = this.formGroups[4].get(
       'priorityWeightsForm'

--- a/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.html
@@ -1,0 +1,50 @@
+<div class="form-wrapper">
+  <div>
+    <h1>Adjust weights</h1>
+    <p>{{text1}}</p>
+  </div>
+
+  <form [formGroup]="formGroup!">
+
+    <!-- Priority weights -->
+    <div>
+      <div class="flex-row space-between">
+        <h2>Selected priorities</h2>
+        <h2>Relative importance (1-5)</h2>
+      </div>
+      <div class="flex-row space-between" *ngFor="let priority of priorityWeightControls">
+        <h3>{{displayNameForPriority(priority.priority)}}</h3>
+        <div class="flex-row">
+          <mat-slider [min]="1" [max]="5" [thumbLabel]="true" [value]="priority.control.value"
+            (input)="updateFormWithSliderValue($event, priority.control)"
+            color="primary" [step]="1">
+            <input matSliderThumb>
+          </mat-slider>
+          <div class="slider-label">{{priority.control.value}}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Project area % -->
+    <div>
+      <h2>Project areas</h2>
+      <div class="flex-row space-between">
+        <h3>Show top % of project areas</h3>
+        <div class="flex-row">
+          <div class="slider-label">10%</div>
+          <mat-slider [min]="10" [max]="40" [thumbLabel]="true" [value]="formGroup?.get('areaPercent')?.value"
+            (input)="updateFormWithSliderValue($event, formGroup?.get('areaPercent'))" color="primary">
+            <input matSliderThumb>
+          </mat-slider>
+          <div class="slider-label">40%</div>
+        </div>
+      </div>
+    </div>
+
+</form>
+
+  <div class="flex-row gap-12">
+    <button mat-raised-button color="primary" [disabled]="formGroup?.invalid">GENERATE SCENARIO</button>
+    <button mat-flat-button (click)="formBackEvent.emit()">BACK</button>
+  </div>
+</div>

--- a/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.scss
@@ -1,0 +1,61 @@
+.form-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.slider-label {
+  color: #3367D6;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 20px;
+  width: 32px;
+}
+
+.flex-row {
+  align-items: center;
+  display: flex;
+}
+
+.space-between {
+  justify-content: space-between;
+}
+
+.gap-12 {
+  gap: 12px;
+}
+
+p {
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+}
+
+h1 {
+  color: #5F6368;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 28px;
+}
+
+h2 {
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+  opacity: 0.5;
+  margin-bottom: 0px;
+  margin-top: 16px;
+}
+
+h3 {
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 20px;
+  margin-bottom: 0px;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 8px 0px 24px 16px;
+}

--- a/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.spec.ts
@@ -1,0 +1,89 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormBuilder,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatSliderHarness } from '@angular/material/slider/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BehaviorSubject } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
+import { MapService } from 'src/app/services';
+
+import { GenerateScenariosComponent } from './generate-scenarios.component';
+
+describe('GenerateScenariosComponent', () => {
+  let component: GenerateScenariosComponent;
+  let fixture: ComponentFixture<GenerateScenariosComponent>;
+  let loader: HarnessLoader;
+  let fakeMapService: MapService;
+
+  beforeEach(async () => {
+    let nameMap = new Map<string, string>();
+    nameMap.set('fake_priority', 'fake_display_priority');
+
+    fakeMapService = jasmine.createSpyObj<MapService>(
+      'MapService',
+      {},
+      {
+        conditionNameToDisplayNameMap$: new BehaviorSubject(nameMap),
+      }
+    );
+    await TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        MaterialModule,
+        ReactiveFormsModule,
+      ],
+      declarations: [GenerateScenariosComponent],
+      providers: [
+        FormBuilder,
+        {
+          provide: MapService,
+          useValue: fakeMapService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GenerateScenariosComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const fb = fixture.componentRef.injector.get(FormBuilder);
+    component.formGroup = fb.group({
+      priorityWeightsForm: fb.group({}),
+      areaPercent: [
+        10,
+        [Validators.required, Validators.min(10), Validators.max(40)],
+      ],
+    });
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should map condition name to display name', () => {
+    expect(component.displayNameForPriority('fake_priority')).toEqual(
+      'fake_display_priority'
+    );
+  });
+
+  it('should update form with slider value', async () => {
+    const sliderHarness: MatSliderHarness = await loader.getHarness(
+      MatSliderHarness
+    );
+
+    // Set slider value to 34
+    await sliderHarness.setValue(34);
+
+    expect(component.formGroup?.get('areaPercent')?.value).toEqual(34);
+    expect(component.formGroup?.get('areaPercent')?.dirty).toBeTrue();
+  });
+});

--- a/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.ts
@@ -1,0 +1,60 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { MatSliderChange } from '@angular/material/slider';
+import { filter } from 'rxjs/operators';
+import { MapService } from 'src/app/services';
+
+@Component({
+  selector: 'app-generate-scenarios',
+  templateUrl: './generate-scenarios.component.html',
+  styleUrls: ['./generate-scenarios.component.scss'],
+})
+export class GenerateScenariosComponent implements OnInit {
+  @Input() formGroup?: FormGroup;
+  @Output() formBackEvent = new EventEmitter<void>();
+
+  private priorityNameMap?: Map<string, string>;
+  priorityWeightControls: {
+    priority: string;
+    control: AbstractControl;
+  }[] = [];
+
+  readonly text1: string = `
+    Adjust the relative importance of each focus to see a different scenario. Saved scenarios
+    will be visible to anyone that has access to the area's plan. You'll be able to compare all
+    your saved scenarios in the Area Overview.
+    `;
+
+  constructor(private mapService: MapService) {
+    this.mapService.conditionNameToDisplayNameMap$
+      .pipe(filter((nameMap) => !!nameMap))
+      .subscribe((nameMap) => {
+        this.priorityNameMap = nameMap;
+      });
+  }
+
+  ngOnInit(): void {
+    this.formGroup?.get('priorityWeightsForm')?.valueChanges.subscribe((_) => {
+      const controls = (this.formGroup?.get('priorityWeightsForm') as FormGroup)
+        .controls;
+      this.priorityWeightControls = Object.keys(controls).map((key) => {
+        return {
+          priority: key,
+          control: controls[key],
+        };
+      });
+    });
+  }
+
+  displayNameForPriority(priority: string): string | undefined {
+    return this.priorityNameMap?.get(priority);
+  }
+
+  updateFormWithSliderValue(
+    sliderEvent: MatSliderChange,
+    control?: AbstractControl | null
+  ): void {
+    control?.setValue(sliderEvent.value);
+    control?.markAsDirty();
+  }
+}

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -8,6 +8,7 @@ import { SharedModule } from './../shared/shared.module';
 import { ConstraintsPanelComponent } from './create-scenarios/constraints-panel/constraints-panel.component';
 import { CreateScenariosIntroComponent } from './create-scenarios/create-scenarios-intro/create-scenarios-intro.component';
 import { CreateScenariosComponent } from './create-scenarios/create-scenarios.component';
+import { GenerateScenariosComponent } from './create-scenarios/generate-scenarios/generate-scenarios.component';
 import { IdentifyProjectAreasComponent } from './create-scenarios/identify-project-areas/identify-project-areas.component';
 import { SetPrioritiesComponent } from './create-scenarios/set-priorities/set-priorities.component';
 import { PlanMapComponent } from './plan-map/plan-map.component';
@@ -39,6 +40,7 @@ import { PlanComponent } from './plan.component';
     CreateScenariosIntroComponent,
     ConstraintsPanelComponent,
     IdentifyProjectAreasComponent,
+    GenerateScenariosComponent,
   ],
   imports: [
     BrowserAnimationsModule,


### PR DESCRIPTION
## Changes
- Addresses #424 
- Adds UI for everything in Step 5 up to the "Generate Scenario" button
- User can set weights for each of the priorities selected in Step 3
- Changed to only save config to the backend when the stepper is advanced, instead of every time the form value changes (as this would result in too many requests once sliders are introduced)
- Unit tests

![image](https://user-images.githubusercontent.com/10444733/217969970-810b2fc0-43d5-4ef2-aaee-75bd2e498caa.png)
