### PR TITLE
new terrain and satellite basemaps

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -79,9 +79,9 @@ export class MapManager {
     if (map.config.baseLayerType === BaseLayerType.Road) {
       map.baseLayerRef = this.stadiaAlidadeTiles();
     } else if (map.config.baseLayerType == BaseLayerType.Terrain) {
-      map.baseLayerRef = this.hillshadeTiles();
+      map.baseLayerRef = this.terrainTiles();
     } else {
-      map.baseLayerRef = this.USGSTiles();
+      map.baseLayerRef = this.satelliteTiles();
     }
 
     map.instance = L.map(mapId, {
@@ -139,14 +139,13 @@ export class MapManager {
     this.setUpEventHandlers(map, createDetailCardCallback);
   }
 
-  /** Creates a basemap layer using the Hillshade tiles. */
-  private hillshadeTiles() {
+  /** Creates a basemap layer using the Esri.WorldTerrain tiles. */
+  private terrainTiles() {
     return L.tileLayer(
-      'https://api.mapbox.com/styles/v1/tsuga11/ckcng1sjp2kat1io3rv2croyl/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoidHN1Z2ExMSIsImEiOiJjanFmaTA5cGIyaXFoM3hqd3R5dzd3bzU3In0.TFqMjIIYtpcyhzNh4iMcQA',
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}',
       {
-        zIndex: 0,
-        tileSize: 512,
-        zoomOffset: -1,
+        maxZoom: 13,
+        attribution: 'Tiles &copy; Esri &mdash; Source: USGS, Esri, TANA, DeLorme, and NPS',
       }
     );
   }
@@ -164,14 +163,12 @@ export class MapManager {
     );
   }
 
-  private USGSTiles() {
+  /** Creates a basemap layer using the Esri.WorldImagery tiles. */
+  private satelliteTiles() {
     return L.tileLayer(
-      'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}',
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
       {
-        zIndex: 0,
-        maxZoom: 20,
-        attribution:
-          'Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>',
+        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
       }
     );
   }
@@ -587,11 +584,11 @@ export class MapManager {
     let baseLayerType = map.config.baseLayerType;
     map.baseLayerRef?.remove();
     if (baseLayerType === BaseLayerType.Terrain) {
-      map.baseLayerRef = this.hillshadeTiles();
+      map.baseLayerRef = this.terrainTiles();
     } else if (baseLayerType === BaseLayerType.Road) {
       map.baseLayerRef = this.stadiaAlidadeTiles();
     } else if (baseLayerType === BaseLayerType.Satellite) {
-      map.baseLayerRef = this.USGSTiles();
+      map.baseLayerRef = this.satelliteTiles();
     }
     map.instance?.addLayer(map.baseLayerRef!);
   }

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -150,7 +150,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
       (id: string, index: number) => {
         return {
           id: id,
-          name: 'Map ' + (index + 1),
+          name: `${index + 1}`,
           config: defaultMapConfig(),
         };
       }

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -123,6 +123,11 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
   }
 }
 
+// Leaflet attribution box
+.leaflet-control-attribution {
+  max-width: calc(100% - 200px);
+}
+
 // Removes the box when a boundary is clicked. https://github.com/OurPlanscape/Planscape/issues/357
 * {
   outline: none;


### PR DESCRIPTION
Replace broken terrain basemap with Esri.WorldTerrain tiles. At UX's request, also replace satellite basemap with Esri.WorldImagery tiles.

Shorten attribution label so it doesn't overlap with the map labels.

Remove 'Map' from the map label to give the layers more room.

Terrain (left) and satellite (right):
![image](https://user-images.githubusercontent.com/10444733/219526652-6bf30c9f-43ee-4382-bc00-079a0329a44b.png)
