### PR TITLE
only sync visible maps

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -568,12 +568,14 @@ export class MapManager {
     }).addTo(map);
   }
 
-  /** Sync pan, zoom, etc. between all maps. */
-  syncAllMaps() {
-    this.maps.forEach((mapA) => {
-      this.maps.forEach((mapB) => {
-        if (mapA !== mapB) {
+  /** Sync pan, zoom, etc. between all maps visible onscreen. */
+  syncVisibleMaps(isMapVisible: (index: number) => boolean) {
+    this.maps.forEach((mapA, indexA) => {
+      this.maps.forEach((mapB, indexB) => {
+        if (mapA !== mapB && isMapVisible(indexA) && isMapVisible(indexB)) {
           (mapA.instance as any).sync(mapB.instance);
+        } else {
+          (mapA.instance as any).unsync(mapB.instance);
         }
       });
     });

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -191,7 +191,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     this.maps.forEach((map: Map) => {
       this.initMap(map, map.id);
     });
-    this.mapManager.syncAllMaps();
+    this.mapManager.syncVisibleMaps(this.isMapVisible.bind(this));
   }
 
   ngOnDestroy(): void {
@@ -563,6 +563,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     const mapViewOptions = this.mapViewOptions$.getValue();
     mapViewOptions.numVisibleMaps = mapCount;
     this.mapViewOptions$.next(mapViewOptions);
+    this.mapManager.syncVisibleMaps(this.isMapVisible.bind(this));
     setTimeout(() => {
       this.maps.forEach((map: Map) => {
         map.instance?.invalidateSize();


### PR DESCRIPTION
Only sync pan/zoom between Leaflet maps that are visible onscreen. This results in significant performance gain for one-map view.