### PR TITLE
swap config and saved scenario tables

### DIFF
--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
@@ -10,9 +10,12 @@
         Saved scenarios are added to the Comparison table. Scenarios consist of Project Areas,
         Treatment plans, Potential Outcomes, and Estimated costs.
       </p>
-      <button mat-raised-button color="primary" (click)="openConfigEvent.emit()">CREATE A NEW SCENARIO</button>
+      <button mat-raised-button color="primary" (click)="openConfigEvent.emit()">
+        <mat-icon class="material-symbols-outlined">add_box</mat-icon>
+        NEW CONFIGURATION
+      </button>
     </div>
-    <app-saved-scenarios [plan]="plan$ | async" (createScenarioEvent)="openConfigEvent.emit()"></app-saved-scenarios>
     <app-scenario-configurations [plan]="plan$ | async" (openConfigEvent)="openConfigEvent.emit($event)"></app-scenario-configurations>
+    <app-saved-scenarios [plan]="plan$ | async" (createScenarioEvent)="openConfigEvent.emit()"></app-saved-scenarios>
   </div>
 </div>

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
@@ -35,10 +35,10 @@ describe('PlanOverviewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('clicking create scenario button should emit event', async () => {
+  it('clicking new configuration button should emit event', async () => {
     spyOn(component.openConfigEvent, 'emit');
     let createScenarioButton = await loader.getHarness(
-      MatButtonHarness.with({ text: 'CREATE A NEW SCENARIO' })
+      MatButtonHarness.with({ text: /NEW CONFIGURATION/ })
     );
 
     await createScenarioButton.click();

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -32,10 +32,6 @@
         <mat-icon>open_in_new</mat-icon>
         SEE ALL
       </button>
-      <button mat-raised-button color="primary" (click)="createScenario()">
-        <mat-icon>add_box</mat-icon>
-        CREATE A NEW SCENARIO
-      </button>
     </mat-card-actions>
   </mat-card>
 

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
@@ -1,77 +1,93 @@
-<mat-card [style.margin-top]="'24px'">
-  <mat-card-header>
-    <mat-card-title>Configurations ({{ configurations.length }})</mat-card-title>
-  </mat-card-header>
+<div class="configurations-wrapper">
+  <mat-card [style.margin-top]="'24px'">
+    <mat-card-header>
+      <mat-card-title>Configurations ({{ configurations.length }})</mat-card-title>
+    </mat-card-header>
 
-  <mat-card-content>
-    <mat-table [dataSource]="configurations" >
-      <!-- Select Column -->
-      <ng-container matColumnDef="select">
-        <mat-header-cell *matHeaderCellDef>
-          <mat-checkbox (change)="selectAllConfigs($event)"></mat-checkbox>
-        </mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          <mat-checkbox [(ngModel)]="element.selected"></mat-checkbox>
-        </mat-cell>
-      </ng-container>
+    <mat-card-content>
+      <mat-table [dataSource]="configurations" >
+        <!-- Select Column -->
+        <ng-container matColumnDef="select">
+          <mat-header-cell *matHeaderCellDef>
+            <mat-checkbox (change)="selectAllConfigs($event)"></mat-checkbox>
+          </mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <mat-checkbox [(ngModel)]="element.selected" (click)="$event.stopPropagation()"></mat-checkbox>
+          </mat-cell>
+        </ng-container>
 
-      <!-- Timestamp Column -->
-      <ng-container matColumnDef="createdTimestamp">
-        <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
-        <mat-cell *matCellDef="let element"> {{element.createdTimestamp | date:'medium' }} </mat-cell>
-      </ng-container>
+        <!-- Timestamp Column -->
+        <ng-container matColumnDef="createdTimestamp">
+          <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
+          <mat-cell *matCellDef="let element"> {{element.createdTimestamp | date:'medium' }} </mat-cell>
+        </ng-container>
 
-      <!-- Score Type Column -->
-      <ng-container matColumnDef="scoreType">
-        <mat-header-cell *matHeaderCellDef> Calculating Score </mat-header-cell>
-        <mat-cell *matCellDef="let element"> Condition Score </mat-cell>
-      </ng-container>
+        <!-- Score Type Column -->
+        <ng-container matColumnDef="scoreType">
+          <mat-header-cell *matHeaderCellDef> Calculating Score </mat-header-cell>
+          <mat-cell *matCellDef="let element"> Condition Score </mat-cell>
+        </ng-container>
 
-      <!-- Priorities Column -->
-      <ng-container matColumnDef="priorities">
-        <mat-header-cell *matHeaderCellDef> Selected Priorities </mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          <div>
-            <div *ngFor="let priority of displayPriorities(element.priorities)">
-              {{priority}}
+        <!-- Priorities Column -->
+        <ng-container matColumnDef="priorities">
+          <mat-header-cell *matHeaderCellDef> Selected Priorities </mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <div>
+              <div *ngFor="let priority of displayPriorities(element.priorities)">
+                {{priority}}
+              </div>
             </div>
-          </div>
-        </mat-cell>
-      </ng-container>
+          </mat-cell>
+        </ng-container>
 
-      <!-- Constraints Column -->
-      <ng-container matColumnDef="constraints">
-        <mat-header-cell *matHeaderCellDef> Selected Constraints </mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          <div>
-            <div *ngIf="element.max_budget">
-              Max budget: ${{element.max_budget}}
+        <!-- Constraints Column -->
+        <ng-container matColumnDef="constraints">
+          <mat-header-cell *matHeaderCellDef> Selected Constraints </mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            <div>
+              <div *ngIf="element.max_budget">
+                Max budget: ${{element.max_budget}}
+              </div>
+              <div *ngIf="element.max_treatment_area_ratio">
+                Max treatment area: {{element.max_treatment_area_ratio}}%
+              </div>
+              <div *ngIf="element.max_slope">
+                Exclude slope > {{element.max_slope}} degrees
+              </div>
+              <div *ngIf="element.max_road_distance">
+                Exclude areas off road by {{element.max_road_distance}} ft.
+              </div>
             </div>
-            <div *ngIf="element.max_treatment_area_ratio">
-              Max treatment area: {{element.max_treatment_area_ratio}}%
-            </div>
-            <div *ngIf="element.max_slope">
-              Exclude slope > {{element.max_slope}} degrees
-            </div>
-            <div *ngIf="element.max_road_distance">
-              Exclude areas off road by {{element.max_road_distance}} ft.
-            </div>
-          </div>
-        </mat-cell>
-      </ng-container>
+          </mat-cell>
+        </ng-container>
 
-      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-    </mat-table>
-  </mat-card-content>
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row
+          *matRowDef="let row; columns: displayedColumns;"
+          class="config-row"
+          (click)="openConfig(row)"></mat-row>
+      </mat-table>
 
-  <mat-card-actions align="end">
-    <button mat-raised-button *ngIf="showDeleteButton()" (click)="deleteSelectedConfigs()">
-      <mat-icon>delete</mat-icon>
-      DELETE
+      <!-- Padding for visual effect if the table is empty -->
+      <div class="no-configs-padding"></div>
+    </mat-card-content>
+
+    <mat-card-actions align="end">
+      <button mat-raised-button *ngIf="showDeleteButton()" (click)="deleteSelectedConfigs()">
+        <mat-icon>delete</mat-icon>
+        DELETE
+      </button>
+      <button mat-raised-button *ngIf="showContinueButton()" color="primary" (click)="openConfig()">
+        CONTINUE PLANNING
+      </button>
+    </mat-card-actions>
+  </mat-card>
+
+  <div *ngIf="configurations.length === 0" class="no-configs-overlay">
+    <p>Configurations use priorities & constraints to identify and rank project areas for treatment.</p>
+    <button mat-raised-button color="primary" (click)="openConfig()">
+      <mat-icon class="material-symbols-outlined">add_box</mat-icon>
+      NEW CONFIGURATION
     </button>
-    <button mat-raised-button *ngIf="showContinueButton()" color="primary" (click)="openConfig()">
-      CONTINUE PLANNING
-    </button>
-  </mat-card-actions>
-</mat-card>
+  </div>
+</div>

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.scss
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.scss
@@ -1,3 +1,40 @@
+.configurations-wrapper {
+  position: relative;
+}
+
+.mat-card {
+  border-radius: 16px;
+}
+
+.no-configs-padding {
+  height: 50px;
+}
+
+.no-configs-overlay {
+  align-items: center;
+  backdrop-filter: blur(2px);
+  background: rgba(79, 79, 79, 0.8);
+  border-radius: 16px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  padding: 24px;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+
+  p {
+    color: white;
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 24px;
+    text-align: center;
+  }
+}
+
 .mat-header-cell {
   font-size: 13px;
   font-weight: 500;
@@ -19,4 +56,8 @@
 
 .mat-column-constraints.mat-cell {
   opacity: 0.66;
+}
+
+.config-row {
+  cursor: pointer;
 }


### PR DESCRIPTION
## Changes
- Fix #520 
- Change CTA buttons to say "New Configuration" instead of "Create a Scenario"
- Add black transparent overlay to config table when there are no configs
- Remove "Create a scenario" button from the saved scenario table

![image](https://user-images.githubusercontent.com/10444733/218870167-190acc4e-410d-4593-b1bc-d14b4467668a.png)
