### PR TITLE
fix layer control tab labels

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -45,7 +45,7 @@
   <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true"
     [selectedIndex]="mapViewOptions?.selectedMapIndex"
     class="layer-controls-tab-group" (selectedIndexChange)="selectMap.emit($event)">
-    <mat-tab *ngFor="let map of maps; index as i" label="{{ map.name }}">
+    <mat-tab *ngFor="let map of maps; index as i" label="MAP {{ map.name }}">
       <mat-accordion multi displayMode="flat">
 
         <!-- Basemap layer controls -->


### PR DESCRIPTION
#547 changed the map nameplates to list just the map number ("1" and "2" instead of "Map 1" and "Map 2") at UX's request, but also mistakenly changed the map names in the layer control tabs. This PR prefixes those labels with "MAP" once again.

![image](https://user-images.githubusercontent.com/10444733/219760413-5c3ebbe0-27a1-4f00-ad09-cddcdc59ce4e.png)
