### PR TITLE
add data units to layer info card

### DIFF
--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
@@ -1,6 +1,10 @@
 <div class="layer-info-card">
   <h2>{{dataLayerConfig?.display_name}}</h2>
 
+  <p *ngIf="dataUnits()">
+    DATA UNITS: {{dataUnits()}}
+  </p>
+
   <p *ngIf="hasMinMax()">
     VALUE RANGE: {{computeMinMax()}}
   </p>

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { DataLayerConfig } from 'src/app/types';
+import { DataLayerConfig, MetricConfig } from 'src/app/types';
 
 @Component({
   selector: 'app-layer-info-card',
@@ -44,5 +44,9 @@ export class LayerInfoCardComponent {
         this.dataLayerConfig?.max_value!,
       ];
     }
+  }
+
+  dataUnits(): string | undefined {
+    return (this.dataLayerConfig as MetricConfig)?.data_units;
   }
 }

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
@@ -47,6 +47,10 @@ export class LayerInfoCardComponent {
   }
 
   dataUnits(): string | undefined {
-    return (this.dataLayerConfig as MetricConfig)?.data_units;
+    if (this.dataLayerConfig?.normalized) {
+      return 'Normalized';
+    } else {
+      return (this.dataLayerConfig as MetricConfig)?.data_units;
+    }
   }
 }

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -36,6 +36,7 @@ export interface ElementConfig extends DataLayerConfig {
 
 export interface MetricConfig extends DataLayerConfig {
   metric_name: string;
+  data_units?: string;
 }
 
 export interface PillarConfig extends DataLayerConfig {


### PR DESCRIPTION
Adds data units from the condition config to the info card. Part of #499 

Raw:
![image](https://user-images.githubusercontent.com/10444733/222273108-d4d94dc7-7de5-4464-a575-02e32a09b858.png)

Normalized:
![image](https://user-images.githubusercontent.com/10444733/222273177-e6ef662f-c5ea-415c-a484-283014d964ad.png)
