### PR TITLE
Update area shape definition color and style

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -120,17 +120,20 @@ export class MapManager {
       snappable: false,
       removeLayerBelowMinVertexCount: false,
       hintlineStyle: {
-        color: '#7b61ff',
+        color: '#3367D6',
+        weight: 8,
       },
       templineStyle: {
-        color: '#7b61ff',
+        color: '#3367D6',
+        weight: 8,
       },
       layerGroup: this.drawingLayer,
     });
     map.instance!.pm.setPathOptions({
-      color: '#7b61ff',
-      fillColor: '#7b61ff',
-      fillOpacity: 0.2,
+      color: '#3367D6',
+      fillColor: '#3367D6',
+      fillOpacity: 0.1,
+      weight: 8,
     });
 
     this.setUpEventHandlers(map, createDetailCardCallback);

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -121,11 +121,11 @@ export class MapManager {
       removeLayerBelowMinVertexCount: false,
       hintlineStyle: {
         color: '#3367D6',
-        weight: 8,
+        weight: 5,
       },
       templineStyle: {
         color: '#3367D6',
-        weight: 8,
+        weight: 5,
       },
       layerGroup: this.drawingLayer,
     });
@@ -133,7 +133,7 @@ export class MapManager {
       color: '#3367D6',
       fillColor: '#3367D6',
       fillOpacity: 0.1,
-      weight: 8,
+      weight: 5,
     });
 
     this.setUpEventHandlers(map, createDetailCardCallback);
@@ -246,9 +246,10 @@ export class MapManager {
   addGeoJsonToDrawing(area: GeoJSON.GeoJSON) {
     L.geoJSON(area, {
       style: (_) => ({
-        color: '#7b61ff',
-        fillColor: '#7b61ff',
-        fillOpacity: 0.2,
+        color: '#3367D6',
+        fillColor: '#3367D6',
+        fillOpacity: 0.1,
+        weight: 5,
       }),
       pmIgnore: false,
       onEachFeature: (_, layer) => {
@@ -272,6 +273,7 @@ export class MapManager {
       const clonedLayer = L.geoJson((layer as L.Polygon).toGeoJSON()).setStyle({
         color: '#ffde9e',
         fillColor: '#ffde9e',
+        weight: 5,
       });
       currMap.clonedDrawingRef?.addLayer(clonedLayer);
       currMap.drawnPolygonLookup![originalId] = clonedLayer;

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -70,10 +70,10 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
     this.drawingLayer = L.geoJSON(plan.planningArea, {
       pane: 'overlayPane',
       style: {
-        color: '#7b61ff',
-        fillColor: '#7b61ff',
-        fillOpacity: 0.2,
-        weight: 3,
+        color: '#3367D6',
+        fillColor: '#3367D6',
+        fillOpacity: 0.1,
+        weight: 5,
       },
     }).addTo(this.map);
     this.map.fitBounds(this.drawingLayer.getBounds(), {
@@ -128,7 +128,8 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
       style: (_) => ({
         color: '#ff4081',
         fillColor: '#ff4081',
-        fillOpacity: 0.2,
+        fillOpacity: 0.1,
+        weight: 5,
       })
     });
     this.projectAreasLayer.addTo(this.map);

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -131,7 +131,7 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 // Geoman drawing vertex styling
 .marker-icon,
  .marker-icon:focus {
-    border: 3px solid #7b61ff;
+    border: 3px solid #3367D6;
     margin: -5px 0 0 -5px !important;
     width: 5px !important;
     height: 5px !important;


### PR DESCRIPTION
# Updates
* Color: #3367D6
* Fill opacity: 10%
* Stroke width: 5 pixels.

* Also updated uploaded and cloned areas with the new stroke width.

<img width="1438" alt="Screenshot 2023-02-15 at 10 29 28 AM" src="https://user-images.githubusercontent.com/114368235/219121997-d4f8322f-38e9-4f75-a6ec-ac3517c4ccf4.png">
<img width="1438" alt="Screenshot 2023-02-15 at 10 39 23 AM" src="https://user-images.githubusercontent.com/114368235/219122158-7860c8b6-b7af-40da-9380-832d7f4e98b1.png">

