### PR TITLE
change constraint form logic and add estimated cost

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -2,50 +2,51 @@
   <!-- Form -->
   <div class="constraints-content">
     <form class="constraints-form" [formGroup]="constraintsForm!">
-      <div class="flex-row">
-        <!-- Budget -->
-        <div formGroupName="budgetForm" required>
-          <label class="form-label" [class.required]="!hasBudgetOrMaxArea()">Budget</label>
-          <mat-radio-group formControlName="optimizeBudget" [required]="!hasBudgetOrMaxArea()">
-            <!-- Custom Budget -->
-              <mat-radio-button [value]="false">
-
-                <!-- Max -->
-                <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-                  <mat-label>Max</mat-label>
-                  <input
-                    [required]="maxBudgetRequired()"
-                    class="right-align"
-                    formControlName="maxBudget"
-                    matInput type="number">
-                    <span matPrefix>$&nbsp;</span>
-                </mat-form-field>
-              </mat-radio-button>
-
-            <!-- Optimized Budget -->
-            <mat-radio-button [value]="true">
-              Show estimated cost range
-            </mat-radio-button>
-          </mat-radio-group>
-        </div>
-
-        <div formGroupName="treatmentForm">
-          <!-- Treatment Percentage -->
-          <label class="form-label" [class.required]="!hasBudgetOrMaxArea()">
-            Max treatment percentage of total planning area
-          </label>
-
-          <!-- Max -->
-          <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-            <mat-label>Max</mat-label>
-            <input formControlName="maxArea" matInput type="number">
-            <span matSuffix>% &nbsp;</span>
-            <mat-hint class="subtext">Cannot exceed 90%</mat-hint>
-          </mat-form-field>
-        </div>
+      <!-- Cost input -->
+      <div formGroupName="budgetForm">
+        <label class="form-label required">
+          Cost input
+        </label>
+        <!-- Estimated cost in $ per acre -->
+        <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+          <mat-label>Est. treatment cost</mat-label>
+          <input
+            class="right-align"
+            formControlName="estimatedCost"
+            matInput
+            type="number">
+            <span matPrefix>$&nbsp;</span>
+            <span matSuffix>per acre</span>
+        </mat-form-field>
       </div>
 
-      <mat-error *ngIf="constraintsForm?.touched && !hasBudgetOrMaxArea()">One required</mat-error>
+      <div formGroupName="treatmentForm">
+        <!-- Treatment of total planning area -->
+        <label class="form-label required">
+          Treatment of total planning area
+        </label>
+
+        <div class="flex-row">
+          <div>
+            <!-- Max percentage of planning area -->
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+              <mat-label>Max</mat-label>
+              <input formControlName="maxArea" matInput type="number">
+              <span matSuffix>% &nbsp;</span>
+              <mat-hint class="subtext">Cannot exceed 90%</mat-hint>
+            </mat-form-field>
+          </div>
+
+          <div>
+            <!-- Max cost of treatment for planning area -->
+            <mat-form-field class="input-field" [class.disabled]="!enableMaxCost()" appearance="outline" floatLabel="always">
+              <mat-label>Max total cost</mat-label>
+              <input formControlName="maxCost" matInput type="number" [readonly]="!enableMaxCost()">
+              <span matPrefix>$&nbsp;</span>
+            </mat-form-field>
+          </div>
+        </div>
+      </div>
 
       <!-- Other Constraints-->
       <div>
@@ -57,7 +58,7 @@
               (change)="toggleRequiredExcludeDistance()">
               Exclude areas off a road by
             </mat-checkbox>
-            <mat-form-field class="input-field margin-left" appearance="outline" floatLabel="always">
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
               <mat-label>Distance</mat-label>
               <input formControlName="excludeDistance" matInput type="number">
               <span matSuffix>ft.</span>
@@ -69,15 +70,20 @@
               (change)="toggleRequiredExcludeSlope()">
               Exclude areas that are over
             </mat-checkbox>
-            <mat-form-field class="input-field margin-left" appearance="outline" floatLabel="always">
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
               <mat-label>Slope</mat-label>
               <input formControlName="excludeSlope" matInput type="number">
               <span matSuffix>degrees</span>
             </mat-form-field>
           </div>
         </div>
-        <div class="error-text">*Required</div>
       </div>
+
+      <mat-hint>
+        <mat-icon class="material-symbols-outlined">info</mat-icon>
+        <span>Total estimated costs are shown only when cost per acre is provided above</span>
+      </mat-hint>
+      <mat-error>*At least one required</mat-error>
 
       <!-- Next and Back -->
       <div>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -2,26 +2,8 @@
   <!-- Form -->
   <div class="constraints-content">
     <form class="constraints-form" [formGroup]="constraintsForm!">
-      <!-- Cost input -->
-      <div formGroupName="budgetForm">
-        <label class="form-label required">
-          Cost input
-        </label>
-        <!-- Estimated cost in $ per acre -->
-        <mat-form-field class="input-field" appearance="outline" floatLabel="always">
-          <mat-label>Est. treatment cost</mat-label>
-          <input
-            class="right-align"
-            formControlName="estimatedCost"
-            matInput
-            type="number">
-            <span matPrefix>$&nbsp;</span>
-            <span matSuffix>per acre</span>
-        </mat-form-field>
-      </div>
-
+      <!-- Treatment of total planning area -->
       <div formGroupName="treatmentForm">
-        <!-- Treatment of total planning area -->
         <label class="form-label required">
           Treatment of total planning area
         </label>
@@ -36,9 +18,32 @@
               <mat-hint class="subtext">Cannot exceed 90%</mat-hint>
             </mat-form-field>
           </div>
+        </div>
+      </div>
+
+      <!-- Cost input -->
+      <div formGroupName="budgetForm">
+        <label class="form-label required">
+          Cost input
+        </label>
+
+        <div class="flex-row">
+          <div>
+            <!-- Estimated cost in $ per acre -->
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+              <mat-label>Est. treatment cost</mat-label>
+              <input
+                class="right-align"
+                formControlName="estimatedCost"
+                matInput
+                type="number">
+                <span matPrefix>$&nbsp;</span>
+                <span matSuffix>per acre</span>
+            </mat-form-field>
+          </div>
 
           <div>
-            <!-- Max cost of treatment for planning area -->
+            <!-- Max cost of treatment -->
             <mat-form-field class="input-field" [class.disabled]="!enableMaxCost()" appearance="outline" floatLabel="always">
               <mat-label>Max total cost</mat-label>
               <input formControlName="maxCost" matInput type="number" [readonly]="!enableMaxCost()">

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
@@ -27,11 +27,11 @@ label.required:after {
 }
 
 .input-field {
-    padding-top: 18px;
-    width: 170px;
+  padding-top: 18px;
+  width: 170px;
 
-  &.margin-left {
-    margin-left: 28px;
+  &.disabled {
+    opacity: .60;
   }
 }
 
@@ -67,4 +67,23 @@ label.required:after {
 
 .flex-row {
   display: flex;
+  gap: 60px;
+
+  div {
+    flex-grow: 1;
+  }
+}
+
+.mat-hint {
+  align-items: center;
+  display: flex;
+  font-size: 12px;
+  line-height: 16px;
+
+  .mat-icon {
+    font-size: 16px;
+    height: 16px;
+    margin-right: 8px;
+    width: 16px;
+  }
 }

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
@@ -37,13 +37,13 @@ describe('ConstraintsPanelComponent', () => {
 
     const fb = fixture.componentRef.injector.get(FormBuilder);
     component.constraintsForm = fb.group({
-      budgetForm: fb.group({
-        // Estimated cost in $ per acre
-        estimatedCost: ['', [Validators.min(0), Validators.required]],
-      }),
       treatmentForm: fb.group({
         // Max area treated as a % of planning area
         maxArea: ['', [Validators.min(0), Validators.max(90)]],
+      }),
+      budgetForm: fb.group({
+        // Estimated cost in $ per acre
+        estimatedCost: ['', [Validators.min(0), Validators.required]],
         // Max cost of treatment for entire planning area
         maxCost: ['', Validators.min(0)],
       }),

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
@@ -38,11 +38,14 @@ describe('ConstraintsPanelComponent', () => {
     const fb = fixture.componentRef.injector.get(FormBuilder);
     component.constraintsForm = fb.group({
       budgetForm: fb.group({
-        maxBudget: [''],
-        optimizeBudget: [false, Validators.required],
+        // Estimated cost in $ per acre
+        estimatedCost: ['', [Validators.min(0), Validators.required]],
       }),
       treatmentForm: fb.group({
-        maxArea: ['', Validators.required],
+        // Max area treated as a % of planning area
+        maxArea: ['', [Validators.min(0), Validators.max(90)]],
+        // Max cost of treatment for entire planning area
+        maxCost: ['', Validators.min(0)],
       }),
       excludeAreasByDegrees: [false],
       excludeAreasByDistance: [false],
@@ -63,8 +66,7 @@ describe('ConstraintsPanelComponent', () => {
       await loader.getAllHarnesses(MatButtonHarness)
     )[0];
     // Set form to valid state
-    component.constraintsForm?.get('budgetForm.maxBudget')?.setValue('1');
-    component.constraintsForm?.get('treatmentForm.maxArea')?.setValue('1');
+    component.constraintsForm?.get('budgetForm.estimatedCost')?.setValue('1');
 
     expect(component.constraintsForm?.valid).toBeTrue();
     expect(await nextButton.isDisabled()).toBeFalse();
@@ -80,6 +82,8 @@ describe('ConstraintsPanelComponent', () => {
     const nextButton: MatButtonHarness = (
       await loader.getAllHarnesses(MatButtonHarness)
     )[0];
+
+    expect(component.constraintsForm?.valid).toBeFalse();
 
     // Click next button
     await nextButton.click();

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -11,19 +11,8 @@ export class ConstraintsPanelComponent {
   @Output() formNextEvent = new EventEmitter<void>();
   @Output() formBackEvent = new EventEmitter<void>();
 
-  hasBudgetOrMaxArea(): boolean {
-    return (
-      !!this.constraintsForm?.get('budgetForm.maxBudget')?.value ||
-      !!this.constraintsForm?.get('budgetForm.optimizeBudget')?.value ||
-      !!this.constraintsForm?.get('treatmentForm.maxArea')?.value
-    );
-  }
-
-  maxBudgetRequired(): boolean {
-    return (
-      !this.constraintsForm?.get('budgetForm.optimizeBudget')?.value &&
-      !this.constraintsForm?.get('treatmentForm.maxArea')?.value
-    );
+  enableMaxCost(): boolean {
+    return !!this.constraintsForm?.get('treatmentForm.maxArea')?.value;
   }
 
   toggleRequiredExcludeDistance() {

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -12,7 +12,7 @@ export class ConstraintsPanelComponent {
   @Output() formBackEvent = new EventEmitter<void>();
 
   enableMaxCost(): boolean {
-    return !!this.constraintsForm?.get('treatmentForm.maxArea')?.value;
+    return !!this.constraintsForm?.get('budgetForm.estimatedCost')?.value;
   }
 
   toggleRequiredExcludeDistance() {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -79,7 +79,7 @@ describe('CreateScenariosComponent', () => {
 
     component.formGroups[1].valueChanges.subscribe((_) => {
       expect(
-        component.formGroups[1].get('treatmentForm.maxCost')?.value
+        component.formGroups[1].get('budgetForm.maxCost')?.value
       ).toEqual(100);
     });
   });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -79,7 +79,7 @@ describe('CreateScenariosComponent', () => {
 
     component.formGroups[1].valueChanges.subscribe((_) => {
       expect(
-        component.formGroups[1].get('budgetForm.maxBudget')?.value
+        component.formGroups[1].get('treatmentForm.maxCost')?.value
       ).toEqual(100);
     });
   });
@@ -91,6 +91,8 @@ describe('CreateScenariosComponent', () => {
     expect(fakePlanService.updateProject).toHaveBeenCalledOnceWith({
       id: 1,
       planId: 1,
+      est_cost: NaN,
+      max_budget: NaN,
       max_treatment_area_ratio: NaN,
       max_road_distance: NaN,
       max_slope: NaN,
@@ -152,6 +154,8 @@ describe('CreateScenariosComponent', () => {
     expect(fakePlanService.createScenario).toHaveBeenCalledOnceWith({
       id: 1,
       planId: 1,
+      est_cost: NaN,
+      max_budget: NaN,
       max_treatment_area_ratio: NaN,
       max_road_distance: NaN,
       max_slope: NaN,

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -71,13 +71,13 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       // Step 2: Set constraints
       this.fb.group(
         {
-          budgetForm: this.fb.group({
-            // Estimated cost in $ per acre
-            estimatedCost: ['', Validators.min(0)],
-          }),
           treatmentForm: this.fb.group({
             // Max area treated as a % of planning area
             maxArea: ['', [Validators.min(0), Validators.max(90)]],
+          }),
+          budgetForm: this.fb.group({
+            // Estimated cost in $ per acre
+            estimatedCost: ['', Validators.min(0)],
             // Max cost of treatment for entire planning area
             maxCost: ['', Validators.min(0)],
           }),
@@ -161,7 +161,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
   private loadConfig(): void {
     this.planService.getProject(this.scenarioConfigId!).subscribe((config) => {
       const estimatedCost = this.formGroups[1].get('budgetForm.estimatedCost');
-      const maxCost = this.formGroups[1].get('treatmentForm.maxCost');
+      const maxCost = this.formGroups[1].get('budgetForm.maxCost');
       const maxArea = this.formGroups[1].get('treatmentForm.maxArea');
       const excludeDistance = this.formGroups[1].get('excludeDistance');
       const excludeSlope = this.formGroups[1].get('excludeSlope');
@@ -213,7 +213,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
 
   private formValueToProjectConfig(): ProjectConfig {
     const estimatedCost = this.formGroups[1].get('budgetForm.estimatedCost');
-    const maxCost = this.formGroups[1].get('treatmentForm.maxCost');
+    const maxCost = this.formGroups[1].get('budgetForm.maxCost');
     const maxArea = this.formGroups[1].get('treatmentForm.maxArea');
     const excludeDistance = this.formGroups[1].get('excludeDistance');
     const excludeSlope = this.formGroups[1].get('excludeSlope');

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -4,11 +4,12 @@ import {
   AbstractControl,
   FormBuilder,
   FormGroup,
+  ValidationErrors,
   Validators,
 } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Subject, take, concatMap, of } from 'rxjs';
+import { BehaviorSubject, concatMap, of, Subject, take } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { PlanService } from 'src/app/services';
 import {
@@ -71,11 +72,14 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       this.fb.group(
         {
           budgetForm: this.fb.group({
-            maxBudget: ['', Validators.min(0)],
-            optimizeBudget: [false],
+            // Estimated cost in $ per acre
+            estimatedCost: ['', Validators.min(0)],
           }),
           treatmentForm: this.fb.group({
+            // Max area treated as a % of planning area
             maxArea: ['', [Validators.min(0), Validators.max(90)]],
+            // Max cost of treatment for entire planning area
+            maxCost: ['', Validators.min(0)],
           }),
           excludeAreasByDegrees: [false],
           excludeAreasByDistance: [false],
@@ -144,17 +148,20 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  private constraintsFormValidator(constraintsForm: AbstractControl): boolean {
-    // Only one of budget or max treatment percentage is required.
-    const maxBudget = constraintsForm.get('budgetForm.maxBudget');
-    const optimizeBudget = constraintsForm.get('budgetForm.optimizeBudget');
+  private constraintsFormValidator(
+    constraintsForm: AbstractControl
+  ): ValidationErrors | null {
+    // Only one of budget or treatment area constraints is required.
+    const estimatedCost = constraintsForm.get('budgetForm.estimatedCost');
     const maxArea = constraintsForm.get('treatmentForm.maxArea');
-    return !!maxBudget?.value || !!optimizeBudget?.value || !!maxArea?.value;
+    const valid = !!estimatedCost?.value || !!maxArea?.value;
+    return valid ? null : { budgetOrAreaRequired: true };
   }
 
   private loadConfig(): void {
     this.planService.getProject(this.scenarioConfigId!).subscribe((config) => {
-      const maxBudget = this.formGroups[1].get('budgetForm.maxBudget');
+      const estimatedCost = this.formGroups[1].get('budgetForm.estimatedCost');
+      const maxCost = this.formGroups[1].get('treatmentForm.maxCost');
       const maxArea = this.formGroups[1].get('treatmentForm.maxArea');
       const excludeDistance = this.formGroups[1].get('excludeDistance');
       const excludeSlope = this.formGroups[1].get('excludeSlope');
@@ -163,8 +170,11 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
         'priorityWeightsForm'
       ) as FormGroup;
 
+      if (config.est_cost) {
+        estimatedCost?.setValue(config.est_cost);
+      }
       if (config.max_budget) {
-        maxBudget?.setValue(config.max_budget);
+        maxCost?.setValue(config.max_budget);
       }
       if (config.max_treatment_area_ratio) {
         maxArea?.setValue(config.max_treatment_area_ratio);
@@ -202,7 +212,8 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
   }
 
   private formValueToProjectConfig(): ProjectConfig {
-    const maxBudget = this.formGroups[1].get('budgetForm.maxBudget');
+    const estimatedCost = this.formGroups[1].get('budgetForm.estimatedCost');
+    const maxCost = this.formGroups[1].get('treatmentForm.maxCost');
     const maxArea = this.formGroups[1].get('treatmentForm.maxArea');
     const excludeDistance = this.formGroups[1].get('excludeDistance');
     const excludeSlope = this.formGroups[1].get('excludeSlope');
@@ -213,8 +224,9 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       id: this.scenarioConfigId!,
       planId: Number(this.plan$.getValue()?.id),
     };
-    if (maxBudget?.valid)
-      projectConfig.max_budget = parseFloat(maxBudget.value);
+    if (estimatedCost?.valid)
+      projectConfig.est_cost = parseFloat(estimatedCost.value);
+    if (maxCost?.valid) projectConfig.max_budget = parseFloat(maxCost.value);
     if (maxArea?.valid)
       projectConfig.max_treatment_area_ratio = parseFloat(maxArea.value);
     if (excludeDistance?.valid)
@@ -251,7 +263,9 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       .pipe(
         take(1),
         concatMap(() => {
-          return this.planService.createScenario(this.formValueToProjectConfig())
+          return this.planService.createScenario(
+            this.formValueToProjectConfig()
+          );
         })
       )
       .subscribe(() => {

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -242,6 +242,7 @@ describe('PlanService', () => {
         {
           id: 1,
           planId: undefined,
+          est_cost: undefined,
           max_budget: 200,
           max_road_distance: undefined,
           max_slope: undefined,
@@ -277,6 +278,7 @@ describe('PlanService', () => {
       const projectConfig: ProjectConfig = {
         id: 1,
         planId: undefined,
+        est_cost: undefined,
         max_budget: 200,
         max_road_distance: undefined,
         max_slope: undefined,
@@ -321,18 +323,18 @@ describe('PlanService', () => {
 
   describe('getScenario', () => {
     it('should make HTTP request to backend', () => {
-      const projectConfig: ProjectConfig =
-        {
-          id: 1,
-          planId: undefined,
-          max_budget: undefined,
-          max_road_distance: undefined,
-          max_slope: undefined,
-          max_treatment_area_ratio: undefined,
-          priorities: undefined,
-          createdTimestamp: undefined,
-          weights: undefined,
-        };
+      const projectConfig: ProjectConfig = {
+        id: 1,
+        planId: undefined,
+        est_cost: undefined,
+        max_budget: undefined,
+        max_road_distance: undefined,
+        max_slope: undefined,
+        max_treatment_area_ratio: undefined,
+        priorities: undefined,
+        createdTimestamp: undefined,
+        weights: undefined,
+      };
       const scenario: Scenario = {
         id: '1',
         planId: undefined,
@@ -376,6 +378,7 @@ describe('PlanService', () => {
       expect(req.request.method).toEqual('POST');
       expect(req.request.body).toEqual({
         plan_id: 2,
+        est_cost: undefined,
         max_budget: 200,
         max_road_distance: undefined,
         max_slope: undefined,
@@ -390,18 +393,18 @@ describe('PlanService', () => {
 
   describe('getScenariosForPlan', () => {
     it('should make HTTP request to backend', (done) => {
-      const projectConfig: ProjectConfig =
-        {
-          id: 1,
-          planId: undefined,
-          max_budget: 200,
-          max_road_distance: undefined,
-          max_slope: undefined,
-          max_treatment_area_ratio: undefined,
-          priorities: undefined,
-          createdTimestamp: undefined,
-          weights: undefined,
-        };
+      const projectConfig: ProjectConfig = {
+        id: 1,
+        planId: undefined,
+        est_cost: undefined,
+        max_budget: 200,
+        max_road_distance: undefined,
+        max_slope: undefined,
+        max_treatment_area_ratio: undefined,
+        priorities: undefined,
+        createdTimestamp: undefined,
+        weights: undefined,
+      };
       service.getScenariosForPlan('1').subscribe((res) => {
         expect(res).toEqual([
           {

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -379,6 +379,7 @@ export class PlanService {
     return {
       id: config.id,
       planId: config.plan_id,
+      est_cost: config.est_cost,
       max_budget: config.max_budget,
       max_road_distance: config.max_road_distance,
       max_slope: config.max_slope,
@@ -440,7 +441,7 @@ export class PlanService {
     Object.keys(scenarioPriorities).forEach((priority, weight) => {
       priorities.push({
         id: priority,
-        name: priority.replace(/_/g, " "),
+        name: priority.replace(/_/g, ' '),
         weight: weight,
       });
     });
@@ -451,6 +452,7 @@ export class PlanService {
   private convertConfigToScenario(config: ProjectConfig): any {
     return {
       plan_id: config.planId,
+      est_cost: config.est_cost,
       max_budget: config.max_budget,
       max_road_distance: config.max_road_distance,
       max_slope: config.max_slope,

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -51,6 +51,7 @@ export interface Priority {
 export interface ProjectConfig {
   id: number;
   planId?: number;
+  est_cost?: number;
   max_budget?: number;
   max_treatment_area_ratio?: number;
   max_road_distance?: number;


### PR DESCRIPTION
## Changes
- Fixes #650 
- Removes "optimize budget" radio button from constraints
- Adds "estimated cost per acre" field
- Updates logic around required fields (see bug)

## Todos
- Add `est_cost` field in the backend so this constraint can actually be saved (#699)

![image](https://user-images.githubusercontent.com/10444733/226736397-11cbe2c6-6d5c-4592-8afd-9de7cc6ba039.png)
