### PR TITLE
fetch scenarios for plan from backend

### DIFF
--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -1,13 +1,17 @@
-import { MaterialModule } from 'src/app/material/material.module';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
+import { PlanService } from 'src/app/services';
+import { Region } from 'src/app/types';
 
 import { SavedScenariosComponent } from './saved-scenarios.component';
 
 describe('SavedScenariosComponent', () => {
   let component: SavedScenariosComponent;
   let fixture: ComponentFixture<SavedScenariosComponent>;
+  let fakePlanService: PlanService;
 
   beforeEach(async () => {
     const fakeRoute = jasmine.createSpyObj(
@@ -20,16 +24,38 @@ describe('SavedScenariosComponent', () => {
       }
     );
 
+    fakePlanService = jasmine.createSpyObj<PlanService>(
+      'PlanService',
+      {
+        getScenariosForPlan: of([
+          {
+            id: '1',
+            createdTimestamp: 100,
+          },
+        ]),
+      },
+      {}
+    );
+
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, MaterialModule],
       declarations: [SavedScenariosComponent],
       providers: [
         { provide: ActivatedRoute, useValue: fakeRoute },
-      ]
+        { provide: PlanService, useValue: fakePlanService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SavedScenariosComponent);
     component = fixture.componentInstance;
+
+    component.plan = {
+      id: '1',
+      name: 'Fake Plan',
+      ownerId: '1',
+      region: Region.SIERRA_NEVADA,
+    };
+
     fixture.detectChanges();
   });
 
@@ -43,5 +69,11 @@ describe('SavedScenariosComponent', () => {
     component.createScenario();
 
     expect(component.createScenarioEvent.emit).toHaveBeenCalled();
+  });
+
+  it('should call service for list of scenarios', () => {
+    expect(fakePlanService.getScenariosForPlan).toHaveBeenCalledOnceWith('1');
+
+    expect(component.scenarios.length).toEqual(1);
   });
 });

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-
+import { take } from 'rxjs';
 import { PlanService } from 'src/app/services';
 import { Plan, Scenario } from 'src/app/types';
 
@@ -9,29 +9,26 @@ import { Plan, Scenario } from 'src/app/types';
   templateUrl: './saved-scenarios.component.html',
   styleUrls: ['./saved-scenarios.component.scss'],
 })
-export class SavedScenariosComponent {
+export class SavedScenariosComponent implements OnInit {
   @Input() plan: Plan | null = null;
   @Output() createScenarioEvent = new EventEmitter<void>();
 
-  scenarios: Scenario[];
+  scenarios: Scenario[] = [];
   displayedColumns: string[] = ['id', 'createdTimestamp'];
 
   constructor(
     private planService: PlanService,
     private route: ActivatedRoute,
     private router: Router
-  ) {
-    // TODO (leehana): query scenarios from backend, fake scenarios below.
-    this.scenarios = [
-      {
-        id: '20',
-        createdTimestamp: 12300000,
-      },
-      {
-        id: '21',
-        createdTimestamp: 12300000,
-      },
-    ];
+  ) {}
+
+  ngOnInit(): void {
+    this.planService
+      .getScenariosForPlan(this.plan?.id!)
+      .pipe(take(1))
+      .subscribe((scenarios) => {
+        this.scenarios = scenarios;
+      });
   }
 
   createScenario(): void {

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -63,6 +63,7 @@ describe('PlanComponent', () => {
       getPlan: of(fakePlan),
       getProjectsForPlan: of([]),
       updateStateWithScenario: of(fakePlan),
+      getScenariosForPlan: of([]),
     });
     fakeService.planState$ = of({});
 

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -293,4 +293,32 @@ describe('PlanService', () => {
       httpTestingController.verify();
     });
   });
+
+  describe('getScenariosForPlan', () => {
+    it('should make HTTP request to backend', (done) => {
+      service.getScenariosForPlan('1').subscribe((res) => {
+        expect(res).toEqual([
+          {
+            id: '1',
+            createdTimestamp: 5000,
+          },
+        ]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat(
+          '/plan/list_scenarios_for_plan/?plan_id=1'
+        )
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush([
+        {
+          id: '1',
+          creation_timestamp: 5,
+        },
+      ]);
+      httpTestingController.verify();
+    });
+  });
 });

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -200,6 +200,21 @@ export class PlanService {
     );
   }
 
+  /** Fetches the scenarios for a plan from the backend. */
+  getScenariosForPlan(planId: string): Observable<Scenario[]> {
+    return this.http
+      .get<any[]>(
+        BackendConstants.END_POINT.concat(
+          '/plan/list_scenarios_for_plan/?plan_id=',
+          planId
+        ),
+        {
+          withCredentials: true,
+        }
+      )
+      .pipe(map((scenarios) => scenarios.map(this.convertToScenario.bind(this))));
+  }
+
   private convertToPlan(plan: BackendPlan): Plan {
     return {
       id: String(plan.id),
@@ -246,6 +261,15 @@ export class PlanService {
       priorities: config.priorities,
       createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
         config.creation_timestamp
+      ),
+    };
+  }
+
+  private convertToScenario(scenario: any): Scenario {
+    return {
+      id: scenario.id,
+      createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
+        scenario.creation_timestamp
       ),
     };
   }

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -31,7 +31,7 @@ export interface PlanPreview {
 
 export interface Scenario {
   id: string;
-  createdTimestamp: number; //in milliseconds since epoch
+  createdTimestamp?: number; //in milliseconds since epoch
 }
 
 export interface ProjectConfig {

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -530,6 +530,12 @@ def create_scenario(request: HttpRequest) -> HttpResponse:
 
 def _serialize_scenario(scenario: Scenario, weights: QuerySet) -> dict:
     result = ScenarioSerializer(scenario).data
+
+    if 'creation_time' in result:
+        result['creation_timestamp'] = round(datetime.datetime.fromisoformat(
+            result['creation_time'].replace('Z', '+00:00')).timestamp())
+        del result['creation_time']
+
     result['priorities'] = {}
 
     for weight in weights:


### PR DESCRIPTION
## Changes
- Convert scenario creation timestamp to seconds since epoch in backend scenario serializer
- Populate saved scenario table in frontend with real scenarios fetched from backend
- Unit tests
- Fixes #356 

## Todos
- Add more columns to scenario table
![image](https://user-images.githubusercontent.com/10444733/220780890-55a69b69-233c-4a9a-9273-8e2fb063b54d.png)
