### PR TITLE
Get real scenario from backend in scenario details component

### DIFF
--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
@@ -1,5 +1,7 @@
-import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+
+import { Scenario, Plan } from 'src/app/types';
 
 @Component({
   selector: 'app-outcome',
@@ -7,6 +9,8 @@ import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
   styleUrls: ['./outcome.component.scss']
 })
 export class OutcomeComponent implements OnInit {
+  @Input() plan: Plan | null = null;
+  @Input() scenario: Scenario | null = null;
   scenarioNotes: FormGroup;
 
   constructor(private fb : FormBuilder) {

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
@@ -1,17 +1,48 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from 'src/app/material/material.module';
+import { of } from 'rxjs';
 
+import { PlanService } from './../../services/plan.service';
+import { Scenario } from './../../types';
 import { ScenarioDetailsComponent } from './scenario-details.component';
 
 describe('ScenarioDetailsComponent', () => {
   let component: ScenarioDetailsComponent;
   let fixture: ComponentFixture<ScenarioDetailsComponent>;
+  let fakeService: jasmine.SpyObj<any>;
 
   beforeEach(async () => {
+    const snackbarSpy = jasmine.createSpyObj<MatSnackBar>(
+      'MatSnackBar',
+      {
+        open: undefined,
+      },
+      {}
+    );
+
+    const fakeScenario: Scenario = {
+      id: '1',
+    };
+    fakeService = jasmine.createSpyObj('PlanService', {
+      getScenario: of(fakeScenario),
+    });
+    fakeService.planState$ = of({ currentScenarioId: 1 });
+
     await TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, MaterialModule],
+      imports: [BrowserAnimationsModule, HttpClientTestingModule, MaterialModule],
       declarations: [ScenarioDetailsComponent],
+      providers: [
+        { provide: MatSnackBar, useValue: snackbarSpy },
+        { provide: PlanService, useValue: fakeService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ScenarioDetailsComponent);
@@ -21,5 +52,9 @@ describe('ScenarioDetailsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call getScenario', () => {
+    expect(fakeService.getScenario).toHaveBeenCalled();
   });
 });

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -10,6 +10,7 @@ import {
   PlanConditionScores,
   PlanPreview,
   ProjectConfig,
+  Scenario,
 } from './../types/plan.types';
 import { BackendPlan, PlanService } from './plan.service';
 
@@ -290,6 +291,31 @@ describe('PlanService', () => {
         project_ids: projectIds,
       });
       req.flush(projectIds);
+      httpTestingController.verify();
+    });
+  });
+
+  describe('getScenario', () => {
+    it('should make HTTP request to backend', () => {
+      const scenario: Scenario = {
+        id: '1',
+        planId: undefined,
+        maxBudget: undefined,
+        maxRoadDistance: undefined,
+        maxSlope: undefined,
+        maxTreatmentAreaRatio: undefined,
+        priorities: undefined,
+        createdTimestamp: undefined,
+      };
+
+      service.getScenario('1').subscribe((res) => {
+        expect(res).toEqual(scenario);
+      });
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/get_scenario/?id=1')
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(scenario);
       httpTestingController.verify();
     });
   });

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -300,12 +300,10 @@ describe('PlanService', () => {
       const scenario: Scenario = {
         id: '1',
         planId: undefined,
-        maxBudget: undefined,
-        maxRoadDistance: undefined,
-        maxSlope: undefined,
-        maxTreatmentAreaRatio: undefined,
         priorities: undefined,
         createdTimestamp: undefined,
+        notes: undefined,
+        owner: undefined,
       };
 
       service.getScenario('1').subscribe((res) => {

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -17,6 +17,7 @@ export interface PlanState {
   };
   currentPlanId: Plan['id'] | null;
   currentScenarioId: Scenario['id'] | null;
+  currentScenario?: Scenario;
 }
 
 export interface BackendPlan {
@@ -198,6 +199,37 @@ export class PlanService {
         withCredentials: true,
       }
     );
+  }
+
+  /** Fetches a scenario by its id from the backend. */
+  getScenario(scenarioId: string): Observable<Scenario> {
+    const url = BackendConstants.END_POINT.concat(
+      '/plan/get_scenario/?id=',
+      scenarioId
+    );
+    return this.http
+      .get(url, {
+        withCredentials: true,
+      })
+      .pipe(
+        take(1),
+        map((response) => this.convertToScenario(response))
+      );
+  }
+
+  private convertToScenario(backendScenario: any): Scenario {
+    return {
+      id: backendScenario.id,
+      planId: backendScenario.plan_id,
+      maxBudget: backendScenario.max_budget,
+      maxRoadDistance: backendScenario.max_road_distance,
+      maxSlope: backendScenario.max_slope,
+      maxTreatmentAreaRatio: backendScenario.max_treatment_area_ratio,
+      priorities: backendScenario.priorities,
+      createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
+        backendScenario.creation_time
+      ),
+    };
   }
 
   private convertToPlan(plan: BackendPlan): Plan {

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -220,15 +220,13 @@ export class PlanService {
   private convertToScenario(backendScenario: any): Scenario {
     return {
       id: backendScenario.id,
-      planId: backendScenario.plan_id,
-      maxBudget: backendScenario.max_budget,
-      maxRoadDistance: backendScenario.max_road_distance,
-      maxSlope: backendScenario.max_slope,
-      maxTreatmentAreaRatio: backendScenario.max_treatment_area_ratio,
-      priorities: backendScenario.priorities,
+      planId: backendScenario.plan,
       createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
         backendScenario.creation_time
       ),
+      priorities: backendScenario.priorities,
+      notes: backendScenario.notes,
+      owner: backendScenario.owner,
     };
   }
 

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -31,7 +31,16 @@ export interface PlanPreview {
 
 export interface Scenario {
   id: string;
-  createdTimestamp: number; //in milliseconds since epoch
+  createdTimestamp?: number; //in milliseconds since epoch
+  owner?: string;
+  planId?: string;
+  maxBudget?: number;
+  maxTreatmentAreaRatio?: number;
+  maxRoadDistance?: number;
+  maxSlope?: number;
+  priorities?: string[];
+  weights?: string[];
+  notes?: string;
 }
 
 export interface ProjectConfig {


### PR DESCRIPTION
* Added getScenario to PlanService
* Updated Scenario typing. Unclear which fields will remain.
* Scenario details component calls PlanService to get the scenario
* Shows matSnackBar error if the scenario is not found

Added scenario 20 to database:
<img width="1039" alt="Screenshot 2023-02-22 at 2 55 31 PM" src="https://user-images.githubusercontent.com/114368235/220792751-7fba7faf-62db-4e3e-804f-67e4c5fbdf6d.png">
<img width="602" alt="Screenshot 2023-02-22 at 1 48 32 PM" src="https://user-images.githubusercontent.com/114368235/220792794-dfcd0d08-6e74-497a-9438-c611f95bd596.png">
<img width="396" alt="Screenshot 2023-02-22 at 1 53 40 PM" src="https://user-images.githubusercontent.com/114368235/220792809-935baeea-0f56-43e4-a506-d403228d222a.png">




