### PR TITLE
Adds debug capabilities for forsys project area generation

### DIFF
--- a/src/planscape/forsys/forsys_request_params.py
+++ b/src/planscape/forsys/forsys_request_params.py
@@ -1,6 +1,4 @@
 import json
-from datetime import datetime
-from pytz import timezone
 from typing import TypedDict
 
 from conditions.models import BaseCondition
@@ -221,8 +219,6 @@ class ForsysGenerationRequestParams():
     _URL_PRIORITIES = 'priorities'
     _URL_PRIORITY_WEIGHTS = 'priority_weights'
     _URL_PLANNING_AREA = 'planning_area'
-    _URL_OUTPUT_SCENARIO_NAME = 'output_scenario_name'
-    _URL_OUTPUT_SCENARIO_TAG = 'output_scenario_tag'
 
     # Constants that act as default values when parsing url parameters.
     _DEFAULT_REGION = 'sierra_cascade_inyo'
@@ -242,11 +238,6 @@ class ForsysGenerationRequestParams():
     priority_weights: list[float]
     # Planning area geometry. Projects are generated within the planning area.
     planning_area: MultiPolygon
-    # Names informing output debug directory.
-    # If not none (or empty), R writes forsys debug data to directory,
-    # output/<output_scenario_name>/<output_scenario_tag>/
-    output_scenario_name: str | None
-    output_scenario_tag: str | None
 
     def __init__(self, request: HttpRequest) -> None:
         params = request.GET
@@ -265,13 +256,6 @@ class ForsysGenerationRequestParams():
                 geo, self._URL_PLANNING_AREA)
         else:
             self.planning_area = self._get_default_planning_area()
-        self.output_scenario_name = params.get(
-            self._URL_OUTPUT_SCENARIO_NAME, "test_scenario")
-        self.output_scenario_tag = params.get(
-            self._URL_OUTPUT_SCENARIO_TAG,
-            datetime.now().astimezone(
-                timezone('US/Pacific')
-            ).strftime("%Y%m%d-%H-%M"))
 
     def _read_db_params(self, request: HttpRequest) -> None:
         params = request.GET
@@ -283,11 +267,6 @@ class ForsysGenerationRequestParams():
         plan = get_plan_by_id(user, params)
         self.region = plan.region_name
         self.planning_area = plan.geometry
-
-        self.output_scenario_name = params.get(
-            self._URL_OUTPUT_SCENARIO_NAME, None)
-        self.output_scenario_tag = params.get(
-            self._URL_OUTPUT_SCENARIO_TAG, None)
 
         # TODO: read priorities and weights from DB once models have been
         # updated.

--- a/src/planscape/forsys/forsys_request_params_test.py
+++ b/src/planscape/forsys/forsys_request_params_test.py
@@ -307,8 +307,6 @@ class TestForsysGenerationRequestParams(TestCase):
               (-120.14015536869722, 38.05413814388948)),))
         )
         self.assertEqual(params.planning_area.srid, 4269)
-        self.assertEqual(params.output_scenario_name, "test_scenario")
-        self.assertIsNotNone(params.output_scenario_tag)
 
     def test_reads_region_from_url_params(self):
         request = HttpRequest()
@@ -439,22 +437,6 @@ class TestForsysGenerationRequestParams(TestCase):
             str(context.exception),
             'url params, planning_area, missing field, "id"')
 
-    def test_sets_output_scenario_name(self):
-        request = HttpRequest()
-        request.GET = QueryDict(
-            'set_all_params_via_url_with_default_values=1' +
-            '&output_scenario_name=foo')
-        params = ForsysGenerationRequestParams(request)
-        self.assertEqual(params.output_scenario_name, "foo")
-
-    def test_sets_output_scenario_tag(self):
-        request = HttpRequest()
-        request.GET = QueryDict(
-            'set_all_params_via_url_with_default_values=1' +
-            '&output_scenario_tag=foo')
-        params = ForsysGenerationRequestParams(request)
-        self.assertEqual(params.output_scenario_tag, "foo")
-
 
 class TestForsysGenerationRequestParams_ReadFromDb(TestCase):
     def setUp(self) -> None:
@@ -477,24 +459,6 @@ class TestForsysGenerationRequestParams_ReadFromDb(TestCase):
         self.assertEqual(params.region, 'sierra_cascade_inyo')
         self.assertEqual(params.planning_area.coords, ((
             ((1.0, 2.0), (2.0, 3.0), (3.0, 4.0), (1.0, 2.0)),),))
-        self.assertIsNone(params.output_scenario_name)
-        self.assertIsNone(params.output_scenario_tag)
-
-    def test_sets_output_scenario_name(self):
-        request = HttpRequest()
-        request.GET = QueryDict(
-            'id=' + str(self.plan_with_user.pk) + '&output_scenario_name=foo')
-        request.user = self.user
-        params = ForsysGenerationRequestParams(request)
-        self.assertEqual(params.output_scenario_name, "foo")
-
-    def test_sets_output_scenario_tag(self):
-        request = HttpRequest()
-        request.GET = QueryDict(
-            'id=' + str(self.plan_with_user.pk) + '&output_scenario_tag=foo')
-        request.user = self.user
-        params = ForsysGenerationRequestParams(request)
-        self.assertEqual(params.output_scenario_tag, "foo")
 
     def test_fails_on_no_user(self):
         request = HttpRequest()

--- a/src/planscape/forsys/forsys_request_params_test.py
+++ b/src/planscape/forsys/forsys_request_params_test.py
@@ -307,6 +307,8 @@ class TestForsysGenerationRequestParams(TestCase):
               (-120.14015536869722, 38.05413814388948)),))
         )
         self.assertEqual(params.planning_area.srid, 4269)
+        self.assertEqual(params.output_scenario_name, "test_scenario")
+        self.assertIsNotNone(params.output_scenario_tag)
 
     def test_reads_region_from_url_params(self):
         request = HttpRequest()
@@ -437,6 +439,22 @@ class TestForsysGenerationRequestParams(TestCase):
             str(context.exception),
             'url params, planning_area, missing field, "id"')
 
+    def test_sets_output_scenario_name(self):
+        request = HttpRequest()
+        request.GET = QueryDict(
+            'set_all_params_via_url_with_default_values=1' +
+            '&output_scenario_name=foo')
+        params = ForsysGenerationRequestParams(request)
+        self.assertEqual(params.output_scenario_name, "foo")
+
+    def test_sets_output_scenario_tag(self):
+        request = HttpRequest()
+        request.GET = QueryDict(
+            'set_all_params_via_url_with_default_values=1' +
+            '&output_scenario_tag=foo')
+        params = ForsysGenerationRequestParams(request)
+        self.assertEqual(params.output_scenario_tag, "foo")
+
 
 class TestForsysGenerationRequestParams_ReadFromDb(TestCase):
     def setUp(self) -> None:
@@ -459,6 +477,24 @@ class TestForsysGenerationRequestParams_ReadFromDb(TestCase):
         self.assertEqual(params.region, 'sierra_cascade_inyo')
         self.assertEqual(params.planning_area.coords, ((
             ((1.0, 2.0), (2.0, 3.0), (3.0, 4.0), (1.0, 2.0)),),))
+        self.assertIsNone(params.output_scenario_name)
+        self.assertIsNone(params.output_scenario_tag)
+
+    def test_sets_output_scenario_name(self):
+        request = HttpRequest()
+        request.GET = QueryDict(
+            'id=' + str(self.plan_with_user.pk) + '&output_scenario_name=foo')
+        request.user = self.user
+        params = ForsysGenerationRequestParams(request)
+        self.assertEqual(params.output_scenario_name, "foo")
+
+    def test_sets_output_scenario_tag(self):
+        request = HttpRequest()
+        request.GET = QueryDict(
+            'id=' + str(self.plan_with_user.pk) + '&output_scenario_tag=foo')
+        request.user = self.user
+        params = ForsysGenerationRequestParams(request)
+        self.assertEqual(params.output_scenario_tag, "foo")
 
     def test_fails_on_no_user(self):
         request = HttpRequest()

--- a/src/planscape/forsys/views.py
+++ b/src/planscape/forsys/views.py
@@ -162,7 +162,9 @@ def run_forsys_generate_project_areas_for_a_single_scenario(
         forsys_proj_id_header: str, forsys_stand_id_header: str,
         forsys_area_header: str, forsys_cost_header: str,
         forsys_geo_wkt_header: str, forsys_priority_headers: list[str],
-        forsys_priority_weights: list[float]) -> ForsysGenerationOutputForASingleScenario:
+        forsys_priority_weights: list[float],
+        output_scenario_name: str | None,
+        output_scenario_tag: str | None) -> ForsysGenerationOutputForASingleScenario:
     import rpy2.robjects as robjects
     robjects.r.source(os.path.join(
         settings.BASE_DIR, 'forsys/generate_projects_for_a_single_scenario.R'))
@@ -175,7 +177,9 @@ def run_forsys_generate_project_areas_for_a_single_scenario(
         forsys_input, robjects.StrVector(forsys_priority_headers),
         robjects.FloatVector(forsys_priority_weights),
         forsys_stand_id_header, forsys_proj_id_header, forsys_area_header,
-        forsys_cost_header, forsys_geo_wkt_header)
+        forsys_cost_header, forsys_geo_wkt_header,
+        "" if output_scenario_name is None else output_scenario_name,
+        "" if output_scenario_tag is None else output_scenario_tag)
 
     priority_weights_dict = {
         forsys_priority_headers[i]: forsys_priority_weights[i]
@@ -196,7 +200,8 @@ def generate_project_areas_for_a_single_scenario(
             forsys_input.forsys_input, headers.FORSYS_PROJECT_ID_HEADER,
             headers.FORSYS_STAND_ID_HEADER, headers.FORSYS_AREA_HEADER,
             headers.FORSYS_COST_HEADER, headers.FORSYS_GEO_WKT_HEADER,
-            headers.priority_headers, params.priority_weights)
+            headers.priority_headers, params.priority_weights,
+            params.output_scenario_name, params.output_scenario_tag)
 
         response = {}
         response['forsys'] = {}

--- a/src/planscape/requirements.txt
+++ b/src/planscape/requirements.txt
@@ -16,3 +16,4 @@ rasterio
 rpy2
 typing_extensions
 uwsgi
+memory-profiler


### PR DESCRIPTION
This adds a few tools for debugging/sanity-checking project area generation when settings.DEBUG=True.
1) In Python, calls memory_profiler and cProfile llibraries to track memory and time.
2) In R, writes input and output dataframes to disk.
3) In R, draws graphs for priority condition rasters, weighted priority raster, and project areas and writes them to pdfs in disk.

With this in place, hopefully, it'll be easier to select forsys run parameters.

A few screenshots:
![image](https://user-images.githubusercontent.com/3720361/221338716-a794a091-654d-4412-854f-721ac72137bd.png)
![image](https://user-images.githubusercontent.com/3720361/221338842-f1f88445-3dab-40fa-8ac7-bea0db253018.png)
![image](https://user-images.githubusercontent.com/3720361/221338875-5d13faf0-9b52-4a68-ab17-99fa0aa2c918.png)
![image](https://user-images.githubusercontent.com/3720361/221338902-42a694ea-e560-4dc5-afe9-4f6e794baffc.png)
