### PR TITLE
Reuse and share components in Scenario Details view

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,13 +1,3 @@
-import {
-  animate,
-  animateChild,
-  group,
-  query,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import {
   Component,
@@ -25,6 +15,7 @@ import { PlanService } from 'src/app/services';
 import {
   colorTransitionTrigger,
   opacityTransitionTrigger,
+  triggerAnimation,
 } from 'src/app/shared/animations';
 import { Plan, ProjectConfig } from 'src/app/types';
 
@@ -40,37 +31,7 @@ interface StepState {
   templateUrl: './create-scenarios.component.html',
   styleUrls: ['./create-scenarios.component.scss'],
   animations: [
-    trigger('expandCollapsePanel', [
-      state(
-        'expanded',
-        style({
-          backgroundColor: 'white',
-          padding: '*',
-          maxWidth: '700px',
-        })
-      ),
-      state(
-        'collapsed',
-        style({
-          backgroundColor: '#ebebeb',
-          width: '36px',
-        })
-      ),
-      transition('expanded => collapsed', [
-        group([
-          query('@expandCollapseButton', animateChild()),
-          query('@expandCollapsePanelContent', animateChild()),
-          animate('300ms 100ms ease-out'),
-        ]),
-      ]),
-      transition('collapsed => expanded', [
-        group([
-          query('@expandCollapseButton', animateChild()),
-          query('@expandCollapsePanelContent', animateChild()),
-          animate('250ms ease-out'),
-        ]),
-      ]),
-    ]),
+    triggerAnimation,
     colorTransitionTrigger({
       triggerName: 'expandCollapseButton',
       colorA: 'white',

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -15,7 +15,7 @@ import { PlanService } from 'src/app/services';
 import {
   colorTransitionTrigger,
   opacityTransitionTrigger,
-  triggerAnimation,
+  expandCollapsePanelTrigger,
 } from 'src/app/shared/animations';
 import { Plan, ProjectConfig } from 'src/app/types';
 
@@ -31,7 +31,7 @@ interface StepState {
   templateUrl: './create-scenarios.component.html',
   styleUrls: ['./create-scenarios.component.scss'],
   animations: [
-    triggerAnimation,
+    expandCollapsePanelTrigger,
     colorTransitionTrigger({
       triggerName: 'expandCollapseButton',
       colorA: 'white',

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -1,27 +1,24 @@
 <div class="root-container">
   <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
   <ng-container *ngIf="!planNotFound && plan">
-    <div class="scenario-details" *ngIf="viewScenario$ | async">
-      <router-outlet #outlet="outlet"></router-outlet>
-    </div>
-
     <div class="plan-summary-panel" *ngIf="!(viewScenario$ | async) && currentPlanStep === PlanStep.Overview">
       <summary-panel [plan]="currentPlan$ | async"></summary-panel>
     </div>
     <mat-divider [vertical]="true" *ngIf="!(viewScenario$ | async)"></mat-divider>
-    <div class="plan-content" *ngIf="!(viewScenario$ | async)">
-      <app-plan-navigation-bar (backToOverviewEvent)="currentPlanStep = PlanStep.Overview" *ngIf="currentPlanStep > PlanStep.Overview"></app-plan-navigation-bar>
+    <div class="plan-content">
+      <app-plan-navigation-bar (backToOverviewEvent)="backToOverview()" *ngIf="currentPlanStep > PlanStep.Overview || (viewScenario$ | async)"></app-plan-navigation-bar>
       <div class="plan-content-inner">
         <app-plan-overview
           [plan$]="currentPlan$"
           (openConfigEvent)="openConfig($event)"
-          *ngIf="currentPlanStep === PlanStep.Overview"></app-plan-overview>
-        <ng-container *ngIf="currentPlanStep > 0">
+          *ngIf="!(viewScenario$ | async) && currentPlanStep === PlanStep.Overview"></app-plan-overview>
+        <ng-container *ngIf="(viewScenario$ | async) || currentPlanStep > 0">
           <div class="plan-map-container">
             <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'" [mapPadding]="[700, 0]"></app-plan-map>
           </div>
           <div class="plan-content-panel">
-            <app-create-scenarios [plan$]="currentPlan$" [planningStep]="currentPlanStep" [scenarioConfigId]="openConfigId"
+            <router-outlet #outlet="outlet"></router-outlet>
+            <app-create-scenarios *ngIf="!(viewScenario$ | async)" [plan$]="currentPlan$" [planningStep]="currentPlanStep" [scenarioConfigId]="openConfigId"
               (changeConditionEvent)="changeCondition($event)" (drawShapesEvent)="drawShapes($event)">
             </app-create-scenarios>
           </div>

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -107,4 +107,9 @@ export class PlanComponent implements OnInit, OnDestroy {
       this.route.snapshot.firstChild?.paramMap.get('id') ?? null;
     this.planService.updateStateWithScenario(scenarioId);
   }
+
+  backToOverview() {
+    this.currentPlanStep = PlanStep.Overview;
+    this.router.navigate(['plan', this.plan!.id]);
+  }
 }

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.html
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.html
@@ -1,11 +1,15 @@
-<div class="scenario-details-container">
-  <div class="details-panel">
+<div class="scenario-details-panel mat-elevation-z2"
+  [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
+  <div class="scenario-details-panel-content"
+    [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
+
     <h1>Scenario Details</h1>
-  </div>
-  <mat-divider [vertical]="true"></mat-divider>
-  <div class="plan-map-container">
-    <div class="plan-map-view">
-      <p>Here is a map view</p>
-    </div>
+
+    <!-- Expand/collapse button -->
+    <div class="scenario-details-panel-expand-button" [class.collapsed]="!panelExpanded"
+      [@expandCollapseButton]="panelExpanded ? 'colorA': 'colorB'">
+    <button mat-icon-button (click)="panelExpanded = !panelExpanded">
+      <mat-icon>chevron_left</mat-icon>
+    </button>
   </div>
 </div>

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.scss
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.scss
@@ -1,11 +1,4 @@
-.scenario-details-container {
-  display: flex;
-  flex-direction: row;
-  height: 100%;
-  width: 100%;
-}
-
-.details-panel {
+.scenario-details-panel {
   background-color: white;
   box-sizing: border-box;
   display: flex;
@@ -30,4 +23,40 @@
   justify-content: center;
   position: relative;
   text-align: center;
+}
+
+.scenario-details-panel-expand-button {
+  align-items: center;
+  background-color: white;
+  border-radius: 8px;
+  display: flex;
+  height: 64px;
+  position: absolute;
+  right: -24px;
+  top: 12px;
+
+  &.collapsed {
+    transform: rotate(180deg);
+  }
+}
+
+.scenario-details-panel-content {
+  box-sizing: border-box;
+  display: flex;
+  height: 100%;
+  overflow-y: scroll;
+  padding: 16px 80px 32px 32px;
+}
+
+/** Always show scrollbar. */
+::-webkit-scrollbar {
+  -webkit-appearance: none;
+  height: 0px;
+  width: 7px;
+}
+
+::-webkit-scrollbar-thumb {
+  -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+  background-color: rgba(0,0,0,.5);
+  border-radius: 4px;
 }

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ScenarioDetailsComponent } from './scenario-details.component';
 
@@ -8,6 +9,7 @@ describe('ScenarioDetailsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [BrowserAnimationsModule],
       declarations: [ ScenarioDetailsComponent ]
     })
     .compileComponents();

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
@@ -1,11 +1,32 @@
 import { Component, OnInit } from '@angular/core';
+import {
+  colorTransitionTrigger,
+  opacityTransitionTrigger,
+  triggerAnimation,
+} from 'src/app/shared/animations';
 
 @Component({
   selector: 'app-scenario-details',
   templateUrl: './scenario-details.component.html',
-  styleUrls: ['./scenario-details.component.scss']
+  styleUrls: ['./scenario-details.component.scss'],
+  animations: [
+    triggerAnimation,
+    colorTransitionTrigger({
+      triggerName: 'expandCollapseButton',
+      colorA: 'white',
+      colorB: '#ebebeb',
+      timingA: '300ms ease-out',
+      timingB: '250ms ease-out',
+    }),
+    opacityTransitionTrigger({
+      triggerName: 'expandCollapsePanelContent',
+      timingA: '100ms ease-out',
+      timingB: '100ms 250ms ease-out',
+    }),
+  ],
 })
 export class ScenarioDetailsComponent implements OnInit {
+  panelExpanded: boolean = true;
 
   constructor() {}
 

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import {
   colorTransitionTrigger,
   opacityTransitionTrigger,
-  triggerAnimation,
+  expandCollapsePanelTrigger,
 } from 'src/app/shared/animations';
 
 @Component({
@@ -10,7 +10,7 @@ import {
   templateUrl: './scenario-details.component.html',
   styleUrls: ['./scenario-details.component.scss'],
   animations: [
-    triggerAnimation,
+    expandCollapsePanelTrigger,
     colorTransitionTrigger({
       triggerName: 'expandCollapseButton',
       colorA: 'white',

--- a/src/interface/src/app/shared/animations.ts
+++ b/src/interface/src/app/shared/animations.ts
@@ -1,5 +1,8 @@
 import {
   animate,
+  animateChild,
+  group,
+  query,
   state,
   style,
   transition,
@@ -51,3 +54,35 @@ export const opacityTransitionTrigger = (params: {
     transition('opaque => transparent', [animate(params.timingA)]),
     transition('transparent => opaque', [animate(params.timingB)]),
   ]);
+
+export const triggerAnimation = trigger('expandCollapsePanel', [
+  state(
+    'expanded',
+    style({
+      backgroundColor: 'white',
+      padding: '*',
+      maxWidth: '700px',
+    })
+  ),
+  state(
+    'collapsed',
+    style({
+      backgroundColor: '#ebebeb',
+      width: '36px',
+    })
+  ),
+  transition('expanded => collapsed', [
+    group([
+      query('@expandCollapseButton', animateChild()),
+      query('@expandCollapsePanelContent', animateChild()),
+      animate('300ms 100ms ease-out'),
+    ]),
+  ]),
+  transition('collapsed => expanded', [
+    group([
+      query('@expandCollapseButton', animateChild()),
+      query('@expandCollapsePanelContent', animateChild()),
+      animate('250ms ease-out'),
+    ]),
+  ]),
+]);

--- a/src/interface/src/app/shared/animations.ts
+++ b/src/interface/src/app/shared/animations.ts
@@ -55,7 +55,7 @@ export const opacityTransitionTrigger = (params: {
     transition('transparent => opaque', [animate(params.timingB)]),
   ]);
 
-export const triggerAnimation = trigger('expandCollapsePanel', [
+export const expandCollapsePanelTrigger = trigger('expandCollapsePanel', [
   state(
     'expanded',
     style({


### PR DESCRIPTION
# Changes
* Reuse animated collapsible panel (thanks @thequeenofspades !)
* Share plan map and navigation bar
* Modify plan-navigation-bar to go back to plan overview route

# UI Updates
<img width="1438" alt="Screenshot 2023-02-16 at 11 30 45 AM" src="https://user-images.githubusercontent.com/114368235/219467972-3b177b64-14d1-4623-99fe-eb967eaf6c80.png">

# Todos
* Use plan service to share data between components (as needed)
* Create fake scenario with the configurations and project areas
* Fill in scenario details panel with configurations
* Draw project areas on the map within the planning area