### PR TITLE
Add /get_scenario endpoint for a single id

### DIFF
--- a/src/planscape/plan/serializers.py
+++ b/src/planscape/plan/serializers.py
@@ -2,7 +2,7 @@ from rest_framework.serializers import IntegerField
 from rest_framework import serializers
 from rest_framework_gis import serializers as gis_serializers
 
-from .models import Plan, Project, ProjectArea
+from .models import Plan, Project, ProjectArea, Scenario
 from conditions.models import Condition
 
 
@@ -22,6 +22,11 @@ class ConditionSerializer(serializers.ModelSerializer):
         model = Condition
         fields = '__all__'
 
+
+class ScenarioSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Scenario
+        fields = '__all__'
 
 class ProjectSerializer(serializers.ModelSerializer):
     priorities = serializers.SlugRelatedField(

--- a/src/planscape/plan/urls.py
+++ b/src/planscape/plan/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from plan.views import (
     create_plan, create_project, delete, get_plan, get_project,
     get_project_areas, get_scores, list_plans_by_owner, delete_projects,
-    create_project_area, update_project, list_projects_for_plan, create_scenario)
+    create_project_area, update_project, list_projects_for_plan, create_scenario, get_scenario)
 
 app_name = 'plan'
 
@@ -23,4 +23,5 @@ urlpatterns = [
     path('create_project_area/', create_project_area, name='create_project_area'),
     path('get_project_areas/', get_project_areas, name='get_project_areas'),
     path('create_scenario/', create_scenario, name='create_scenario'),
+    path('get_scenario/', get_scenario, name='get_scenario'),
 ]

--- a/src/planscape/plan/urls.py
+++ b/src/planscape/plan/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from plan.views import (
-    create_plan, create_project, delete, get_plan, get_project,
-    get_project_areas, get_scores, list_plans_by_owner, delete_projects,
-    create_project_area, update_project, list_projects_for_plan, create_scenario, get_scenario)
+from plan.views import (create_plan, create_project, create_project_area,
+                        create_scenario, delete, delete_projects, get_plan,
+                        get_project, get_project_areas, get_scenario,
+                        get_scores, list_plans_by_owner,
+                        list_projects_for_plan, update_project)
 
 app_name = 'plan'
 

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -9,11 +9,11 @@ from django.db.models import Count
 from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
                          JsonResponse, QueryDict)
 from django.views.decorators.csrf import csrf_exempt
-from plan.models import Plan, Project, ProjectArea, Scenario, ScenarioWeightedPriority
+from plan.models import (Plan, Project, ProjectArea, Scenario,
+                         ScenarioWeightedPriority)
 from plan.serializers import (PlanSerializer, ProjectAreaSerializer,
                               ProjectSerializer, ScenarioSerializer)
 from planscape import settings
-from django.shortcuts import get_list_or_404
 
 # TODO: remove csrf_exempt decorators when logged in users are required.
 
@@ -509,15 +509,16 @@ def get_scenario(request: HttpRequest) -> HttpResponse:
     try:
         assert isinstance(request.GET['id'], str)
         scenario_id = request.GET.get('id', "0")
-        scenario_exists = Scenario.objects.get(id=scenario_id)
+        scenario = Scenario.objects.get(id=scenario_id)
 
         user = get_user(request)
 
-        if scenario_exists.owner != user:
+        if scenario.owner != user:
             raise ValueError(
                 "You do not have permission to view this scenario.")
 
-        return JsonResponse(ScenarioSerializer(scenario_exists).data, safe=False)
+        # TODO: retrieve and return weights as part of Scenario
+        return JsonResponse(ScenarioSerializer(scenario).data, safe=False)
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 


### PR DESCRIPTION
This endpoint should be called when the user tries to view Scenario details.
Specific errors: if id does not exist or user does not have access to the scenario

Example input:
{'id': scenario_id}