### PR TITLE
Map control bugfixes and improvements

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { SharedModule } from './shared/shared.module';
 import { SignupComponent } from './signup/signup.component';
 import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
+import { ConditionTreeComponent } from './map/map-control-panel/condition-tree/condition-tree.component';
 
 @NgModule({
   declarations: [
@@ -55,6 +56,7 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     PlanCreateDialogComponent,
     LayerInfoCardComponent,
     MapControlPanelComponent,
+    ConditionTreeComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -1,6 +1,6 @@
 <mat-expansion-panel expanded="false">
   <mat-expansion-panel-header class="layer-panel-header">
-    Ecosystem scores
+    {{header}}
   </mat-expansion-panel-header>
 
   <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
@@ -22,7 +22,6 @@
               {{node.display_name}}
             </span>
             <button mat-icon-button
-              *ngIf="!isNoneNode(node)"
               [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
               (menuClosed)="node.infoMenuOpen = false">
               <mat-icon color="primary">info_outline</mat-icon>

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -1,0 +1,64 @@
+<mat-expansion-panel expanded="false">
+  <mat-expansion-panel-header class="layer-panel-header">
+    Ecosystem scores
+  </mat-expansion-panel-header>
+
+  <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
+    color="primary"
+    [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionLayer.emit(map)">
+    <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl"
+      class="condition-tree">
+      <!-- This is the tree node template for leaf nodes -->
+      <!-- There is inline padding applied to this node using styles.
+        This padding value depends on the mat-icon-button width. -->
+      <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+        <div class="mat-tree-node">
+          <div [class.disabled]="node.styleDisabled">
+            <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+              (change)="onSelect(node)">
+              {{node.display_name}}
+            </mat-radio-button>
+            <span *ngIf="node.disableSelect">
+              {{node.display_name}}
+            </span>
+            <button mat-icon-button
+              *ngIf="!isNoneNode(node)"
+              [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+              (menuClosed)="node.infoMenuOpen = false">
+              <mat-icon color="primary">info_outline</mat-icon>
+            </button>
+            <mat-menu #popoverMenu="matMenu">
+              <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+            </mat-menu>
+          </div>
+        </div>
+      </mat-tree-node>
+      <!-- This is the tree node template for expandable nodes -->
+      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+        <div class="mat-tree-node expandable-condition-node" [class.selected]="node.selected">
+          <div [class.disabled]="node.styleDisabled">
+            <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+              (change)="onSelect(node)">
+              {{node.display_name}}
+            </mat-radio-button>
+            <span *ngIf="node.disableSelect">
+              {{node.display_name}}
+            </span>
+          </div>
+            <button mat-icon-button matTreeNodeToggle
+                    [attr.aria-label]="'Toggle ' + node.display_name">
+              <mat-icon class="mat-icon-rtl-mirror">
+                {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
+              </mat-icon>
+            </button>
+        </div>
+        <!-- There is inline padding applied to this div using styles.
+            This padding value depends on the mat-icon-button width.  -->
+        <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
+            role="group">
+            <ng-container matTreeNodeOutlet></ng-container>
+        </div>
+      </mat-nested-tree-node>
+    </mat-tree>
+  </mat-radio-group>
+</mat-expansion-panel>

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -34,7 +34,7 @@
       </mat-tree-node>
       <!-- This is the tree node template for expandable nodes -->
       <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-        <div class="mat-tree-node expandable-condition-node" [class.selected]="node.selected">
+        <div class="mat-tree-node expandable-condition-node">
           <div [class.disabled]="node.styleDisabled">
             <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
               (change)="onSelect(node)">

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -1,7 +1,7 @@
 .layer-panel-header {
   background-color: #D8D8D8 !important;
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 500;
   height: 40px !important;
   line-height: 20px;
 }

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -1,0 +1,48 @@
+.layer-panel-header {
+  background-color: #D8D8D8 !important;
+  font-size: 14px;
+  font-weight: 700;
+  height: 40px !important;
+  line-height: 20px;
+}
+
+::ng-deep .mat-expansion-panel-body {
+  padding-bottom: 0px !important;
+}
+
+.condition-tree-invisible {
+  display: none;
+}
+
+.condition-tree ul,
+.condition-tree li {
+  margin-top: 0;
+  margin-bottom: 0;
+  list-style-type: none;
+}
+
+/*
+ * This padding sets alignment of the nested nodes.
+ */
+.condition-tree .mat-nested-tree-node div[role=group] {
+  padding-left: 20px;
+}
+
+/*
+ * Padding for leaf nodes.
+ * Leaf nodes need to have padding so as to align with other non-leaf nodes
+ * under the same parent.
+ */
+.condition-tree div[role=group] > .mat-tree-node {
+  padding-left: 20px;
+}
+
+.mat-tree-node > .disabled {
+  opacity: 0.5;
+}
+
+.expandable-condition-node {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -1,3 +1,11 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@import "../../../../styles.scss";
+
+$color-config:    mat.get-color-config($planscape-frontend-theme);
+$primary-palette: map.get($color-config, 'primary');
+
 .layer-panel-header {
   background-color: #D8D8D8 !important;
   font-size: 14px;
@@ -37,12 +45,21 @@
   padding-left: 20px;
 }
 
-.mat-tree-node > .disabled {
-  opacity: 0.5;
+.mat-tree-node {
+  margin: 0px -16px 0px 0px;
+
+  > .disabled {
+    opacity: 0.5;
+  }
 }
 
 .expandable-condition-node {
   align-items: center;
   display: flex;
   justify-content: space-between;
+}
+
+.mat-expansion-panel-body {
+  margin: 0px -24px;
+  padding: 0px 24px;
 }

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
@@ -16,7 +16,14 @@ describe('ConditionTreeComponent', () => {
     fixture = TestBed.createComponent(ConditionTreeComponent);
     component = fixture.componentInstance;
 
-    component.conditionsConfig$ = of({});
+    component.conditionsData$ = of([
+      {
+        children: [{}, {}, {}],
+      },
+      {
+        children: [],
+      },
+    ]);
     component.map = {
       id: 'map1',
       name: 'Map 1',

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { defaultMapConfig } from 'src/app/types';
+
+import { ConditionTreeComponent } from './condition-tree.component';
+
+describe('ConditionTreeComponent', () => {
+  let component: ConditionTreeComponent;
+  let fixture: ComponentFixture<ConditionTreeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ConditionTreeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConditionTreeComponent);
+    component = fixture.componentInstance;
+
+    component.conditionsConfig$ = of({});
+    component.map = {
+      id: 'map1',
+      name: 'Map 1',
+      config: defaultMapConfig(),
+    };
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('condition tree', () => {
+    beforeEach(() => {
+      component.conditionDataSource.data = [
+        {
+          children: [{}, {}, {}],
+        },
+        {
+          children: [],
+        },
+      ];
+    });
+
+    it('styles children of a selected node and unstyles all other nodes', () => {
+      const nodeWithChildren = component.conditionDataSource.data[0];
+      const nodeWithoutChildren = component.conditionDataSource.data[1];
+
+      component.onSelect(nodeWithChildren);
+
+      nodeWithChildren.children?.forEach((child) => {
+        expect(child.styleDisabled).toBeTrue();
+      });
+      expect(nodeWithChildren.styleDisabled).toBeFalse();
+      expect(nodeWithoutChildren.styleDisabled).toBeFalse();
+
+      component.onSelect(nodeWithoutChildren);
+
+      component.conditionDataSource.data.forEach((node) => {
+        expect(node.styleDisabled).toBeFalse();
+        node.children?.forEach((child) => {
+          expect(child.styleDisabled).toBeFalse();
+        });
+      });
+    });
+  });
+});

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
@@ -1,0 +1,187 @@
+import { NestedTreeControl } from '@angular/cdk/tree';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { MatTreeNestedDataSource } from '@angular/material/tree';
+import { filter, Observable } from 'rxjs';
+import {
+  ConditionsConfig,
+  DataLayerConfig,
+  Map,
+  NONE_DATA_LAYER_CONFIG,
+} from 'src/app/types';
+
+export interface ConditionsNode extends DataLayerConfig {
+  selected?: boolean;
+  infoMenuOpen?: boolean;
+  disableSelect?: boolean; // Node should not include a radio button
+  styleDisabled?: boolean; // Node should be greyed out but still selectable
+  children?: ConditionsNode[];
+}
+
+@Component({
+  selector: 'app-condition-tree',
+  templateUrl: './condition-tree.component.html',
+  styleUrls: ['./condition-tree.component.scss'],
+})
+export class ConditionTreeComponent implements OnInit {
+  @Input() conditionsConfig$!: Observable<ConditionsConfig | null>;
+  @Input() map!: Map;
+
+  @Output() changeConditionLayer = new EventEmitter<Map>();
+
+  conditionTreeControl = new NestedTreeControl<ConditionsNode>(
+    (node) => node.children
+  );
+  conditionDataSource = new MatTreeNestedDataSource<ConditionsNode>();
+
+  constructor() {
+    this.conditionDataSource.data = [NONE_DATA_LAYER_CONFIG];
+  }
+
+  ngOnInit(): void {
+    this.conditionsConfig$
+      .pipe(filter((config) => !!config))
+      .subscribe((config) => {
+        this.conditionDataSource.data = this.conditionsConfigToData(config!);
+        // Ensure the radio button corresponding to the saved selection is selected.
+        this.map.config.dataLayerConfig = this.findAndRevealNodeWithFilepath(
+          this.map.config.dataLayerConfig.filepath
+        );
+      });
+  }
+
+  /** Used to compute whether a node in the condition layer tree has children. */
+  hasChild = (_: number, node: ConditionsNode) =>
+    !!node.children && node.children.length > 0;
+
+  onSelect(node: ConditionsNode): void {
+    this.unstyleAndDeselectAllNodes();
+    node.selected = true;
+    this.styleDescendantsDisabled(node);
+  }
+
+  isNoneNode(node: ConditionsNode): boolean {
+    return node === NONE_DATA_LAYER_CONFIG;
+  }
+
+  /** Unstyles and deselects all nodes in the tree using recursion. */
+  private unstyleAndDeselectAllNodes(node?: ConditionsNode): void {
+    if (!node && this.conditionDataSource.data.length > 0) {
+      this.conditionDataSource.data.forEach((node) =>
+        this.unstyleAndDeselectAllNodes(node)
+      );
+    } else if (node) {
+      node.styleDisabled = false;
+      node.selected = false;
+      node.children?.forEach((child) => this.unstyleAndDeselectAllNodes(child));
+    }
+  }
+
+  /** Visually indicates that all the descendants of a condition layer node are
+   *  included in the current analysis by setting their style, using recursion.
+   */
+  private styleDescendantsDisabled(node: ConditionsNode): void {
+    node.children?.forEach((child) => {
+      child.styleDisabled = true;
+      this.styleDescendantsDisabled(child);
+    });
+  }
+
+  private conditionsConfigToData(config: ConditionsConfig): ConditionsNode[] {
+    return [
+      NONE_DATA_LAYER_CONFIG,
+      {
+        ...config,
+        display_name: 'Current condition',
+        disableSelect: true,
+        children: config.pillars
+          ?.filter((pillar) => pillar.display)
+          .map((pillar): ConditionsNode => {
+            return {
+              ...pillar,
+              disableSelect: true,
+              children: pillar.elements?.map((element): ConditionsNode => {
+                return {
+                  ...element,
+                  disableSelect: true,
+                  children: element.metrics,
+                };
+              }),
+            };
+          }),
+      },
+      {
+        display_name: 'Current condition (normalized)',
+        filepath: config.filepath?.concat('_normalized'),
+        colormap: config.colormap,
+        normalized: true,
+        disableSelect: true,
+        children: config.pillars
+          ?.filter((pillar) => pillar.display)
+          .map((pillar): ConditionsNode => {
+            return {
+              ...pillar,
+              filepath: pillar.filepath?.concat('_normalized'),
+              normalized: true,
+              children: pillar.elements?.map((element): ConditionsNode => {
+                return {
+                  ...element,
+                  filepath: element.filepath?.concat('_normalized'),
+                  normalized: true,
+                  children: element.metrics?.map((metric): ConditionsNode => {
+                    return {
+                      ...metric,
+                      filepath: metric.filepath?.concat('_normalized'),
+                      normalized: true,
+                      min_value: undefined,
+                      max_value: undefined,
+                    };
+                  }),
+                };
+              }),
+            };
+          }),
+      },
+    ];
+  }
+
+  /** Find the node matching the given filepath in the condition tree (if any), and expand its ancestors
+   *  so it becomes visible.
+   */
+  private findAndRevealNodeWithFilepath(
+    filepath: string | undefined
+  ): ConditionsNode {
+    if (!filepath || filepath === NONE_DATA_LAYER_CONFIG.filepath)
+      return NONE_DATA_LAYER_CONFIG;
+    for (let tree of this.conditionDataSource.data) {
+      if (tree.filepath === filepath) return tree;
+      if (tree.children) {
+        for (let pillar of tree.children) {
+          if (pillar.filepath === filepath) {
+            this.conditionTreeControl.expand(tree);
+            return pillar;
+          }
+          if (pillar.children) {
+            for (let element of pillar.children) {
+              if (element.filepath === filepath) {
+                this.conditionTreeControl.expand(tree);
+                this.conditionTreeControl.expand(pillar);
+                return element;
+              }
+              if (element.children) {
+                for (let metric of element.children) {
+                  if (metric.filepath === filepath) {
+                    this.conditionTreeControl.expand(tree);
+                    this.conditionTreeControl.expand(pillar);
+                    this.conditionTreeControl.expand(element);
+                    return metric;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return NONE_DATA_LAYER_CONFIG;
+  }
+}

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -114,10 +114,11 @@
             </mat-panel-title>
           </mat-expansion-panel-header>
           <div class="layer-control-container flex-center">
-            <mat-radio-group class="layer-radio-group">
+            <mat-radio-group class="layer-radio-group" color="primary" [(ngModel)]="map.config.dataLayerConfig">
               <mat-radio-button (change)="conditionTreeRaw.toggleAllLayersOff();
                 conditionTreeNormalized.toggleAllLayersOff()"
-                [checked]="map.config.dataLayerConfig.filepath === ''">
+                color="primary"
+                [value]="noneDataLayerConfig">
                 All Layers Off
               </mat-radio-button>
             </mat-radio-group>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -12,214 +12,222 @@
 
   </div>
 
-    <!-- Controls for specifying how many maps should be shown -->
-    <div class="map-count-button-row">
-      <button mat-button class="map-count-button" (click)="changeMapCount.emit(1)" aria-label="Show 1 map"
+  <!-- Controls for specifying how many maps should be shown -->
+  <div class="map-count-button-row">
+    <button mat-button class="map-count-button" (click)="changeMapCount.emit(1)"
+      aria-label="Show 1 map"
       [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 1}">
-        <div class="map-count-button-grid-cell"></div>
-      </button>
-      <button mat-button class="map-count-button" (click)="changeMapCount.emit(2)" aria-label="Show 2 maps"
+      <div class="map-count-button-grid-cell"></div>
+    </button>
+    <button mat-button class="map-count-button" (click)="changeMapCount.emit(2)"
+      aria-label="Show 2 maps"
       [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 2}">
-        <div class="map-count-button-grid-row">
-          <div class="map-count-button-grid-cell"></div>
-          <div class="map-count-button-grid-cell"></div>
-        </div>
-      </button>
-      <button mat-button class="map-count-button" (click)="changeMapCount.emit(4)" aria-label="Show 4 maps"
+      <div class="map-count-button-grid-row">
+        <div class="map-count-button-grid-cell"></div>
+        <div class="map-count-button-grid-cell"></div>
+      </div>
+    </button>
+    <button mat-button class="map-count-button" (click)="changeMapCount.emit(4)"
+      aria-label="Show 4 maps"
       [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 4}">
-      <div class="map-count-button-grid-row">
-        <div class="map-count-button-grid-cell"></div>
-        <div class="map-count-button-grid-cell"></div>
-      </div>
-      <div class="map-count-button-grid-row">
-        <div class="map-count-button-grid-cell"></div>
-        <div class="map-count-button-grid-cell"></div>
-      </div>
-      </button>
+    <div class="map-count-button-grid-row">
+      <div class="map-count-button-grid-cell"></div>
+      <div class="map-count-button-grid-cell"></div>
     </div>
+    <div class="map-count-button-grid-row">
+      <div class="map-count-button-grid-cell"></div>
+      <div class="map-count-button-grid-cell"></div>
+    </div>
+    </button>
+  </div>
 
-    <!-- Layer controls for each map, displayed in tabs -->
-    <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true" [selectedIndex]="mapViewOptions?.selectedMapIndex"
-      class="layer-controls-tab-group" (selectedIndexChange)="selectMap.emit($event)">
-      <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}">
-        <mat-accordion multi displayMode="flat">
+  <!-- Layer controls for each map, displayed in tabs -->
+  <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true"
+    [selectedIndex]="mapViewOptions?.selectedMapIndex"
+    class="layer-controls-tab-group" (selectedIndexChange)="selectMap.emit($event)">
+    <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}">
+      <mat-accordion multi displayMode="flat">
 
-          <!-- Basemap layer controls -->
-          <mat-expansion-panel expanded="true">
-            <mat-expansion-panel-header>
-              Basemaps
-            </mat-expansion-panel-header>
-            <mat-radio-group name="{{ map.id + '-base-layer-select' }}" aria-label="Select an option"
-              class="layer-radio-group" [(ngModel)]="map.config.baseLayerType" (change)="changeBaseLayer.emit(map)">
-              <mat-radio-button *ngFor="let baseLayerType of baseLayerTypes" [value]="baseLayerType"
-                checked="{{ baseLayerType == map.config.baseLayerType }}" class="layer-radio-button">
-                {{ BaseLayerType[baseLayerType] }}
-              </mat-radio-button>
-            </mat-radio-group>
-          </mat-expansion-panel>
+        <!-- Basemap layer controls -->
+        <mat-expansion-panel expanded="true">
+          <mat-expansion-panel-header>
+            Basemaps
+          </mat-expansion-panel-header>
+          <mat-radio-group name="{{ map.id + '-base-layer-select' }}" aria-label="Select an option"
+            class="layer-radio-group" [(ngModel)]="map.config.baseLayerType"
+            (change)="changeBaseLayer.emit(map)">
+            <mat-radio-button *ngFor="let baseLayerType of baseLayerTypes" [value]="baseLayerType"
+              checked="{{ baseLayerType == map.config.baseLayerType }}" class="layer-radio-button">
+              {{ BaseLayerType[baseLayerType] }}
+            </mat-radio-button>
+          </mat-radio-group>
+        </mat-expansion-panel>
 
-          <!-- Boundary layer controls -->
-          <mat-expansion-panel expanded="true">
-            <mat-expansion-panel-header>
-              Boundaries
-            </mat-expansion-panel-header>
-            <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
-              class="layer-radio-group"
-              [(ngModel)]="map.config.boundaryLayerConfig" (change)="changeBoundaryLayer.emit(map)">
-              <div class="layer-control-container">
-                <mat-radio-button class="layer-radio-button" [value]="noneBoundaryConfig">
-                  None
-                </mat-radio-button>
-              </div>
-              <div *ngFor="let boundary of boundaryConfig" class="layer-control-container">
-                <mat-radio-button class="layer-radio-button" [value]="boundary">
-                  {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
-                </mat-radio-button>
-                <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]"></mat-spinner>
-              </div>
-            </mat-radio-group>
-          </mat-expansion-panel>
-
-          <!-- Recent treatment areas controls -->
-          <mat-expansion-panel expanded="false">
-            <mat-expansion-panel-header>
-              Recent treatment areas
-            </mat-expansion-panel-header>
+        <!-- Boundary layer controls -->
+        <mat-expansion-panel expanded="true">
+          <mat-expansion-panel-header>
+            Boundaries
+          </mat-expansion-panel-header>
+          <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
+            class="layer-radio-group"
+            [(ngModel)]="map.config.boundaryLayerConfig" (change)="changeBoundaryLayer.emit(map)">
             <div class="layer-control-container">
-              <mat-checkbox name="{{ map.id + '-existing-projects-toggle' }}" aria-label="Select or deselect"
-                class="layer-checkbox" [(ngModel)]="map.config.showExistingProjectsLayer"
-                (change)="toggleExistingProjectsLayer.emit(map)">
-                Existing projects
-              </mat-checkbox>
-              <mat-spinner [diameter]="24" *ngIf="loadingIndicators['existing_projects']"></mat-spinner>
+              <mat-radio-button class="layer-radio-button" [value]="noneBoundaryConfig">
+                None
+              </mat-radio-button>
             </div>
-          </mat-expansion-panel>
+            <div *ngFor="let boundary of boundaryConfig" class="layer-control-container">
+              <mat-radio-button class="layer-radio-button" [value]="boundary">
+                {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
+              </mat-radio-button>
+              <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]">
+              </mat-spinner>
+            </div>
+          </mat-radio-group>
+        </mat-expansion-panel>
 
-          <!-- Ecosystem scores controls -->
-          <mat-expansion-panel expanded="false">
-            <mat-expansion-panel-header>
-              Ecosystem scores
-            </mat-expansion-panel-header>
+        <!-- Recent treatment areas controls -->
+        <mat-expansion-panel expanded="false">
+          <mat-expansion-panel-header>
+            Recent treatment areas
+          </mat-expansion-panel-header>
+          <div class="layer-control-container">
+            <mat-checkbox name="{{ map.id + '-existing-projects-toggle' }}"
+              aria-label="Select or deselect"
+              class="layer-checkbox" [(ngModel)]="map.config.showExistingProjectsLayer"
+              (change)="toggleExistingProjectsLayer.emit(map)">
+              Existing projects
+            </mat-checkbox>
+            <mat-spinner [diameter]="24" *ngIf="loadingIndicators['existing_projects']">
+            </mat-spinner>
+          </div>
+        </mat-expansion-panel>
 
-            <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
-              [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionLayer.emit(map)">
-              <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl"
-                class="condition-tree">
-                <!-- This is the tree node template for leaf nodes -->
-                <!-- There is inline padding applied to this node using styles.
-                  This padding value depends on the mat-icon-button width. -->
-                <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-                  <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
-                    (mouseleave)="node.showInfoIcon = false">
-                    <div [class.disabled]="node.styleDisabled">
-                      <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
-                        (change)="onSelect(node)">
-                        {{node.display_name}}
-                      </mat-radio-button>
-                      <span *ngIf="node.disableSelect">
-                        {{node.display_name}}
-                      </span>
-                      <button mat-icon-button
-                        [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
-                        [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
-                        (menuClosed)="node.infoMenuOpen = false">
-                        <mat-icon>info_outline</mat-icon>
-                      </button>
-                      <mat-menu #popoverMenu="matMenu">
-                        <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
-                      </mat-menu>
-                    </div>
+        <!-- Ecosystem scores controls -->
+        <mat-expansion-panel expanded="false">
+          <mat-expansion-panel-header>
+            Ecosystem scores
+          </mat-expansion-panel-header>
+
+          <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
+            [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionLayer.emit(map)">
+            <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl"
+              class="condition-tree">
+              <!-- This is the tree node template for leaf nodes -->
+              <!-- There is inline padding applied to this node using styles.
+                This padding value depends on the mat-icon-button width. -->
+              <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+                <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
+                  (mouseleave)="node.showInfoIcon = false">
+                  <div [class.disabled]="node.styleDisabled">
+                    <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+                      (change)="onSelect(node)">
+                      {{node.display_name}}
+                    </mat-radio-button>
+                    <span *ngIf="node.disableSelect">
+                      {{node.display_name}}
+                    </span>
+                    <button mat-icon-button
+                      [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
+                      [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+                      (menuClosed)="node.infoMenuOpen = false">
+                      <mat-icon>info_outline</mat-icon>
+                    </button>
+                    <mat-menu #popoverMenu="matMenu">
+                      <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+                    </mat-menu>
                   </div>
-                </mat-tree-node>
-                <!-- This is the tree node template for expandable nodes -->
-                <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-                  <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
-                    (mouseleave)="node.showInfoIcon = false">
-                    <div [class.disabled]="node.styleDisabled">
-                      <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
-                        (change)="onSelect(node)">
-                        {{node.display_name}}
-                      </mat-radio-button>
-                      <span *ngIf="node.disableSelect">
-                        {{node.display_name}}
-                      </span>
-                      <button mat-icon-button
-                        [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
-                        [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
-                        (menuClosed)="node.infoMenuOpen = false">
-                        <mat-icon>info_outline</mat-icon>
-                      </button>
-                      <mat-menu #popoverMenu="matMenu">
-                        <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
-                      </mat-menu>
-                      <button mat-icon-button matTreeNodeToggle
-                              [attr.aria-label]="'Toggle ' + node.display_name">
-                        <mat-icon class="mat-icon-rtl-mirror">
-                          {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
-                        </mat-icon>
-                      </button>
-                    </div>
+                </div>
+              </mat-tree-node>
+              <!-- This is the tree node template for expandable nodes -->
+              <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+                <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
+                  (mouseleave)="node.showInfoIcon = false">
+                  <div [class.disabled]="node.styleDisabled">
+                    <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+                      (change)="onSelect(node)">
+                      {{node.display_name}}
+                    </mat-radio-button>
+                    <span *ngIf="node.disableSelect">
+                      {{node.display_name}}
+                    </span>
+                    <button mat-icon-button
+                      [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
+                      [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+                      (menuClosed)="node.infoMenuOpen = false">
+                      <mat-icon>info_outline</mat-icon>
+                    </button>
+                    <mat-menu #popoverMenu="matMenu">
+                      <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+                    </mat-menu>
+                    <button mat-icon-button matTreeNodeToggle
+                            [attr.aria-label]="'Toggle ' + node.display_name">
+                      <mat-icon class="mat-icon-rtl-mirror">
+                        {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
+                      </mat-icon>
+                    </button>
                   </div>
-                  <!-- There is inline padding applied to this div using styles.
-                      This padding value depends on the mat-icon-button width.  -->
-                  <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
-                      role="group">
-                      <ng-container matTreeNodeOutlet></ng-container>
-                  </div>
-                </mat-nested-tree-node>
-              </mat-tree>
-            </mat-radio-group>
-          </mat-expansion-panel>
+                </div>
+                <!-- There is inline padding applied to this div using styles.
+                    This padding value depends on the mat-icon-button width.  -->
+                <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
+                    role="group">
+                    <ng-container matTreeNodeOutlet></ng-container>
+                </div>
+              </mat-nested-tree-node>
+            </mat-tree>
+          </mat-radio-group>
+        </mat-expansion-panel>
 
-          <!-- Disturbances controls -->
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Disturbances
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
+        <!-- Disturbances controls -->
+        <mat-expansion-panel disabled="true">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              Disturbances
+            </mat-panel-title>
+            <mat-panel-description>
+              Coming soon!
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+        </mat-expansion-panel>
 
-          <!-- HVRAs controls -->
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                HVRAs
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
+        <!-- HVRAs controls -->
+        <mat-expansion-panel disabled="true">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              HVRAs
+            </mat-panel-title>
+            <mat-panel-description>
+              Coming soon!
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+        </mat-expansion-panel>
 
-          <!-- Land types controls -->
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Land types
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
+        <!-- Land types controls -->
+        <mat-expansion-panel disabled="true">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              Land types
+            </mat-panel-title>
+            <mat-panel-description>
+              Coming soon!
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+        </mat-expansion-panel>
 
-          <!-- Operability controls -->
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Operability
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
+        <!-- Operability controls -->
+        <mat-expansion-panel disabled="true">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              Operability
+            </mat-panel-title>
+            <mat-panel-description>
+              Coming soon!
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+        </mat-expansion-panel>
 
-        </mat-accordion>
-      </mat-tab>
-    </mat-tab-group>
+      </mat-accordion>
+    </mat-tab>
+  </mat-tab-group>
 </div>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -59,7 +59,7 @@
             (change)="changeBaseLayer.emit(map)">
             <div class="layer-control-container" *ngFor="let baseLayerType of baseLayerTypes">
               <mat-radio-button [value]="baseLayerType"
-                checked="{{ baseLayerType == map.config.baseLayerType }}" class="layer-radio-button">
+                checked="{{ baseLayerType == map.config.baseLayerType }}">
                 {{ BaseLayerType[baseLayerType] }}
               </mat-radio-button>
             </div>
@@ -75,12 +75,12 @@
             class="layer-radio-group" color="primary"
             [(ngModel)]="map.config.boundaryLayerConfig" (change)="changeBoundaryLayer.emit(map)">
             <div class="layer-control-container">
-              <mat-radio-button class="layer-radio-button" [value]="noneBoundaryConfig">
+              <mat-radio-button [value]="noneBoundaryConfig">
                 None
               </mat-radio-button>
             </div>
             <div *ngFor="let boundary of boundaryConfig" class="layer-control-container">
-              <mat-radio-button class="layer-radio-button" [value]="boundary">
+              <mat-radio-button [value]="boundary">
                 {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
               </mat-radio-button>
               <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]">
@@ -107,8 +107,36 @@
         </mat-expansion-panel>
 
         <!-- Ecosystem scores controls -->
+        <mat-expansion-panel expanded="false">
+          <mat-expansion-panel-header class="layer-panel-header">
+            <mat-panel-title>
+              Ecosystem scores
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <div class="layer-control-container flex-center">
+            <mat-radio-group class="layer-radio-group">
+              <mat-radio-button (change)="conditionTreeRaw.toggleAllLayersOff()"
+                [checked]="map.config.dataLayerConfig.filepath === ''">
+                All Layers Off
+              </mat-radio-button>
+            </mat-radio-group>
+          </div>
+        </mat-expansion-panel>
+
+        <!-- Current condition controls -->
         <app-condition-tree
-          [conditionsConfig$]="conditionsConfig$"
+          #conditionTreeRaw
+          [conditionsData$]="conditionDataRaw$"
+          [header]="'Current Condition'"
+          [map]="map"
+          (changeConditionLayer)="changeConditionLayer.emit($event)">
+        </app-condition-tree>
+
+        <!-- Normalized current condition controls -->
+        <app-condition-tree
+          #conditionTreeNormalized
+          [conditionsData$]="conditionDataNormalized$"
+          [header]="'Current Condition (Normalized)'"
           [map]="map"
           (changeConditionLayer)="changeConditionLayer.emit($event)">
         </app-condition-tree>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -117,8 +117,7 @@
               <!-- There is inline padding applied to this node using styles.
                 This padding value depends on the mat-icon-button width. -->
               <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-                <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
-                  (mouseleave)="node.showInfoIcon = false">
+                <div class="mat-tree-node">
                   <div [class.disabled]="node.styleDisabled">
                     <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
                       (change)="onSelect(node)">
@@ -128,10 +127,10 @@
                       {{node.display_name}}
                     </span>
                     <button mat-icon-button
-                      [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
+                      *ngIf="!isNoneNode(node)"
                       [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
                       (menuClosed)="node.infoMenuOpen = false">
-                      <mat-icon>info_outline</mat-icon>
+                      <mat-icon color="primary">info_outline</mat-icon>
                     </button>
                     <mat-menu #popoverMenu="matMenu">
                       <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -50,26 +50,29 @@
 
         <!-- Basemap layer controls -->
         <mat-expansion-panel expanded="true">
-          <mat-expansion-panel-header>
+          <mat-expansion-panel-header class="layer-panel-header">
             Basemaps
           </mat-expansion-panel-header>
           <mat-radio-group name="{{ map.id + '-base-layer-select' }}" aria-label="Select an option"
             class="layer-radio-group" [(ngModel)]="map.config.baseLayerType"
+            color="primary"
             (change)="changeBaseLayer.emit(map)">
-            <mat-radio-button *ngFor="let baseLayerType of baseLayerTypes" [value]="baseLayerType"
-              checked="{{ baseLayerType == map.config.baseLayerType }}" class="layer-radio-button">
-              {{ BaseLayerType[baseLayerType] }}
-            </mat-radio-button>
+            <div class="layer-control-container" *ngFor="let baseLayerType of baseLayerTypes">
+              <mat-radio-button [value]="baseLayerType"
+                checked="{{ baseLayerType == map.config.baseLayerType }}" class="layer-radio-button">
+                {{ BaseLayerType[baseLayerType] }}
+              </mat-radio-button>
+            </div>
           </mat-radio-group>
         </mat-expansion-panel>
 
         <!-- Boundary layer controls -->
         <mat-expansion-panel expanded="true">
-          <mat-expansion-panel-header>
+          <mat-expansion-panel-header class="layer-panel-header">
             Boundaries
           </mat-expansion-panel-header>
           <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
-            class="layer-radio-group"
+            class="layer-radio-group" color="primary"
             [(ngModel)]="map.config.boundaryLayerConfig" (change)="changeBoundaryLayer.emit(map)">
             <div class="layer-control-container">
               <mat-radio-button class="layer-radio-button" [value]="noneBoundaryConfig">
@@ -88,12 +91,12 @@
 
         <!-- Recent treatment areas controls -->
         <mat-expansion-panel expanded="false">
-          <mat-expansion-panel-header>
+          <mat-expansion-panel-header class="layer-panel-header">
             Recent treatment areas
           </mat-expansion-panel-header>
           <div class="layer-control-container">
             <mat-checkbox name="{{ map.id + '-existing-projects-toggle' }}"
-              aria-label="Select or deselect"
+              aria-label="Select or deselect" color="primary"
               class="layer-checkbox" [(ngModel)]="map.config.showExistingProjectsLayer"
               (change)="toggleExistingProjectsLayer.emit(map)">
               Existing projects
@@ -104,74 +107,15 @@
         </mat-expansion-panel>
 
         <!-- Ecosystem scores controls -->
-        <mat-expansion-panel expanded="false">
-          <mat-expansion-panel-header>
-            Ecosystem scores
-          </mat-expansion-panel-header>
-
-          <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
-            [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionLayer.emit(map)">
-            <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl"
-              class="condition-tree">
-              <!-- This is the tree node template for leaf nodes -->
-              <!-- There is inline padding applied to this node using styles.
-                This padding value depends on the mat-icon-button width. -->
-              <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-                <div class="mat-tree-node">
-                  <div [class.disabled]="node.styleDisabled">
-                    <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
-                      (change)="onSelect(node)">
-                      {{node.display_name}}
-                    </mat-radio-button>
-                    <span *ngIf="node.disableSelect">
-                      {{node.display_name}}
-                    </span>
-                    <button mat-icon-button
-                      *ngIf="!isNoneNode(node)"
-                      [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
-                      (menuClosed)="node.infoMenuOpen = false">
-                      <mat-icon color="primary">info_outline</mat-icon>
-                    </button>
-                    <mat-menu #popoverMenu="matMenu">
-                      <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
-                    </mat-menu>
-                  </div>
-                </div>
-              </mat-tree-node>
-              <!-- This is the tree node template for expandable nodes -->
-              <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-                <div class="mat-tree-node" (mouseenter)="node.showInfoIcon = true"
-                  (mouseleave)="node.showInfoIcon = false">
-                  <div [class.disabled]="node.styleDisabled">
-                    <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
-                      (change)="onSelect(node)">
-                      {{node.display_name}}
-                    </mat-radio-button>
-                    <span *ngIf="node.disableSelect">
-                      {{node.display_name}}
-                    </span>
-                    <button mat-icon-button matTreeNodeToggle
-                            [attr.aria-label]="'Toggle ' + node.display_name">
-                      <mat-icon class="mat-icon-rtl-mirror">
-                        {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
-                      </mat-icon>
-                    </button>
-                  </div>
-                </div>
-                <!-- There is inline padding applied to this div using styles.
-                    This padding value depends on the mat-icon-button width.  -->
-                <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
-                    role="group">
-                    <ng-container matTreeNodeOutlet></ng-container>
-                </div>
-              </mat-nested-tree-node>
-            </mat-tree>
-          </mat-radio-group>
-        </mat-expansion-panel>
+        <app-condition-tree
+          [conditionsConfig$]="conditionsConfig$"
+          [map]="map"
+          (changeConditionLayer)="changeConditionLayer.emit($event)">
+        </app-condition-tree>
 
         <!-- Disturbances controls -->
         <mat-expansion-panel disabled="true">
-          <mat-expansion-panel-header>
+          <mat-expansion-panel-header class="layer-panel-header">
             <mat-panel-title>
               Disturbances
             </mat-panel-title>
@@ -183,7 +127,7 @@
 
         <!-- HVRAs controls -->
         <mat-expansion-panel disabled="true">
-          <mat-expansion-panel-header>
+          <mat-expansion-panel-header class="layer-panel-header">
             <mat-panel-title>
               HVRAs
             </mat-panel-title>
@@ -195,7 +139,7 @@
 
         <!-- Land types controls -->
         <mat-expansion-panel disabled="true">
-          <mat-expansion-panel-header>
+          <mat-expansion-panel-header class="layer-panel-header">
             <mat-panel-title>
               Land types
             </mat-panel-title>
@@ -207,7 +151,7 @@
 
         <!-- Operability controls -->
         <mat-expansion-panel disabled="true">
-          <mat-expansion-panel-header>
+          <mat-expansion-panel-header class="layer-panel-header">
             <mat-panel-title>
               Operability
             </mat-panel-title>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -151,15 +151,6 @@
                     <span *ngIf="node.disableSelect">
                       {{node.display_name}}
                     </span>
-                    <button mat-icon-button
-                      [style.visibility]="showInfoIcon(node) ? 'visible': 'hidden'"
-                      [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
-                      (menuClosed)="node.infoMenuOpen = false">
-                      <mat-icon>info_outline</mat-icon>
-                    </button>
-                    <mat-menu #popoverMenu="matMenu">
-                      <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
-                    </mat-menu>
                     <button mat-icon-button matTreeNodeToggle
                             [attr.aria-label]="'Toggle ' + node.display_name">
                       <mat-icon class="mat-icon-rtl-mirror">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -115,7 +115,8 @@
           </mat-expansion-panel-header>
           <div class="layer-control-container flex-center">
             <mat-radio-group class="layer-radio-group">
-              <mat-radio-button (change)="conditionTreeRaw.toggleAllLayersOff()"
+              <mat-radio-button (change)="conditionTreeRaw.toggleAllLayersOff();
+                conditionTreeNormalized.toggleAllLayersOff()"
                 [checked]="map.config.dataLayerConfig.filepath === ''">
                 All Layers Off
               </mat-radio-button>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.scss
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.scss
@@ -81,6 +81,10 @@ $primary-palette: map.get($color-config, 'primary');
   margin: 15px 0;
 }
 
+.layer-single-radio-button {
+  margin: 15px 0;
+}
+
 .layer-checkbox {
   margin: 15px 0;
 }
@@ -91,6 +95,11 @@ $primary-palette: map.get($color-config, 'primary');
   font-weight: 700;
   height: 40px !important;
   line-height: 20px;
+}
+
+.flex-center {
+  display: flex;
+  justify-content: center;
 }
 
 // Overrides of Material component styles

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.scss
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.scss
@@ -1,3 +1,11 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@import "../../../styles.scss";
+
+$color-config:    mat.get-color-config($planscape-frontend-theme);
+$primary-palette: map.get($color-config, 'primary');
+
 .controls-container {
   background-color: white;
   box-sizing: border-box;
@@ -58,6 +66,7 @@
 .layer-control-container {
   display: flex;
   flex-direction: row;
+  margin: 5px;
 }
 
 .layer-controls-tab-group {
@@ -72,43 +81,28 @@
   margin: 15px 0;
 }
 
-.layer-radio-button {
-  margin: 5px;
-}
-
 .layer-checkbox {
-  margin: 0px 5px 0px;
+  margin: 15px 0;
 }
 
-.condition-tree-invisible {
-  display: none;
+.layer-panel-header {
+  background-color: #D8D8D8 !important;
+  font-size: 14px;
+  font-weight: 700;
+  height: 40px !important;
+  line-height: 20px;
 }
 
-.condition-tree ul,
-.condition-tree li {
-  margin-top: 0;
-  margin-bottom: 0;
-  list-style-type: none;
+// Overrides of Material component styles
+
+::ng-deep .mat-radio-checked {
+  label {
+    color: mat.get-color-from-palette($primary-palette, 500);
+  }
 }
 
-/*
- * This padding sets alignment of the nested nodes.
- */
-.condition-tree .mat-nested-tree-node div[role=group] {
-  padding-left: 20px;
-}
-
-/*
- * Padding for leaf nodes.
- * Leaf nodes need to have padding so as to align with other non-leaf nodes
- * under the same parent.
- */
-.condition-tree div[role=group] > .mat-tree-node {
-  padding-left: 20px;
-}
-
-.mat-tree-node > .disabled {
-  opacity: 0.5;
+::ng-deep .mat-expansion-panel-body {
+  padding-bottom: 0px !important;
 }
 
 // Workaround for unresolved Angular bug re: tab width on desktop

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.spec.ts
@@ -38,7 +38,6 @@ describe('MapControlPanelComponent', () => {
         display_name: 'HUC-12',
       },
     ];
-    component.conditionsConfig$ = of({});
     component.maps = [1, 2, 3, 4].map((id) => {
       return {
         id: `map${id}`,
@@ -46,7 +45,6 @@ describe('MapControlPanelComponent', () => {
         config: defaultMapConfig(),
       };
     });
-    console.log(component.maps);
     component.mapViewOptions = defaultMapViewOptions();
 
     fixture.detectChanges();
@@ -75,41 +73,6 @@ describe('MapControlPanelComponent', () => {
       await buttonHarnesses[1].click();
 
       expect(component.changeMapCount.emit).toHaveBeenCalledOnceWith(2);
-    });
-  });
-
-  describe('condition tree', () => {
-    beforeEach(() => {
-      component.conditionDataSource.data = [
-        {
-          children: [{}, {}, {}],
-        },
-        {
-          children: [],
-        },
-      ];
-    });
-
-    it('styles children of a selected node and unstyles all other nodes', () => {
-      const nodeWithChildren = component.conditionDataSource.data[0];
-      const nodeWithoutChildren = component.conditionDataSource.data[1];
-
-      component.onSelect(nodeWithChildren);
-
-      nodeWithChildren.children?.forEach((child) => {
-        expect(child.styleDisabled).toBeTrue();
-      });
-      expect(nodeWithChildren.styleDisabled).toBeFalse();
-      expect(nodeWithoutChildren.styleDisabled).toBeFalse();
-
-      component.onSelect(nodeWithoutChildren);
-
-      component.conditionDataSource.data.forEach((node) => {
-        expect(node.styleDisabled).toBeFalse();
-        node.children?.forEach((child) => {
-          expect(child.styleDisabled).toBeFalse();
-        });
-      });
     });
   });
 

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.spec.ts
@@ -38,6 +38,7 @@ describe('MapControlPanelComponent', () => {
         display_name: 'HUC-12',
       },
     ];
+    component.conditionsConfig$ = of({});
     component.maps = [1, 2, 3, 4].map((id) => {
       return {
         id: `map${id}`,

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -1,25 +1,14 @@
-import { NestedTreeControl } from '@angular/cdk/tree';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { MatTreeNestedDataSource } from '@angular/material/tree';
-import { filter, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import {
   BaseLayerType,
   BoundaryConfig,
   ConditionsConfig,
-  DataLayerConfig,
   Legend,
   NONE_BOUNDARY_CONFIG,
-  NONE_DATA_LAYER_CONFIG,
 } from 'src/app/types';
 
 import { Map, MapViewOptions } from './../../types/map.types';
-
-export interface ConditionsNode extends DataLayerConfig {
-  infoMenuOpen?: boolean;
-  disableSelect?: boolean; // Node should not include a radio button
-  styleDisabled?: boolean; // Node should be greyed out but still selectable
-  children?: ConditionsNode[];
-}
 
 @Component({
   selector: 'app-map-control-panel',
@@ -52,28 +41,9 @@ export class MapControlPanelComponent implements OnInit {
 
   readonly noneBoundaryConfig = NONE_BOUNDARY_CONFIG;
 
-  conditionTreeControl = new NestedTreeControl<ConditionsNode>(
-    (node) => node.children
-  );
-  conditionDataSource = new MatTreeNestedDataSource<ConditionsNode>();
+  constructor() {}
 
-  constructor() {
-    this.conditionDataSource.data = [NONE_DATA_LAYER_CONFIG];
-  }
-
-  ngOnInit(): void {
-    this.conditionsConfig$
-      .pipe(filter((config) => !!config))
-      .subscribe((config) => {
-        this.conditionDataSource.data = this.conditionsConfigToData(config!);
-        this.maps.forEach((map) => {
-          // Ensure the radio button corresponding to the saved selection is selected.
-          map.config.dataLayerConfig = this.findAndRevealNodeWithFilepath(
-            map.config.dataLayerConfig.filepath
-          );
-        });
-      });
-  }
+  ngOnInit(): void {}
 
   /** Gets the legend that should be shown in the sidebar.
    *
@@ -85,139 +55,5 @@ export class MapControlPanelComponent implements OnInit {
     } else {
       return undefined;
     }
-  }
-
-  /** Used to compute whether a node in the condition layer tree has children. */
-  hasChild = (_: number, node: ConditionsNode) =>
-    !!node.children && node.children.length > 0;
-
-  onSelect(node: ConditionsNode): void {
-    this.unstyleAllNodes();
-    this.styleDescendantsDisabled(node);
-  }
-
-  isNoneNode(node: ConditionsNode): boolean {
-    return node === NONE_DATA_LAYER_CONFIG;
-  }
-
-  /** Unstyles all nodes in the tree using recursion. */
-  private unstyleAllNodes(node?: ConditionsNode): void {
-    if (!node && this.conditionDataSource.data.length > 0) {
-      this.conditionDataSource.data.forEach((node) =>
-        this.unstyleAllNodes(node)
-      );
-    } else if (node) {
-      node.styleDisabled = false;
-      node.children?.forEach((child) => this.unstyleAllNodes(child));
-    }
-  }
-
-  /** Visually indicates that all the descendants of a condition layer node are
-   *  included in the current analysis by setting their style, using recursion.
-   */
-  private styleDescendantsDisabled(node: ConditionsNode): void {
-    node.children?.forEach((child) => {
-      child.styleDisabled = true;
-      this.styleDescendantsDisabled(child);
-    });
-  }
-
-  private conditionsConfigToData(config: ConditionsConfig): ConditionsNode[] {
-    return [
-      NONE_DATA_LAYER_CONFIG,
-      {
-        ...config,
-        display_name: 'Current condition',
-        disableSelect: true,
-        children: config.pillars
-          ?.filter((pillar) => pillar.display)
-          .map((pillar): ConditionsNode => {
-            return {
-              ...pillar,
-              disableSelect: true,
-              children: pillar.elements?.map((element): ConditionsNode => {
-                return {
-                  ...element,
-                  disableSelect: true,
-                  children: element.metrics,
-                };
-              }),
-            };
-          }),
-      },
-      {
-        display_name: 'Current condition (normalized)',
-        filepath: config.filepath?.concat('_normalized'),
-        colormap: config.colormap,
-        normalized: true,
-        disableSelect: true,
-        children: config.pillars
-          ?.filter((pillar) => pillar.display)
-          .map((pillar): ConditionsNode => {
-            return {
-              ...pillar,
-              filepath: pillar.filepath?.concat('_normalized'),
-              normalized: true,
-              children: pillar.elements?.map((element): ConditionsNode => {
-                return {
-                  ...element,
-                  filepath: element.filepath?.concat('_normalized'),
-                  normalized: true,
-                  children: element.metrics?.map((metric): ConditionsNode => {
-                    return {
-                      ...metric,
-                      filepath: metric.filepath?.concat('_normalized'),
-                      normalized: true,
-                      min_value: undefined,
-                      max_value: undefined,
-                    };
-                  }),
-                };
-              }),
-            };
-          }),
-      },
-    ];
-  }
-
-  /** Find the node matching the given filepath in the condition tree (if any), and expand its ancestors
-   *  so it becomes visible.
-   */
-  private findAndRevealNodeWithFilepath(
-    filepath: string | undefined
-  ): ConditionsNode {
-    if (!filepath || filepath === NONE_DATA_LAYER_CONFIG.filepath)
-      return NONE_DATA_LAYER_CONFIG;
-    for (let tree of this.conditionDataSource.data) {
-      if (tree.filepath === filepath) return tree;
-      if (tree.children) {
-        for (let pillar of tree.children) {
-          if (pillar.filepath === filepath) {
-            this.conditionTreeControl.expand(tree);
-            return pillar;
-          }
-          if (pillar.children) {
-            for (let element of pillar.children) {
-              if (element.filepath === filepath) {
-                this.conditionTreeControl.expand(tree);
-                this.conditionTreeControl.expand(pillar);
-                return element;
-              }
-              if (element.children) {
-                for (let metric of element.children) {
-                  if (metric.filepath === filepath) {
-                    this.conditionTreeControl.expand(tree);
-                    this.conditionTreeControl.expand(pillar);
-                    this.conditionTreeControl.expand(element);
-                    return metric;
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    return NONE_DATA_LAYER_CONFIG;
   }
 }

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -15,7 +15,6 @@ import {
 import { Map, MapViewOptions } from './../../types/map.types';
 
 export interface ConditionsNode extends DataLayerConfig {
-  showInfoIcon?: boolean;
   infoMenuOpen?: boolean;
   disableSelect?: boolean; // Node should not include a radio button
   styleDisabled?: boolean; // Node should be greyed out but still selectable
@@ -92,13 +91,13 @@ export class MapControlPanelComponent implements OnInit {
   hasChild = (_: number, node: ConditionsNode) =>
     !!node.children && node.children.length > 0;
 
-  /** Used to compute whether to show the info button on a condition layer node. */
-  showInfoIcon = (node: ConditionsNode) =>
-    node.filepath?.length && (node.showInfoIcon || node.infoMenuOpen);
-
   onSelect(node: ConditionsNode): void {
     this.unstyleAllNodes();
     this.styleDescendantsDisabled(node);
+  }
+
+  isNoneNode(node: ConditionsNode): boolean {
+    return node === NONE_DATA_LAYER_CONFIG;
   }
 
   /** Unstyles all nodes in the tree using recursion. */

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -169,6 +169,8 @@ export class MapControlPanelComponent implements OnInit {
                       ...metric,
                       filepath: metric.filepath?.concat('_normalized'),
                       normalized: true,
+                      min_value: undefined,
+                      max_value: undefined,
                     };
                   }),
                 };

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, filter, map, Observable } from 'rxjs';
 import {
   BaseLayerType,
   BoundaryConfig,
@@ -8,7 +8,9 @@ import {
   NONE_BOUNDARY_CONFIG,
 } from 'src/app/types';
 
+import { NONE_DATA_LAYER_CONFIG } from './../../types/data.types';
 import { Map, MapViewOptions } from './../../types/map.types';
+import { ConditionsNode } from './condition-tree/condition-tree.component';
 
 @Component({
   selector: 'app-map-control-panel',
@@ -40,10 +42,31 @@ export class MapControlPanelComponent implements OnInit {
   readonly BaseLayerType = BaseLayerType;
 
   readonly noneBoundaryConfig = NONE_BOUNDARY_CONFIG;
+  readonly noneDataLayerConfig = NONE_DATA_LAYER_CONFIG;
+
+  conditionDataRaw$ = new BehaviorSubject<ConditionsNode[]>([]);
+  conditionDataNormalized$ = new BehaviorSubject<ConditionsNode[]>([]);
 
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.conditionsConfig$
+      .pipe(
+        filter((config) => !!config),
+        map((config) => this.conditionsConfigToDataRaw(config!))
+      )
+      .subscribe((data) => {
+        this.conditionDataRaw$.next(data);
+      });
+    this.conditionsConfig$
+      .pipe(
+        filter((config) => !!config),
+        map((config) => this.conditionsConfigToDataNormalized(config!))
+      )
+      .subscribe((data) => {
+        this.conditionDataNormalized$.next(data);
+      });
+  }
 
   /** Gets the legend that should be shown in the sidebar.
    *
@@ -55,5 +78,59 @@ export class MapControlPanelComponent implements OnInit {
     } else {
       return undefined;
     }
+  }
+
+  private conditionsConfigToDataRaw(
+    config: ConditionsConfig
+  ): ConditionsNode[] {
+    return config.pillars
+      ? config.pillars
+          ?.filter((pillar) => pillar.display)
+          .map((pillar): ConditionsNode => {
+            return {
+              ...pillar,
+              disableSelect: true,
+              children: pillar.elements?.map((element): ConditionsNode => {
+                return {
+                  ...element,
+                  disableSelect: true,
+                  children: element.metrics,
+                };
+              }),
+            };
+          })
+      : [];
+  }
+
+  private conditionsConfigToDataNormalized(
+    config: ConditionsConfig
+  ): ConditionsNode[] {
+    return config.pillars
+      ? config.pillars
+          ?.filter((pillar) => pillar.display)
+          .map((pillar): ConditionsNode => {
+            return {
+              ...pillar,
+              filepath: pillar.filepath?.concat('_normalized'),
+              normalized: true,
+              children: pillar.elements?.map((element): ConditionsNode => {
+                return {
+                  ...element,
+                  filepath: element.filepath?.concat('_normalized'),
+                  normalized: true,
+                  children: element.metrics?.map((metric): ConditionsNode => {
+                    return {
+                      ...metric,
+                      filepath: metric.filepath?.concat('_normalized'),
+                      normalized: true,
+                      min_value: undefined,
+                      max_value: undefined,
+                    };
+                  }),
+                };
+              }),
+            };
+          })
+      : [];
   }
 }


### PR DESCRIPTION
## Changes
- Partial resolution to #499 (info card content is unchanged, but info button is always visible instead of only on rollover)
- Fix #490 
- Partial fix to #498 (restyling of map layer controls; I made some of the changes but not all, as some of them are quite complicated given the way Angular components work)
- Made the condition tree into a reusable component and split it across two different expansion panels, one for raw and one for normalized

## Before
![image](https://user-images.githubusercontent.com/10444733/218828656-42d6736e-82c8-42f1-8560-0c3470aedd6f.png)

## After
![image](https://user-images.githubusercontent.com/10444733/218828403-32275776-baff-4e1a-817d-bf6e6bae7fa8.png)
