### PR TITLE
Revamp registration page

### DIFF
--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -1,64 +1,140 @@
-<mat-card>
-  <mat-card-title>Register</mat-card-title>
+<div class="signup-root">
 
-  <form (ngSubmit)="onSubmit()">
-    <mat-card-content>
-      <div>
-        <mat-form-field>
-          <input
-            type="text" id="username"
-            required
-            placeholder="Username"
-            [(ngModel)]="model.username" name="username"
-            #name="ngModel"
-            matInput>
-        </mat-form-field>
-      </div>
+  <div class="info-card-container">
+    <div class="info-card">
+      <h3><b>With a Planscape account, you can:</b></h3>
 
-      <div>
-        <mat-form-field>
-          <input
-            type="text" id="email"
-            required
-            placeholder="Email address"
-            [(ngModel)]="model.email" name="email"
-            #name="ngModel"
-            matInput>
-        </mat-form-field>
-      </div>
+      <ul>
+        <li><h3>
+          Save planning areas
+        </h3></li>
+        <li><h3>
+          Create plans, configurations, and scenarios
+        </h3></li>
+        <li><h3>
+          Download shapefiles & metadata
+        </h3></li>
+        <li><h3>
+          Share work with collaborators
+        </h3></li>
+      </ul>
 
-      <div>
-        <mat-form-field>
-          <input
-            type="password" id="password1"
-            required
-            placeholder="Password"
-            [(ngModel)]="model.password1" name="password1"
-            #password="ngModel"
-            matInput>
-        </mat-form-field>
-      </div>
+      <h3><b>As a guest user, you can:</b></h3>
 
-      <div>
-        <mat-form-field>
-          <input
-            type="password" id="password2"
-            required
-            placeholder="Repeat password"
-            [(ngModel)]="model.password2" name="password2"
-            #password="ngModel"
-            matInput>
-        </mat-form-field>
-      </div>
+      <ul>
+        <li><h3>
+          Explore regional data on the map
+        </h3></li>
+        <li><h3>
+          View plans and/or scenarios that are publicly visible*
+        </h3></li>
+      </ul>
 
-    </mat-card-content>
+      <p><i>
+        *Accessible only via direct links
+      </i></p>
+    </div>
+  </div>
 
-    <mat-card-actions align="end">
-      <button mat-raised-button (click)="login()" type="button">Login</button>
-      <button mat-raised-button color="primary" type="submit">Register</button>
-    </mat-card-actions>
-  </form>
-</mat-card>
+  <div class="signup-form-container">
+    <div class="signup-form">
+      <h1 class="signup-title">Create your account</h1>
 
-<p>{{ error?.message }}</p>
-<p *ngIf="error">{{ error?.error | json }}</p>
+      <form [formGroup]="form" (ngSubmit)="step === 0 ? step = 1 : signup()">
+        <ng-container *ngIf="step === 0; else finalStep">
+
+          <mat-form-field appearance="fill">
+            <mat-label>First name</mat-label>
+            <input
+              type="text"
+              required
+              formControlName="firstName"
+              matInput>
+          </mat-form-field>
+
+          <mat-form-field appearance="fill">
+            <mat-label>Last name</mat-label>
+            <input
+              type="text"
+              required
+              formControlName="lastName"
+              matInput>
+          </mat-form-field>
+
+          <mat-form-field appearance="fill">
+            <mat-label>Who are you representing? (e.g. department, agency)</mat-label>
+            <input
+              type="text"
+              formControlName="department"
+              matInput>
+          </mat-form-field>
+
+          <button mat-flat-button
+            type="submit"
+            color="primary"
+            (click)="step = 1"
+            [disabled]="!enableContinue()">
+            Continue
+          </button>
+
+          <button mat-button color="primary" type="button" (click)="login()">Log in</button>
+        </ng-container>
+
+        <ng-template #finalStep>
+
+          <mat-form-field appearance="fill">
+            <mat-label>Email</mat-label>
+            <input
+              type="text"
+              required
+              formControlName="email"
+              matInput>
+          </mat-form-field>
+
+          <mat-form-field appearance="fill">
+            <mat-label>Create password</mat-label>
+            <input
+              type="password"
+              required
+              formControlName="password1"
+              matInput>
+              <mat-error *ngIf="form.get('password1')?.hasError('minlength')">
+                Password must contain at least 6 characters.
+              </mat-error>
+          </mat-form-field>
+
+          <mat-form-field appearance="fill">
+            <mat-label>Confirm password</mat-label>
+            <input
+              type="password"
+              required
+              formControlName="password2"
+              matInput>
+              <mat-error *ngIf="form.hasError('passwordsNotEqual')">
+                Passwords must match.
+              </mat-error>
+          </mat-form-field>
+
+          <p>{{ error?.message }}</p>
+          <p *ngIf="error">{{ error?.error | json }}</p>
+
+          <button mat-flat-button
+            type="submit"
+            color="primary"
+            (click)="signup()"
+            [disabled]="!form.valid">
+            Create account
+          </button>
+
+          <button mat-button color="primary" type="button" (click)="step = 0">Back</button>
+        </ng-template>
+      </form>
+    </div>
+
+    <div class="section-dots">
+      <div class="section-dot" [class.selected]="step === 0"></div>
+      <div class="section-dot" [class.selected]="step === 1"></div>
+    </div>
+  </div>
+
+</div>

--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -83,6 +83,15 @@
         <ng-template #finalStep>
 
           <mat-form-field appearance="fill">
+            <mat-label>Username</mat-label>
+            <input
+              type="text"
+              required
+              formControlName="username"
+              matInput>
+          </mat-form-field>
+
+          <mat-form-field appearance="fill">
             <mat-label>Email</mat-label>
             <input
               type="text"
@@ -122,8 +131,8 @@
             type="submit"
             color="primary"
             (click)="signup()"
-            [disabled]="!form.valid">
-            Create account
+            [disabled]="!form.valid || submitted">
+            {{submitted ? 'Please wait...' : 'Create account'}}
           </button>
 
           <button mat-button color="primary" type="button" (click)="step = 0">Back</button>

--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -99,7 +99,7 @@
               formControlName="password1"
               matInput>
               <mat-error *ngIf="form.get('password1')?.hasError('minlength')">
-                Password must contain at least 6 characters.
+                Password must contain at least 8 characters.
               </mat-error>
           </mat-form-field>
 

--- a/src/interface/src/app/signup/signup.component.scss
+++ b/src/interface/src/app/signup/signup.component.scss
@@ -1,0 +1,91 @@
+.signup-root {
+  display: flex;
+  height: 100%;
+}
+
+.info-card-container {
+  background-image: url('/assets/png/planscape_signin_bg.png');
+  background-repeat: no-repeat;
+  background-size: cover;
+  display: flex;
+  width: 50%;
+}
+
+.info-card {
+  align-items: stretch;
+  background-color: white;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  margin: auto 100px;
+  padding: 50px;
+}
+
+h3 {
+  font-family: 'Public Sans', 'Roboto';
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 24px;
+}
+
+.signup-form-container {
+  align-items: center;
+  background-color: white;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding: 145px 120px 120px 82px;
+  width: 50%;
+}
+
+.signup-form {
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: auto;
+  width: 300px;
+}
+
+h1 {
+  font-family: 'Roboto';
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 32px;
+
+  &.signup-title {
+    margin-bottom: 48px;
+    text-align: center;
+  }
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+button {
+  margin-bottom: 5px;
+  width: 100%;
+}
+
+.section-dots {
+  bottom: 40px;
+  box-sizing: border-box;
+  display: flex;
+  gap: 12px;
+  margin: 0px auto;
+  position: absolute;
+}
+
+.section-dot {
+  background-color: #C4C7C5;
+  border-radius: 5px;
+  height: 10px;
+  width: 10px;
+
+  &.selected {
+    background-color: #444746;
+  }
+}

--- a/src/interface/src/app/signup/signup.component.spec.ts
+++ b/src/interface/src/app/signup/signup.component.spec.ts
@@ -1,31 +1,31 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
 
+import { MaterialModule } from '../material/material.module';
 import { AuthService } from '../services';
 import { SignupComponent } from './signup.component';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
   let fixture: ComponentFixture<SignupComponent>;
+  let fakeAuthService: AuthService;
 
   beforeEach(() => {
     const routerStub = () => ({ navigate: (array: string[]) => ({}) });
-    const fakeAuthService = jasmine.createSpyObj<AuthService>(
+    fakeAuthService = jasmine.createSpyObj<AuthService>(
       'AuthService',
       { signup: of({}) },
-      {},
+      {}
     );
     TestBed.configureTestingModule({
-      imports: [FormsModule],
-      schemas: [NO_ERRORS_SCHEMA],
+      imports: [FormsModule, MaterialModule, ReactiveFormsModule],
       declarations: [SignupComponent],
       providers: [
         { provide: Router, useFactory: routerStub },
-        { provide: AuthService, useValue: fakeAuthService }
-      ]
+        { provide: AuthService, useValue: fakeAuthService },
+      ],
     });
     fixture = TestBed.createComponent(SignupComponent);
     component = fixture.componentInstance;
@@ -35,13 +35,50 @@ describe('SignupComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('onSubmit', () => {
-    it('calls signup()', () => {
-      spyOn(component, 'signup').and.callThrough();
+  describe('signup form', () => {
+    it('disables continue button when first half of form is incomplete', () => {
+      expect(component.enableContinue()).toBeFalse();
+    });
 
-      component.onSubmit();
+    it('enables continue button when first half of form is complete', () => {
+      component.form.get('firstName')?.setValue('Foo');
+      component.form.get('lastName')?.setValue('Bar');
 
-      expect(component.signup).toHaveBeenCalled();
+      expect(component.enableContinue()).toBeTrue();
+    });
+
+    it('disables submit when password fields are not equal', () => {
+      component.form.get('password1')?.setValue('foo');
+      component.form.get('password2')?.setValue('bar');
+
+      expect(component.form.valid).toBeFalse();
+    });
+
+    it('enables submit when all fields are valid', () => {
+      component.form.get('firstName')?.setValue('Foo');
+      component.form.get('lastName')?.setValue('Bar');
+      component.form.get('email')?.setValue('test@test.com');
+      component.form.get('password1')?.setValue('password');
+      component.form.get('password2')?.setValue('password');
+
+      expect(component.form.valid).toBeTrue();
+    });
+  });
+
+  describe('signup', () => {
+    it('calls authentication service', () => {
+      component.form.get('email')?.setValue('test@test.com');
+      component.form.get('password1')?.setValue('password');
+      component.form.get('password2')?.setValue('password');
+
+      component.signup();
+
+      expect(fakeAuthService.signup).toHaveBeenCalledOnceWith(
+        'test@test.com',
+        'test@test.com',
+        'password',
+        'password'
+      );
     });
   });
 

--- a/src/interface/src/app/signup/signup.component.spec.ts
+++ b/src/interface/src/app/signup/signup.component.spec.ts
@@ -57,6 +57,7 @@ describe('SignupComponent', () => {
     it('enables submit when all fields are valid', () => {
       component.form.get('firstName')?.setValue('Foo');
       component.form.get('lastName')?.setValue('Bar');
+      component.form.get('username')?.setValue('testuser');
       component.form.get('email')?.setValue('test@test.com');
       component.form.get('password1')?.setValue('password');
       component.form.get('password2')?.setValue('password');
@@ -67,6 +68,7 @@ describe('SignupComponent', () => {
 
   describe('signup', () => {
     it('calls authentication service', () => {
+      component.form.get('username')?.setValue('testuser');
       component.form.get('email')?.setValue('test@test.com');
       component.form.get('password1')?.setValue('password');
       component.form.get('password2')?.setValue('password');
@@ -74,7 +76,7 @@ describe('SignupComponent', () => {
       component.signup();
 
       expect(fakeAuthService.signup).toHaveBeenCalledOnceWith(
-        'test@test.com',
+        'testuser',
         'test@test.com',
         'password',
         'password'

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -58,7 +58,10 @@ export class SignupComponent {
     const password2: string = this.form.get('password2')?.value;
     this.authService.signup(username, email, password1, password2).subscribe(
       (_) => this.router.navigate(['map']),
-      (error) => (this.error = error)
+      (error) => {
+        this.error = error;
+        this.submitted = false;
+      }
     );
   }
 

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -1,4 +1,10 @@
 import { Component } from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { AuthService } from './../services';
@@ -6,27 +12,47 @@ import { AuthService } from './../services';
 @Component({
   selector: 'app-signup',
   templateUrl: './signup.component.html',
-  styleUrls: ['./signup.component.scss']
+  styleUrls: ['./signup.component.scss'],
 })
 export class SignupComponent {
-
   error: any;
 
-  model: any = {};
+  form: FormGroup;
+  step: number = 0;
 
   constructor(
     private authService: AuthService,
-    private router: Router,
-  ) { }
-
-  onSubmit() {
-    this.signup(this.model.username, this.model.email, this.model.password1, this.model.password2);
+    private formBuilder: FormBuilder,
+    private router: Router
+  ) {
+    this.form = this.formBuilder.group(
+      {
+        firstName: this.formBuilder.control('', Validators.required),
+        lastName: this.formBuilder.control('', Validators.required),
+        department: this.formBuilder.control(''),
+        email: this.formBuilder.control('', [
+          Validators.required,
+          Validators.email,
+        ]),
+        password1: this.formBuilder.control('', [
+          Validators.required,
+          Validators.minLength(6),
+        ]),
+        password2: this.formBuilder.control('', Validators.required),
+      },
+      {
+        validator: this.passwordsMatchValidator,
+      }
+    );
   }
 
-  signup(username: string, email: string, password1: string, password2: string) {
-    this.authService.signup(username, email, password1, password2).subscribe(
-      _ => this.router.navigate(['map']),
-      error => this.error = error
+  signup() {
+    const email: string = this.form.get('email')?.value;
+    const password1: string = this.form.get('password1')?.value;
+    const password2: string = this.form.get('password2')?.value;
+    this.authService.signup(email, email, password1, password2).subscribe(
+      (_) => this.router.navigate(['map']),
+      (error) => (this.error = error)
     );
   }
 
@@ -34,4 +60,15 @@ export class SignupComponent {
     this.router.navigate(['login']);
   }
 
+  enableContinue(): boolean {
+    return !!(
+      this.form.get('firstName')?.valid && this.form.get('lastName')?.valid
+    );
+  }
+
+  private passwordsMatchValidator(group: AbstractControl) {
+    const password1 = group.get('password1')?.value;
+    const password2 = group.get('password2')?.value;
+    return password1 === password2 ? null : { passwordsNotEqual: true };
+  }
 }

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -19,6 +19,7 @@ export class SignupComponent {
 
   form: FormGroup;
   step: number = 0;
+  submitted: boolean = false;
 
   constructor(
     private authService: AuthService,
@@ -30,6 +31,7 @@ export class SignupComponent {
         firstName: this.formBuilder.control('', Validators.required),
         lastName: this.formBuilder.control('', Validators.required),
         department: this.formBuilder.control(''),
+        username: this.formBuilder.control('', [Validators.required]),
         email: this.formBuilder.control('', [
           Validators.required,
           Validators.email,
@@ -47,10 +49,14 @@ export class SignupComponent {
   }
 
   signup() {
+    if (this.submitted) return;
+
+    this.submitted = true;
+    const username: string = this.form.get('username')?.value;
     const email: string = this.form.get('email')?.value;
     const password1: string = this.form.get('password1')?.value;
     const password2: string = this.form.get('password2')?.value;
-    this.authService.signup(email, email, password1, password2).subscribe(
+    this.authService.signup(username, email, password1, password2).subscribe(
       (_) => this.router.navigate(['map']),
       (error) => (this.error = error)
     );

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -36,7 +36,7 @@ export class SignupComponent {
         ]),
         password1: this.formBuilder.control('', [
           Validators.required,
-          Validators.minLength(6),
+          Validators.minLength(8),
         ]),
         password2: this.formBuilder.control('', Validators.required),
       },

--- a/src/interface/src/index.html
+++ b/src/interface/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@300;400;500&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body class="mat-typography">


### PR DESCRIPTION
Revamp registration page to match the new UX mocks. These are UI changes only; the user model is unchanged, meaning first name and last name are collected in the form but not passed to the backend. Fixes #629 

Todos:
- Change user model to accept new fields and stop collecting username (#693 )
- Fix signin not triggering login bug (#692 )

![image](https://user-images.githubusercontent.com/10444733/225720314-6a2d2e3d-95cd-47b6-98b7-dc6592faaee6.png)
![image](https://user-images.githubusercontent.com/10444733/225720384-badd54bb-fb1f-4524-8dc6-b6f78a1db44f.png)
