### PR TITLE
Small fix for converting project areas from backend response

### DIFF
--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -44,6 +44,16 @@ export interface BackendPlan {
   creation_timestamp?: number; // in seconds since epoch
 }
 
+export interface BackendProjectArea {
+  id: number;
+  geometry: GeoJSON.GeoJSON;
+  properties?: {
+    estimated_area_treated?: number;
+    owner?: number;
+    project?: number;
+  };
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -391,27 +401,30 @@ export class PlanService {
         scenario.creation_timestamp
       ),
       priorities: scenario.priorities,
-      projectAreas: this.convertToProjectAreas(scenario.project_areas || []),
+      projectAreas: this.convertToProjectAreas(scenario.project_areas),
       notes: scenario.notes,
       favorited: scenario.favorited,
     };
   }
 
-  private convertToProjectAreas(scenarioProjectAreas: any[]): ProjectArea[] {
+  private convertToProjectAreas(scenarioProjectAreas: {
+    [id: number]: BackendProjectArea;
+  }): ProjectArea[] {
     if (!scenarioProjectAreas) {
       return [];
     }
+
     let projectAreas: ProjectArea[] = [];
-    Object.values(scenarioProjectAreas)
-    .forEach((projectArea) => {
+    Object.values(scenarioProjectAreas).forEach((projectArea) => {
       projectAreas.push({
-        id: projectArea.id,
-        projectId: projectArea.properties?.project,
+        id: projectArea.id.toString(),
+        projectId: projectArea.properties?.project?.toString(),
         projectArea: projectArea.geometry,
-        owner: projectArea.properties?.owner,
+        owner: projectArea.properties?.owner?.toString(),
         estimatedAreaTreated: projectArea.properties?.estimated_area_treated,
-      })
+      });
     });
+
     return projectAreas;
   }
 

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -401,13 +401,18 @@ export class PlanService {
     if (!scenarioProjectAreas) {
       return [];
     }
-    return scenarioProjectAreas.map((projectArea) => ({
-      id: projectArea.id,
-      projectId: projectArea.properties?.project,
-      projectArea: projectArea.geometry,
-      owner: projectArea.properties?.owner,
-      estimatedAreaTreated: projectArea.properties?.estimated_area_treated,
-    }));
+    let projectAreas: ProjectArea[] = [];
+    Object.values(scenarioProjectAreas)
+    .forEach((projectArea) => {
+      projectAreas.push({
+        id: projectArea.id,
+        projectId: projectArea.properties?.project,
+        projectArea: projectArea.geometry,
+        owner: projectArea.properties?.owner,
+        estimatedAreaTreated: projectArea.properties?.estimated_area_treated,
+      })
+    });
+    return projectAreas;
   }
 
   private convertConfigToScenario(config: ProjectConfig): any {


### PR DESCRIPTION
The response now returns an object for the project areas instead of an array. Fixed the conversion call to convert to ProjectAreas.