### PR TITLE
Limit frontend features for logged out users to region selection + explore

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -1,4 +1,3 @@
-import { HomeComponent } from './home/home.component';
 import { Injectable, NgModule } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import {
@@ -9,12 +8,14 @@ import {
 } from '@angular/router';
 
 import { createFeatureGuard } from './features/feature.guard';
+import { HomeComponent } from './home/home.component';
 import { LoginComponent } from './login/login.component';
 import { MapComponent } from './map/map.component';
 import { CreateScenariosComponent } from './plan/create-scenarios/create-scenarios.component';
 import { PlanComponent } from './plan/plan.component';
 import { ScenarioConfirmationComponent } from './plan/scenario-confirmation/scenario-confirmation.component';
 import { ScenarioDetailsComponent } from './plan/scenario-details/scenario-details.component';
+import { AuthGuard } from './services';
 import { SignupComponent } from './signup/signup.component';
 
 const routes: Routes = [
@@ -45,6 +46,7 @@ const routes: Routes = [
         path: 'plan/:id',
         title: 'Plan Details',
         component: PlanComponent,
+        canActivate: [AuthGuard],
         children: [
           {
             path: `scenario/:id`,
@@ -62,7 +64,9 @@ const routes: Routes = [
         path: 'scenario-confirmation/:id',
         title: 'Generating Scenario',
         component: ScenarioConfirmationComponent,
+        canActivate: [AuthGuard],
       },
+      { path: '**', redirectTo: '' },
     ],
   },
 ];

--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { MapNameplateComponent } from './map/map-nameplate/map-nameplate.compone
 import { MapComponent } from './map/map.component';
 import { PlanCreateDialogComponent } from './map/plan-create-dialog/plan-create-dialog.component';
 import { ProjectCardComponent } from './map/project-card/project-card.component';
+import { SignInDialogComponent } from './map/sign-in-dialog/sign-in-dialog.component';
 import { MaterialModule } from './material/material.module';
 import { NavigationComponent } from './navigation/navigation.component';
 import { PlanModule } from './plan/plan.module';
@@ -61,6 +62,7 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     ConditionTreeComponent,
     HomeComponent,
     PlanTableComponent,
+    SignInDialogComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -1,10 +1,12 @@
 <div class="root-container">
-  <h1>{{ datasource.data.length ? 'Welcome back!' : 'Welcome to Planscape!' }}</h1>
+  <h1>
+    {{ datasource.data.length && (loggedIn$ | async) ? 'Welcome back!' : 'Welcome to Planscape!' }}
+  </h1>
 
   <div class="plans-container">
     <h2>My Plans</h2>
 
-    <div *ngIf="datasource.data.length; else noplans">
+    <div *ngIf="datasource.data.length && (loggedIn$ | async); else noplans">
       <mat-table [dataSource]="datasource" matSort>
         <!-- Select Column -->
         <ng-container matColumnDef="select">
@@ -115,7 +117,10 @@
     </div>
 
     <ng-template #noplans class="no-saved-plans">
-      <p>There are no saved plans.</p>
+      <p *ngIf="(loggedIn$ | async); else signedout">There are no saved plans.</p>
+      <ng-template #signedout>
+        <p><a href="/signup">Create an account</a> to start making plans.</p>
+    </ng-template>
     </ng-template>
   </div>
 </div>

--- a/src/interface/src/app/home/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/home/plan-table/plan-table.component.ts
@@ -34,6 +34,7 @@ export class PlanTableComponent implements OnInit {
     'status',
     'options',
   ];
+  loggedIn$ = this.authService.loggedInStatus$;
 
   constructor(
     private dialog: MatDialog,

--- a/src/interface/src/app/home/region-selection/region-selection.component.html
+++ b/src/interface/src/app/home/region-selection/region-selection.component.html
@@ -1,12 +1,12 @@
 <div class="center-block">
   <!-- Content text -->
   <section class="content-section">
-    <span *ngIf="!hasPlans">Welcome to Planscape!<br></span>
+    <span *ngIf="!hasPlans || !(loggedIn$ | async)">Welcome to Planscape!</span>
     Choose a region to explore
   </section>
 
   <!-- The region buttons -->
-  <section class="content-section">
+  <section class="button-row">
     <button
       mat-raised-button
       *ngFor="let region of regionOptions"

--- a/src/interface/src/app/home/region-selection/region-selection.component.scss
+++ b/src/interface/src/app/home/region-selection/region-selection.component.scss
@@ -18,6 +18,11 @@
 // A section within the main section
 .content-section {
   display: flex;
+  flex-direction: column;
+}
+
+.button-row {
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   gap: 40px;

--- a/src/interface/src/app/home/region-selection/region-selection.component.ts
+++ b/src/interface/src/app/home/region-selection/region-selection.component.ts
@@ -16,6 +16,7 @@ import { RegionOption, regionOptions } from '../../types';
 })
 export class RegionSelectionComponent implements OnInit {
   hasPlans: boolean = false;
+  loggedIn$ = this.authService.isLoggedIn$;
   readonly regionOptions: RegionOption[] = regionOptions;
 
   constructor(

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -23,6 +23,7 @@ import { filter, switchMap } from 'rxjs/operators';
 import * as shp from 'shpjs';
 
 import {
+  AuthService,
   MapService,
   PlanService,
   PlanState,
@@ -47,6 +48,7 @@ import {
 import { MapManager } from './map-manager';
 import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dialog.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
+import { SignInDialogComponent } from './sign-in-dialog/sign-in-dialog.component';
 
 export enum AreaCreationAction {
   NONE = 0,
@@ -116,6 +118,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
 
   constructor(
     public applicationRef: ApplicationRef,
+    private authService: AuthService,
     private mapService: MapService,
     private dialog: MatDialog,
     private matSnackBar: MatSnackBar,
@@ -330,14 +333,20 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
     );
   }
 
-  /** Configures and opens the Create Plan dialog */
+  /** If the user is signed in, configures and opens the Create Plan dialog.
+   *  If the user is signed out, configure and open the Sign In dialog.
+   */
   openCreatePlanDialog() {
-    const dialogConfig = new MatDialogConfig();
-    dialogConfig.maxWidth = '560px';
+    if (!this.authService.loggedInStatus$.value) {
+      this.openSignInDialog();
+      return;
+    }
 
     const openedDialog = this.dialog.open(
       PlanCreateDialogComponent,
-      dialogConfig
+      {
+        maxWidth: '560px'
+      }
     );
 
     openedDialog.afterClosed().subscribe((result) => {
@@ -345,6 +354,15 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit {
         this.createPlan(result.value, this.mapManager.convertToPlanningArea());
       }
     });
+  }
+
+  private openSignInDialog() {
+    this.dialog.open(
+      SignInDialogComponent,
+      {
+        maxWidth: '560px'
+      }
+    );
   }
 
   private createPlan(name: string, shape: GeoJSON.GeoJSON) {

--- a/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.html
+++ b/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.html
@@ -1,0 +1,12 @@
+<h1 mat-dialog-title>Sign in or create an account to continue</h1>
+
+<div mat-dialog-content>
+  <p>
+    You must be signed in to save plans and collaborate with others.
+  </p>
+</div>
+
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="dialogRef.close()" color="primary">CANCEL</button>
+  <a mat-button href="login/" cdkFocusInitial color="primary">SIGN IN</a>
+</div>

--- a/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.spec.ts
+++ b/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+
+import { SignInDialogComponent } from './sign-in-dialog.component';
+
+describe('SignInCardComponent', () => {
+  let component: SignInDialogComponent;
+  let fixture: ComponentFixture<SignInDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SignInDialogComponent ],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+      ],
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SignInDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.ts
+++ b/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-sign-in-dialog',
+  templateUrl: './sign-in-dialog.component.html',
+  styleUrls: ['./sign-in-dialog.component.scss']
+})
+export class SignInDialogComponent {
+  constructor(public dialogRef: MatDialogRef<SignInDialogComponent>) { }
+}

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import { of, throwError } from 'rxjs';
 
@@ -396,13 +397,16 @@ describe('AuthGuard', () => {
       });
     });
 
-    it('returns false if refreshLoggedInUser fails', (done) => {
+    it('returns false and redirects to login if refreshLoggedInUser fails', (done) => {
       const authServiceStub: AuthService = TestBed.inject(AuthService);
       spyOn(authServiceStub, 'refreshLoggedInUser').and.returnValue(
         throwError(() => new Error())
       );
+      const routerStub: Router = TestBed.inject(Router);
+      spyOn(routerStub, 'navigate');
 
       service.canActivate().subscribe((result) => {
+        expect(routerStub.navigate).toHaveBeenCalledOnceWith(['login']);
         expect(result).toBeFalse();
         done();
       });

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -1,9 +1,18 @@
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { CanActivate } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { CanActivate, Router } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
-import { BehaviorSubject, catchError, map, Observable, of, Subject, tap, concatMap, take } from 'rxjs';
+import {
+  BehaviorSubject,
+  catchError,
+  concatMap,
+  map,
+  Observable,
+  of,
+  take,
+  tap,
+} from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
 
@@ -12,14 +21,13 @@ interface LogoutResponse {
 }
 
 export interface User {
-  username: string,
+  username: string;
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AuthService {
-
   loggedInStatus$ = new BehaviorSubject(false);
   isLoggedIn$: Observable<boolean> = this.loggedInStatus$;
   loggedInUser$ = new BehaviorSubject<User | null>(null);
@@ -29,92 +37,116 @@ export class AuthService {
   constructor(
     private http: HttpClient,
     private cookieService: CookieService,
-    private snackbar: MatSnackBar) { }
+    private snackbar: MatSnackBar
+  ) {}
 
   login(username: string, password: string) {
-    return this.http.post(
-      this.API_ROOT.concat('login/'),
-      { username, password },
-      { withCredentials: true }
-    ).pipe(
-      tap(_ => {
-        this.loggedInStatus$.next(true);
-        this.getLoggedInUser().pipe(take(1)).subscribe(user => {
-          this.loggedInUser$.next(user);
-        });
-      }),
-
-    );
+    return this.http
+      .post(
+        this.API_ROOT.concat('login/'),
+        { username, password },
+        { withCredentials: true }
+      )
+      .pipe(
+        tap((_) => {
+          this.loggedInStatus$.next(true);
+          this.getLoggedInUser()
+            .pipe(take(1))
+            .subscribe((user) => {
+              this.loggedInUser$.next(user);
+            });
+        })
+      );
   }
 
-  signup(username: string, email: string, password1: string, password2: string) {
-    return this.http.post(
-      this.API_ROOT.concat('registration/'),
-      { username, password1, password2, email }
-    ).pipe(
-      tap(_ => {
-        this.loggedInStatus$.next(true);
-        this.getLoggedInUser().pipe(take(1)).subscribe();
+  signup(
+    username: string,
+    email: string,
+    password1: string,
+    password2: string
+  ) {
+    return this.http
+      .post(this.API_ROOT.concat('registration/'), {
+        username,
+        password1,
+        password2,
+        email,
       })
-    );
+      .pipe(
+        tap((_) => {
+          this.loggedInStatus$.next(true);
+          this.getLoggedInUser().pipe(take(1)).subscribe();
+        })
+      );
   }
 
   logout() {
-    return this.http.get<LogoutResponse>(
-      this.API_ROOT.concat('logout/'),
-      { withCredentials: true }
-    ).pipe(
-      tap(response => {
-        this.loggedInStatus$.next(false);
-        this.loggedInUser$.next(null);
-        this.snackbar.open(response.detail);
+    return this.http
+      .get<LogoutResponse>(this.API_ROOT.concat('logout/'), {
+        withCredentials: true,
       })
-    );
+      .pipe(
+        tap((response) => {
+          this.loggedInStatus$.next(false);
+          this.loggedInUser$.next(null);
+          this.snackbar.open(response.detail);
+        })
+      );
   }
 
   private refreshToken() {
-    return this.http.post(
-      this.API_ROOT.concat('token/refresh/'),
-      { refresh: this.cookieService.get('my-refresh-token') },
-      { withCredentials: true }
-    ).pipe(tap((response: any) => {
-      this.loggedInStatus$.next(!!(response.access));
-    }));
+    return this.http
+      .post(
+        this.API_ROOT.concat('token/refresh/'),
+        { refresh: this.cookieService.get('my-refresh-token') },
+        { withCredentials: true }
+      )
+      .pipe(
+        tap((response: any) => {
+          this.loggedInStatus$.next(!!response.access);
+        })
+      );
   }
 
   /** Fetch the currently logged in user from the backend. */
   refreshLoggedInUser(): Observable<User> {
     // Must refresh the auth cookie to retrieve user
-    return this.refreshToken().pipe(concatMap(_ => {
-      return this.getLoggedInUser();
-    }));
+    return this.refreshToken().pipe(
+      concatMap((_) => {
+        return this.getLoggedInUser();
+      })
+    );
   }
 
   private getLoggedInUser(): Observable<User> {
-    return this.http.get(
-      this.API_ROOT.concat('user/'),
-      { withCredentials: true }
-    ).pipe(map((response: any) => {
-      const user: User = {
-        username: response.username
-      }
-      this.loggedInUser$.next(user);
-      return user;
-    }));
+    return this.http
+      .get(this.API_ROOT.concat('user/'), { withCredentials: true })
+      .pipe(
+        map((response: any) => {
+          const user: User = {
+            username: response.username,
+          };
+          this.loggedInUser$.next(user);
+          return user;
+        })
+      );
   }
 }
 
-// This AuthGuard can be used to guard any routes that require permissions or a
-// logged in user. Currently it isn't used to guard any routes.
+/** An AuthGuard used to prevent access to pages that require sign-in. If the user is not signed
+ *  in, redirect to the sign-in page.
+ */
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private authService: AuthService) { }
+  constructor(private authService: AuthService, private router: Router) {}
 
   canActivate(): Observable<boolean> {
     return this.authService.refreshLoggedInUser().pipe(
-      map(_ => true),
-      catchError(_ => of(false))
+      map((_) => true),
+      catchError((_) => {
+        this.router.navigate(['login']);
+        return of(false);
+      })
     );
-
   }
 }


### PR DESCRIPTION
## Changes
- Fixes #657 
- Adds route guarding to all paths except sign in, registration, home, and map
- Replaces plan creation dialog with a prompt to sign in if the user is logged out
- Hides plans from homepage if the user is logged out (temporary until we delete ownerless plans from DB)

## Home page for signed out user
![image](https://user-images.githubusercontent.com/10444733/226055129-8d963312-25d7-41da-8241-777433f19676.png)

## Dialog after signed out user tries to finish creating a plan
![image](https://user-images.githubusercontent.com/10444733/226055408-8b1c8b38-0362-453a-8624-9263333234f1.png)
