### PR TITLE
Add Map Layers component to Scenario Details

### DIFF
--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -65,7 +65,7 @@ export class PlanMapComponent implements AfterViewInit, OnDestroy {
     this.planService.planState$
       .pipe(takeUntil(this.destroy$))
       .subscribe((state) => {
-        if (state.mapConditionFilepath ?? '' !== this.filepath) {
+        if (state.mapConditionFilepath !== this.filepath) {
           this.filepath = state.mapConditionFilepath ?? '';
           this.setCondition(state.mapConditionFilepath ?? '');
         }

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -24,6 +24,7 @@ import { PlanComponent } from './plan.component';
 import { ScenarioDetailsComponent } from './scenario-details/scenario-details.component';
 import { OutcomeComponent } from './scenario-details/outcome/outcome.component';
 import { ScenarioConfirmationComponent } from './scenario-confirmation/scenario-confirmation.component';
+import { MapLayersComponent } from './scenario-details/map-layers/map-layers.component';
 
 /** Components used in the plan flow. */
 @NgModule({
@@ -46,6 +47,7 @@ import { ScenarioConfirmationComponent } from './scenario-confirmation/scenario-
     ScenarioDetailsComponent,
     OutcomeComponent,
     ScenarioConfirmationComponent,
+    MapLayersComponent,
   ],
   imports: [
     BrowserAnimationsModule,

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.html
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.html
@@ -1,0 +1,49 @@
+<div class="legend-container">
+  <app-legend [legend]="legend"></app-legend>
+</div>
+
+<mat-table [dataSource]="datasource" class="priority-table">
+  <ng-container matColumnDef="displayName">
+    <mat-header-cell *matHeaderCellDef>
+      Priorities
+    </mat-header-cell>
+    <mat-cell *matCellDef="let element" class="level-{{ element.level }}">
+      <span class="indent-level-{{ element.level }}"></span>
+      <button mat-icon-button *ngIf="element.children.length" class="expand-button"
+        (click)="toggleExpand(element)">
+        <mat-icon>{{ element.expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+      </button>
+      {{ element.displayName ? element.displayName : element.conditionName }}
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="score">
+    <mat-header-cell *matHeaderCellDef>
+      Condition score
+    </mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      <mat-spinner [diameter]="24" *ngIf="!conditionScores.has(element.conditionName)"></mat-spinner>
+      <ng-container *ngIf="conditionScores.has(element.conditionName)">
+        <div>
+          <div>{{ getScoreLabel(element.conditionName) }}</div>
+          <div class="score">{{  getScore(element.conditionName) | number: '1.1-1' }}</div>
+        </div>
+      </ng-container>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="visible">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      <button mat-icon-button>
+        <mat-icon class="material-symbols-outlined" (click)="toggleVisibility(element)"
+          [class.grey-icon]="!element.visible">
+          {{ element.visible ? 'image' : 'hide_image' }}
+        </mat-icon>
+      </button>
+    </mat-cell>
+  </ng-container>
+
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns;" [class.hide-row]="row.hidden"></mat-row>
+</mat-table>

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.scss
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.scss
@@ -1,0 +1,136 @@
+.panel-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+}
+
+.legend-container {
+  gap: 12px;
+  justify-content: center;
+  margin: 12px 50px;
+}
+
+h4 {
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.mat-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-left: 44px;
+}
+
+::ng-deep .mat-radio-label-content {
+  white-space: normal !important;
+}
+
+app-legend {
+  flex: 2 0 224px;
+}
+
+.secondary-text {
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+  opacity: 0.66;
+}
+
+.priority-table {
+  overflow-y: auto;
+}
+
+.mat-header-cell {
+  color: black;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+  opacity: 0.5;
+}
+
+.mat-column-selected {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  padding-right: 24px;
+  width: 36px;
+}
+
+.mat-column-visible {
+  flex: 0 0 auto;
+  width: 48px;
+}
+
+.mat-column-displayName {
+  box-sizing: border-box;
+  flex: 2 0 auto;
+  padding-right: 24px;
+  width: 224px;
+
+  &.mat-cell {
+    font-size: 15px;
+    line-height: 20px;
+
+    &.level-0 {
+      font-weight: 500;
+    }
+  }
+}
+
+.mat-column-score {
+  flex: 0 0 auto;
+  padding-right: 24px;
+  width: 120px;
+
+  &.mat-cell {
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 20px;
+  }
+}
+
+.indent-level-1 {
+  flex: 0 0 auto;
+  width: 10px;
+}
+
+.indent-level-2 {
+  flex: 0 0 auto;
+  width: 44px;
+}
+
+.hide-row {
+  display: none;
+}
+
+/** Always show scrollbar. */
+::-webkit-scrollbar {
+  -webkit-appearance: none;
+  height: 0px;
+  width: 7px;
+}
+
+::-webkit-scrollbar-thumb {
+  -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+  background-color: rgba(0,0,0,.5);
+  border-radius: 4px;
+}
+
+.score {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+}
+
+.expand-button {
+  height: 24px;
+  line-height: 24px;
+  width: 24px;
+}
+
+.grey-icon {
+  color: #8e918f;
+}

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.spec.ts
@@ -1,0 +1,81 @@
+import { SharedModule } from 'src/app/shared/shared.module';
+import { MaterialModule } from 'src/app/material/material.module';
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BehaviorSubject, of } from 'rxjs';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MapLayersComponent } from './map-layers.component';
+import { MapService, PlanService } from 'src/app/services';
+import { ConditionsConfig } from 'src/app/types';
+
+describe('MapLayersComponent', () => {
+  let component: MapLayersComponent;
+  let fixture: ComponentFixture<MapLayersComponent>;
+  let fakeMapService: MapService;
+  let fakePlanService: PlanService;
+
+  beforeEach(async () => {
+    let nameMap = new Map<string, string>();
+    nameMap.set('fake_priority', 'fake_display_priority');
+    fakeMapService = jasmine.createSpyObj<MapService>(
+      'MapService',
+      {
+        getColormap: of({}),
+      },
+      {
+        conditionsConfig$: new BehaviorSubject<ConditionsConfig | null>({
+          pillars: [
+            {
+              pillar_name: 'test_pillar_1',
+              filepath: 'test_pillar_1',
+              display: true,
+              elements: [
+                {
+                  element_name: 'test_element_1',
+                  filepath: 'test_element_1',
+                  metrics: [
+                    {
+                      metric_name: 'test_metric_1',
+                      filepath: 'test_metric_1',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      }
+    );
+
+    fakePlanService = jasmine.createSpyObj('PlanService', {
+      getConditionScoresForPlanningArea: of({conditions: []}),
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        MaterialModule,
+        SharedModule,
+      ],
+      declarations: [ MapLayersComponent ],
+      providers: [
+        {
+          provide: MapService,
+          useValue: fakeMapService,
+        },
+        { provide: PlanService, useValue: fakePlanService },
+      ],
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MapLayersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.ts
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.ts
@@ -71,7 +71,6 @@ export class MapLayersComponent implements OnInit {
 
   ngOnChanges() {
     if (this.plan) {
-      console.log('map-layers ngOnChanges', { plan: this.plan });
       this.planService
         .getConditionScoresForPlanningArea(this.plan!.id)
         .subscribe((response) => {

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.ts
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.ts
@@ -1,0 +1,191 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { MatTableDataSource } from '@angular/material/table';
+import { filter, take } from 'rxjs';
+
+import { MapService, PlanService } from 'src/app/services';
+import {
+  Legend,
+  colormapConfigToLegend,
+  ConditionsConfig,
+  PlanConditionScores,
+  Plan,
+} from 'src/app/types';
+
+// TODO: Share common types and methods (set-priorities component)
+export interface ScoreColumn {
+  label: string;
+  score: number;
+}
+
+interface PriorityRow {
+  selected?: boolean;
+  visible?: boolean; // Visible as raster data on map
+  expanded?: boolean; // Children in table are not hidden
+  hidden?: boolean; // Row hidden from table (independent of "visible" attribute)
+  conditionName: string;
+  displayName?: string;
+  filepath: string;
+  children: PriorityRow[];
+  level: number;
+}
+
+@Component({
+  selector: 'app-map-layers',
+  templateUrl: './map-layers.component.html',
+  styleUrls: ['./map-layers.component.scss'],
+})
+export class MapLayersComponent implements OnInit {
+  @Input() plan: Plan | null = null;
+  @Output() changeConditionEvent = new EventEmitter<string>();
+
+  conditionScores = new Map<string, ScoreColumn>();
+  displayedColumns: string[] = ['displayName', 'score', 'visible'];
+  datasource = new MatTableDataSource<PriorityRow>();
+  legend: Legend | undefined;
+
+  constructor(
+    private mapService: MapService,
+    private planService: PlanService
+  ) {
+    this.mapService
+      .getColormap('turbo')
+      .pipe(take(1))
+      .subscribe((colormapConfig) => {
+        this.legend = colormapConfigToLegend(colormapConfig);
+        this.legend!.labels = ['Poor', 'OK', 'Excellent'];
+      });
+  }
+
+  ngOnInit(): void {
+    this.mapService.conditionsConfig$
+      .pipe(
+        filter((result) => !!result),
+        take(1)
+      )
+      .subscribe((conditionsConfig) => {
+        this.datasource.data = this.conditionsConfigToPriorityData(
+          conditionsConfig!
+        );
+      });
+  }
+
+  ngOnChanges() {
+    if (this.plan) {
+      console.log('map-layers ngOnChanges', { plan: this.plan });
+      this.planService
+        .getConditionScoresForPlanningArea(this.plan!.id)
+        .subscribe((response) => {
+          this.conditionScores =
+            this.convertConditionScoresToDictionary(response);
+        });
+    }
+  }
+
+  private conditionsConfigToPriorityData(
+    config: ConditionsConfig
+  ): PriorityRow[] {
+    let data: PriorityRow[] = [];
+    config.pillars
+      ?.filter((pillar) => pillar.display)
+      .forEach((pillar) => {
+        let pillarRow: PriorityRow = {
+          conditionName: pillar.pillar_name!,
+          displayName: pillar.display_name,
+          filepath: pillar.filepath!.concat('_normalized'),
+          children: [],
+          level: 0,
+          expanded: false,
+        };
+        data.push(pillarRow);
+        pillar.elements?.forEach((element) => {
+          let elementRow: PriorityRow = {
+            conditionName: element.element_name!,
+            displayName: element.display_name,
+            filepath: element.filepath!.concat('_normalized'),
+            children: [],
+            level: 1,
+            expanded: false,
+            hidden: true,
+          };
+          data.push(elementRow);
+          pillarRow.children.push(elementRow);
+          element.metrics?.forEach((metric) => {
+            let metricRow: PriorityRow = {
+              conditionName: metric.metric_name!,
+              displayName: metric.display_name,
+              filepath: metric.filepath!.concat('_normalized'),
+              children: [],
+              level: 2,
+              hidden: true,
+            };
+            data.push(metricRow);
+            elementRow.children.push(metricRow);
+          });
+        });
+      });
+    return data;
+  }
+
+  private convertConditionScoresToDictionary(
+    scores: PlanConditionScores
+  ): Map<string, ScoreColumn> {
+    let scoreMap = new Map<string, ScoreColumn>();
+    scores.conditions.forEach((condition) => {
+      scoreMap.set(condition.condition, {
+        label: this.scoreToLabel(condition.mean_score),
+        score: condition.mean_score,
+      });
+    });
+    return scoreMap;
+  }
+
+  private scoreToLabel(score: number): string {
+    // TEMPORARY: use 5 equal buckets for scores [-1, 1] (Lowest, Low, Medium, High, Highest)
+    if (score < -0.6) return 'Lowest';
+    if (score < -0.2) return 'Low';
+    if (score < 0.2) return 'Medium';
+    if (score < 0.6) return 'High';
+    return 'Highest';
+  }
+
+  getScoreLabel(conditionName: string): string | undefined {
+    return this.conditionScores.get(conditionName)?.label;
+  }
+
+  getScore(conditionName: string): number | undefined {
+    return this.conditionScores.get(conditionName)?.score;
+  }
+
+  /** Toggle whether a priority condition's children are expanded. */
+  toggleExpand(
+    priority: PriorityRow,
+    expanded?: boolean,
+    hideChildren?: boolean
+  ): void {
+    priority.expanded = expanded !== undefined ? expanded : !priority.expanded;
+    priority.children.forEach((child) => {
+      child.hidden = hideChildren !== undefined ? hideChildren : !child.hidden;
+      if (child.hidden) {
+        this.toggleExpand(child, false, true);
+      }
+    });
+  }
+
+  /**
+   * Toggle visibility for a priority condition. If visibility is ON, turn visibility
+   *  for all other conditions to OFF.
+   */
+  toggleVisibility(priority: PriorityRow): void {
+    priority.visible = !priority.visible;
+    if (priority.visible) {
+      this.changeConditionEvent.emit(priority.filepath);
+      this.datasource.data.forEach((priorityRow) => {
+        if (priorityRow !== priority) {
+          priorityRow.visible = false;
+        }
+      });
+    } else {
+      this.changeConditionEvent.emit('');
+    }
+  }
+}

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.html
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.html
@@ -8,7 +8,9 @@
     <div>
       <mat-tab-group>
         <mat-tab class="scenario-tab" label="OUTCOME"><app-outcome [scenario]="scenario$ | async"></app-outcome></mat-tab>
-        <mat-tab class="scenario-tab" label="MAP LAYERS"> Map Layers </mat-tab>
+        <mat-tab class="scenario-tab" label="MAP LAYERS">
+          <app-map-layers [plan]="plan$ | async" (changeConditionEvent)="changeCondition($event)"></app-map-layers>
+        </mat-tab>
         <mat-tab class="scenario-tab" label="INFO"> Info </mat-tab>
       </mat-tab-group>
     </div>

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
@@ -1,3 +1,4 @@
+import { MapLayersComponent } from './map-layers/map-layers.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
   ComponentFixture,
@@ -38,7 +39,7 @@ describe('ScenarioDetailsComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, HttpClientTestingModule, MaterialModule],
-      declarations: [ScenarioDetailsComponent, OutcomeComponent],
+      declarations: [ScenarioDetailsComponent, MapLayersComponent, OutcomeComponent],
       providers: [
         { provide: MatSnackBar, useValue: snackbarSpy },
         { provide: PlanService, useValue: fakeService },

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
@@ -10,6 +10,7 @@ import {
   switchMap,
   take,
   takeUntil,
+  tap,
 } from 'rxjs';
 
 import {
@@ -18,7 +19,7 @@ import {
   expandCollapsePanelTrigger,
 } from 'src/app/shared/animations';
 import { PlanService } from 'src/app/services';
-import { Scenario } from 'src/app/types';
+import { Plan, Scenario } from 'src/app/types';
 
 @Component({
   selector: 'app-scenario-details',
@@ -42,6 +43,7 @@ import { Scenario } from 'src/app/types';
 })
 export class ScenarioDetailsComponent implements OnInit {
   scenarioId: string | null = null;
+  plan$: Observable<Plan | null> = of(null);
   scenario$?: Observable<Scenario | null>;
   panelExpanded: boolean = true;
 
@@ -54,9 +56,7 @@ export class ScenarioDetailsComponent implements OnInit {
 
   ngOnInit(): void {
     this.scenario$ = this.getScenario();
-    this.scenario$.subscribe((scenario) => {
-      console.log(scenario);
-    });
+    this.plan$ = this.getPlan();
   }
 
   private getScenario() {
@@ -74,7 +74,25 @@ export class ScenarioDetailsComponent implements OnInit {
         });
         return of(null);
       }),
+      tap((scenario) => console.log(scenario)),
       takeUntil(this.destroy$)
     );
+  }
+
+  private getPlan() {
+    return this.planService.planState$.pipe(
+      map((state) => {
+        if (state.currentPlanId) {
+          console.log(state.all[state.currentPlanId]);
+          return state.all[state.currentPlanId];
+        } else {
+          return null;
+        }
+      })
+    );
+  }
+
+  changeCondition(filepath: string): void {
+    this.planService.updateStateWithConditionFilepath(filepath);
   }
 }

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
@@ -74,7 +74,6 @@ export class ScenarioDetailsComponent implements OnInit {
         });
         return of(null);
       }),
-      tap((scenario) => console.log(scenario)),
       takeUntil(this.destroy$)
     );
   }
@@ -83,7 +82,6 @@ export class ScenarioDetailsComponent implements OnInit {
     return this.planService.planState$.pipe(
       map((state) => {
         if (state.currentPlanId) {
-          console.log(state.all[state.currentPlanId]);
           return state.all[state.currentPlanId];
         } else {
           return null;


### PR DESCRIPTION
* Added map layer panel in the Map Layers tab by reusing most of the code in set-priorities (thanks Hana!)
* Note: Not sharing the component because of differences in form logic, but can optimize later if it's worth the effort!
* Plan map shows/hides layers when visibility icon is toggled
* XS bug fix on layer visibility (not hiding the layer when untoggled)
* The subset of tests should be the same in the map layer component as in set-priorities, so didn't bother writing tests

# UI
<img width="1431" alt="Screenshot 2023-02-27 at 6 22 12 PM" src="https://user-images.githubusercontent.com/114368235/221738274-2a32aae4-208b-4114-a999-013cf2e826e6.png">
