### PR TITLE
Includes pixels that Patchmax should pass through but not treat

### DIFF
--- a/src/planscape/forsys/assert_dict_almost_equal.py
+++ b/src/planscape/forsys/assert_dict_almost_equal.py
@@ -3,6 +3,12 @@ import numpy as np
 
 # Validates that two dictionaries have values that are "almost equal".
 # Must be called from a TestCase class.
+# Mostly calls Django TestCase assertion checks, but for lists of floats, calls 
+# numpy.testing.assert_array_almost_equal instaed since a similar check isn't 
+# available in Django.
+# TODO: this covers many cases, but a better solution would be recursive to
+# cover dictionaries within dictionaries (not implemented in the interest of 
+# time).
 def assert_dict_almost_equal(self,
                              d1: dict,
                              d2: dict) -> None:
@@ -10,9 +16,16 @@ def assert_dict_almost_equal(self,
     for k in d1.keys():
         l1 = d1[k]
         if isinstance(l1, list):
+            # Note: both assert_array_almost_equal and assertListEqual checks 
+            # for element order - [1, 2] and [2, 1] are not equal even though 
+            # they contain the same values in different orders.
             if len(l1) > 0 and type(l1[0]) is float:
+                # TestCase doesn't have an assertListAlmostEqual check -
+                # resorting to numpy.
                 np.testing.assert_array_almost_equal(l1, d2[k])
             else:
                 self.assertListEqual(l1, d2[k])
         else:
+            # TODO: split assertEqual into other cases to accommodate floats, 
+            # dictionaries, sets, etc.
             self.assertEqual(l1, d2[k])

--- a/src/planscape/forsys/assert_dict_almost_equal.py
+++ b/src/planscape/forsys/assert_dict_almost_equal.py
@@ -4,7 +4,7 @@ import numpy as np
 # Validates that two dictionaries have values that are "almost equal".
 # Must be called from a TestCase class.
 # Mostly calls Django TestCase assertion checks, but for lists of floats, calls 
-# numpy.testing.assert_array_almost_equal instaed since a similar check isn't 
+# numpy.testing.assert_array_almost_equal instead since a similar check isn't 
 # available in Django.
 # TODO: this covers many cases, but a better solution would be recursive to
 # cover dictionaries within dictionaries (not implemented in the interest of 
@@ -16,9 +16,9 @@ def assert_dict_almost_equal(self,
     for k in d1.keys():
         l1 = d1[k]
         if isinstance(l1, list):
-            # Note: both assert_array_almost_equal and assertListEqual checks 
-            # for element order - [1, 2] and [2, 1] are not equal even though 
-            # they contain the same values in different orders.
+            # Note: both assert_array_almost_equal and assertListEqual check 
+            # for element order - i.e. [1, 2] and [2, 1] are not equal even 
+            # though they contain the same values in different orders.
             if len(l1) > 0 and type(l1[0]) is float:
                 # TestCase doesn't have an assertListAlmostEqual check -
                 # resorting to numpy.

--- a/src/planscape/forsys/assert_dict_almost_equal.py
+++ b/src/planscape/forsys/assert_dict_almost_equal.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+
+# Validates that two dictionaries have values that are "almost equal".
+# Must be called from a TestCase class.
+def assert_dict_almost_equal(self,
+                             d1: dict,
+                             d2: dict) -> None:
+    self.assertEqual(len(d1.keys()), len(d2.keys()))
+    for k in d1.keys():
+        l1 = d1[k]
+        if isinstance(l1, list):
+            if len(l1) > 0 and type(l1[0]) is float:
+                np.testing.assert_array_almost_equal(l1, d2[k])
+            else:
+                self.assertListEqual(l1, d2[k])
+        else:
+            self.assertEqual(l1, d2[k])

--- a/src/planscape/forsys/get_forsys_inputs.py
+++ b/src/planscape/forsys/get_forsys_inputs.py
@@ -229,7 +229,7 @@ class ForsysGenerationInput():
         return forsys_input
 
     # Appends stands to treat to the forsys input dataframe.
-    # The first stand to be appended will have stand ID, starting_stand_id, and 
+    # The first stand to be appended will have stand ID, starting_stand_id, and
     # the one following will have starting_stand_id + 1.
     # Returns the next available integer that can be used as a stand ID.
     def _append_stands_to_treat_to_input_df(
@@ -249,19 +249,19 @@ class ForsysGenerationInput():
                         p)] = raster_conditions.data[p][i]
                     priority_scores[headers.get_condition_header(
                         p)] = raster_conditions.data[p][i]
-                pixel_geo = self._get_raster_pixel_geo(x, y,
-                                               raster_conditions.topleft_coords).wkt, True)
+                pixel_geo = self._get_raster_pixel_geo(
+                    x, y, raster_conditions.topleft_coords)
                 self._append_single_stand_to_forsys_input_df(
                     headers, forsys_input, priority_scores, DUMMY_PROJECT_ID,
                     stand_id, settings.RASTER_PIXEL_AREA,
                     settings.RASTER_PIXEL_AREA *
-                    self.TREATMENT_COST_PER_KM_SQUARED, pixel_geo)
-                stand_id=stand_id + 1
+                    self.TREATMENT_COST_PER_KM_SQUARED, pixel_geo.wkt, True)
+                stand_id = stand_id + 1
         return stand_id
 
-    # Appends stands to pass (i.e. stands ineligible for treatment that can 
-    # still be included in project areas) to the forsys input dataframe.
-    # The first stand to be appended will have stand ID, starting_stand_id, and 
+    # Appends stands to pass (i.e. stands ineligible for treatment that can
+    # still be included sin project areas) to the forsys input dataframe.
+    # The first stand to be appended will have stand ID, starting_stand_id, and
     # the one following will have starting_stand_id + 1.
     # Returns the next available integer that can be used as a stand ID.
     # Of note: if a stand is to be passed, its priority and condition scores
@@ -272,34 +272,34 @@ class ForsysGenerationInput():
             pixels: dict[int, dict[int, int]],
             forsys_input: dict[str, list],
             starting_stand_id: int) -> int:
-        DUMMY_PROJECT_ID=0
-        stand_id=starting_stand_id
+        DUMMY_PROJECT_ID = 0
+        stand_id = starting_stand_id
         for x in pixels.keys():
             for y in pixels[x].keys():
-                i=pixels[x][y]
-                priority_scores={}
+                priority_scores = {}
                 for p in priorities:
                     priority_scores[headers.get_priority_header(
-                        p)]=0
+                        p)] = 0
                     priority_scores[headers.get_condition_header(
-                        p)]=0
+                        p)] = 0
+                pixel_geo = self._get_raster_pixel_geo(
+                    x, y, raster_conditions.topleft_coords)
                 self._append_single_stand_to_forsys_input_df(
                     headers, forsys_input, priority_scores, DUMMY_PROJECT_ID,
                     stand_id, settings.RASTER_PIXEL_AREA,
                     settings.RASTER_PIXEL_AREA *
                     self.TREATMENT_COST_PER_KM_SQUARED,
-                    self._get_raster_pixel_geo(x, y,
-                                               raster_conditions.topleft_coords).wkt, False)
-                stand_id=stand_id + 1
+                    pixel_geo.wkt, False)
+                stand_id = stand_id + 1
         return stand_id
 
     # Appends stands to treat to the forsys input dataframe.
-    # In this version, a stand is actually a cluster of pixels, and stands may 
+    # In this version, a stand is actually a cluster of pixels, and stands may
     # have different acreages.
-    # The first stand to be appended will have stand ID, starting_stand_id, and 
+    # The first stand to be appended will have stand ID, starting_stand_id, and
     # the one following will have starting_stand_id + 1.
     # Returns the next available integer that can be used as a stand ID.
-    # Of note: a stand's condition score is the mean of each pixel's impact 
+    # Of note: a stand's condition score is the mean of each pixel's impact
     # score. A stand's priority score is the sum of each pixel's imppact score.
     def _append_clustered_stands_to_treat_to_input_df(
         self, headers: ForsysInputHeaders,
@@ -308,39 +308,40 @@ class ForsysGenerationInput():
         raster_conditions: RasterConditionFetcher,
         forsys_input: dict[str, list], starting_stand_id: int
     ) -> int:
-        stand_id=starting_stand_id
-        DUMMY_PROJECT_ID=0
+        stand_id = starting_stand_id
+        DUMMY_PROJECT_ID = 0
         for cluster_id in clusters_to_stands.keys():
-            stands=clusters_to_stands[cluster_id]
-            num_stands=len(stands)
-            geos=[]
-            priority_scores={}
+            stands = clusters_to_stands[cluster_id]
+            num_stands = len(stands)
+            geos = []
+            priority_scores = {}
             for stand_pixel_pos in stands:
-                x=stand_pixel_pos[0]
-                y=stand_pixel_pos[1]
+                x = stand_pixel_pos[0]
+                y = stand_pixel_pos[1]
                 if x not in raster_conditions.x_to_y_to_index.keys():
                     raise Exception(
                         "raster condition data missing x-pixel, %d" % x)
                 if y not in raster_conditions.x_to_y_to_index[x].keys():
                     raise Exception(
-                        "raster condition data missing x-pixel/y-pixel pair, (%d, %d)" % (x, y))
-                i=raster_conditions.x_to_y_to_index[x][y]
+                        "raster condition data missing x-pixel/y-pixel " +
+                        "pair, (%d, %d)" % (x, y))
+                i = raster_conditions.x_to_y_to_index[x][y]
 
                 geos.append(self._get_raster_pixel_geo(
                     x, y, raster_conditions.topleft_coords))
 
                 for p in priorities:
-                    priority_header=headers.get_priority_header(p)
-                    priority_score=raster_conditions.data[p][i]
+                    priority_header = headers.get_priority_header(p)
+                    priority_score = raster_conditions.data[p][i]
                     if priority_header in priority_scores.keys():
-                        priority_scores[priority_header]=
+                        priority_scores[priority_header] = \
                             priority_scores[priority_header] + priority_score
                     else:
-                        priority_scores[priority_header]=priority_score
+                        priority_scores[priority_header] = priority_score
 
             for p in priorities:
-                condition_header=headers.get_condition_header(p)
-                priority_scores[condition_header]=
+                condition_header = headers.get_condition_header(p)
+                priority_scores[condition_header] = \
                     priority_scores[priority_header] / num_stands
             self._append_single_stand_to_forsys_input_df(
                 headers, forsys_input, priority_scores, DUMMY_PROJECT_ID,

--- a/src/planscape/forsys/get_forsys_inputs.py
+++ b/src/planscape/forsys/get_forsys_inputs.py
@@ -253,6 +253,8 @@ class ForsysGenerationInput():
                 stand_id = stand_id + 1
         return stand_id
 
+    # Of note: if a stand is to be passed, its priority and condition scores 
+    # are set to 0.
     def _append_stands_to_pass_to_input_df(
             self, headers: ForsysInputHeaders, priorities: list[str],
             raster_conditions: RasterConditionFetcher,

--- a/src/planscape/forsys/get_forsys_inputs.py
+++ b/src/planscape/forsys/get_forsys_inputs.py
@@ -7,7 +7,6 @@ from forsys.forsys_request_params import (ClusterAlgorithmType,
                                           ForsysRankingRequestParams)
 from forsys.merge_polygons import merge_polygons
 from forsys.raster_condition_fetcher import (RasterConditionFetcher,
-                                             get_base_condition_ids_to_names,
                                              get_conditions)
 from forsys.raster_condition_treatment_eligibility_selector import (
     RasterConditionTreatmentEligibilitySelector)
@@ -104,9 +103,7 @@ class ForsysRankingInput():
         priorities = params.priorities
         project_areas = params.project_areas
 
-        base_condition_ids_to_names = get_base_condition_ids_to_names(
-            region, priorities)
-        conditions = get_conditions(base_condition_ids_to_names.keys())
+        conditions = get_conditions(region, priorities)
 
         self.forsys_input = _get_initialized_forsys_input_with_common_headers(
             headers, priorities)
@@ -120,8 +117,7 @@ class ForsysRankingInput():
 
             num_pixels = 0  # number of non-NaN raster pixels captured by geo.
             for c in conditions:
-                # TODO: replace this with select_related.
-                name = base_condition_ids_to_names[c.condition_dataset_id]
+                name = c.base_condition.condition_name
                 stats = compute_condition_stats_from_raster(
                     geo, c.raster_name)
                 if stats['count'] == 0:
@@ -156,7 +152,6 @@ class ForsysGenerationInput():
     # row represents a unique stand.
     # Dictionary keys are dataframe headers. Dictionary values are lists
     # corresponding to columns below each dataframe header.
-    # TODO: only populate condition scores when settings.DEBUG is true.
     forsys_input: dict[str, list]
 
     # ----- Intermediate data -----

--- a/src/planscape/forsys/get_forsys_inputs.py
+++ b/src/planscape/forsys/get_forsys_inputs.py
@@ -117,7 +117,7 @@ class ForsysRankingInput():
 
             num_pixels = 0  # number of non-NaN raster pixels captured by geo.
             for c in conditions:
-                name = c.base_condition.condition_name
+                name = c.condition_dataset.condition_name
                 stats = compute_condition_stats_from_raster(
                     geo, c.raster_name)
                 if stats['count'] == 0:

--- a/src/planscape/forsys/get_forsys_inputs_test.py
+++ b/src/planscape/forsys/get_forsys_inputs_test.py
@@ -197,10 +197,11 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
                     self._create_polygon_for_pixel(2, 0).wkt,
                     self._create_polygon_for_pixel(2, 1).wkt,
                     self._create_polygon_for_pixel(3, 0).wkt,
-                    self._create_polygon_for_pixel(3, 1).wkt]
+                    self._create_polygon_for_pixel(3, 1).wkt],
+            'eligible': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
         })
 
-    def test_gets_forsys_input_ignoring_nan(self):
+    def test_gets_forsys_input_making_nan_ineligible(self):
         baz_raster = RasterConditionRetrievalTestCase._create_raster(
             self, 4, 4, (np.nan, np.nan, np.nan, np.nan,
                          .2, .2, .2, .2,
@@ -220,18 +221,24 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
 
         input = ForsysGenerationInput(params, headers)
         _assert_dict_almost_equal(self, input.forsys_input, {
-            'proj_id': [0, 0, 0, 0],
-            'stand_id': [0, 1, 2, 3],
-            'area': [.09, .09, .09, .09],
-            'cost': [450000000, 450000000, 450000000, 450000000],
-            'p_foo': [.95, .94, .93, .92],
-            'p_baz': [.8, .8, .8, .8],
-            'c_foo': [.95, .94, .93, .92],
-            'c_baz': [.8, .8, .8, .8],
+            'proj_id': [0, 0, 0, 0, 0, 0, 0, 0],
+            'stand_id': [0, 1, 2, 3, 4, 5, 6, 7],
+            'area': [.09, .09, .09, .09, .09, .09, .09, .09],
+            'cost': [450000000, 450000000, 450000000, 450000000,
+                     450000000, 450000000, 450000000, 450000000],
+            'p_foo': [.95, .94, .93, .92, 0, 0, 0, 0],
+            'p_baz': [.8, .8, .8, .8, 0, 0, 0, 0],
+            'c_foo': [.95, .94, .93, .92, 0, 0, 0, 0],
+            'c_baz': [.8, .8, .8, .8, 0, 0, 0, 0],
             'geo': [self._create_polygon_for_pixel(0, 1).wkt,
                     self._create_polygon_for_pixel(1, 1).wkt,
                     self._create_polygon_for_pixel(2, 1).wkt,
-                    self._create_polygon_for_pixel(3, 1).wkt]
+                    self._create_polygon_for_pixel(3, 1).wkt,
+                    self._create_polygon_for_pixel(0, 0).wkt,
+                    self._create_polygon_for_pixel(1, 0).wkt,
+                    self._create_polygon_for_pixel(2, 0).wkt,
+                    self._create_polygon_for_pixel(3, 0).wkt],
+            'eligible': [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
         })
 
     def _create_polygon_for_pixel(self, x, y) -> Polygon:
@@ -322,7 +329,7 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
 
         _assert_dict_almost_equal(self, input.forsys_input, {
             'proj_id': [0, 0, 0, 0],
-            'stand_id': [1, 0, 3, 2],
+            'stand_id': [0, 1, 2, 3],
             'area': [0.18, 0.18, 0.09, 0.09],
             'cost': [900000000, 900000000, 450000000, 450000000],
             'p_bar': [1.8, 1.6, 0.9, 0.8],
@@ -345,7 +352,8 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
                 # y spans 2100654, 2100354: 1 pixel
                 'POLYGON ((-2116371 2100654, -2116371 2100354, -2116071 ' + \
                 '2100354, -2116071 2100654, -2116371 2100654))'
-            ]
+            ],
+            'eligible': [1.0, 1.0, 1.0, 1.0]
         })
 
     def test_gets_forsys_input_with_clustering_aborted(self):
@@ -382,5 +390,6 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
                     self._create_polygon_for_pixel(2, 0).wkt,
                     self._create_polygon_for_pixel(2, 1).wkt,
                     self._create_polygon_for_pixel(3, 0).wkt,
-                    self._create_polygon_for_pixel(3, 1).wkt]
+                    self._create_polygon_for_pixel(3, 1).wkt],
+            'eligible': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
         })

--- a/src/planscape/forsys/get_forsys_inputs_test.py
+++ b/src/planscape/forsys/get_forsys_inputs_test.py
@@ -204,6 +204,10 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
         headers = ForsysInputHeaders(params.priorities)
 
         input = ForsysGenerationInput(params, headers)
+        # Of note: stands in row 0 are ineligible for treatment because one of 
+        # the conditions is missing values. Because they're ineligible for 
+        # treatment, all condition and and prioritiy scores are set to 0 
+        # regardless of whether they originally had non-zero values. 
         assert_dict_almost_equal(self, input.forsys_input, {
             'proj_id': [0, 0, 0, 0, 0, 0, 0, 0],
             'stand_id': [0, 1, 2, 3, 4, 5, 6, 7],

--- a/src/planscape/forsys/get_forsys_inputs_test.py
+++ b/src/planscape/forsys/get_forsys_inputs_test.py
@@ -4,27 +4,15 @@ from conditions.models import BaseCondition
 from conditions.raster_condition_retrieval_testcase import \
     RasterConditionRetrievalTestCase
 from django.contrib.gis.geos import Polygon
-from django.http import HttpRequest, QueryDict
+from django.http import QueryDict
 from django.test import TestCase
 from forsys.forsys_request_params import (
     ClusterAlgorithmType, ForsysGenerationRequestParamsFromUrlWithDefaults,
     ForsysRankingRequestParamsFromUrlWithDefaults)
 from forsys.get_forsys_inputs import (ForsysGenerationInput,
                                       ForsysInputHeaders, ForsysRankingInput)
-from forsys.merge_polygons import merge_polygons
 from planscape import settings
-
-
-def _assert_dict_almost_equal(self,
-                              d1: dict[str, list],
-                              d2: dict[str, list]) -> None:
-    self.assertEqual(len(d1.keys()), len(d2.keys()))
-    for k in d1.keys():
-        l1 = d1[k]
-        if len(l1) > 0 and type(l1[0]) is float:
-            np.testing.assert_array_almost_equal(l1, d2[k])
-        else:
-            self.assertListEqual(l1, d2[k])
+from forsys.assert_dict_almost_equal import assert_dict_almost_equal
 
 
 class ForsysInputHeadersTest(TestCase):
@@ -81,7 +69,7 @@ class ForsysRankingInputTest(RasterConditionRetrievalTestCase):
         headers = ForsysInputHeaders(params.priorities)
 
         input = ForsysRankingInput(params, headers)
-        _assert_dict_almost_equal(self, input.forsys_input, {
+        assert_dict_almost_equal(self, input.forsys_input, {
             'proj_id': [1, 2],
             'stand_id': [1, 2],
             'area': [0.72, 0.36],
@@ -176,7 +164,7 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
         headers = ForsysInputHeaders(params.priorities)
 
         input = ForsysGenerationInput(params, headers)
-        _assert_dict_almost_equal(self, input.forsys_input, {
+        assert_dict_almost_equal(self, input.forsys_input, {
             'proj_id': [0, 0, 0, 0, 0, 0, 0, 0],
             'stand_id': [0, 1, 2, 3, 4, 5, 6, 7],
             'area': [.09, .09, .09, .09, .09, .09, .09, .09],
@@ -216,7 +204,7 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
         headers = ForsysInputHeaders(params.priorities)
 
         input = ForsysGenerationInput(params, headers)
-        _assert_dict_almost_equal(self, input.forsys_input, {
+        assert_dict_almost_equal(self, input.forsys_input, {
             'proj_id': [0, 0, 0, 0, 0, 0, 0, 0],
             'stand_id': [0, 1, 2, 3, 4, 5, 6, 7],
             'area': [.09, .09, .09, .09, .09, .09, .09, .09],
@@ -323,7 +311,7 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
 
         input = ForsysGenerationInput(params, headers)
 
-        _assert_dict_almost_equal(self, input.forsys_input, {
+        assert_dict_almost_equal(self, input.forsys_input, {
             'proj_id': [0, 0, 0, 0],
             'stand_id': [0, 1, 2, 3],
             'area': [0.18, 0.18, 0.09, 0.09],
@@ -369,7 +357,7 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
         headers = ForsysInputHeaders(params.priorities)
 
         input = ForsysGenerationInput(params, headers)
-        _assert_dict_almost_equal(self, input.forsys_input, {
+        assert_dict_almost_equal(self, input.forsys_input, {
             'proj_id': [0, 0, 0, 0, 0, 0, 0, 0],
             'stand_id': [0, 1, 2, 3, 4, 5, 6, 7],
             'area': [.09, .09, .09, .09, .09, .09, .09, .09],

--- a/src/planscape/forsys/get_forsys_inputs_test.py
+++ b/src/planscape/forsys/get_forsys_inputs_test.py
@@ -69,8 +69,7 @@ class ForsysRankingInputTest(RasterConditionRetrievalTestCase):
             self, "bar", "bar_normalized", bar_raster)
 
     def test_gets_forsys_input(self):
-        qd = QueryDict('set_all_params_via_url_with_default_values=1')
-        params = ForsysRankingRequestParamsFromUrlWithDefaults(qd)
+        params = ForsysRankingRequestParamsFromUrlWithDefaults(QueryDict(''))
         params.region = self.region
         params.priorities = ["foo", "bar"]
         params.project_areas.clear()
@@ -92,8 +91,7 @@ class ForsysRankingInputTest(RasterConditionRetrievalTestCase):
         })
 
     def test_missing_base_condition(self):
-        qd = QueryDict('set_all_params_via_url_with_default_values=1')
-        params = ForsysRankingRequestParamsFromUrlWithDefaults(qd)
+        params = ForsysRankingRequestParamsFromUrlWithDefaults(QueryDict(''))
         params.region = self.region
         # No base conditions exist for baz.
         params.priorities = ["foo", "bar", "baz"]
@@ -115,8 +113,7 @@ class ForsysRankingInputTest(RasterConditionRetrievalTestCase):
             condition_name="baz", region_name=self.region,
             condition_level=ConditionLevel.METRIC)
 
-        qd = QueryDict('set_all_params_via_url_with_default_values=1')
-        params = ForsysRankingRequestParamsFromUrlWithDefaults(qd)
+        params = ForsysRankingRequestParamsFromUrlWithDefaults(QueryDict(''))
         params.region = self.region
         params.priorities = ["foo", "bar", "baz"]
         params.project_areas.clear()
@@ -132,8 +129,7 @@ class ForsysRankingInputTest(RasterConditionRetrievalTestCase):
             "of 3 priorities, only 2 had conditions")
 
     def test_missing_condition_score(self):
-        qd = QueryDict('set_all_params_via_url_with_default_values=1')
-        params = ForsysRankingRequestParamsFromUrlWithDefaults(qd)
+        params = ForsysRankingRequestParamsFromUrlWithDefaults(QueryDict(''))
         params.region = self.region
         params.priorities = ["foo"]
         params.project_areas.clear()

--- a/src/planscape/forsys/get_forsys_inputs_test.py
+++ b/src/planscape/forsys/get_forsys_inputs_test.py
@@ -107,7 +107,7 @@ class ForsysRankingInputTest(RasterConditionRetrievalTestCase):
             ForsysRankingInput(params, headers)
         self.assertEqual(
             str(context.exception),
-            "of 3 priorities, only 2 had base conditions")
+            "of 3 priorities, only 2 had conditions")
 
     def test_missing_condition(self):
         # A base condition exists for baz, but a condition dosen't.
@@ -271,7 +271,7 @@ class ForsysGenerationInputTest(RasterConditionRetrievalTestCase):
             ForsysGenerationInput(params, headers)
         self.assertEqual(
             str(context.exception),
-            "of 3 priorities, only 2 had base conditions")
+            "of 3 priorities, only 2 had conditions")
 
     def test_missing_condition(self):
         # A base condition exists for baz, but a condition dosen't.

--- a/src/planscape/forsys/raster_condition_fetcher.py
+++ b/src/planscape/forsys/raster_condition_fetcher.py
@@ -44,7 +44,8 @@ class RasterConditionFetcher:
     #   - y: the y pixel (starting from 0)
     #   - <priority name>: each priority has its own column. If a priority
     #       value exists for a given pixel, the element corresponding to the
-    #       pixel is a float; otherwise, it's None.
+    #       pixel is a float; otherwise, it's np.nan.
+    #       note: the value, for now, is 1.0 - normalized condition value.
     data: dict[str, list]
     # Maps x and y pixel positions to a row index in the data.
     x_to_y_to_index: dict[int, dict[int, int]]
@@ -145,7 +146,9 @@ class RasterConditionFetcher:
             for i in range(len(raster_values["pixel_dist_x"])):
                 x = raster_values["pixel_dist_x"][i]
                 y = raster_values["pixel_dist_y"][i]
-                value = raster_values["values"][i]
+                # TODO: using normalized conditions, impact is 1.0 - condition
+                # score. This needs to be updated once we move to AP scores.
+                value = 1.0 - raster_values["values"][i]
 
                 if x not in x_to_y_to_index.keys():
                     x_to_y_to_index[x] = {}

--- a/src/planscape/forsys/raster_condition_fetcher.py
+++ b/src/planscape/forsys/raster_condition_fetcher.py
@@ -29,6 +29,8 @@ def get_conditions(region: str, priorities: list[str]) -> list[Condition]:
 # a dataframe.
 class RasterConditionFetcher:
     # Maps condition names to retrieved ConditionPixelValues instances.
+    # This contains results that were directly returned by 
+    # conditions.raster_utils.get_condition_values_from_raster.
     conditions_to_raster_values: dict[str, ConditionPixelValues]
 
     # The origin coordinate used to merging ConditionPixelValues instances into
@@ -38,7 +40,8 @@ class RasterConditionFetcher:
     width: int
     height: int
     # A reformatted version of retrieved ConditionPixelValues instances where
-    # each row represents a pixel.
+    # each row represents a pixel, and each column represents a specific 
+    # feature.
     # Column headers include:
     #   - x: the x pixel (starting from 0)
     #   - y: the y pixel (starting from 0)
@@ -64,6 +67,11 @@ class RasterConditionFetcher:
             self.conditions_to_raster_values, priorities)
         self.width, self.height = self._get_width_and_height(
             self.x_to_y_to_index)
+        
+        # TODO: Only stands with at least one condition value are saved; 
+        # however, some stands may have 0 condition values, but still be useful 
+        # to include in the forsys input (think stand threshold, EPW). These 
+        # should be added to self.data.
 
     # Fetches condition raster values for a given GEOSGeometry and emits it in
     # a {condition name: ConditionPixelValues} dictionary.

--- a/src/planscape/forsys/raster_condition_fetcher.py
+++ b/src/planscape/forsys/raster_condition_fetcher.py
@@ -1,0 +1,107 @@
+from conditions.models import BaseCondition, Condition
+from conditions.raster_utils import (ConditionPixelValues,
+                                     get_condition_values_from_raster,
+                                     get_raster_geo)
+from django.contrib.gis.geos import GEOSGeometry
+from planscape import settings
+
+
+# Given a list of priorities (i.e. condition names), returns a dictionary
+# mapping condition ID's to condition names.
+# Raises an error if any of the priorities don't have a corresponding condition.
+# TODO: this may not be necessary if we use Django's "select_related" function.
+def get_base_condition_ids_to_names(region: str,
+                                    priorities: list) -> dict[int, str]:
+    base_condition_ids_to_names = {
+        c.pk: c.condition_name
+        for c in BaseCondition.objects.filter(region_name=region).filter(
+            condition_name__in=priorities).all()}
+    if len(priorities) != len(base_condition_ids_to_names.keys()):
+        raise Exception("of %d priorities, only %d had base conditions" % (
+            len(priorities), len(base_condition_ids_to_names.keys())))
+    return base_condition_ids_to_names
+
+
+# Given a list of condition ID's, returns a list of conditions.
+# Output conditions may not be listed in the same order as condition_ids.
+# Raises an error if any of the input condition ID's don't have a corresponding
+# condition.
+def get_conditions(condition_ids: list[int]) -> list[Condition]:
+    conditions = list(Condition.objects.filter(
+        condition_dataset_id__in=condition_ids).filter(
+        is_raw=False).all())
+    if len(condition_ids) != len(conditions):
+        raise Exception(
+            "of %d priorities, only %d had conditions" %
+            (len(condition_ids),
+                len(conditions)))
+    return conditions
+
+
+class RasterConditionFetcher:
+    # Maps condition names to retrieved ConditionPixelValues instances.
+    conditions_to_raster_values: dict[str, ConditionPixelValues]
+    # The origin coordinate used when merging ConditionPixelValues instances, which may have different top-left coordinates, across all conditions.
+    topleft_coords: tuple[float, float]
+
+    def __init__(self, region: str, priorities: list[str], geo: GEOSGeometry):
+        raster_geo = get_raster_geo(geo)
+
+        base_condition_ids_to_names = get_base_condition_ids_to_names(
+            region, priorities)
+        conditions = get_conditions(base_condition_ids_to_names.keys())
+
+        self.conditions_to_raster_values, self.topleft_coords = \
+            self._fetch_conditions_to_raster_values(
+                conditions, base_condition_ids_to_names, raster_geo)
+
+    def _fetch_conditions_to_raster_values(
+            self, conditions: list[str],
+            base_condition_ids_to_names: dict[int, str],
+            geo: GEOSGeometry):
+        conditions_to_raster_values = {}
+        topleft_coords = None
+        for c in conditions:
+            # TODO: replace this with select_related.
+            name = base_condition_ids_to_names[c.condition_dataset_id]
+            values = get_condition_values_from_raster(geo, c.raster_name)
+            if values is None:
+                raise Exception(
+                    "plan has no intersection with condition raster, %s" %
+                    name)
+            conditions_to_raster_values[name] = values
+            topleft_coords = self._get_updated_topleft_coords(
+                values, topleft_coords)
+        return conditions_to_raster_values, topleft_coords
+
+    def _get_updated_topleft_coords(
+            self, condition_pixel_values: ConditionPixelValues,
+            topleft_coords: tuple[float, float] | None) -> tuple[float, float]:
+        # TODO: these shouldn't be local constants.
+        UPPER_LEFT_COORD_X_KEY = "upper_left_coord_x"
+        UPPER_LEFT_COORD_Y_KEY = "upper_left_coord_y"
+
+        if condition_pixel_values[UPPER_LEFT_COORD_X_KEY] is None:
+            raise Exception(
+                "fetched poorly-formatted raster pixel data" +
+                " - missing " + UPPER_LEFT_COORD_X_KEY)
+        if condition_pixel_values[UPPER_LEFT_COORD_Y_KEY] is None:
+            raise Exception(
+                "fetched poorly-formatted raster pixel data" +
+                " - missing " + UPPER_LEFT_COORD_Y_KEY)
+        if topleft_coords is None:
+            return (condition_pixel_values[UPPER_LEFT_COORD_X_KEY],
+                    condition_pixel_values[UPPER_LEFT_COORD_Y_KEY])
+        return (
+            self._select_topleft_coord(topleft_coords[0],
+                                       condition_pixel_values[UPPER_LEFT_COORD_X_KEY],
+                                       settings.CRS_9822_SCALE[0]),
+            self._select_topleft_coord(topleft_coords[1],
+                                       condition_pixel_values[UPPER_LEFT_COORD_Y_KEY],
+                                       settings.CRS_9822_SCALE[1]))
+
+    # Given two coordinates, selects the one that represents a lower pixel
+    # distance index according to the scale.
+    def _select_topleft_coord(
+            self, coord1: float, coord2: float, scale: float) -> float:
+        return min(coord1, coord2) if scale > 0 else max(coord1, coord2)

--- a/src/planscape/forsys/raster_condition_fetcher.py
+++ b/src/planscape/forsys/raster_condition_fetcher.py
@@ -1,4 +1,6 @@
-from conditions.models import BaseCondition, Condition
+import numpy as np
+
+from conditions.models import Condition
 from conditions.raster_utils import (ConditionPixelValues,
                                      get_condition_values_from_raster,
                                      get_raster_geo)
@@ -23,26 +25,46 @@ def get_conditions(region: str, priorities: list[str]) -> list[Condition]:
     return conditions
 
 
+# Fetches ConditionPixelValues for multiple conditions and reformats them into
+# a dataframe.
 class RasterConditionFetcher:
     # Maps condition names to retrieved ConditionPixelValues instances.
     conditions_to_raster_values: dict[str, ConditionPixelValues]
-    # The origin coordinate used when merging ConditionPixelValues instances, which may have different top-left coordinates, across all conditions.
+
+    # The origin coordinate used when merging ConditionPixelValues instances,
+    # which may have different top-left coordinates, across all conditions.
     topleft_coords: tuple[float, float]
+    # A reformatted version of retrieved ConditionPixelValues instances where
+    # each row represents a pixel.
+    # Column headers include:
+    #   - x: the x pixel (starting from 0)
+    #   - y: the y pixel (starting from 0)
+    #   - <priority name>: each priority has its own column. If a priority
+    #       value exists for a given pixel, the element corresponding to the
+    #       pixel is a float; otherwise, it's None.
+    data: dict[str, list]
+    # Maps x and y pixel positions to a row index in the data.
+    x_to_y_to_index: dict[int, dict[int, int]]
 
     def __init__(self, region: str, priorities: list[str], geo: GEOSGeometry):
         raster_geo = get_raster_geo(geo)
 
         conditions = get_conditions(region, priorities)
-
-        self.conditions_to_raster_values, self.topleft_coords = \
+        self.conditions_to_raster_values = \
             self._fetch_conditions_to_raster_values(
                 conditions, raster_geo)
 
+        self.topleft_coords = self._get_topleft_coords(
+            self.conditions_to_raster_values)
+        self.data, self.x_to_y_to_index = self._reformat_to_dataframe(
+            self.conditions_to_raster_values, priorities)
+
+    # Fetches condition raster values for a given GEOSGeometry and emits it in
+    # a {condition name: ConditionPixelValues} dictionary.
     def _fetch_conditions_to_raster_values(
-            self, conditions: list[str],
-            geo: GEOSGeometry):
+            self, conditions: list[Condition],
+            geo: GEOSGeometry) -> dict[str, ConditionPixelValues]:
         conditions_to_raster_values = {}
-        topleft_coords = None
         for c in conditions:
             name = c.condition_dataset.condition_name
             values = get_condition_values_from_raster(geo, c.raster_name)
@@ -51,38 +73,93 @@ class RasterConditionFetcher:
                     "plan has no intersection with condition raster, %s" %
                     name)
             conditions_to_raster_values[name] = values
-            topleft_coords = self._get_updated_topleft_coords(
-                values, topleft_coords)
-        return conditions_to_raster_values, topleft_coords
+        return conditions_to_raster_values
 
+    # Identifies the topleft (aka origin) coordinates across all
+    # ConditionPixelValues instances in a {condition name:
+    # ConditionPixelValues} dictionary.
+    def _get_topleft_coords(
+            self,
+            conditions_to_raster_values:
+            dict[str, ConditionPixelValues]) -> tuple[float, float]:
+        topleft_coords = None
+        for c in conditions_to_raster_values.keys():
+            topleft_coords = self._get_updated_topleft_coords(
+                conditions_to_raster_values[c], topleft_coords)
+        return topleft_coords
+
+    # Given a ConditionPixelValues instance and coordinates represeting the
+    # top-left origin, updates the coordinates if the ConditionPixelValues are
+    # further up/further left according to the scale in settings.CRS_9822_SCALE.
     def _get_updated_topleft_coords(
             self, condition_pixel_values: ConditionPixelValues,
             topleft_coords: tuple[float, float] | None) -> tuple[float, float]:
-        # TODO: these shouldn't be local constants.
-        UPPER_LEFT_COORD_X_KEY = "upper_left_coord_x"
-        UPPER_LEFT_COORD_Y_KEY = "upper_left_coord_y"
-
-        if condition_pixel_values[UPPER_LEFT_COORD_X_KEY] is None:
+        if condition_pixel_values["upper_left_coord_x"] is None:
             raise Exception(
                 "fetched poorly-formatted raster pixel data" +
-                " - missing " + UPPER_LEFT_COORD_X_KEY)
-        if condition_pixel_values[UPPER_LEFT_COORD_Y_KEY] is None:
+                " - missing upper_left_coord_x")
+        if condition_pixel_values["upper_left_coord_y"] is None:
             raise Exception(
                 "fetched poorly-formatted raster pixel data" +
-                " - missing " + UPPER_LEFT_COORD_Y_KEY)
+                " - missing upper_left_coord_x")
         if topleft_coords is None:
-            return (condition_pixel_values[UPPER_LEFT_COORD_X_KEY],
-                    condition_pixel_values[UPPER_LEFT_COORD_Y_KEY])
+            return (condition_pixel_values["upper_left_coord_x"],
+                    condition_pixel_values["upper_left_coord_y"])
         return (
-            self._select_topleft_coord(topleft_coords[0],
-                                       condition_pixel_values[UPPER_LEFT_COORD_X_KEY],
-                                       settings.CRS_9822_SCALE[0]),
-            self._select_topleft_coord(topleft_coords[1],
-                                       condition_pixel_values[UPPER_LEFT_COORD_Y_KEY],
-                                       settings.CRS_9822_SCALE[1]))
+            self._select_topleft_coord(
+                topleft_coords[0],
+                condition_pixel_values["upper_left_coord_x"],
+                settings.CRS_9822_SCALE[0]),
+            self._select_topleft_coord(
+                topleft_coords[1],
+                condition_pixel_values["upper_left_coord_y"],
+                settings.CRS_9822_SCALE[1]))
 
     # Given two coordinates, selects the one that represents a lower pixel
     # distance index according to the scale.
     def _select_topleft_coord(
             self, coord1: float, coord2: float, scale: float) -> float:
         return min(coord1, coord2) if scale > 0 else max(coord1, coord2)
+
+    # Reformats the input {condition name, ConditionPixelValues} dictionary
+    # into a dataframe where columns represent x pixel position, y pixel
+    # position, and priority conditions, and rows represent individual pixels
+    # and their condition values.
+    def _reformat_to_dataframe(
+        self,
+        conditions_to_raster_values: dict[str, ConditionPixelValues],
+        priorities: list[str]) -> tuple[dict[str, list],
+                                        dict[int, dict[int, int]]]:
+        data = {'x': [], 'y': []}
+        for p in priorities:
+            data[p] = []
+        x_to_y_to_index = {}
+
+        for c in conditions_to_raster_values.keys():
+            raster_values = conditions_to_raster_values[c]
+            for i in range(len(raster_values["pixel_dist_x"])):
+                x = raster_values["pixel_dist_x"][i]
+                y = raster_values["pixel_dist_y"][i]
+                value = raster_values["values"][i]
+
+                if x not in x_to_y_to_index.keys():
+                    x_to_y_to_index[x] = {}
+
+                if y in x_to_y_to_index[x].keys():
+                    index = x_to_y_to_index[x][y]
+                    data[c][index] = value
+                else:
+                    x_to_y_to_index[x][y] = len(data['x'])
+                    data['x'].append(x)
+                    data['y'].append(y)
+                    for p in priorities:
+                        if p == c:
+                            data[p].append(value)
+                        else:
+                            data[p].append(np.nan)
+        return data, x_to_y_to_index
+
+    # Gets the difference, in pixels, between a given coordinate and its origin.
+    def _get_pixel_dist_diff(
+            self, coord: float, origin_coord: float, scale: float) -> int:
+        return int((coord - origin_coord) / scale)

--- a/src/planscape/forsys/raster_condition_fetcher_test.py
+++ b/src/planscape/forsys/raster_condition_fetcher_test.py
@@ -1,0 +1,113 @@
+import numpy as np
+
+from django.test import TestCase
+from conditions.raster_condition_retrieval_testcase import \
+    RasterConditionRetrievalTestCase
+from conditions.models import BaseCondition, Condition
+from base.condition_types import ConditionLevel
+from forsys.raster_condition_fetcher import (
+    get_conditions, RasterConditionFetcher)
+from forsys.assert_dict_almost_equal import assert_dict_almost_equal
+
+
+class GetConditionsTest(TestCase):
+    def setUp(self):
+        foo_base_condition = BaseCondition.objects.create(
+            condition_name="foo", region_name="my_region",
+            condition_level=ConditionLevel.METRIC)
+        Condition.objects.create(
+            raster_name="foo_raster",
+            condition_dataset=foo_base_condition, is_raw=False)
+
+        bar_base_condition = BaseCondition.objects.create(
+            condition_name="bar", region_name="my_region",
+            condition_level=ConditionLevel.METRIC)
+        Condition.objects.create(
+            raster_name="bar_raster",
+            condition_dataset=bar_base_condition, is_raw=False)
+
+    def test_retrieves_conditions(self):
+        conditions = get_conditions("my_region", ["foo", "bar"])
+        self.assertEqual(len(conditions), 2)
+        self.assertEqual(conditions[0].condition_dataset.condition_name, "foo")
+        self.assertEqual(conditions[0].raster_name, "foo_raster")
+        self.assertEqual(conditions[1].condition_dataset.condition_name, "bar")
+        self.assertEqual(conditions[1].raster_name, "bar_raster")
+
+    def test_fails_for_missing_conditions(self):
+        with self.assertRaises(Exception) as context:
+            get_conditions("my_region", ["foo", "bar", "baz"])
+        self.assertEqual(
+            str(context.exception),
+            "of 3 priorities, only 2 had conditions")
+
+    def test_fails_for_wrong_region(self):
+        with self.assertRaises(Exception) as context:
+            get_conditions("wrong_region", ["foo", "bar"])
+        self.assertEqual(
+            str(context.exception),
+            "of 2 priorities, only 0 had conditions")
+
+
+class RasterConditionFetcherTest(RasterConditionRetrievalTestCase):
+    def setUp(self) -> None:
+        RasterConditionRetrievalTestCase.setUp(self)
+
+        foo_raster = RasterConditionRetrievalTestCase._create_raster(
+            self, 4, 4, (.01, .02, .03, .04,
+                         .05, .06, .07, .08,
+                         .09, .10, .11, .12,
+                         .13, .14, .15, .16))
+        RasterConditionRetrievalTestCase._save_condition_to_db(
+            self, "foo", "foo_normalized", foo_raster)
+        bar_raster = RasterConditionRetrievalTestCase._create_raster(
+            self, 4, 4, (np.nan, np.nan, np.nan, np.nan,
+                         .2, .2, .2, .2,
+                         .3, .3, .3, .3,
+                         .4, .4, .4, .4))
+        RasterConditionRetrievalTestCase._save_condition_to_db(
+            self, "bar", "bar_normalized", bar_raster)
+
+    def test_fetches_raster_conditions(self):
+        condition_fetcher = RasterConditionFetcher(
+            self.region, ["foo", "bar"],
+            RasterConditionRetrievalTestCase._create_geo(self, 0, 3, 0, 1))
+
+        assert_dict_almost_equal(
+            self, condition_fetcher.conditions_to_raster_values["foo"],
+            {'upper_left_coord_x': -2116971.0,
+             'upper_left_coord_y': 2100954.0,
+             'pixel_dist_x': [0, 1, 2, 3,
+                              0, 1, 2, 3],
+             'pixel_dist_y': [0, 0, 0, 0,
+                              1, 1, 1, 1],
+             'values': [0.01, 0.02, 0.03, 0.04,
+                        0.05, 0.06, 0.07, 0.08]})
+        assert_dict_almost_equal(
+            self, condition_fetcher.conditions_to_raster_values["bar"],
+            {'upper_left_coord_x': -2116971.0,
+             'upper_left_coord_y': 2100954.0,
+             'pixel_dist_x': [0, 1, 2, 3],
+             'pixel_dist_y': [1, 1, 1, 1],
+             'values': [0.2, 0.2, 0.2, 0.2]})
+
+        self.assertEqual(condition_fetcher.topleft_coords[0], -2116971.0)
+        self.assertEqual(condition_fetcher.topleft_coords[1], 2100954.0)
+        self.assertEqual(condition_fetcher.width, 4)
+        self.assertEqual(condition_fetcher.height, 2)
+
+        assert_dict_almost_equal(
+            self, condition_fetcher.data,
+            {'x': [0, 1, 2, 3, 0, 1, 2, 3],
+                'y': [0, 0, 0, 0, 1, 1, 1, 1],
+                'foo': [0.01, 0.02, 0.03, 0.04,
+                        0.05, 0.06, 0.07, 0.08],
+                'bar': [np.nan, np.nan, np.nan, np.nan,
+                        0.2, 0.2, 0.2, 0.2]})
+
+        assert_dict_almost_equal(
+            self, condition_fetcher.x_to_y_to_index,
+            {0: {0: 0, 1: 4},
+                1: {0: 1, 1: 5},
+                2: {0: 2, 1: 6},
+                3: {0: 3, 1: 7}})

--- a/src/planscape/forsys/raster_condition_fetcher_test.py
+++ b/src/planscape/forsys/raster_condition_fetcher_test.py
@@ -100,10 +100,10 @@ class RasterConditionFetcherTest(RasterConditionRetrievalTestCase):
             self, condition_fetcher.data,
             {'x': [0, 1, 2, 3, 0, 1, 2, 3],
                 'y': [0, 0, 0, 0, 1, 1, 1, 1],
-                'foo': [0.01, 0.02, 0.03, 0.04,
-                        0.05, 0.06, 0.07, 0.08],
+                'foo': [0.99, 0.98, 0.97, 0.96,
+                        0.95, 0.94, 0.93, 0.92],
                 'bar': [np.nan, np.nan, np.nan, np.nan,
-                        0.2, 0.2, 0.2, 0.2]})
+                        0.8, 0.8, 0.8, 0.8]})
 
         assert_dict_almost_equal(
             self, condition_fetcher.x_to_y_to_index,

--- a/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
+++ b/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
@@ -1,0 +1,149 @@
+from conditions.raster_utils import ConditionPixelValues
+from django.contrib.gis.geos import GEOSGeometry, Point
+from planscape import settings
+
+
+class RasterConditionTreatmentEligibilitySelector:
+    width: int
+    height: int
+
+    x_to_y_to_condition_to_values: dict[int, dict[int, dict[str, float]]]
+    pixels_to_treat: dict[int, set[int]]
+    pixels_to_pass_through: dict[int, set[int]]
+
+    def __init__(
+            self, conditions_to_raster_values: dict
+            [str, ConditionPixelValues],
+            topleft_coords: tuple[float, float],
+            conditions: list[str],
+            geo: GEOSGeometry):
+        self.x_to_y_to_condition_to_values, self.width, self.height = \
+            self._merge_condition_raster_values(
+                conditions_to_raster_values, topleft_coords)
+
+        self.pixels_to_treat, self.pixels_to_pass_through = self._get_pixels_to_treat_and_pass_through(
+            self.x_to_y_to_condition_to_values, self.width, self.height, topleft_coords, geo, conditions)
+
+    def get_values_eligible_for_treatment(self) -> \
+            dict[int, dict[int, dict[str, float]]]:
+        eligible_x_to_y_to_condition_to_values = {}
+        for x in self.pixels_to_treat.keys():
+            if x not in eligible_x_to_y_to_condition_to_values.keys():
+                eligible_x_to_y_to_condition_to_values[x] = {}
+            for y in self.pixels_to_treat[x]:
+                if y not in eligible_x_to_y_to_condition_to_values[x].keys():
+                    eligible_x_to_y_to_condition_to_values[x][y] = \
+                        self.x_to_y_to_condition_to_values[x][y]
+        return eligible_x_to_y_to_condition_to_values
+
+    def _merge_condition_raster_values(
+            self,
+            conditions_to_raster_values: dict[str, ConditionPixelValues],
+            topleft_coords: tuple[float, float]
+    ) -> tuple[dict[int, dict[int, dict[str, float]]], int, int]:
+        UPPER_LEFT_COORD_X_KEY = "upper_left_coord_x"
+        UPPER_LEFT_COORD_Y_KEY = "upper_left_coord_y"
+        PIXEL_DIST_X_KEY = "pixel_dist_x"
+        PIXEL_DIST_Y_KEY = "pixel_dist_y"
+        VALUES_KEY = "values"
+
+        pixel_dist_x_to_y_to_condition_to_values = {}
+        max_x = None
+        max_y = None
+
+        for condition_name in conditions_to_raster_values.keys():
+            values = conditions_to_raster_values[condition_name]
+            xdiff = self._get_pixel_dist_diff(
+                values[UPPER_LEFT_COORD_X_KEY],
+                topleft_coords[0],
+                settings.CRS_9822_SCALE[0])
+            ydiff = self._get_pixel_dist_diff(
+                values[UPPER_LEFT_COORD_Y_KEY],
+                topleft_coords[1],
+                settings.CRS_9822_SCALE[1])
+            for i in range(len(values[PIXEL_DIST_X_KEY])):
+                x = values[PIXEL_DIST_X_KEY][i] + xdiff
+                y = values[PIXEL_DIST_Y_KEY][i] + ydiff
+                max_x = self._update_dimension(max_x, x)
+                max_y = self._update_dimension(max_y, y)
+                # TODO: adjust the 1 - score logic as we move to AP score.
+                value = 1.0 - values[VALUES_KEY][i]
+                self._insert_value_in_position_and_condition_dict(
+                    x, y, condition_name, value,
+                    pixel_dist_x_to_y_to_condition_to_values)
+        return (pixel_dist_x_to_y_to_condition_to_values, max_x + 1, max_y + 1)
+
+    # Computes the distance, in pixels, between two coordinates.
+    def _get_pixel_dist_diff(
+            self, coord: float, origin_coord: float, scale: float) -> int:
+        return int((coord - origin_coord) / scale)
+
+    def _update_dimension(self, x: int, new_x: int) -> int:
+        if x is None:
+            return new_x
+        return max(x, new_x)
+
+    # Inserts a value into the x-to-y-to-condition-to-value dictionary.
+    def _insert_value_in_position_and_condition_dict(
+            self, x: int, y: int, condition: str, value: float,
+            d: dict[int, dict[int, dict[str, float]]]) -> None:
+        if x not in d.keys():
+            d[x] = {}
+
+        d = d[x]
+        if y not in d.keys():
+            d[y] = {}
+
+        d = d[y]
+        d[condition] = value
+
+    def _get_pixels_to_treat_and_pass_through(
+            self,
+            x_to_y_to_conditions_to_values:
+            dict[int, dict[int, dict[str, float]]],
+            width: int, height: int, topleft_coords: tuple[float, float],
+            geo: GEOSGeometry, conditions: list[str]) -> tuple[
+            dict[int, dict[int, dict[str, float]]],
+            dict[int, dict[int, dict[str, float]]]]:
+        pixels_to_treat = {}
+        pixels_to_pass_through = {}
+        for x in range(width):
+            for y in range(height):
+                p = self._get_pixel_point(
+                    x, y, topleft_coords)
+                if not geo.intersects(self._get_pixel_point(
+                        x, y, topleft_coords)):
+                    continue
+                if self._has_all_condition_values(
+                        x_to_y_to_conditions_to_values, x, y, conditions):
+                    self._insert_value_in_position_dict(x, y, pixels_to_treat)
+                else:
+                    self._insert_value_in_position_dict(
+                        x, y, pixels_to_pass_through)
+        return pixels_to_treat, pixels_to_pass_through
+
+    def _get_pixel_point(self, x, y, topleft_coords):
+        p = Point((topleft_coords[0] + x * settings.CRS_9822_SCALE[0],
+                   topleft_coords[1] + y * settings.CRS_9822_SCALE[1]))
+        p.srid = settings.CRS_FOR_RASTERS
+        return p
+
+    def _has_all_condition_values(
+            self, x_to_y_to_conditions_to_values, x, y, conditions):
+        if x not in x_to_y_to_conditions_to_values.keys():
+            return False
+        y_to_conditions_to_values = x_to_y_to_conditions_to_values[x]
+        if y not in y_to_conditions_to_values.keys():
+            return False
+        conditions_to_values = y_to_conditions_to_values[y]
+        for c in conditions:
+            if c not in conditions_to_values.keys():
+                return False
+        return True
+
+    def _insert_value_in_position_dict(self, x: int, y: int,
+                                       d: dict[int, set[int]]) -> None:
+        if x in d.keys():
+            d[x].add(y)
+        else:
+            d[x] = {y}

--- a/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
+++ b/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
@@ -7,22 +7,21 @@ import numpy as np
 # areas.
 class RasterConditionTreatmentEligibilitySelector:
     # Pixels that are eligible for treatment, keyed by x-pixel, then y-pixel.
-    # The value is the index representing the pixel.
+    # The value is the index representing the pixel in the input dataframe.
     pixels_to_treat: dict[int, dict[int, int]]
-    # Pixels that are ineligible for treatment, but may be included in project
-    # areas, keyed by x-pixel, then y-pixel.
-    # The value is the index representing the pixel.
+    # Pixels that are ineligible for treatment (but may be included in project
+    # areas), keyed by x-pixel, then y-pixel.
+    # The value is the index representing the pixel in the input dataframe.
     pixels_to_pass_through: dict[int, dict[int, int]]
 
     # Input parameter, data, is expected to be one of the outputs of class,
     # RasterConditionFetcher. Each row represents a pixel, and each column
     # represents a specific feature. Column headers include:
-    #   - x: the x pixel (starting from 0)
-    #   - y: the y pixel (starting from 0)
+    #   - x: the x-pixel index
+    #   - y: the y-pixel index
     #   - <priority name>: each priority has its own column. If a priority
     #       value exists for a given pixel, the element corresponding to the
     #       pixel is a float; otherwise, it's np.nan.
-    #       note: the value, for now, is 1.0 - normalized condition value.
     def __init__(
             self, data: dict[str, list],
             priorities: list[str]):
@@ -31,8 +30,8 @@ class RasterConditionTreatmentEligibilitySelector:
         self.pixels_to_treat, self.pixels_to_pass_through = \
             self._get_pixels_to_treat_and_pass_through(data, priorities)
 
-    # Double-checks that the values for the priorties listed are available in
-    # the data.
+    # Double-checks that the input data is a valid dataframe and contains all 
+    # the listed priorities. 
     def _validate_data_and_priorities(
             self, data: dict[str, list],
             priorities: list[str]):
@@ -51,7 +50,8 @@ class RasterConditionTreatmentEligibilitySelector:
                     "data column lengths are unequal for keys, x and %s" %
                     (p))
 
-    # Returns two dictionaries mapping each x-pixel to a set of y-pixels.
+    # Returns two dictionaries mapping each x-pixels to y-pixels to input 
+    # dataframe row index.
     # They capture the list of pixels to treat, and the list of pixels to pass
     # through via Patchmax's stand_threshold parameter.
     def _get_pixels_to_treat_and_pass_through(
@@ -82,7 +82,7 @@ class RasterConditionTreatmentEligibilitySelector:
         return True
 
     # Inserts an (x-pixel, y-pixel) pair into a dictionary mapping x-pixel to
-    # y-pixel to data index.
+    # y-pixel to input dataframe index.
     def _insert_value_in_position_dict(self, x: int, y: int, i: int,
                                        d: dict[int, set[int]]) -> None:
         if x not in d.keys():

--- a/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
+++ b/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
@@ -6,7 +6,7 @@ import numpy as np
 # 2) pixels that are ineligible for treatment but may be included in project
 # areas.
 class RasterConditionTreatmentEligibilitySelector:
-    # Pixels that are eligible for treatment, keyed by x-pixel, then y-pixel. 
+    # Pixels that are eligible for treatment, keyed by x-pixel, then y-pixel.
     # The value is the index representing the pixel.
     pixels_to_treat: dict[int, dict[int, int]]
     # Pixels that are ineligible for treatment, but may be included in project
@@ -14,6 +14,15 @@ class RasterConditionTreatmentEligibilitySelector:
     # The value is the index representing the pixel.
     pixels_to_pass_through: dict[int, dict[int, int]]
 
+    # Input parameter, data, is expected to be one of the outputs of class,
+    # RasterConditionFetcher. Each row represents a pixel, and each column
+    # represents a specific feature. Column headers include:
+    #   - x: the x pixel (starting from 0)
+    #   - y: the y pixel (starting from 0)
+    #   - <priority name>: each priority has its own column. If a priority
+    #       value exists for a given pixel, the element corresponding to the
+    #       pixel is a float; otherwise, it's np.nan.
+    #       note: the value, for now, is 1.0 - normalized condition value.
     def __init__(
             self, data: dict[str, list],
             priorities: list[str]):
@@ -22,14 +31,25 @@ class RasterConditionTreatmentEligibilitySelector:
         self.pixels_to_treat, self.pixels_to_pass_through = \
             self._get_pixels_to_treat_and_pass_through(data, priorities)
 
-    # Double-checks that the values for the priorties listed are available in 
+    # Double-checks that the values for the priorties listed are available in
     # the data.
     def _validate_data_and_priorities(
             self, data: dict[str, list],
             priorities: list[str]):
+        if "x" not in data.keys():
+            raise Exception("data missing key, x")
+        if "y" not in data.keys():
+            raise Exception("data missing key, y")
+        if len(data["x"]) != len(data["y"]):
+            raise Exception(
+                "data column lengths are unequal for keys, x and y")
         for p in priorities:
             if p not in data.keys():
                 raise Exception("data missing input priority, %s" % (p))
+            if len(data[p]) != len(data["x"]):
+                raise Exception(
+                    "data column lengths are unequal for keys, x and %s" %
+                    (p))
 
     # Returns two dictionaries mapping each x-pixel to a set of y-pixels.
     # They capture the list of pixels to treat, and the list of pixels to pass
@@ -51,7 +71,7 @@ class RasterConditionTreatmentEligibilitySelector:
                     x, y, i, pixels_to_pass_through)
         return pixels_to_treat, pixels_to_pass_through
 
-    # Returns true if all condition impact scores are present in the condition 
+    # Returns true if all condition impact scores are present in the condition
     # impact score data frame (i.e. none of them are NaN).
     def _all_condition_scores_are_present(
         self, data: dict[str, list],
@@ -61,7 +81,7 @@ class RasterConditionTreatmentEligibilitySelector:
                 return False
         return True
 
-    # Inserts an (x-pixel, y-pixel) pair into a dictionary mapping x-pixel to 
+    # Inserts an (x-pixel, y-pixel) pair into a dictionary mapping x-pixel to
     # y-pixel to data index.
     def _insert_value_in_position_dict(self, x: int, y: int, i: int,
                                        d: dict[int, set[int]]) -> None:

--- a/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
+++ b/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
@@ -1,61 +1,58 @@
 import numpy as np
 
+
 # Identifies ...
 # 1) pixels that are eligible for treatment and
 # 2) pixels that are ineligible for treatment but may be included in project
 # areas.
-
-
 class RasterConditionTreatmentEligibilitySelector:
-    pixels_to_treat: dict[int, set[int]]
-    pixels_to_pass_through: dict[int, set[int]]
+    # Pixels that are eligible for treatment, keyed by x-pixel, then y-pixel. 
+    # The value is the index representing the pixel.
+    pixels_to_treat: dict[int, dict[int, int]]
+    # Pixels that are ineligible for treatment, but may be included in project
+    # areas, keyed by x-pixel, then y-pixel.
+    # The value is the index representing the pixel.
+    pixels_to_pass_through: dict[int, dict[int, int]]
 
     def __init__(
             self, data: dict[str, list],
             priorities: list[str]):
+        self._validate_data_and_priorities(data, priorities)
+
         self.pixels_to_treat, self.pixels_to_pass_through = \
             self._get_pixels_to_treat_and_pass_through(data, priorities)
 
-    # A temporary method until ClusteredStands is modified to accept different
-    # input types.
-    def get_values_eligible_for_treatment(
-            self, priorities: list[str],
-            data: dict[str, list],
-            x_to_y_to_index: dict[int, dict[int, int]]):
-        output = {}
-        for x in self.pixels_to_treat.keys():
-            if x not in x_to_y_to_index.keys():
-                continue
-            if x not in output.keys():
-                output[x] = {}
-            for y in self.pixels_to_treat[x]:
-                if y not in x_to_y_to_index[x].keys():
-                    continue
-                i = x_to_y_to_index[x][y]
-                if y not in output[x].keys():
-                    output[x][y] = {}
-                for p in priorities:
-                    output[x][y][p] = data[p][i]
-        return output
+    # Double-checks that the values for the priorties listed are available in 
+    # the data.
+    def _validate_data_and_priorities(
+            self, data: dict[str, list],
+            priorities: list[str]):
+        for p in priorities:
+            if p not in data.keys():
+                raise Exception("data missing input priority, %s" % (p))
 
+    # Returns two dictionaries mapping each x-pixel to a set of y-pixels.
+    # They capture the list of pixels to treat, and the list of pixels to pass
+    # through via Patchmax's stand_threshold parameter.
     def _get_pixels_to_treat_and_pass_through(
             self,
         data: dict[str, list],
-        priorities: list[str]) -> tuple[dict[int, set[int]],
-                                        dict[int, set[int]]]:
-
+        priorities: list[str]) -> tuple[dict[int, dict[int, int]],
+                                        dict[int, dict[int, int]]]:
         pixels_to_treat = {}
         pixels_to_pass_through = {}
         for i in range(len(data['x'])):
             x = data['x'][i]
             y = data['y'][i]
             if self._all_condition_scores_are_present(data, priorities, i):
-                self._insert_value_in_position_dict(x, y, pixels_to_treat)
+                self._insert_value_in_position_dict(x, y, i, pixels_to_treat)
             else:
                 self._insert_value_in_position_dict(
-                    x, y, pixels_to_pass_through)
+                    x, y, i, pixels_to_pass_through)
         return pixels_to_treat, pixels_to_pass_through
 
+    # Returns true if all condition impact scores are present in the condition 
+    # impact score data frame (i.e. none of them are NaN).
     def _all_condition_scores_are_present(
         self, data: dict[str, list],
             priorities: list[str], i: int):
@@ -64,9 +61,10 @@ class RasterConditionTreatmentEligibilitySelector:
                 return False
         return True
 
-    def _insert_value_in_position_dict(self, x: int, y: int,
+    # Inserts an (x-pixel, y-pixel) pair into a dictionary mapping x-pixel to 
+    # y-pixel to data index.
+    def _insert_value_in_position_dict(self, x: int, y: int, i: int,
                                        d: dict[int, set[int]]) -> None:
-        if x in d.keys():
-            d[x].add(y)
-        else:
-            d[x] = {y}
+        if x not in d.keys():
+            d[x] = {}
+        d[x][y] = i

--- a/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
+++ b/src/planscape/forsys/raster_condition_treatment_eligibility_selector.py
@@ -1,143 +1,66 @@
-from conditions.raster_utils import ConditionPixelValues
-from django.contrib.gis.geos import GEOSGeometry, Point
-from planscape import settings
+import numpy as np
+
+# Identifies ...
+# 1) pixels that are eligible for treatment and
+# 2) pixels that are ineligible for treatment but may be included in project
+# areas.
 
 
 class RasterConditionTreatmentEligibilitySelector:
-    width: int
-    height: int
-
-    x_to_y_to_condition_to_values: dict[int, dict[int, dict[str, float]]]
     pixels_to_treat: dict[int, set[int]]
     pixels_to_pass_through: dict[int, set[int]]
 
     def __init__(
-            self, conditions_to_raster_values: dict
-            [str, ConditionPixelValues],
-            topleft_coords: tuple[float, float],
-            conditions: list[str],
-            geo: GEOSGeometry):
-        self.x_to_y_to_condition_to_values, self.width, self.height = \
-            self._merge_condition_raster_values(
-                conditions_to_raster_values, topleft_coords)
+            self, data: dict[str, list],
+            priorities: list[str]):
+        self.pixels_to_treat, self.pixels_to_pass_through = \
+            self._get_pixels_to_treat_and_pass_through(data, priorities)
 
-        self.pixels_to_treat, self.pixels_to_pass_through = self._get_pixels_to_treat_and_pass_through(
-            self.x_to_y_to_condition_to_values, self.width, self.height, topleft_coords, geo, conditions)
-
-    def get_values_eligible_for_treatment(self) -> \
-            dict[int, dict[int, dict[str, float]]]:
-        eligible_x_to_y_to_condition_to_values = {}
+    # A temporary method until ClusteredStands is modified to accept different
+    # input types.
+    def get_values_eligible_for_treatment(
+            self, priorities: list[str],
+            data: dict[str, list],
+            x_to_y_to_index: dict[int, dict[int, int]]):
+        output = {}
         for x in self.pixels_to_treat.keys():
-            if x not in eligible_x_to_y_to_condition_to_values.keys():
-                eligible_x_to_y_to_condition_to_values[x] = {}
+            if x not in x_to_y_to_index.keys():
+                continue
+            if x not in output.keys():
+                output[x] = {}
             for y in self.pixels_to_treat[x]:
-                if y not in eligible_x_to_y_to_condition_to_values[x].keys():
-                    eligible_x_to_y_to_condition_to_values[x][y] = \
-                        self.x_to_y_to_condition_to_values[x][y]
-        return eligible_x_to_y_to_condition_to_values
-
-    def _merge_condition_raster_values(
-            self,
-            conditions_to_raster_values: dict[str, ConditionPixelValues],
-            topleft_coords: tuple[float, float]
-    ) -> tuple[dict[int, dict[int, dict[str, float]]], int, int]:
-        UPPER_LEFT_COORD_X_KEY = "upper_left_coord_x"
-        UPPER_LEFT_COORD_Y_KEY = "upper_left_coord_y"
-        PIXEL_DIST_X_KEY = "pixel_dist_x"
-        PIXEL_DIST_Y_KEY = "pixel_dist_y"
-        VALUES_KEY = "values"
-
-        pixel_dist_x_to_y_to_condition_to_values = {}
-        max_x = None
-        max_y = None
-
-        for condition_name in conditions_to_raster_values.keys():
-            values = conditions_to_raster_values[condition_name]
-            xdiff = self._get_pixel_dist_diff(
-                values[UPPER_LEFT_COORD_X_KEY],
-                topleft_coords[0],
-                settings.CRS_9822_SCALE[0])
-            ydiff = self._get_pixel_dist_diff(
-                values[UPPER_LEFT_COORD_Y_KEY],
-                topleft_coords[1],
-                settings.CRS_9822_SCALE[1])
-            for i in range(len(values[PIXEL_DIST_X_KEY])):
-                x = values[PIXEL_DIST_X_KEY][i] + xdiff
-                y = values[PIXEL_DIST_Y_KEY][i] + ydiff
-                max_x = self._update_dimension(max_x, x)
-                max_y = self._update_dimension(max_y, y)
-                # TODO: adjust the 1 - score logic as we move to AP score.
-                value = 1.0 - values[VALUES_KEY][i]
-                self._insert_value_in_position_and_condition_dict(
-                    x, y, condition_name, value,
-                    pixel_dist_x_to_y_to_condition_to_values)
-        return (pixel_dist_x_to_y_to_condition_to_values, max_x + 1, max_y + 1)
-
-    # Computes the distance, in pixels, between two coordinates.
-    def _get_pixel_dist_diff(
-            self, coord: float, origin_coord: float, scale: float) -> int:
-        return int((coord - origin_coord) / scale)
-
-    def _update_dimension(self, x: int, new_x: int) -> int:
-        if x is None:
-            return new_x
-        return max(x, new_x)
-
-    # Inserts a value into the x-to-y-to-condition-to-value dictionary.
-    def _insert_value_in_position_and_condition_dict(
-            self, x: int, y: int, condition: str, value: float,
-            d: dict[int, dict[int, dict[str, float]]]) -> None:
-        if x not in d.keys():
-            d[x] = {}
-
-        d = d[x]
-        if y not in d.keys():
-            d[y] = {}
-
-        d = d[y]
-        d[condition] = value
+                if y not in x_to_y_to_index[x].keys():
+                    continue
+                i = x_to_y_to_index[x][y]
+                if y not in output[x].keys():
+                    output[x][y] = {}
+                for p in priorities:
+                    output[x][y][p] = data[p][i]
+        return output
 
     def _get_pixels_to_treat_and_pass_through(
             self,
-            x_to_y_to_conditions_to_values:
-            dict[int, dict[int, dict[str, float]]],
-            width: int, height: int, topleft_coords: tuple[float, float],
-            geo: GEOSGeometry, conditions: list[str]) -> tuple[
-            dict[int, dict[int, dict[str, float]]],
-            dict[int, dict[int, dict[str, float]]]]:
+        data: dict[str, list],
+        priorities: list[str]) -> tuple[dict[int, set[int]],
+                                        dict[int, set[int]]]:
+
         pixels_to_treat = {}
         pixels_to_pass_through = {}
-        for x in range(width):
-            for y in range(height):
-                p = self._get_pixel_point(
-                    x, y, topleft_coords)
-                if not geo.intersects(self._get_pixel_point(
-                        x, y, topleft_coords)):
-                    continue
-                if self._has_all_condition_values(
-                        x_to_y_to_conditions_to_values, x, y, conditions):
-                    self._insert_value_in_position_dict(x, y, pixels_to_treat)
-                else:
-                    self._insert_value_in_position_dict(
-                        x, y, pixels_to_pass_through)
+        for i in range(len(data['x'])):
+            x = data['x'][i]
+            y = data['y'][i]
+            if self._all_condition_scores_are_present(data, priorities, i):
+                self._insert_value_in_position_dict(x, y, pixels_to_treat)
+            else:
+                self._insert_value_in_position_dict(
+                    x, y, pixels_to_pass_through)
         return pixels_to_treat, pixels_to_pass_through
 
-    def _get_pixel_point(self, x, y, topleft_coords):
-        p = Point((topleft_coords[0] + x * settings.CRS_9822_SCALE[0],
-                   topleft_coords[1] + y * settings.CRS_9822_SCALE[1]))
-        p.srid = settings.CRS_FOR_RASTERS
-        return p
-
-    def _has_all_condition_values(
-            self, x_to_y_to_conditions_to_values, x, y, conditions):
-        if x not in x_to_y_to_conditions_to_values.keys():
-            return False
-        y_to_conditions_to_values = x_to_y_to_conditions_to_values[x]
-        if y not in y_to_conditions_to_values.keys():
-            return False
-        conditions_to_values = y_to_conditions_to_values[y]
-        for c in conditions:
-            if c not in conditions_to_values.keys():
+    def _all_condition_scores_are_present(
+        self, data: dict[str, list],
+            priorities: list[str], i: int):
+        for p in priorities:
+            if np.isnan(data[p][i]):
                 return False
         return True
 

--- a/src/planscape/forsys/raster_condition_treatment_eligibility_selector_test.py
+++ b/src/planscape/forsys/raster_condition_treatment_eligibility_selector_test.py
@@ -19,10 +19,55 @@ class RasterConditionTreatmentEligibilitySelectorTest(TestCase):
         self.assertEqual(selector.pixels_to_pass_through,
                          {0: {1: 2}, 1: {1: 3}})
 
-    def test_fails_for_extraneous_priorities(self):
+    def test_fails_for_missing_priorities(self):
         with self.assertRaises(Exception) as context:
             RasterConditionTreatmentEligibilitySelector(
                 self.data,  ['foo', 'bar', 'baz'])
         self.assertEqual(
             str(context.exception),
             "data missing input priority, baz")
+
+    def test_fails_for_missing_x(self):
+        data = self.data
+        data.pop('x')
+        with self.assertRaises(Exception) as context:
+            RasterConditionTreatmentEligibilitySelector(
+                self.data,  ['foo', 'bar'])
+        self.assertEqual(
+            str(context.exception),
+            "data missing key, x")
+        
+    def test_fails_for_missing_y(self):
+        data = self.data
+        data.pop('y')
+        with self.assertRaises(Exception) as context:
+            RasterConditionTreatmentEligibilitySelector(
+                self.data,  ['foo', 'bar'])
+        self.assertEqual(
+            str(context.exception),
+            "data missing key, y")
+        
+    def test_fails_for_different_x_and_y_column_lengths(self):
+        data = self.data
+        data['x'].append(10)
+        with self.assertRaises(Exception) as context:
+            RasterConditionTreatmentEligibilitySelector(
+                self.data,  ['foo', 'bar'])
+        self.assertEqual(
+            str(context.exception),
+            "data column lengths are unequal for keys, x and y")
+        
+    def test_fails_for_different_x_and_priority_column_lengths(self):
+        data = self.data
+        data['x'].append(0)
+        data['x'].append(1)
+        data['y'].append(2)
+        data['y'].append(2)
+        data['bar'].append(0.1)
+        data['bar'].append(0.1)
+        with self.assertRaises(Exception) as context:
+            RasterConditionTreatmentEligibilitySelector(
+                self.data,  ['foo', 'bar'])
+        self.assertEqual(
+            str(context.exception),
+            "data column lengths are unequal for keys, x and foo")

--- a/src/planscape/forsys/raster_condition_treatment_eligibility_selector_test.py
+++ b/src/planscape/forsys/raster_condition_treatment_eligibility_selector_test.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from django.test import TestCase
+from forsys.raster_condition_treatment_eligibility_selector import RasterConditionTreatmentEligibilitySelector
+
+
+class RasterConditionTreatmentEligibilitySelectorTest(TestCase):
+    def setUp(self):
+        self.data = {'x': [0, 1, 0, 1],
+                     'y': [0, 0, 1, 1],
+                     'foo': [0.1, 0.2, 0.5, np.nan],
+                     'bar': [0.5, 0.1, np.nan, 0.2]
+                     }
+
+    def test_selects_pixels(self):
+        selector = RasterConditionTreatmentEligibilitySelector(
+            self.data,  ['foo', 'bar'])
+        self.assertEqual(selector.pixels_to_treat, {0: {0: 0}, 1: {0: 1}})
+        self.assertEqual(selector.pixels_to_pass_through,
+                         {0: {1: 2}, 1: {1: 3}})
+
+    def test_fails_for_extraneous_priorities(self):
+        with self.assertRaises(Exception) as context:
+            RasterConditionTreatmentEligibilitySelector(
+                self.data,  ['foo', 'bar', 'baz'])
+        self.assertEqual(
+            str(context.exception),
+            "data missing input priority, baz")


### PR DESCRIPTION
Patchmax has two thresholding parameters:
1) stand_threshold identifies stands that are ineligible for treatment, but can be included in project areas (with an edge distance penalty controlled by EPW, and a max untreatable project area percent controlled by max_exclusion_limit)
2) global_threshold identifies stands that are ineligible for treatment, and shouldn't be included in project areas

Prior to this PR, Planscape has been sending only stands eligible for treatment to Patchmax so stand_threshold and global_threshold were irrelevant.
This PR enables Planscape to send stands to Patchmax that may either pass or fail the stand_threshold check, and adds a new column to the Forsys input dataframe headed, 'eligible', to be considered by stand_threshold.

For now, the only pixels that are ineligible for treatment but could be included in project areas are pixels that have between 1 and len(priorities) - 1 condition scores, which doesn't change behavior much (so this PR just looks like a big refactor); however, this paves the way for the inclusion of distance-from-road data.

At a lower level, this PR splits get_forsys_inputs.py into two additional files:
1) raster_condition_fetcher: fetches condition rasters for multiple priorities and merges them into a single dataframe
2) raster_condition_treatment_eligibility_selector: decides whether a dataframe entry is eligible for treatment