### PR TITLE
Display data from scenario and fake priorities

### DIFF
--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
@@ -1,8 +1,8 @@
 <!-- Plan Info -->
 <div class="plan-info">
-  <span>Creator: First Name, Last Name, Department</span>
+  <span>Creator: {{ scenario?.owner }}</span>
   <br>
-  <span>Created:</span>
+  <span>Created: {{ scenario?.createdTimestamp | date:'MM/dd/yyyy'}}</span>
 </div>
 
 <div class="outcome-content">
@@ -12,7 +12,55 @@
       <mat-expansion-panel-header class="scenario-panel-header">
         Configuration
       </mat-expansion-panel-header>
-      content
+      <div class="constraints">
+        <h3>Constraints</h3>
+        <ul>
+          <li>Calculating score: Current conditions</li>
+          <li>Show estimated cost range based on estimated treatment costs per acre
+            (Est. max: <b>${{ scenario?.maxBudget }}</b>)</li>
+          <li><b>{{ scenario?.maxTreatmentAreaRatio }}%</b> max treatment percentage of total planning area</li>
+          <li>Exclude areas off a road by <b>{{ scenario?.maxRoadDistance}} ft.</b></li>
+          <li>Include areas that are over {{ scenario?.maxSlope }} degrees</li>
+        </ul>
+      </div>
+
+      <div class="sliders-wrapper">
+        <!-- Priority weights -->
+        <div>
+          <div class="flex-row space-between">
+            <h3>Selected priorities</h3>
+            <h3>Relative importance (1-5)</h3>
+          </div>
+          <ng-container *ngFor="let priority of priorities">
+            <div class="flex-row space-between">
+              <h2>{{ priority.name }}</h2>
+              <div class="flex-row">
+                <mat-slider [disabled]=true [min]="1" [max]="5" [thumbLabel]="true" [value]="priority.value"
+                  color="primary" [step]="1">
+                  <input matSliderThumb>
+                </mat-slider>
+                <div class="slider-label">{{priority.value}}</div>
+              </div>
+            </div>
+            <mat-divider></mat-divider>
+          </ng-container>
+        </div>
+
+        <!-- Project area % -->
+        <div>
+          <h3>Project areas</h3>
+          <div class="flex-row space-between">
+            <h2>Show top % of project areas</h2>
+            <div class="flex-row">
+              <div class="slider-label">10%</div>
+              <mat-slider [disabled]=true [min]="10" [max]="40" [thumbLabel]="true" [value]="30">
+                <input matSliderThumb>
+              </mat-slider>
+              <div class="slider-label">40%</div>
+            </div>
+          </div>
+        </div>
+      </div>
     </mat-expansion-panel>
 
     <!-- Outcome -->
@@ -25,7 +73,7 @@
   </mat-accordion>
 
   <!-- Notes -->
-  <div class="scenario-notes">
+  <div class="scenario-notes-wrapper">
     <div class="notes-header">Scenario creator's notes</div>
     <form [formGroup] = "scenarioNotes">
       <div>

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.scss
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.scss
@@ -1,3 +1,34 @@
+h3 {
+  color: #5F6368;
+  font-size: 13px;
+}
+
+h2 {
+  font-size: 15px;
+}
+
+.sliders-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.slider-label {
+  color: rgba(0, 0, 0, 0.26);
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 20px;
+  width: 32px;
+}
+
+.flex-row {
+  align-items: center;
+  display: flex;
+}
+
+.space-between {
+  justify-content: space-between;
+}
+
 .plan-info {
   background-color: #F8F8F8;
   padding: 12px 24px;
@@ -12,7 +43,7 @@
   font-weight: 700;
 }
 
-.scenario-notes {
+.scenario-notes-wrapper {
   border-radius: 16px;
   box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.12);
   color: #5F6368;

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.spec.ts
@@ -1,5 +1,7 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MaterialModule } from 'src/app/material/material.module';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormBuilder } from '@angular/forms';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 
 import { OutcomeComponent } from './outcome.component';
 
@@ -9,6 +11,7 @@ describe('OutcomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [ BrowserAnimationsModule, MaterialModule, ReactiveFormsModule],
       declarations: [ OutcomeComponent ],
       providers: [ FormBuilder ],
     })

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, SimpleChanges } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
 import { Scenario, Plan } from 'src/app/types';
@@ -6,7 +6,7 @@ import { Scenario, Plan } from 'src/app/types';
 @Component({
   selector: 'app-outcome',
   templateUrl: './outcome.component.html',
-  styleUrls: ['./outcome.component.scss']
+  styleUrls: ['./outcome.component.scss'],
 })
 export class OutcomeComponent {
   @Input() plan: Plan | null = null;
@@ -21,19 +21,24 @@ export class OutcomeComponent {
     {
       name: 'Fire Dynamics',
       value: 3,
-    }
+    },
   ];
 
-  constructor(private fb : FormBuilder) {
+  constructor(private fb: FormBuilder) {
     // TODO: Call update scenario on submit.
     this.scenarioNotes = fb.group({
-      notes: "",
+      notes: '',
     });
   }
 
-  ngOnChanges(): void {
+  ngOnChanges(changes: SimpleChanges): void {
     if (this.scenario) {
-      this.scenarioNotes.controls['notes'].setValue(this.scenario.notes);
+      if (
+        changes['scenario'].previousValue?.['notes'] !==
+        changes['scenario'].currentValue?.['notes']
+      ) {
+        this.scenarioNotes.controls['notes'].setValue(this.scenario.notes);
+      }
     }
   }
 }

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
@@ -8,18 +8,32 @@ import { Scenario, Plan } from 'src/app/types';
   templateUrl: './outcome.component.html',
   styleUrls: ['./outcome.component.scss']
 })
-export class OutcomeComponent implements OnInit {
+export class OutcomeComponent {
   @Input() plan: Plan | null = null;
   @Input() scenario: Scenario | null = null;
   scenarioNotes: FormGroup;
 
+  // TODO: Use real priorities from the backend.
+  priorities: {
+    name: string;
+    value: number;
+  }[] = [
+    {
+      name: 'Fire Dynamics',
+      value: 3,
+    }
+  ];
+
   constructor(private fb : FormBuilder) {
+    // TODO: Call update scenario on submit.
     this.scenarioNotes = fb.group({
       notes: "",
     });
   }
 
-  ngOnInit(): void {
+  ngOnChanges(): void {
+    if (this.scenario) {
+      this.scenarioNotes.controls['notes'].setValue(this.scenario.notes);
+    }
   }
-
 }

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.html
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.html
@@ -7,7 +7,7 @@
 
     <div>
       <mat-tab-group>
-        <mat-tab class="scenario-tab" label="OUTCOME"><app-outcome></app-outcome></mat-tab>
+        <mat-tab class="scenario-tab" label="OUTCOME"><app-outcome [scenario]="scenario$ | async"></app-outcome></mat-tab>
         <mat-tab class="scenario-tab" label="MAP LAYERS"> Map Layers </mat-tab>
         <mat-tab class="scenario-tab" label="INFO"> Info </mat-tab>
       </mat-tab-group>

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
@@ -1,10 +1,9 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
   ComponentFixture,
-  fakeAsync,
   TestBed,
-  tick,
 } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from 'src/app/material/material.module';
@@ -13,6 +12,7 @@ import { of } from 'rxjs';
 import { PlanService } from './../../services/plan.service';
 import { Scenario } from './../../types';
 import { ScenarioDetailsComponent } from './scenario-details.component';
+import { OutcomeComponent } from './outcome/outcome.component';
 
 describe('ScenarioDetailsComponent', () => {
   let component: ScenarioDetailsComponent;
@@ -38,10 +38,11 @@ describe('ScenarioDetailsComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, HttpClientTestingModule, MaterialModule],
-      declarations: [ScenarioDetailsComponent],
+      declarations: [ScenarioDetailsComponent, OutcomeComponent],
       providers: [
         { provide: MatSnackBar, useValue: snackbarSpy },
         { provide: PlanService, useValue: fakeService },
+        FormBuilder,
       ],
     }).compileComponents();
 

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -222,7 +222,7 @@ export class PlanService {
       id: backendScenario.id,
       planId: backendScenario.plan,
       createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
-        backendScenario.creation_time
+        backendScenario.creation_timestamp
       ),
       priorities: backendScenario.priorities,
       notes: backendScenario.notes,


### PR DESCRIPTION
# Changes
* Filled in planning area details
* Filled in configuration section with constraints and priorities sliders (fake data)
* Filled in scenario notes

# UI
<img width="1438" alt="Screenshot 2023-02-23 at 11 40 50 PM" src="https://user-images.githubusercontent.com/114368235/221125860-2fb3eab9-5494-4e7b-94ef-ab8842b57ef0.png">

# Todo
* Get actual priorities / weights from backend for each scenario 
(and clarify the where the other fields should come from)
* Call update scenario once available on clicking note "send" button
* Add map layers component
* Display project areas in scenario details map
* Fill in outcomes project areas section