### PR TITLE
User changes

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -1,1 +1,3 @@
-<p>You are logged in as {{ (user$ | async) ? (user$ | async)!.username : 'Guest' }}.</p>
+<p>
+  You are logged in as {{ (user$ | async) ? displayName((user$ | async)!) : 'Guest' }}.
+</p>

--- a/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
 
 import { AuthService } from '../services';
-import { User } from './../services/auth.service';
+import { User } from './../types/user.types';
 import { AccountDialogComponent } from './account-dialog.component';
 
 describe('AccountDialogComponent', () => {

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -17,4 +17,9 @@ export class AccountDialogComponent implements OnInit {
   ngOnInit(): void {
     this.user$ = this.authService.loggedInUser$;
   }
+
+  displayName(user: User): string {
+    if (user.firstName) return user.firstName.concat(' ', user.lastName ?? '');
+    else return user.username ?? user.email!;
+  }
 }

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { AuthService, User } from '../services';
+import { AuthService } from '../services';
+import { User } from '../types';
 
 @Component({
   selector: 'app-account-dialog',

--- a/src/interface/src/app/home/region-selection/region-selection.component.ts
+++ b/src/interface/src/app/home/region-selection/region-selection.component.ts
@@ -28,7 +28,7 @@ export class RegionSelectionComponent implements OnInit {
   ngOnInit(): void {
     let user$ = this.authService.loggedInUser$;
     this.planService
-      .listPlansByUser(user$.value ? user$.value.username : null)
+      .listPlansByUser(user$.value?.username ? user$.value.username : null)
       .pipe(take(1))
       .subscribe((plans) => (this.hasPlans = plans.length !== 0));
   }

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.spec.ts
@@ -1,12 +1,13 @@
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MaterialModule } from 'src/app/material/material.module';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SimpleChange, SimpleChanges } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
+import { AuthService } from 'src/app/services';
+import { User } from 'src/app/types';
 
 import { OutcomeComponent } from './outcome.component';
-import { AuthService, User } from 'src/app/services';
 
 describe('OutcomeComponent', () => {
   let component: OutcomeComponent;
@@ -29,26 +30,26 @@ describe('OutcomeComponent', () => {
       id: '1',
       notes: 'bee happy',
       projectAreas: [{
-        id: 10,
-        estimatedAreaTreated: 2000,
-      },
-      {
-        id: 11,
-        estimatedAreaTreated: 5000,
-      },
-      {
-        id: 12,
-        estimatedAreaTreated: 6000,
-      },
-    ],
+          id: 10,
+          estimatedAreaTreated: 2000,
+        },
+        {
+          id: 11,
+          estimatedAreaTreated: 5000,
+        },
+        {
+          id: 12,
+          estimatedAreaTreated: 6000,
+        },
+      ],
     }
     await TestBed.configureTestingModule({
       imports: [ BrowserAnimationsModule, MaterialModule, ReactiveFormsModule],
       declarations: [ OutcomeComponent ],
       providers: [ FormBuilder,
         {
-        provide: AuthService,
-        useValue: fakeAuthService,
+          provide: AuthService,
+          useValue: fakeAuthService,
         },
       ],
     })

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
@@ -1,9 +1,15 @@
-import { Component, Input, SimpleChanges, OnChanges, ChangeDetectionStrategy, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { take, BehaviorSubject } from 'rxjs';
-import { User, AuthService } from 'src/app/services';
-
-import { Scenario, Plan, ProjectArea } from 'src/app/types';
+import { BehaviorSubject, take } from 'rxjs';
+import { AuthService } from 'src/app/services';
+import { Plan, ProjectArea, Scenario, User } from 'src/app/types';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -150,7 +150,7 @@ describe('AuthService', () => {
       };
 
       service
-        .signup('email', 'password1', 'password2', 'Foo', 'Bar', '')
+        .signup('email', 'password1', 'password2', 'Foo', 'Bar')
         .subscribe((_) => {
           expect(service.loggedInStatus$.value).toBeTrue();
           done();
@@ -169,7 +169,7 @@ describe('AuthService', () => {
 
     it('if unsuccessful, does not make request to backend /login endpoint', (done) => {
       service
-        .signup('email', 'password1', 'password2', 'Foo', 'Bar', '')
+        .signup('email', 'password1', 'password2', 'Foo', 'Bar')
         .subscribe(
           (_) => {},
           (_) => {

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -52,7 +52,7 @@ describe('AuthService', () => {
         accessToken: 'test',
       };
 
-      service.login('username', 'password').subscribe((res) => {
+      service.login('email', 'password').subscribe((res) => {
         expect(res).toEqual(mockResponse);
         done();
       });
@@ -64,7 +64,7 @@ describe('AuthService', () => {
       req.flush(mockResponse);
       httpTestingController
         .expectOne(BackendConstants.END_POINT + '/dj-rest-auth/user/')
-        .flush({ username: 'username' });
+        .flush({ email: 'test@test.com' });
       httpTestingController.verify();
     });
 
@@ -73,7 +73,7 @@ describe('AuthService', () => {
         accessToken: 'test',
       };
 
-      service.login('username', 'password').subscribe((_) => {
+      service.login('email', 'password').subscribe((_) => {
         expect(service.loggedInStatus$.value).toBeTrue();
         done();
       });
@@ -85,7 +85,7 @@ describe('AuthService', () => {
     });
 
     it('if unsuccessful, does not update logged in status', (done) => {
-      service.login('username', 'password').subscribe(
+      service.login('email', 'password').subscribe(
         (_) => {},
         (_) => {
           expect(service.loggedInStatus$.value).toBeFalse();
@@ -104,10 +104,10 @@ describe('AuthService', () => {
         accessToken: 'test',
       };
       const mockUser = {
-        username: 'username',
+        email: 'test@test.com',
       };
 
-      service.login('username', 'password').subscribe((_) => {
+      service.login('email', 'password').subscribe((_) => {
         expect(service.loggedInStatus$.value).toBeTrue();
         done();
       });
@@ -124,7 +124,7 @@ describe('AuthService', () => {
     });
 
     it('if unsuccessful, does not make request to backend /user endpoint', (done) => {
-      service.login('username', 'password').subscribe(
+      service.login('email', 'password').subscribe(
         (_) => {
           expect(service.loggedInStatus$.value).toBeFalse();
           done();
@@ -144,72 +144,13 @@ describe('AuthService', () => {
   });
 
   describe('signup', () => {
-    it('makes request to /registration backend endpoint', (done) => {
+    it('if successful, makes request to backend /login endpoint', (done) => {
       const mockResponse = {
         accessToken: 'test',
       };
 
       service
-        .signup('username', 'email', 'password1', 'password2')
-        .subscribe((res) => {
-          expect(res).toEqual(mockResponse);
-          done();
-        });
-
-      const req = httpTestingController.expectOne(
-        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
-      );
-      expect(req.request.method).toEqual('POST');
-      req.flush(mockResponse);
-      httpTestingController
-        .expectOne(BackendConstants.END_POINT + '/dj-rest-auth/user/')
-        .flush({ username: 'username' });
-      httpTestingController.verify();
-    });
-
-    it('if successful, updates logged in status to true', (done) => {
-      const mockResponse = {
-        accessToken: 'test',
-      };
-
-      service
-        .signup('username', 'email', 'password1', 'password2')
-        .subscribe((_) => {
-          expect(service.loggedInStatus$.value).toBeTrue();
-          done();
-        });
-
-      const req = httpTestingController.expectOne(
-        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
-      );
-      req.flush(mockResponse);
-    });
-
-    it('if unsuccessful, does not update logged in status', (done) => {
-      service.signup('username', 'email', 'password1', 'password2').subscribe(
-        (_) => {},
-        (_) => {
-          expect(service.loggedInStatus$.value).toBeFalse();
-          done();
-        }
-      );
-
-      const req = httpTestingController.expectOne(
-        BackendConstants.END_POINT + '/dj-rest-auth/registration/'
-      );
-      req.flush('Unsuccessful', { status: 400, statusText: 'Bad request' });
-    });
-
-    it('if successful, makes request to backend /user endpoint', (done) => {
-      const mockResponse = {
-        accessToken: 'test',
-      };
-      const mockUser = {
-        username: 'username',
-      };
-
-      service
-        .signup('username', 'email', 'password1', 'password2')
+        .signup('email', 'password1', 'password2', 'Foo', 'Bar', '')
         .subscribe((_) => {
           expect(service.loggedInStatus$.value).toBeTrue();
           done();
@@ -221,19 +162,21 @@ describe('AuthService', () => {
       req1.flush(mockResponse);
 
       const req2 = httpTestingController.expectOne(
-        BackendConstants.END_POINT + '/dj-rest-auth/user/'
+        BackendConstants.END_POINT + '/dj-rest-auth/login/'
       );
-      req2.flush(mockUser);
+      req2.flush(mockResponse);
     });
 
-    it('if unsuccessful, does not make request to backend /user endpoint', (done) => {
-      service.signup('username', 'email', 'password1', 'password2').subscribe(
-        (_) => {},
-        (_) => {
-          expect(service.loggedInStatus$.value).toBeFalse();
-          done();
-        }
-      );
+    it('if unsuccessful, does not make request to backend /login endpoint', (done) => {
+      service
+        .signup('email', 'password1', 'password2', 'Foo', 'Bar', '')
+        .subscribe(
+          (_) => {},
+          (_) => {
+            expect(service.loggedInStatus$.value).toBeFalse();
+            done();
+          }
+        );
 
       const req = httpTestingController.expectOne(
         BackendConstants.END_POINT + '/dj-rest-auth/registration/'
@@ -286,7 +229,8 @@ describe('AuthService', () => {
       spyOn(cookieServiceStub, 'get').and.callThrough();
       const mockResponse = { access: true };
       const mockUser = {
-        username: 'username',
+        email: 'test@test.com',
+        username: 'test',
       };
 
       service.refreshLoggedInUser().subscribe((res) => {
@@ -313,7 +257,8 @@ describe('AuthService', () => {
     it('updates loggedInStatus to true when token is refreshed', (done) => {
       const mockResponse = { access: true };
       const mockUser = {
-        username: 'username',
+        email: 'test@test.com',
+        username: 'test',
       };
 
       service.refreshLoggedInUser().subscribe((_) => {
@@ -387,7 +332,7 @@ describe('AuthGuard', () => {
     it('returns true if refreshLoggedInUser succeeds', (done) => {
       const authServiceStub: AuthService = TestBed.inject(AuthService);
       spyOn(authServiceStub, 'refreshLoggedInUser').and.returnValue(
-        of({ username: 'username' })
+        of({ email: 'test@test.com' })
       );
 
       service.canActivate().subscribe((result) => {

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -231,10 +231,17 @@ describe('AuthService', () => {
       const mockUser = {
         email: 'test@test.com',
         username: 'test',
+        first_name: 'Foo',
+        last_name: 'Bar',
       };
 
       service.refreshLoggedInUser().subscribe((res) => {
-        expect(res).toEqual(mockUser);
+        expect(res).toEqual({
+          email: 'test@test.com',
+          username: 'test',
+          firstName: 'Foo',
+          lastName: 'Bar',
+        });
         done();
       });
 
@@ -259,11 +266,18 @@ describe('AuthService', () => {
       const mockUser = {
         email: 'test@test.com',
         username: 'test',
+        first_name: 'Foo',
+        last_name: 'Bar',
       };
 
       service.refreshLoggedInUser().subscribe((_) => {
         expect(service.loggedInStatus$.value).toBeTrue();
-        expect(service.loggedInUser$.value).toEqual(mockUser);
+        expect(service.loggedInUser$.value).toEqual({
+          email: 'test@test.com',
+          username: 'test',
+          firstName: 'Foo',
+          lastName: 'Bar',
+        });
         done();
       });
 

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -1,9 +1,18 @@
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { CanActivate } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
-import { BehaviorSubject, catchError, map, Observable, of, Subject, tap, concatMap, take } from 'rxjs';
+import {
+  BehaviorSubject,
+  catchError,
+  concatMap,
+  map,
+  Observable,
+  of,
+  take,
+  tap,
+} from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
 
@@ -12,14 +21,14 @@ interface LogoutResponse {
 }
 
 export interface User {
-  username: string,
+  email?: string;
+  username?: string;
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AuthService {
-
   loggedInStatus$ = new BehaviorSubject(false);
   isLoggedIn$: Observable<boolean> = this.loggedInStatus$;
   loggedInUser$ = new BehaviorSubject<User | null>(null);
@@ -29,78 +38,103 @@ export class AuthService {
   constructor(
     private http: HttpClient,
     private cookieService: CookieService,
-    private snackbar: MatSnackBar) { }
+    private snackbar: MatSnackBar
+  ) {}
 
-  login(username: string, password: string) {
-    return this.http.post(
-      this.API_ROOT.concat('login/'),
-      { username, password },
-      { withCredentials: true }
-    ).pipe(
-      tap(_ => {
-        this.loggedInStatus$.next(true);
-        this.getLoggedInUser().pipe(take(1)).subscribe(user => {
-          this.loggedInUser$.next(user);
-        });
-      }),
-
-    );
+  login(email: string, password: string) {
+    return this.http
+      .post(
+        this.API_ROOT.concat('login/'),
+        { email, password },
+        { withCredentials: true }
+      )
+      .pipe(
+        tap((_) => {
+          this.loggedInStatus$.next(true);
+          this.getLoggedInUser()
+            .pipe(take(1))
+            .subscribe((user) => {
+              this.loggedInUser$.next(user);
+            });
+        })
+      );
   }
 
-  signup(username: string, email: string, password1: string, password2: string) {
-    return this.http.post(
-      this.API_ROOT.concat('registration/'),
-      { username, password1, password2, email }
-    ).pipe(
-      tap(_ => {
-        this.loggedInStatus$.next(true);
-        this.getLoggedInUser().pipe(take(1)).subscribe();
+  signup(
+    email: string,
+    password1: string,
+    password2: string,
+    firstName: string,
+    lastName: string,
+    department: string
+  ) {
+    return this.http
+      .post(this.API_ROOT.concat('registration/'), {
+        password1,
+        password2,
+        email,
+        first_name: firstName,
+        last_name: lastName,
+        department: department
       })
-    );
+      .pipe(
+        concatMap((_) => {
+          return this.login(email, password1);
+        })
+      );
   }
 
   logout() {
-    return this.http.get<LogoutResponse>(
-      this.API_ROOT.concat('logout/'),
-      { withCredentials: true }
-    ).pipe(
-      tap(response => {
-        this.loggedInStatus$.next(false);
-        this.loggedInUser$.next(null);
-        this.snackbar.open(response.detail);
+    return this.http
+      .get<LogoutResponse>(this.API_ROOT.concat('logout/'), {
+        withCredentials: true,
       })
-    );
+      .pipe(
+        tap((response) => {
+          this.loggedInStatus$.next(false);
+          this.loggedInUser$.next(null);
+          this.snackbar.open(response.detail);
+        })
+      );
   }
 
   private refreshToken() {
-    return this.http.post(
-      this.API_ROOT.concat('token/refresh/'),
-      { refresh: this.cookieService.get('my-refresh-token') },
-      { withCredentials: true }
-    ).pipe(tap((response: any) => {
-      this.loggedInStatus$.next(!!(response.access));
-    }));
+    return this.http
+      .post(
+        this.API_ROOT.concat('token/refresh/'),
+        { refresh: this.cookieService.get('my-refresh-token') },
+        { withCredentials: true }
+      )
+      .pipe(
+        tap((response: any) => {
+          this.loggedInStatus$.next(!!response.access);
+        })
+      );
   }
 
   /** Fetch the currently logged in user from the backend. */
   refreshLoggedInUser(): Observable<User> {
     // Must refresh the auth cookie to retrieve user
-    return this.refreshToken().pipe(concatMap(_ => {
-      return this.getLoggedInUser();
-    }));
+    return this.refreshToken().pipe(
+      concatMap((_) => {
+        return this.getLoggedInUser();
+      })
+    );
   }
 
   private getLoggedInUser(): Observable<User> {
-    return this.http.get(
-      this.API_ROOT.concat('user/'),
-      { withCredentials: true }
-    ).pipe(map((response: any) => {
-      const user: User = {
-        username: response.username
-      }
-      this.loggedInUser$.next(user);
-      return user;
-    }));
+    return this.http
+      .get(this.API_ROOT.concat('user/'), { withCredentials: true })
+      .pipe(
+        map((response: any) => {
+          const user: User = {
+            email: response.email,
+            username: response.username,
+          };
+          this.loggedInUser$.next(user);
+          return user;
+        })
+      );
   }
 }
 
@@ -108,13 +142,12 @@ export class AuthService {
 // logged in user. Currently it isn't used to guard any routes.
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private authService: AuthService) { }
+  constructor(private authService: AuthService) {}
 
   canActivate(): Observable<boolean> {
     return this.authService.refreshLoggedInUser().pipe(
-      map(_ => true),
-      catchError(_ => of(false))
+      map((_) => true),
+      catchError((_) => of(false))
     );
-
   }
 }

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -126,6 +126,8 @@ export class AuthService {
           const user: User = {
             email: response.email,
             username: response.username,
+            firstName: response.first_name,
+            lastName: response.last_name,
           };
           this.loggedInUser$.next(user);
           return user;

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -15,14 +15,10 @@ import {
 } from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
+import { User } from '../types';
 
 interface LogoutResponse {
   detail: string;
-}
-
-export interface User {
-  email?: string;
-  username?: string;
 }
 
 @Injectable({
@@ -75,7 +71,7 @@ export class AuthService {
         email,
         first_name: firstName,
         last_name: lastName,
-        department: department
+        department: department,
       })
       .pipe(
         concatMap((_) => {

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -62,7 +62,6 @@ export class AuthService {
     password2: string,
     firstName: string,
     lastName: string,
-    department: string
   ) {
     return this.http
       .post(this.API_ROOT.concat('registration/'), {
@@ -71,7 +70,6 @@ export class AuthService {
         email,
         first_name: firstName,
         last_name: lastName,
-        department: department,
       })
       .pipe(
         concatMap((_) => {

--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -61,14 +61,6 @@
               matInput>
           </mat-form-field>
 
-          <mat-form-field appearance="fill">
-            <mat-label>Who are you representing? (e.g. department, agency)</mat-label>
-            <input
-              type="text"
-              formControlName="department"
-              matInput>
-          </mat-form-field>
-
           <button mat-flat-button
             type="submit"
             color="primary"

--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -83,15 +83,6 @@
         <ng-template #finalStep>
 
           <mat-form-field appearance="fill">
-            <mat-label>Username</mat-label>
-            <input
-              type="text"
-              required
-              formControlName="username"
-              matInput>
-          </mat-form-field>
-
-          <mat-form-field appearance="fill">
             <mat-label>Email</mat-label>
             <input
               type="text"

--- a/src/interface/src/app/signup/signup.component.spec.ts
+++ b/src/interface/src/app/signup/signup.component.spec.ts
@@ -57,7 +57,6 @@ describe('SignupComponent', () => {
     it('enables submit when all fields are valid', () => {
       component.form.get('firstName')?.setValue('Foo');
       component.form.get('lastName')?.setValue('Bar');
-      component.form.get('username')?.setValue('testuser');
       component.form.get('email')?.setValue('test@test.com');
       component.form.get('password1')?.setValue('password');
       component.form.get('password2')?.setValue('password');
@@ -68,7 +67,8 @@ describe('SignupComponent', () => {
 
   describe('signup', () => {
     it('calls authentication service', () => {
-      component.form.get('username')?.setValue('testuser');
+      component.form.get('firstName')?.setValue('Foo');
+      component.form.get('lastName')?.setValue('Bar');
       component.form.get('email')?.setValue('test@test.com');
       component.form.get('password1')?.setValue('password');
       component.form.get('password2')?.setValue('password');
@@ -76,10 +76,12 @@ describe('SignupComponent', () => {
       component.signup();
 
       expect(fakeAuthService.signup).toHaveBeenCalledOnceWith(
-        'testuser',
         'test@test.com',
         'password',
-        'password'
+        'password',
+        'Foo',
+        'Bar',
+        ''
       );
     });
   });

--- a/src/interface/src/app/signup/signup.component.spec.ts
+++ b/src/interface/src/app/signup/signup.component.spec.ts
@@ -81,7 +81,6 @@ describe('SignupComponent', () => {
         'password',
         'Foo',
         'Bar',
-        ''
       );
     });
   });

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -30,7 +30,6 @@ export class SignupComponent {
       {
         firstName: this.formBuilder.control('', Validators.required),
         lastName: this.formBuilder.control('', Validators.required),
-        department: this.formBuilder.control(''),
         email: this.formBuilder.control('', [
           Validators.required,
           Validators.email,
@@ -56,9 +55,8 @@ export class SignupComponent {
     const password2: string = this.form.get('password2')?.value;
     const firstName: string = this.form.get('firstName')?.value;
     const lastName: string = this.form.get('lastName')?.value;
-    const department: string = this.form.get('department')?.value;
     this.authService
-      .signup(email, password1, password2, firstName, lastName, department)
+      .signup(email, password1, password2, firstName, lastName)
       .subscribe(
         (_) => this.router.navigate(['map']),
         (error) => {

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -31,7 +31,6 @@ export class SignupComponent {
         firstName: this.formBuilder.control('', Validators.required),
         lastName: this.formBuilder.control('', Validators.required),
         department: this.formBuilder.control(''),
-        username: this.formBuilder.control('', [Validators.required]),
         email: this.formBuilder.control('', [
           Validators.required,
           Validators.email,
@@ -52,17 +51,21 @@ export class SignupComponent {
     if (this.submitted) return;
 
     this.submitted = true;
-    const username: string = this.form.get('username')?.value;
     const email: string = this.form.get('email')?.value;
     const password1: string = this.form.get('password1')?.value;
     const password2: string = this.form.get('password2')?.value;
-    this.authService.signup(username, email, password1, password2).subscribe(
-      (_) => this.router.navigate(['map']),
-      (error) => {
-        this.error = error;
-        this.submitted = false;
-      }
-    );
+    const firstName: string = this.form.get('firstName')?.value;
+    const lastName: string = this.form.get('lastName')?.value;
+    const department: string = this.form.get('department')?.value;
+    this.authService
+      .signup(email, password1, password2, firstName, lastName, department)
+      .subscribe(
+        (_) => this.router.navigate(['map']),
+        (error) => {
+          this.error = error;
+          this.submitted = false;
+        }
+      );
   }
 
   login() {

--- a/src/interface/src/app/top-bar/top-bar.component.html
+++ b/src/interface/src/app/top-bar/top-bar.component.html
@@ -30,7 +30,7 @@
   <span class="spacer"></span>
 
   <!-- Account Name & Button -->
-  <span class="username">{{ username }}</span>
+  <span class="username">{{ displayName }}</span>
   <button
     mat-icon-button
     data-testid="account-button"

--- a/src/interface/src/app/top-bar/top-bar.component.spec.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.spec.ts
@@ -5,8 +5,8 @@ import { By } from '@angular/platform-browser';
 import { BehaviorSubject } from 'rxjs';
 
 import { MaterialModule } from '../material/material.module';
-import { AuthService, SessionService, User } from '../services';
-import { Region } from '../types';
+import { AuthService, SessionService } from '../services';
+import { Region, User } from '../types';
 import { AccountDialogComponent } from './../account-dialog/account-dialog.component';
 import { TopBarComponent } from './top-bar.component';
 
@@ -96,13 +96,22 @@ describe('TopBarComponent', () => {
 
   describe('username', () => {
     it('should be "Guest" when no user is logged in', () => {
-      expect(component.username).toEqual('Guest');
+      expect(component.displayName).toEqual('Guest');
     });
 
-    it('should be the username of the logged in user', () => {
+    it('should be the first name of the logged in user', () => {
+      mockAuthService.loggedInUser$?.next({
+        firstName: 'Foo',
+        username: 'User',
+      });
+
+      expect(component.displayName).toEqual('Foo');
+    });
+
+    it('should be the username of the logged in user if they have no first name', () => {
       mockAuthService.loggedInUser$?.next({ username: 'User' });
 
-      expect(component.username).toEqual('User');
+      expect(component.displayName).toEqual('User');
     });
   });
 });

--- a/src/interface/src/app/top-bar/top-bar.component.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.ts
@@ -22,7 +22,7 @@ export class TopBarComponent implements OnInit, OnDestroy {
   @Output()
   toggleEvent = new EventEmitter<Event>();
 
-  username: string = '';
+  displayName: string = '';
 
   readonly color = 'primary';
   readonly regionOptions: RegionOption[] = regionOptions;
@@ -42,9 +42,9 @@ export class TopBarComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((user) => {
         if (user) {
-          this.username = user.username;
+          this.displayName = user.firstName ? user.firstName : (user.username ? user.username : '');
         } else {
-          this.username = 'Guest';
+          this.displayName = 'Guest';
         }
       });
   }

--- a/src/interface/src/app/types/index.ts
+++ b/src/interface/src/app/types/index.ts
@@ -4,3 +4,4 @@ export * from './legend.types';
 export * from './map.types';
 export * from './plan.types';
 export * from './region.types';
+export * from './user.types';

--- a/src/interface/src/app/types/user.types.ts
+++ b/src/interface/src/app/types/user.types.ts
@@ -1,0 +1,7 @@
+export interface User {
+  email?: string;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  department?: string;
+}

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -74,6 +74,7 @@ INSTALLED_APPS = [
     'plan',
     'leaflet',
     'corsheaders',
+    'users',
 ]
 
 MIDDLEWARE = [
@@ -201,6 +202,10 @@ AUTHENTICATION_BACKENDS = [
     # `allauth` specific authentication methods, such as login by e-mail
     'allauth.account.auth_backends.AuthenticationBackend',
 ]
+
+REST_AUTH_REGISTER_SERIALIZERS = {
+    'REGISTER_SERIALIZER': 'users.serializers.NameRegistrationSerializer',
+}
 
 # JWT settings
 

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -53,6 +53,10 @@ ALLOWED_HOSTS: list[str] = str(
 # Application definition
 
 INSTALLED_APPS = [
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'dj_rest_auth',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -62,17 +66,14 @@ INSTALLED_APPS = [
     'django.contrib.gis',
     'rest_framework',
     'rest_framework_gis',
+    'rest_framework_simplejwt',
+    'rest_framework.authtoken',
     'boundary',
     'conditions',
     'existing_projects',
     'plan',
     'leaflet',
     'corsheaders',
-    'allauth',
-    'allauth.account',
-    'rest_framework.authtoken',
-    'dj_rest_auth',
-    'rest_framework_simplejwt',
 ]
 
 MIDDLEWARE = [
@@ -194,6 +195,13 @@ REST_FRAMEWORK = {
     'NON_FIELD_ERRORS_KEY': 'global',
 }
 
+AUTHENTICATION_BACKENDS = [
+    # Needed to login by username in Django admin, regardless of `allauth`
+    'django.contrib.auth.backends.ModelBackend',
+    # `allauth` specific authentication methods, such as login by e-mail
+    'allauth.account.auth_backends.AuthenticationBackend',
+]
+
 # JWT settings
 
 REST_USE_JWT = True
@@ -204,8 +212,11 @@ JWT_AUTH_HTTPONLY = False
 # allauth
 
 SITE_ID = 1
+ACCOUNT_AUTHENTICATION_METHOD = 'email'
+ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_LOGOUT_ON_GET = True
+ACCOUNT_USERNAME_REQUIRED = False
 
 # PostGIS constants. All raster data should be ingested with a common
 # Coordinate Reference System (CRS).  The values below are those for the

--- a/src/planscape/users/admin.py
+++ b/src/planscape/users/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/src/planscape/users/apps.py
+++ b/src/planscape/users/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'users'

--- a/src/planscape/users/models.py
+++ b/src/planscape/users/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/src/planscape/users/serializers.py
+++ b/src/planscape/users/serializers.py
@@ -1,0 +1,13 @@
+from dj_rest_auth.registration.serializers import RegisterSerializer
+from rest_framework import serializers
+
+
+class NameRegistrationSerializer(RegisterSerializer):
+
+  first_name = serializers.CharField(required=False)
+  last_name = serializers.CharField(required=False)
+
+  def custom_signup(self, request, user):
+    user.first_name = self.validated_data.get('first_name', '')
+    user.last_name = self.validated_data.get('last_name', '')
+    user.save(update_fields=['first_name', 'last_name'])

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/src/planscape/users/views.py
+++ b/src/planscape/users/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.


### PR DESCRIPTION
## Changes:
- Login automatically after successful registration. Fixes #692 
- Create new Django `users` app containing custom registration serializer for first name and last name. This allows us to collect first and last during registration and store them in the existing columns. Fixes #693 
- Collect email address during registration, but not username. Username is stored automatically based on everything in the email address prior to `@`. Login uses email address, not username. Part of #693
- Re-enable the form submission button on the registration page if the registration failed (so the user can fix things and try again).
- Create new `User` type under `types` folder in frontend.
- Show user's full name in the account dialog instead of username, if possible.
- Remove department field from signup form since we won't store it.

## Todos:
- Update other places in the frontend to display first and last name (#483 )

### Account dialog showing first and last name of user
![image](https://user-images.githubusercontent.com/10444733/225758727-8fdf51c5-038f-4029-8f46-dfc35f566c44.png)

### Signup form with department field removed
![image](https://user-images.githubusercontent.com/10444733/226464790-45b850eb-02ab-4e27-8f60-270696917717.png)

## Signup form 2nd screen with username field removed
![image](https://user-images.githubusercontent.com/10444733/226464867-1ac74bc2-87f1-4ed9-9438-9aee2a256426.png)
