### PR TITLE
turn on preferCanvas for performance

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -93,6 +93,7 @@ export class MapManager {
       zoomControl: false,
       pmIgnore: false,
       scrollWheelZoom: false,
+      preferCanvas: true,
     });
 
     // Add zoom controls to bottom right corner


### PR DESCRIPTION
Turns on `preferCanvas` which may improve frontend map performance. I can't tell if it's helping. Maybe a little? But it's not hurting.