### PR TITLE
Create uploaded project area upon generating scenario

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -56,7 +56,7 @@
         <app-generate-scenarios
           [formGroup]="formGroups[3]"
           (formBackEvent)="stepper.previous()"
-          (createScenarioEvent)="createScenario()">
+          (createScenarioEvent)="createScenarioAndProjectArea()">
         </app-generate-scenarios>
       </mat-step>
     </mat-stepper>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -14,8 +14,13 @@ describe('CreateScenariosComponent', () => {
   let component: CreateScenariosComponent;
   let fixture: ComponentFixture<CreateScenariosComponent>;
   let fakePlanService: PlanService;
+  let fakeGeoJson: GeoJSON.GeoJSON;
 
   beforeEach(async () => {
+    fakeGeoJson = {
+      type: 'FeatureCollection',
+      features: [],
+    };
     fakePlanService = jasmine.createSpyObj<PlanService>(
       'PlanService',
       {
@@ -25,6 +30,7 @@ describe('CreateScenariosComponent', () => {
           maxBudget: 100,
         }),
         updateProject: of(1),
+        createProjectArea: of(1),
         createScenario: of('1'),
         updateStateWithShapes: undefined,
       },
@@ -141,7 +147,7 @@ describe('CreateScenariosComponent', () => {
     const router = fixture.debugElement.injector.get(Router);
     spyOn(router, 'navigate');
 
-    component.createScenario();
+    component.createScenarioAndProjectArea();
 
     expect(fakePlanService.createScenario).toHaveBeenCalledOnceWith({
       id: 1,
@@ -152,6 +158,24 @@ describe('CreateScenariosComponent', () => {
       priorities: ['test'],
       weights: [1],
     });
-    expect(router.navigate).toHaveBeenCalledOnceWith(['scenario-confirmation', '1']);
+    expect(router.navigate).toHaveBeenCalledOnceWith([
+      'scenario-confirmation',
+      '1',
+    ]);
+  });
+
+  it('creates uploaded project area when event is emitted', () => {
+    component.scenarioConfigId = 1;
+    component.formGroups[0].get('priorities')?.setValue(['test']);
+    component.formGroups[2].get('uploadedArea')?.setValue(fakeGeoJson);
+    const router = fixture.debugElement.injector.get(Router);
+    spyOn(router, 'navigate');
+
+    component.createScenarioAndProjectArea();
+
+    expect(fakePlanService.createProjectArea).toHaveBeenCalledOnceWith(
+      component.scenarioConfigId,
+      fakeGeoJson
+    );
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -247,15 +247,14 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
 
   /** Creates the scenario and the uploaded project area, if provided. */
   createScenarioAndProjectArea(): void {
-    this.planService
-      .createScenario(this.formValueToProjectConfig())
+    this.createUploadedProjectArea()
       .pipe(
         take(1),
-        concatMap((_) => {
-          return this.createUploadedProjectArea();
+        concatMap(() => {
+          return this.planService.createScenario(this.formValueToProjectConfig())
         })
       )
-      .subscribe((_) => {
+      .subscribe(() => {
         // Navigate to scenario confirmation page
         const planId = this.plan$.getValue()?.id;
         this.router.navigate(['scenario-confirmation', planId]);

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Subject, take } from 'rxjs';
+import { BehaviorSubject, Subject, take, concatMap, of } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { PlanService } from 'src/app/services';
 import {
@@ -245,15 +245,33 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     });
   }
 
-  createScenario(): void {
+  /** Creates the scenario and the uploaded project area, if provided. */
+  createScenarioAndProjectArea(): void {
     this.planService
       .createScenario(this.formValueToProjectConfig())
-      .pipe(take(1))
+      .pipe(
+        take(1),
+        concatMap((_) => {
+          return this.createUploadedProjectArea();
+        })
+      )
       .subscribe((_) => {
         // Navigate to scenario confirmation page
         const planId = this.plan$.getValue()?.id;
         this.router.navigate(['scenario-confirmation', planId]);
       });
+  }
+
+  createUploadedProjectArea() {
+    const uploadedArea = this.formGroups[2].get('uploadedArea')?.value;
+    console.log(uploadedArea);
+    if (this.scenarioConfigId && uploadedArea) {
+      return this.planService.createProjectArea(
+        this.scenarioConfigId,
+        uploadedArea
+      );
+    }
+    return of(null);
   }
 
   changeCondition(filepath: string): void {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -264,7 +264,6 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
 
   createUploadedProjectArea() {
     const uploadedArea = this.formGroups[2].get('uploadedArea')?.value;
-    console.log(uploadedArea);
     if (this.scenarioConfigId && uploadedArea) {
       return this.planService.createProjectArea(
         this.scenarioConfigId,

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -18,9 +18,10 @@ describe('PlanService', () => {
   let httpTestingController: HttpTestingController;
   let service: PlanService;
   let mockPlan: BasePlan;
+  let fakeGeoJson: GeoJSON.GeoJSON;
 
   beforeEach(() => {
-    const fakeGeoJson: GeoJSON.GeoJSON = {
+    fakeGeoJson = {
       type: 'FeatureCollection',
       features: [],
     };
@@ -189,6 +190,25 @@ describe('PlanService', () => {
         BackendConstants.END_POINT.concat('/plan/create_project/')
       );
       expect(req.request.body).toEqual({ plan_id: 1 });
+      expect(req.request.method).toEqual('POST');
+      req.flush(1);
+      httpTestingController.verify();
+    });
+  });
+
+  describe('createProjectArea', () => {
+    it('should make HTTP request to backend', () => {
+      service.createProjectArea(1, fakeGeoJson).subscribe((res) => {
+        expect(res).toEqual(1);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/create_project_area/')
+      );
+      expect(req.request.body).toEqual({
+        project_id: 1,
+        geometry: fakeGeoJson,
+      });
       expect(req.request.method).toEqual('POST');
       req.flush(1);
       httpTestingController.verify();

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -1,6 +1,14 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, map, Observable, take, tap } from 'rxjs';
+import {
+  BehaviorSubject,
+  catchError,
+  map,
+  Observable,
+  of,
+  take,
+  tap,
+} from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
 import { BasePlan, Plan, Region } from '../types';
@@ -126,7 +134,7 @@ export class PlanService {
   getConditionScoresForPlanningArea(
     planId: string
   ): Observable<PlanConditionScores> {
-    let url = BackendConstants.END_POINT.concat('/plan/scores/?id=', planId);
+    const url = BackendConstants.END_POINT.concat('/plan/scores/?id=', planId);
     return this.http
       .get<PlanConditionScores>(url, {
         withCredentials: true,
@@ -134,10 +142,12 @@ export class PlanService {
       .pipe(take(1));
   }
 
-  /** Creates a project in a plan, and returns an ID which can be used to get or update the
-   *  project. */
+  /**
+   * Creates a project in a plan, and returns an ID which can be used to get or update the
+   *  project. "Project" is synonymous with "Config" in the frontend.
+   * */
   createProjectInPlan(planId: string): Observable<number> {
-    let url = BackendConstants.END_POINT.concat('/plan/create_project/');
+    const url = BackendConstants.END_POINT.concat('/plan/create_project/');
     return this.http
       .post<number>(
         url,
@@ -151,9 +161,32 @@ export class PlanService {
       .pipe(take(1));
   }
 
+  /** Creates project area and returns the ID of the created project area. */
+  createProjectArea(projectId: number, projectArea: GeoJSON.GeoJSON) {
+    const url = BackendConstants.END_POINT.concat('/plan/create_project_area/');
+    return this.http
+      .post<number>(
+        url,
+        {
+          project_id: Number(projectId),
+          geometry: projectArea,
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .pipe(
+        take(1),
+        catchError((error) => {
+          // TODO: Show error message! Move all error logic to the service.
+          return of(null);
+        })
+      );
+  }
+
   /** Updates a project with new parameters. */
   updateProject(projectConfig: ProjectConfig): Observable<number> {
-    let url = BackendConstants.END_POINT.concat('/plan/update_project/');
+    const url = BackendConstants.END_POINT.concat('/plan/update_project/');
     return this.http
       .put<number>(url, projectConfig, {
         withCredentials: true,
@@ -163,7 +196,7 @@ export class PlanService {
 
   /** Fetches the projects for a plan from the backend. */
   getProjectsForPlan(planId: string): Observable<ProjectConfig[]> {
-    let url = BackendConstants.END_POINT.concat(
+    const url = BackendConstants.END_POINT.concat(
       '/plan/list_projects_for_plan/?plan_id=',
       planId
     );
@@ -183,7 +216,7 @@ export class PlanService {
 
   /** Fetches a project by its ID from the backend. */
   getProject(projectId: number): Observable<ProjectConfig> {
-    let url = BackendConstants.END_POINT.concat(
+    const url = BackendConstants.END_POINT.concat(
       '/plan/get_project/?id=',
       projectId.toString()
     );


### PR DESCRIPTION
# Changes
* Added createProjectArea() method in PlanService to call backend to create project area
* Invokes call when the user clicks "generate scenario"
* Saves uploaded project areas to the db
* Added tests