### PR TITLE
scenario generation confirmation page

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ import { MapComponent } from './map/map.component';
 import { CreateScenariosComponent } from './plan/create-scenarios/create-scenarios.component';
 import { PlanTableComponent } from './plan/plan-table/plan-table.component';
 import { PlanComponent } from './plan/plan.component';
+import { ScenarioConfirmationComponent } from './plan/scenario-confirmation/scenario-confirmation.component';
 import { ScenarioDetailsComponent } from './plan/scenario-details/scenario-details.component';
 import { RegionSelectionComponent } from './region-selection/region-selection.component';
 import { SignupComponent } from './signup/signup.component';
@@ -57,6 +58,11 @@ const routes: Routes = [
             component: CreateScenariosComponent,
           },
         ],
+      },
+      {
+        path: 'scenario-confirmation/:id',
+        title: 'Generating Scenario',
+        component: ScenarioConfirmationComponent,
       },
       { path: 'plan', title: 'My Plans', component: PlanTableComponent },
     ],

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -151,6 +151,6 @@ describe('CreateScenariosComponent', () => {
       priorities: ['test'],
       weights: [1],
     });
-    expect(router.navigate).toHaveBeenCalledOnceWith(['plan', '1']);
+    expect(router.navigate).toHaveBeenCalledOnceWith(['scenario-confirmation', '1']);
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -256,9 +256,9 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       .createScenario(this.formValueToProjectConfig())
       .pipe(take(1))
       .subscribe((_) => {
-        // Navigate back to plan overview
+        // Navigate to scenario confirmation page
         const planId = this.plan$.getValue()?.id;
-        this.router.navigate(['plan', planId]);
+        this.router.navigate(['scenario-confirmation', planId]);
       });
   }
 

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -23,6 +23,7 @@ import { PlanUnavailableComponent } from './plan-unavailable/plan-unavailable.co
 import { PlanComponent } from './plan.component';
 import { ScenarioDetailsComponent } from './scenario-details/scenario-details.component';
 import { OutcomeComponent } from './scenario-details/outcome/outcome.component';
+import { ScenarioConfirmationComponent } from './scenario-confirmation/scenario-confirmation.component';
 
 /** Components used in the plan flow. */
 @NgModule({
@@ -44,6 +45,7 @@ import { OutcomeComponent } from './scenario-details/outcome/outcome.component';
     GenerateScenariosComponent,
     ScenarioDetailsComponent,
     OutcomeComponent,
+    ScenarioConfirmationComponent,
   ],
   imports: [
     BrowserAnimationsModule,

--- a/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.html
+++ b/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.html
@@ -1,0 +1,13 @@
+<div class="root-container">
+  <mat-icon class="material-symbols-outlined large-icon">check_circle</mat-icon>
+
+  <h1>Planscape is generating your scenario.</h1>
+
+  <h1>Check "My Scenarios" on the Area Overview page to see it after it's done.</h1>
+
+  <h3>You can continue creating new configurations or explore the map.</h3>
+
+  <button mat-raised-button color="primary" (click)="navigateToAreaOverview()">
+    RETURN TO AREA OVERVIEW
+  </button>
+</div>

--- a/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.scss
+++ b/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.scss
@@ -1,0 +1,27 @@
+.root-container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}
+
+.large-icon {
+  height: 90px;
+  font-size: 90px;
+  width: 90px;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 28px;
+}
+
+h3 {
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 24px;
+}

--- a/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.spec.ts
@@ -1,0 +1,56 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+
+import { MaterialModule } from './../../material/material.module';
+import { ScenarioConfirmationComponent } from './scenario-confirmation.component';
+
+describe('ScenarioConfirmationComponent', () => {
+  let component: ScenarioConfirmationComponent;
+  let fixture: ComponentFixture<ScenarioConfirmationComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    const fakeRoute = jasmine.createSpyObj(
+      'ActivatedRoute',
+      {},
+      {
+        snapshot: {
+          paramMap: convertToParamMap({ id: '1' }),
+        },
+      }
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [MaterialModule],
+      declarations: [ScenarioConfirmationComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: fakeRoute,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ScenarioConfirmationComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('navigates to area overview when button is clicked', async () => {
+    const router = fixture.debugElement.injector.get(Router);
+    spyOn(router, 'navigate');
+    const buttonHarness = await loader.getHarness(MatButtonHarness);
+
+    await buttonHarness.click();
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['plan', '1']);
+  });
+});

--- a/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.ts
+++ b/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'app-scenario-confirmation',
+  templateUrl: './scenario-confirmation.component.html',
+  styleUrls: ['./scenario-confirmation.component.scss'],
+})
+export class ScenarioConfirmationComponent {
+  constructor(private route: ActivatedRoute, private router: Router) {}
+
+  navigateToAreaOverview(): void {
+    const planId = this.route.snapshot.paramMap.get('id');
+    this.router.navigate(['plan', planId]);
+  }
+}


### PR DESCRIPTION
Add scenario confirmation page with a button to redirect the user back to the Area Overview. Fixes #571 

![image](https://user-images.githubusercontent.com/10444733/221315817-0d842dc4-6231-4eb0-8f04-beaa34a29bf7.png)
