### PR TITLE
Plan final step: generate scenario

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -53,7 +53,11 @@
             Weigh priorities to determine acreage of treatment and estimated impact on priorities.
           </div>
         </ng-template>
-        <app-generate-scenarios [formGroup]="formGroups[3]" (formBackEvent)="stepper.previous()"></app-generate-scenarios>
+        <app-generate-scenarios
+          [formGroup]="formGroups[3]"
+          (formBackEvent)="stepper.previous()"
+          (createScenarioEvent)="createScenario()">
+        </app-generate-scenarios>
       </mat-step>
     </mat-stepper>
   </div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -79,10 +79,12 @@ describe('CreateScenariosComponent', () => {
 
     expect(fakePlanService.updateProject).toHaveBeenCalledOnceWith({
       id: 1,
+      planId: 1,
       max_treatment_area_ratio: NaN,
       max_road_distance: NaN,
       max_slope: NaN,
       priorities: ['test'],
+      weights: [1],
     });
   });
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -25,6 +25,7 @@ describe('CreateScenariosComponent', () => {
           maxBudget: 100,
         }),
         updateProject: of(1),
+        createScenario: of('1'),
       },
       {}
     );
@@ -126,6 +127,23 @@ describe('CreateScenariosComponent', () => {
     expect(priorityWeightsForm.value).toEqual({
       priority1: 1,
       priority2: 1,
+    });
+  });
+
+  it('creates scenario when event is emitted', () => {
+    component.scenarioConfigId = 1;
+    component.formGroups[0].get('priorities')?.setValue(['test']);
+
+    component.createScenario();
+
+    expect(fakePlanService.createScenario).toHaveBeenCalledOnceWith({
+      id: 1,
+      planId: 1,
+      max_treatment_area_ratio: NaN,
+      max_road_distance: NaN,
+      max_slope: NaN,
+      priorities: ['test'],
+      weights: [1],
     });
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -117,12 +117,6 @@ export class CreateScenariosComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    if (this.scenarioConfigId !== undefined) {
-      this.loadExistingConfig();
-    } else {
-      this.createNewConfig();
-    }
-
     // When an area is uploaded, issue an event to draw it on the map.
     // If the "generate areas" option is selected, remove any drawn areas.
     this.formGroups[2].valueChanges.subscribe((_) => {
@@ -139,6 +133,12 @@ export class CreateScenariosComponent implements OnInit {
     this.formGroups[0].get('priorities')?.valueChanges.subscribe((_) => {
       this.updatePriorityWeightsFormControls();
     });
+
+    if (this.scenarioConfigId !== undefined) {
+      this.loadExistingConfig();
+    } else {
+      this.createNewConfig();
+    }
   }
 
   private constraintsFormValidator(constraintsForm: AbstractControl): boolean {
@@ -156,6 +156,9 @@ export class CreateScenariosComponent implements OnInit {
       const excludeDistance = this.formGroups[1].get('excludeDistance');
       const excludeSlope = this.formGroups[1].get('excludeSlope');
       const priorities = this.formGroups[0].get('priorities');
+      const weights = this.formGroups[3].get(
+        'priorityWeightsForm'
+      ) as FormGroup;
 
       if (config.max_budget) {
         maxBudget?.setValue(config.max_budget);
@@ -171,6 +174,11 @@ export class CreateScenariosComponent implements OnInit {
       }
       if (config.priorities) {
         priorities?.setValue(config.priorities);
+      }
+      if (config.weights) {
+        config.priorities?.forEach((priority, index) => {
+          weights.controls[priority].setValue(config.weights![index]);
+        });
       }
     });
   }
@@ -211,9 +219,11 @@ export class CreateScenariosComponent implements OnInit {
     const excludeDistance = this.formGroups[1].get('excludeDistance');
     const excludeSlope = this.formGroups[1].get('excludeSlope');
     const priorities = this.formGroups[0].get('priorities');
+    const weights = this.formGroups[3].get('priorityWeightsForm') as FormGroup;
 
     let projectConfig: ProjectConfig = {
       id: this.scenarioConfigId!,
+      planId: Number(this.plan$.getValue()?.id),
     };
     if (maxBudget?.valid)
       projectConfig.max_budget = parseFloat(maxBudget.value);
@@ -224,6 +234,9 @@ export class CreateScenariosComponent implements OnInit {
     if (excludeSlope?.valid)
       projectConfig.max_slope = parseFloat(excludeSlope.value);
     if (priorities?.valid) projectConfig.priorities = priorities.value;
+    projectConfig.weights = Object.values(weights.controls).map(
+      (control) => control.value
+    );
 
     return projectConfig;
   }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -19,8 +19,8 @@ import { filter } from 'rxjs/operators';
 import { PlanService } from 'src/app/services';
 import {
   colorTransitionTrigger,
-  opacityTransitionTrigger,
   expandCollapsePanelTrigger,
+  opacityTransitionTrigger,
 } from 'src/app/shared/animations';
 import { Plan, ProjectConfig } from 'src/app/types';
 
@@ -57,6 +57,7 @@ export class CreateScenariosComponent implements OnInit {
   @Input() scenarioConfigId?: number;
   @Input() plan$ = new BehaviorSubject<Plan | null>(null);
   @Input() planningStep: PlanStep = PlanStep.CreateScenarios;
+  @Output() backToOverviewEvent = new EventEmitter<void>();
   @Output() changeConditionEvent = new EventEmitter<string>();
   @Output() drawShapesEvent = new EventEmitter<any>();
 
@@ -213,7 +214,7 @@ export class CreateScenariosComponent implements OnInit {
     }
   }
 
-  formValueToProjectConfig(): ProjectConfig {
+  private formValueToProjectConfig(): ProjectConfig {
     const maxBudget = this.formGroups[1].get('budgetForm.maxBudget');
     const maxArea = this.formGroups[1].get('treatmentForm.maxArea');
     const excludeDistance = this.formGroups[1].get('excludeDistance');
@@ -255,5 +256,13 @@ export class CreateScenariosComponent implements OnInit {
       ]);
       priorityWeightsForm.addControl(priority, priorityControl);
     });
+  }
+
+  createScenario(): void {
+    this.planService
+      .createScenario(this.formValueToProjectConfig())
+      .subscribe((_) => {
+        this.backToOverviewEvent.emit();
+      });
   }
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -261,6 +261,7 @@ export class CreateScenariosComponent implements OnInit {
   createScenario(): void {
     this.planService
       .createScenario(this.formValueToProjectConfig())
+      .pipe(take(1))
       .subscribe((_) => {
         this.backToOverviewEvent.emit();
       });

--- a/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.html
@@ -44,7 +44,13 @@
 </form>
 
   <div class="flex-row gap-12">
-    <button mat-raised-button color="primary" [disabled]="formGroup?.invalid">GENERATE SCENARIO</button>
+    <button
+      mat-raised-button
+      color="primary"
+      [disabled]="formGroup?.invalid || generatingScenario"
+      (click)="generateScenario()">
+      {{ generatingScenario ? 'GENERATING SCENARIO...' : 'GENERATE SCENARIO' }}
+    </button>
     <button mat-flat-button (click)="formBackEvent.emit()">BACK</button>
   </div>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.spec.ts
@@ -7,6 +7,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
+import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatSliderHarness } from '@angular/material/slider/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
@@ -85,5 +86,18 @@ describe('GenerateScenariosComponent', () => {
 
     expect(component.formGroup?.get('areaPercent')?.value).toEqual(34);
     expect(component.formGroup?.get('areaPercent')?.dirty).toBeTrue();
+  });
+
+  it('should emit create scenario event', async () => {
+    spyOn(component.createScenarioEvent, 'emit');
+    const buttonHarness: MatButtonHarness = await loader.getHarness(
+      MatButtonHarness.with({ text: /GENERATE SCENARIO/ })
+    );
+
+    // Click on "GENERATE SCENARIO" button
+    await buttonHarness.click();
+
+    expect(component.createScenarioEvent.emit).toHaveBeenCalledOnceWith();
+    expect(component.generatingScenario).toBeTrue();
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/generate-scenarios/generate-scenarios.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { MatSliderChange } from '@angular/material/slider';
 import { filter } from 'rxjs/operators';
-import { MapService } from 'src/app/services';
+import { MapService, PlanService } from 'src/app/services';
 
 @Component({
   selector: 'app-generate-scenarios',
@@ -12,6 +12,9 @@ import { MapService } from 'src/app/services';
 export class GenerateScenariosComponent implements OnInit {
   @Input() formGroup?: FormGroup;
   @Output() formBackEvent = new EventEmitter<void>();
+  @Output() createScenarioEvent = new EventEmitter<void>();
+
+  generatingScenario: boolean = false;
 
   private priorityNameMap?: Map<string, string>;
   priorityWeightControls: {
@@ -56,5 +59,10 @@ export class GenerateScenariosComponent implements OnInit {
   ): void {
     control?.setValue(sliderEvent.value);
     control?.markAsDirty();
+  }
+
+  generateScenario(): void {
+    this.generatingScenario = true;
+    this.createScenarioEvent.emit();
   }
 }

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -18,8 +18,14 @@
           </div>
           <div class="plan-content-panel">
             <router-outlet #outlet="outlet"></router-outlet>
-            <app-create-scenarios *ngIf="!(viewScenario$ | async)" [plan$]="currentPlan$" [planningStep]="currentPlanStep" [scenarioConfigId]="openConfigId"
-              (changeConditionEvent)="changeCondition($event)" (drawShapesEvent)="drawShapes($event)">
+            <app-create-scenarios
+              *ngIf="!(viewScenario$ | async)"
+              [plan$]="currentPlan$"
+              [planningStep]="currentPlanStep"
+              [scenarioConfigId]="openConfigId"
+              (backToOverviewEvent)="backToOverview()"
+              (changeConditionEvent)="changeCondition($event)"
+              (drawShapesEvent)="drawShapes($event)">
             </app-create-scenarios>
           </div>
         </ng-container>

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -297,4 +297,35 @@ describe('PlanService', () => {
       httpTestingController.verify();
     });
   });
+
+  describe('createScenario', () => {
+    it('should make HTTP request to backend', (done) => {
+      const projectConfig: ProjectConfig = {
+        id: 1,
+        planId: 2,
+        max_budget: 200,
+      };
+
+      service.createScenario(projectConfig).subscribe((res) => {
+        expect(res).toEqual('1');
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/create_scenario/')
+      );
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({
+        plan_id: 2,
+        max_budget: 200,
+        max_road_distance: undefined,
+        max_slope: undefined,
+        max_treatment_area_ratio: undefined,
+        priorities: undefined,
+        weights: undefined,
+      });
+      req.flush('1');
+      httpTestingController.verify();
+    });
+  });
 });

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -220,12 +220,14 @@ describe('PlanService', () => {
       const projectConfigs: ProjectConfig[] = [
         {
           id: 1,
+          planId: undefined,
           max_budget: 200,
           max_road_distance: undefined,
           max_slope: undefined,
           max_treatment_area_ratio: undefined,
           priorities: undefined,
           createdTimestamp: undefined,
+          weights: undefined,
         },
       ];
 
@@ -253,12 +255,14 @@ describe('PlanService', () => {
     it('should make HTTP request to backend', () => {
       const projectConfig: ProjectConfig = {
         id: 1,
+        planId: undefined,
         max_budget: 200,
         max_road_distance: undefined,
         max_slope: undefined,
         max_treatment_area_ratio: undefined,
         priorities: undefined,
         createdTimestamp: undefined,
+        weights: undefined,
       };
 
       service.getProject(1).subscribe((res) => {

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -200,6 +200,17 @@ export class PlanService {
     );
   }
 
+  /** Creates a scenario in the backend. Returns scenario ID. */
+  createScenario(config: ProjectConfig): Observable<string> {
+    return this.http.post<string>(
+      BackendConstants.END_POINT.concat('/plan/create_scenario/'),
+      this.convertToScenario(config),
+      {
+        withCredentials: true,
+      }
+    );
+  }
+
   private convertToPlan(plan: BackendPlan): Plan {
     return {
       id: String(plan.id),
@@ -239,14 +250,28 @@ export class PlanService {
   private convertToProjectConfig(config: any): ProjectConfig {
     return {
       id: config.id,
+      planId: config.plan_id,
       max_budget: config.max_budget,
       max_road_distance: config.max_road_distance,
       max_slope: config.max_slope,
       max_treatment_area_ratio: config.max_treatment_area_ratio,
       priorities: config.priorities,
+      weights: config.weights,
       createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
         config.creation_timestamp
       ),
+    };
+  }
+
+  private convertToScenario(config: ProjectConfig): any {
+    return {
+      plan_id: config.planId,
+      max_budget: config.max_budget,
+      max_road_distance: config.max_road_distance,
+      max_slope: config.max_slope,
+      max_treatment_area_ratio: config.max_treatment_area_ratio,
+      priorities: config.priorities,
+      weights: config.weights,
     };
   }
 

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -36,11 +36,13 @@ export interface Scenario {
 
 export interface ProjectConfig {
   id: number;
+  planId?: number;
   max_budget?: number;
   max_treatment_area_ratio?: number;
   max_road_distance?: number;
   max_slope?: number;
   priorities?: string[];
+  weights?: number[];
   createdTimestamp? : number;
 }
 


### PR DESCRIPTION
## Changes
- Save priority weights as part of the project config
- Call the `plan/create_scenario` backend stub API when user clicks the "GENERATE SCENARIO" button in Plan Step 4 (formerly Plan Step 5)
- Disable the "GENERATE SCENARIO" button after one click so the user can't kick off multiple scenarios from the same config
- Route back to the Plan Overview after the user clicks the button
- Fixes #424 
- Unit tests

## Todo
- Add confirmation screen according to new mocks