### PR TITLE
Update plan state with config details and add routing

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -10,11 +10,12 @@ import {
 import { createFeatureGuard } from './features/feature.guard';
 import { LoginComponent } from './login/login.component';
 import { MapComponent } from './map/map.component';
+import { CreateScenariosComponent } from './plan/create-scenarios/create-scenarios.component';
 import { PlanTableComponent } from './plan/plan-table/plan-table.component';
 import { PlanComponent } from './plan/plan.component';
+import { ScenarioDetailsComponent } from './plan/scenario-details/scenario-details.component';
 import { RegionSelectionComponent } from './region-selection/region-selection.component';
 import { SignupComponent } from './signup/signup.component';
-import { ScenarioDetailsComponent } from './plan/scenario-details/scenario-details.component';
 
 const routes: Routes = [
   {
@@ -49,6 +50,11 @@ const routes: Routes = [
             path: `scenario/:id`,
             title: 'Saved Scenario Details',
             component: ScenarioDetailsComponent,
+          },
+          {
+            path: 'config/:id',
+            title: 'Scenario Configuration',
+            component: CreateScenariosComponent,
           },
         ],
       },

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -115,6 +115,9 @@ describe('MapComponent', () => {
           all: {}, // All plans indexed by id
           currentPlanId: 'temp',
           currentScenarioId: null,
+          currentConfigId: null,
+          mapConditionFilepath: null,
+          mapShapes: null,
         }),
       }
     );

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -16,7 +16,7 @@
         </ng-template>
         <app-set-priorities [plan$]="plan$" [formGroup]="formGroups[0]"
           (formNextEvent)="stepper.next()" (formBackEvent)="stepper.previous()"
-          (changeConditionEvent)="changeConditionEvent.emit($event)">
+          (changeConditionEvent)="changeCondition($event)">
         </app-set-priorities>
       </mat-step>
 
@@ -32,7 +32,7 @@
         </app-constraints-panel>
       </mat-step>
 
-      <!-- Step 4: Identify project areas -->
+      <!-- Step 3: Identify project areas -->
       <mat-step>
         <ng-template matStepLabel>
           <div class="step-label-header">Identify project areas</div>
@@ -45,7 +45,7 @@
         </app-identify-project-areas>
       </mat-step>
 
-      <!-- Step 5: Generate scenarios -->
+      <!-- Step 4: Generate scenarios -->
       <mat-step>
         <ng-template matStepLabel>
           <div class="step-label-header">Generate scenarios</div>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -2,9 +2,10 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
-import { PlanService } from 'src/app/services';
-import { Plan, Region } from 'src/app/types';
+import { PlanService, PlanState } from 'src/app/services';
+import { Region } from 'src/app/types';
 
 import { PlanModule } from '../plan.module';
 import { CreateScenariosComponent } from './create-scenarios.component';
@@ -18,7 +19,6 @@ describe('CreateScenariosComponent', () => {
     fakePlanService = jasmine.createSpyObj<PlanService>(
       'PlanService',
       {
-        createProjectInPlan: of(1),
         getConditionScoresForPlanningArea: of(),
         getProject: of({
           id: 1,
@@ -26,8 +26,25 @@ describe('CreateScenariosComponent', () => {
         }),
         updateProject: of(1),
         createScenario: of('1'),
+        updateStateWithShapes: undefined,
       },
-      {}
+      {
+        planState$: new BehaviorSubject<PlanState>({
+          all: {
+            '1': {
+              id: '1',
+              ownerId: 'fakeowner',
+              name: 'testplan',
+              region: Region.SIERRA_NEVADA,
+            },
+          },
+          currentPlanId: '1',
+          currentConfigId: 1,
+          currentScenarioId: null,
+          mapConditionFilepath: null,
+          mapShapes: null,
+        }),
+      }
     );
 
     await TestBed.configureTestingModule({
@@ -38,13 +55,6 @@ describe('CreateScenariosComponent', () => {
 
     fixture = TestBed.createComponent(CreateScenariosComponent);
     component = fixture.componentInstance;
-
-    component.plan$ = new BehaviorSubject<Plan | null>({
-      id: '1',
-      ownerId: 'fakeowner',
-      name: 'testplan',
-      region: Region.SIERRA_NEVADA,
-    });
 
     fixture.detectChanges();
   });
@@ -57,14 +67,7 @@ describe('CreateScenariosComponent', () => {
     expect(component.stepper?.selectedIndex).toEqual(0);
   });
 
-  it('should create a new project when initialized with no config ID', () => {
-    expect(fakePlanService.createProjectInPlan).toHaveBeenCalledOnceWith('1');
-  });
-
-  it('should load existing config into form when initialized with config ID', () => {
-    component.scenarioConfigId = 1;
-    component.ngOnInit();
-
+  it('should load existing config into form', () => {
     expect(fakePlanService.getProject).toHaveBeenCalledOnceWith(1);
 
     component.formGroups[1].valueChanges.subscribe((_) => {
@@ -99,21 +102,22 @@ describe('CreateScenariosComponent', () => {
     expect(fakePlanService.updateProject).toHaveBeenCalledTimes(1);
   });
 
-  it('emits drawShapes event when "identify project areas" form inputs change', () => {
+  it('update plan state when "identify project areas" form inputs change', () => {
     const generateAreas = component.formGroups[2].get('generateAreas');
     const uploadedArea = component.formGroups[2].get('uploadedArea');
-    spyOn(component.drawShapesEvent, 'emit');
 
     // Set "generate areas automatically" to true
     generateAreas?.setValue(true);
 
-    expect(component.drawShapesEvent.emit).toHaveBeenCalledWith(null);
+    expect(fakePlanService.updateStateWithShapes).toHaveBeenCalledWith(null);
 
     // Add an uploaded area and set "generate areas automatically" to false
     generateAreas?.setValue(false);
     uploadedArea?.setValue('testvalue');
 
-    expect(component.drawShapesEvent.emit).toHaveBeenCalledWith('testvalue');
+    expect(fakePlanService.updateStateWithShapes).toHaveBeenCalledWith(
+      'testvalue'
+    );
   });
 
   it('adds a priority weight form control for each priority', () => {
@@ -133,6 +137,8 @@ describe('CreateScenariosComponent', () => {
   it('creates scenario when event is emitted', () => {
     component.scenarioConfigId = 1;
     component.formGroups[0].get('priorities')?.setValue(['test']);
+    const router = fixture.debugElement.injector.get(Router);
+    spyOn(router, 'navigate');
 
     component.createScenario();
 
@@ -145,5 +151,6 @@ describe('CreateScenariosComponent', () => {
       priorities: ['test'],
       weights: [1],
     });
+    expect(router.navigate).toHaveBeenCalledOnceWith(['plan', '1']);
   });
 });

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -25,6 +25,9 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
   projectAreasLayer: L.GeoJSON | undefined;
   tileLayer: L.TileLayer | undefined;
 
+  private filepath: string = '';
+  private shapes: any | null = null;
+
   constructor(private planService: PlanService, private router: Router) {}
 
   ngAfterViewInit(): void {
@@ -62,8 +65,14 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
     this.planService.planState$
       .pipe(takeUntil(this.destroy$))
       .subscribe((state) => {
-        this.setCondition(state.mapConditionFilepath ?? '');
-        this.drawShapes(state.mapShapes);
+        if (state.mapConditionFilepath ?? '' !== this.filepath) {
+          this.filepath = state.mapConditionFilepath ?? '';
+          this.setCondition(state.mapConditionFilepath ?? '');
+        }
+        if (state.mapShapes !== this.shapes) {
+          this.shapes = state.mapShapes;
+          this.drawShapes(state.mapShapes);
+        }
       });
   }
 

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
@@ -10,12 +10,12 @@
         Saved scenarios are added to the Comparison table. Scenarios consist of Project Areas,
         Treatment plans, Potential Outcomes, and Estimated costs.
       </p>
-      <button mat-raised-button color="primary" (click)="openConfigEvent.emit()">
+      <button mat-raised-button color="primary" (click)="openConfig()">
         <mat-icon class="material-symbols-outlined">add_box</mat-icon>
         NEW CONFIGURATION
       </button>
     </div>
-    <app-scenario-configurations [plan]="plan$ | async" (openConfigEvent)="openConfigEvent.emit($event)"></app-scenario-configurations>
-    <app-saved-scenarios [plan]="plan$ | async" (createScenarioEvent)="openConfigEvent.emit()"></app-saved-scenarios>
+    <app-scenario-configurations [plan]="plan$ | async" (openConfigEvent)="openConfig($event)"></app-scenario-configurations>
+    <app-saved-scenarios [plan]="plan$ | async" (createScenarioEvent)="openConfig()"></app-saved-scenarios>
   </div>
 </div>

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
@@ -3,8 +3,11 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BehaviorSubject, of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
+import { PlanService, PlanState } from 'src/app/services';
 
 import { PlanModule } from './../../plan.module';
 import { PlanOverviewComponent } from './plan-overview.component';
@@ -13,8 +16,28 @@ describe('PlanOverviewComponent', () => {
   let component: PlanOverviewComponent;
   let fixture: ComponentFixture<PlanOverviewComponent>;
   let loader: HarnessLoader;
+  let fakePlanService: PlanService;
 
   beforeEach(async () => {
+    fakePlanService = jasmine.createSpyObj<PlanService>(
+      'PlanService',
+      {
+        createProjectInPlan: of(1),
+        getProjectsForPlan: of([]),
+        getScenariosForPlan: of([]),
+      },
+      {
+        planState$: new BehaviorSubject<PlanState>({
+          all: {},
+          currentPlanId: '1',
+          currentConfigId: null,
+          currentScenarioId: null,
+          mapConditionFilepath: null,
+          mapShapes: null,
+        }),
+      }
+    );
+
     await TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -23,6 +46,12 @@ describe('PlanOverviewComponent', () => {
         RouterTestingModule,
       ],
       declarations: [PlanOverviewComponent],
+      providers: [
+        {
+          provide: PlanService,
+          useValue: fakePlanService,
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PlanOverviewComponent);
@@ -35,14 +64,31 @@ describe('PlanOverviewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('clicking new configuration button should emit event', async () => {
-    spyOn(component.openConfigEvent, 'emit');
+  it('clicking new configuration button should call service and navigate', async () => {
+    const route = fixture.debugElement.injector.get(ActivatedRoute);
+    const router = fixture.debugElement.injector.get(Router);
+    spyOn(router, 'navigate');
     let createScenarioButton = await loader.getHarness(
       MatButtonHarness.with({ text: /NEW CONFIGURATION/ })
     );
 
     await createScenarioButton.click();
 
-    expect(component.openConfigEvent.emit).toHaveBeenCalledOnceWith();
+    expect(fakePlanService.createProjectInPlan).toHaveBeenCalledOnceWith('1');
+    expect(router.navigate).toHaveBeenCalledOnceWith(['config', 1], {
+      relativeTo: route,
+    });
+  });
+
+  it('opening a config should navigate', () => {
+    const route = fixture.debugElement.injector.get(ActivatedRoute);
+    const router = fixture.debugElement.injector.get(Router);
+    spyOn(router, 'navigate');
+
+    component.openConfig(2);
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['config', 2], {
+      relativeTo: route,
+    });
   });
 });

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -1,32 +1,22 @@
 <div class="root-container">
   <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
   <ng-container *ngIf="!planNotFound && plan">
-    <div class="plan-summary-panel" *ngIf="!(viewScenario$ | async) && currentPlanStep === PlanStep.Overview">
+    <div class="plan-summary-panel" *ngIf="showOverview$ | async">
       <summary-panel [plan]="currentPlan$ | async"></summary-panel>
     </div>
-    <mat-divider [vertical]="true" *ngIf="!(viewScenario$ | async)"></mat-divider>
+    <mat-divider [vertical]="true" *ngIf="showOverview$ | async"></mat-divider>
     <div class="plan-content">
-      <app-plan-navigation-bar (backToOverviewEvent)="backToOverview()" *ngIf="currentPlanStep > PlanStep.Overview || (viewScenario$ | async)"></app-plan-navigation-bar>
+      <app-plan-navigation-bar (backToOverviewEvent)="backToOverview()" *ngIf="!(showOverview$ | async)"></app-plan-navigation-bar>
       <div class="plan-content-inner">
         <app-plan-overview
           [plan$]="currentPlan$"
-          (openConfigEvent)="openConfig($event)"
-          *ngIf="!(viewScenario$ | async) && currentPlanStep === PlanStep.Overview"></app-plan-overview>
-        <ng-container *ngIf="(viewScenario$ | async) || currentPlanStep > 0">
+          *ngIf="showOverview$ | async"></app-plan-overview>
+        <ng-container *ngIf="!(showOverview$ | async)">
           <div class="plan-map-container">
             <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'" [mapPadding]="[700, 0]"></app-plan-map>
           </div>
           <div class="plan-content-panel">
             <router-outlet #outlet="outlet"></router-outlet>
-            <app-create-scenarios
-              *ngIf="!(viewScenario$ | async)"
-              [plan$]="currentPlan$"
-              [planningStep]="currentPlanStep"
-              [scenarioConfigId]="openConfigId"
-              (backToOverviewEvent)="backToOverview()"
-              (changeConditionEvent)="changeCondition($event)"
-              (drawShapesEvent)="drawShapes($event)">
-            </app-create-scenarios>
           </div>
         </ng-container>
       </div>

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 import { Plan, Region } from 'src/app/types';
@@ -41,7 +41,7 @@ describe('PlanComponent', () => {
   };
 
   const fakePlan: Plan = {
-    id: 'temp',
+    id: '24',
     name: 'somePlan',
     ownerId: 'owner',
     region: Region.SIERRA_NEVADA,
@@ -62,7 +62,9 @@ describe('PlanComponent', () => {
     const fakeService = jasmine.createSpyObj('PlanService', {
       getPlan: of(fakePlan),
       getProjectsForPlan: of([]),
-      updateStateWithScenario: of(fakePlan),
+      updateStateWithPlan: of(),
+      updateStateWithScenario: of(),
+      updateStateWithConfig: of(),
       getScenariosForPlan: of([]),
     });
     fakeService.planState$ = of({});
@@ -90,19 +92,24 @@ describe('PlanComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('currentPlanStep should be 0', () => {
-    expect(component.currentPlanStep).toBe(0);
-  });
-
   it('fetches plan from service using ID', () => {
     expect(component.planNotFound).toBeFalse();
     expect(component.plan).toEqual(fakePlan);
   });
 
-  it('opening a config advances the plan step', () => {
-    component.openConfig(1);
+  it('calls service to update plan state based on route', () => {
+    const planService = fixture.debugElement.injector.get(PlanService);
 
-    expect(component.openConfigId).toEqual(1);
-    expect(component.currentPlanStep).toBe(1);
+    expect(planService.updateStateWithPlan).toHaveBeenCalledOnceWith('24');
+    expect(component.showOverview$.value).toBeTrue();
+  });
+
+  it('backToOverview navigates back to overview', () => {
+    const router = fixture.debugElement.injector.get(Router);
+    spyOn(router, 'navigate');
+
+    component.backToOverview();
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['plan', '24']);
   });
 });

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -17,6 +17,9 @@ export interface PlanState {
   };
   currentPlanId: Plan['id'] | null;
   currentScenarioId: Scenario['id'] | null;
+  currentConfigId: ProjectConfig['id'] | null;
+  mapConditionFilepath: string | null;
+  mapShapes: any | null;
 }
 
 export interface BackendPlan {
@@ -39,6 +42,9 @@ export class PlanService {
     all: {}, // All plans indexed by id
     currentPlanId: null,
     currentScenarioId: null,
+    currentConfigId: null,
+    mapConditionFilepath: null,
+    mapShapes: null,
   });
 
   constructor(private http: HttpClient) {}
@@ -88,7 +94,8 @@ export class PlanService {
       )
       .pipe(
         take(1),
-        map((dbPlan) => this.convertToPlan(dbPlan))
+        map((dbPlan) => this.convertToPlan(dbPlan)),
+        tap(plan => this.addPlanToState(plan))
       );
   }
 
@@ -325,6 +332,19 @@ export class PlanService {
     this.planState$.next(updatedState);
   }
 
+  updateStateWithPlan(planId: string | null) {
+    const currentState = Object.freeze(this.planState$.value);
+    const updatedState = Object.freeze({
+      ...currentState,
+      all: {
+        ...currentState.all,
+      },
+      currentPlanId: planId,
+    });
+
+    this.planState$.next(updatedState);
+  }
+
   updateStateWithScenario(scenarioId: string | null) {
     const currentState = Object.freeze(this.planState$.value);
     const updatedState = Object.freeze({
@@ -335,6 +355,42 @@ export class PlanService {
       currentScenarioId: scenarioId,
     });
 
+    this.planState$.next(updatedState);
+  }
+
+  updateStateWithConfig(configId: number | null) {
+    const currentState = Object.freeze(this.planState$.value);
+    const updatedState = Object.freeze({
+      ...currentState,
+      all: {
+        ...currentState.all,
+      },
+      currentConfigId: configId,
+    });
+    this.planState$.next(updatedState);
+  }
+
+  updateStateWithConditionFilepath(filepath: string | null) {
+    const currentState = Object.freeze(this.planState$.value);
+    const updatedState = Object.freeze({
+      ...currentState,
+      all: {
+        ...currentState.all,
+      },
+      mapConditionFilepath: filepath,
+    });
+    this.planState$.next(updatedState);
+  }
+
+  updateStateWithShapes(shapes: any | null) {
+    const currentState = Object.freeze(this.planState$.value);
+    const updatedState = Object.freeze({
+      ...currentState,
+      all: {
+        ...currentState.all,
+      },
+      mapShapes: shapes,
+    });
     this.planState$.next(updatedState);
   }
 


### PR DESCRIPTION
## Changes
- Refactoring of components in the PlanModule to enable accessing configurations by URL (`/plan/<id>/config/<id>`) and reduce code complexity
- Fill out `PlanState` with other details (config ID, condition filepath for the map, and shapes for the map)
- Unit tests
- No UI change

## Todo
- Since configs are now accessible by URL, we need to show a "Sorry not found / don't have access" view when appropriate