### PR TITLE
add hover state for config and scenario table rows

### DIFF
--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -1,8 +1,7 @@
 <div class="saved-scenarios-wrapper">
   <mat-card [style.margin-top]="'24px'">
     <mat-card-header>
-      <mat-card-title>Saved Scenarios</mat-card-title>
-      <mat-card-subtitle>{{ scenarios.length }}</mat-card-subtitle>
+      <mat-card-title>Saved Scenarios ({{ scenarios.length }})</mat-card-title>
     </mat-card-header>
 
     <mat-card-content>
@@ -10,7 +9,10 @@
         <!-- ID Column -->
         <ng-container matColumnDef="id">
           <mat-header-cell *matHeaderCellDef> Scenario </mat-header-cell>
-          <mat-cell *matCellDef="let element"> {{element.id}} </mat-cell>
+          <mat-cell *matCellDef="let element">
+            <div class="hover-indicator"></div>
+            {{element.id}}
+          </mat-cell>
         </ng-container>
 
         <!-- Timestamp Column -->

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
@@ -1,3 +1,11 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@import "../../../../styles.scss";
+
+$color-config:    mat.get-color-config($planscape-frontend-theme);
+$primary-palette: map.get($color-config, 'primary');
+
 .saved-scenarios-wrapper {
   position: relative;
 }
@@ -30,4 +38,19 @@
 
 .scenario-row {
   cursor: pointer;
+
+  &:hover {
+    background-color: transparentize($color: mat.get-color-from-palette($primary-palette, 500), $amount: 0.9);
+
+    mat-cell div.hover-indicator {
+      background-color: mat.get-color-from-palette($primary-palette, 500);
+    }
+  }
+}
+
+.hover-indicator {
+  height: 48px;
+  margin-left: -24px;
+  margin-right: 18px;
+  width: 4px;
 }

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
@@ -12,6 +12,7 @@
             <mat-checkbox (change)="selectAllConfigs($event)"></mat-checkbox>
           </mat-header-cell>
           <mat-cell *matCellDef="let element">
+            <div class="hover-indicator"></div>
             <mat-checkbox [(ngModel)]="element.selected" (click)="$event.stopPropagation()"></mat-checkbox>
           </mat-cell>
         </ng-container>

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.scss
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.scss
@@ -1,3 +1,11 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@import "../../../../styles.scss";
+
+$color-config:    mat.get-color-config($planscape-frontend-theme);
+$primary-palette: map.get($color-config, 'primary');
+
 .configurations-wrapper {
   position: relative;
 }
@@ -48,10 +56,14 @@
 }
 
 .mat-column-select {
-  flex: 0 1 16px;
+  flex: 0 1 38px;
   padding-left: 16px;
   padding-right: 32px;
-  width: 16px;
+  width: 38px;
+
+  &.mat-header-cell {
+    padding-left: 22px;
+  }
 }
 
 .mat-column-constraints.mat-cell {
@@ -60,4 +72,19 @@
 
 .config-row {
   cursor: pointer;
+
+  &:hover {
+    background-color: transparentize($color: mat.get-color-from-palette($primary-palette, 500), $amount: 0.9);
+
+    mat-cell div.hover-indicator {
+      background-color: mat.get-color-from-palette($primary-palette, 500);
+    }
+  }
+}
+
+.hover-indicator {
+  height: 48px;
+  margin-left: -16px;
+  margin-right: 18px;
+  width: 4px;
 }


### PR DESCRIPTION
Part of #524 UI changes

Adds hover state to rows for config and scenario tables (see screenshot)

Moves scenario count into the card title to be consistent with config table

![image](https://user-images.githubusercontent.com/10444733/219228227-040a10c8-f8ea-42fb-af04-815bb02ad5a3.png)
