### PR TITLE
Update plan legend and panel toggle button

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,12 +1,5 @@
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
-import {
-  Component,
-  EventEmitter,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -14,7 +7,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { BehaviorSubject, Subject, take } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { PlanService } from 'src/app/services';
@@ -125,6 +118,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
         this.plan$.next(planState.all[planState.currentPlanId!]);
         this.scenarioConfigId = planState.currentConfigId;
         this.loadConfig();
+        this.panelExpanded = planState.panelExpanded ?? false;
       });
 
     // When an area is uploaded, issue an event to draw it on the map.

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -20,9 +20,38 @@
     </mat-radio-group>
   </form>
 
-  <div class="flex-row">
+  <div class="flex-row gap-32">
     <h4>{{ text2 }}</h4>
-    <app-legend [legend]="legend"></app-legend>
+    <div class="legend-wrapper">
+      <div class="legend-title-wrapper">
+        <h5>Current Condition (normalized)</h5>
+        <button mat-icon-button [matMenuTriggerFor]="menu">
+          <mat-icon class="material-symbols-outlined" color="primary">info</mat-icon>
+        </button>
+      </div>
+      <mat-menu #menu="matMenu">
+        <div class="legend-info">
+          <h4>Condition score ranges</h4>
+          <div class="flex-row">
+            <div class="legend-info-labels">
+              <p>Poor</p>
+              <p>Fair</p>
+              <p>OK</p>
+              <p>Good</p>
+              <p>Excellent</p>
+            </div>
+            <div class="legend-info-scores">
+              <p>-1.0 to -0.7</p>
+              <p>-0.6 to -0.3</p>
+              <p>-0.2 to 0.2</p>
+              <p>0.3 to 0.6</p>
+              <p>0.7 to 1.0</p>
+            </div>
+          </div>
+        </div>
+      </mat-menu>
+      <app-legend [legend]="legend"></app-legend>
+    </div>
   </div>
 
   <mat-table [dataSource]="datasource" class="priority-table">

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.scss
@@ -27,8 +27,39 @@ h4 {
   white-space: normal !important;
 }
 
-app-legend {
+.legend-wrapper {
   flex: 2 0 224px;
+}
+
+.legend-title-wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+
+h5 {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 15px;
+  margin: 0px;
+  text-align: center;
+}
+
+.legend-info {
+  padding: 24px 48px 24px 16px;
+}
+
+.legend-info-labels {
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 24px;
+}
+
+.legend-info-scores {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 24px;
 }
 
 .secondary-text {

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -135,6 +135,7 @@ describe('SetPrioritiesComponent', () => {
   it('should fetch colormap from service to create legend', () => {
     let legend = colormapConfigToLegend(fakeColormapConfig);
     legend!.labels = ['Poor', 'OK', 'Excellent'];
+    legend!.secondaryLabels = ['-1', '0', '1'];
 
     expect(fakeMapService.getColormap).toHaveBeenCalledOnceWith('turbo');
     expect(component.legend).toEqual(legend);

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -64,6 +64,7 @@ export class SetPrioritiesComponent implements OnInit {
       .subscribe((colormapConfig) => {
         this.legend = colormapConfigToLegend(colormapConfig);
         this.legend!.labels = ['Poor', 'OK', 'Excellent'];
+        this.legend!.secondaryLabels = ['-1', '0', '1'];
       });
   }
 

--- a/src/interface/src/app/plan/plan-map/plan-map.component.html
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.html
@@ -1,2 +1,7 @@
 <div id="{{mapId ? mapId : 'map'}}" class="plan-map"></div>
-<button mat-raised-button class="expand-map-button" disabled (click)="expandMap()">EXPAND MAP</button>
+<button
+  mat-raised-button
+  class="expand-panel-button"
+  (click)="togglePanel()">
+  {{panelExpanded ? 'COLLAPSE PANEL' : 'EXPAND PANEL'}}
+</button>

--- a/src/interface/src/app/plan/plan-map/plan-map.component.scss
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.scss
@@ -4,7 +4,7 @@
   z-index: 1;
 }
 
-.expand-map-button {
+.expand-panel-button {
   bottom: 12px;
   position: absolute;
   right: 60px;

--- a/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.spec.ts
@@ -35,7 +35,7 @@ describe('PlanMapComponent', () => {
 
     fakePlanService = jasmine.createSpyObj<PlanService>(
       'PlanService',
-      {},
+      ['updateStateWithPanelState'],
       {
         planState$: fakePlanState$,
       }
@@ -106,13 +106,17 @@ describe('PlanMapComponent', () => {
     expect(component.tileLayer).toBeDefined();
   });
 
-  describe('expand map button', () => {
-    it('button is disabled', async () => {
+  describe('expand panel button', () => {
+    it('button updates plan state', async () => {
       const button = await loader.getHarness(
-        MatButtonHarness.with({ text: 'EXPAND MAP' })
+        MatButtonHarness.with({ text: /COLLAPSE/ })
       );
 
-      expect(await button.isDisabled()).toBeTrue();
+      await button.click();
+
+      expect(
+        fakePlanService.updateStateWithPanelState
+      ).toHaveBeenCalledOnceWith(false);
     });
   });
 

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -1,9 +1,9 @@
-import { PlanService } from 'src/app/services';
 import { AfterViewInit, Component, Input, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import * as L from 'leaflet';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { PlanService } from 'src/app/services';
 import { FrontendConstants, Plan } from 'src/app/types';
 
 import { BackendConstants } from './../../backend-constants';
@@ -24,6 +24,7 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
   drawingLayer: L.GeoJSON | undefined;
   projectAreasLayer: L.GeoJSON | undefined;
   tileLayer: L.TileLayer | undefined;
+  panelExpanded: boolean = true;
 
   private filepath: string = '';
   private shapes: any | null = null;
@@ -147,12 +148,13 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
         fillColor: '#ff4081',
         fillOpacity: 0.1,
         weight: 5,
-      })
+      }),
     });
     this.projectAreasLayer.addTo(this.map);
   }
 
-  expandMap() {
-    this.router.navigate(['map']);
+  togglePanel(): void {
+    this.panelExpanded = !this.panelExpanded;
+    this.planService.updateStateWithPanelState(this.panelExpanded);
   }
 }

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
@@ -10,14 +10,14 @@ import {
   switchMap,
   take,
   takeUntil,
+  tap,
 } from 'rxjs';
-
+import { PlanService } from 'src/app/services';
 import {
   colorTransitionTrigger,
-  opacityTransitionTrigger,
   expandCollapsePanelTrigger,
+  opacityTransitionTrigger,
 } from 'src/app/shared/animations';
-import { PlanService } from 'src/app/services';
 import { Scenario } from 'src/app/types';
 
 @Component({
@@ -61,6 +61,9 @@ export class ScenarioDetailsComponent implements OnInit {
 
   private getScenario() {
     return this.planService.planState$.pipe(
+      tap((state) => {
+        this.panelExpanded = state.panelExpanded ?? false;
+      }),
       map((state) => state.currentScenarioId),
       filter((scenarioId) => !!scenarioId),
       switchMap((scenarioId) => {

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -21,6 +21,7 @@ export interface PlanState {
   mapConditionFilepath: string | null;
   mapShapes: any | null;
   currentScenario?: Scenario;
+  panelExpanded?: boolean;
 }
 
 export interface BackendPlan {
@@ -46,6 +47,7 @@ export class PlanService {
     currentConfigId: null,
     mapConditionFilepath: null,
     mapShapes: null,
+    panelExpanded: true,
   });
 
   constructor(private http: HttpClient) {}
@@ -96,7 +98,7 @@ export class PlanService {
       .pipe(
         take(1),
         map((dbPlan) => this.convertToPlan(dbPlan)),
-        tap(plan => this.addPlanToState(plan))
+        tap((plan) => this.addPlanToState(plan))
       );
   }
 
@@ -420,6 +422,18 @@ export class PlanService {
         ...currentState.all,
       },
       mapShapes: shapes,
+    });
+    this.planState$.next(updatedState);
+  }
+
+  updateStateWithPanelState(panelExpanded: boolean) {
+    const currentState = Object.freeze(this.planState$.value);
+    const updatedState = Object.freeze({
+      ...currentState,
+      all: {
+        ...currentState.all,
+      },
+      panelExpanded: panelExpanded,
     });
     this.planState$.next(updatedState);
   }

--- a/src/interface/src/app/shared/legend/legend.component.html
+++ b/src/interface/src/app/shared/legend/legend.component.html
@@ -15,4 +15,11 @@
       <div class="label" *ngFor="let label of legend?.labels">{{ label }}</div>
     </div>
   </ng-template>
+
+  <!-- Secondary string labels (e.g. "-1 => 1") -->
+  <ng-container *ngIf="legend.secondaryLabels">
+    <div class="labels">
+      <div class="label secondary-label" *ngFor="let label of legend?.secondaryLabels">{{ label }}</div>
+    </div>
+  </ng-container>
 </div>

--- a/src/interface/src/app/shared/legend/legend.component.scss
+++ b/src/interface/src/app/shared/legend/legend.component.scss
@@ -15,17 +15,31 @@ h1 {
 }
 
 .labels {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: space-between;
+  display: table;
+  table-layout: fixed;
   width: 100%;
 }
 
 .label {
+  display: table-cell;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 20px;
   margin-top: 5px;
   min-width: 24px;
   text-align: center;
+}
+
+.label:first-child {
+  text-align: left;
+}
+
+.label:last-child {
+  text-align: right;
+}
+
+.secondary-label {
+  font-weight: 400;
 }
 
 .gradient {

--- a/src/interface/src/app/types/legend.types.ts
+++ b/src/interface/src/app/types/legend.types.ts
@@ -16,6 +16,7 @@ export interface Legend {
   colors?: string[];
   labels?: string[];
   minMaxValues?: number[];
+  secondaryLabels?: string[];
 }
 
 /** Convert a colormap to a legend object. */


### PR DESCRIPTION
## Changes
- Fix #523 
- Add "COLLAPSE/EXPAND PANEL" button to plan map, replacing disabled "EXPAND MAP" button. The button now expands/collapses the panel in both the scenario creation and scenario details views.
- Add title and number labels to plan legend
- Add info card to plan legend

![image](https://user-images.githubusercontent.com/10444733/221727084-3b6ea934-a9fe-4f1c-9ea6-e092b732f5cc.png)

![image](https://user-images.githubusercontent.com/10444733/221727128-c3f0144f-e95e-47df-9846-5ee37af60c8d.png)
