### PR TITLE
Adds DB interactions to ForsysGenerationRequestParams

### DIFF
--- a/src/planscape/forsys/forsys_request_params.py
+++ b/src/planscape/forsys/forsys_request_params.py
@@ -2,6 +2,7 @@ from enum import IntEnum
 
 from boundary.models import BoundaryDetails
 from conditions.models import BaseCondition
+from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
 from django.http import HttpRequest, QueryDict
 from forsys.default_forsys_request_params_polygons import (
@@ -9,7 +10,8 @@ from forsys.default_forsys_request_params_polygons import (
 from forsys.merge_polygons import merge_polygons
 from plan.models import (Project, ProjectArea, Plan,
                          Scenario, ScenarioWeightedPriority)
-from plan.views import get_project_by_id, get_scenario_by_id, get_user
+from plan.views import get_scenario_by_id, get_user
+from planscape import settings
 
 # URL parameter name for ForsysRankingRequestParamsType or
 # ForsysGenerationRequestParamsType.
@@ -81,41 +83,80 @@ class ClusterAlgorithmRequestParams():
             raise Exception("expected cluster_pixel_index_weight to be > 0")
 
 
+# TODO: incorporate this with RankingRequestParams, too.
 class DbRequestParams():
     # Constants for parsing url parameters.
     # Scenario ID indicates the scenario to be processed.
     _URL_SCENARIO_ID = 'scenario_id'
-    # A boolean representing whether output data is to be saved to the DB.
+    # A boolean representing whether Forsys output data will be saved to the DB.
     _URL_WRITE_TO_DB = 'write_to_db'
 
-    # Class constructor inputs consists of an HttpRequest and parameters
-    # controlling whether or not to read and write from DB.
-    # - read_from_db indicates whether self.scenario should be None. It's
-    #   intended to be true for ForsysRankingRequestParamsFromDb and false for
-    #   ForsysGenerationRequestParamsFromUrlWithDefaults.
-    # - default_write_output_to_db_value sets the default value for
-    #   self.write_to_db. It's intended to be true for
-    #   ForsysRankingRequestParamsFromDb and false for
-    #   ForsysGenerationRequestParamsFromUrlWithDefaults.
-    def __init__(self, request: HttpRequest,
-                 default_write_output_to_db_value: bool,
-                 read_from_db: bool) -> None:
-        params = request.GET
+    # In production, the user can be accessed via get_user(request); however,
+    # for backend debugging purposes, this url parameter is also available for
+    # use if settings.DEBUG is true.
+    _URL_DEBUG_USER_ID = 'debug_user_id'
 
-        self.write_to_db = params.get(
-            self._URL_WRITE_TO_DB, default_write_output_to_db_value)
+    def __init__(self, request: HttpRequest,) -> None:
+        self.write_to_db = None
+        self.scenario = None
+        self.user = self._get_user(request)
 
-        if read_from_db and isinstance(params[self._URL_SCENARIO_ID], str):
-            user = get_user(request)
-            self.scenario = get_scenario_by_id(
-                user, self._URL_SCENARIO_ID, params)
-        else:
-            self.scenario = None
-
-    # If true, writes the output to the DB.
+    # If true, the output data of a Forsys run will be saved to the DB.
     write_to_db: bool
     # The scenario.
+    # This guides the write-to-db functions:
+    # - If none, an entirely new plan, project, and scenario are written to the
+    #   DB along with Forsys output data.
+    # - Otherwise, Forsys output data is saved to this scenario.
     scenario: Scenario | None
+    # The user.
+    # This is typically an HttpRequest attribute.
+    # If settings.DEBUG is true, however, this may also be set via url
+    # parameter, debug_user_id.
+    # This informs Scenario retrieval (since only scenarios visible to the user 
+    # may be retrieved) and is a field value when saving Forsys output data to 
+    # the DB.
+    user: User
+
+    def _get_user(self, request: HttpRequest) -> User:
+        if hasattr(request, 'user'):
+            user = get_user(request)
+            if user is not None:
+                return user
+
+        params = request.GET
+        if settings.DEBUG and self._URL_DEBUG_USER_ID in params.keys():
+            if not isinstance(params[self._URL_DEBUG_USER_ID], str):
+                raise Exception(
+                    "expected parameter, debug_user_id, to have a string value")
+            user_id = int(params.get(self._URL_DEBUG_USER_ID, "0"))
+            return User.objects.get(id=user_id)
+
+        return None
+
+
+# When Forsys parameters are read from url parameters with default values 
+# (for the sake of e2e tests), no scenario needs to be retrieved and, by 
+# default, write_to_db is false.
+class DbRequestParamsForGenerationFromUrlWithDefaults(DbRequestParams):
+    def __init__(self, request: HttpRequest):
+        DbRequestParams.__init__(self, request)
+        params = request.GET
+        self.write_to_db = params.get(
+            DbRequestParams._URL_WRITE_TO_DB, False)
+        self.scenario = None
+
+
+# When Forsys parameters are gleaned from DB table values (for production), a 
+# scenario is retrieved, and, by default, write_to_db is true.
+class DbRequestParamsForGenerationFromDb(DbRequestParams):
+    def __init__(self, request: HttpRequest):
+        DbRequestParams.__init__(self, request)
+        params = request.GET
+        self.write_to_db = params.get(
+            DbRequestParams._URL_WRITE_TO_DB, True)
+        self.scenario = get_scenario_by_id(
+            self.user, self._URL_SCENARIO_ID, params)
 
 
 # Reads url parameters common to both
@@ -292,12 +333,15 @@ class ForsysGenerationRequestParamsFromUrlWithDefaults(
 
     def __init__(self, params: QueryDict) -> None:
         ForsysGenerationRequestParams.__init__(self)
-        self._read_url_params_with_defaults(params)
+        
+        self.cluster_params = ClusterAlgorithmRequestParams(params)
+
         request = HttpRequest()
         request.GET = params
-        # By default, this request type is for sanity checking the flow and
-        # nothing should be written to DB.
-        self.db_params = DbRequestParams(request, False, False)
+        self.db_params = DbRequestParamsForGenerationFromUrlWithDefaults(
+            request)
+
+        self._read_url_params_with_defaults(params)
 
     def get_priority_weights_dict(self) -> dict[str, float]:
         return ForsysGenerationRequestParams.get_priority_weights_dict(self)
@@ -305,7 +349,6 @@ class ForsysGenerationRequestParamsFromUrlWithDefaults(
     def _read_url_params_with_defaults(self, params: QueryDict) -> None:
         _read_common_url_params(self, params)
         self.planning_area = get_default_planning_area()
-        self.cluster_params = ClusterAlgorithmRequestParams(params)
 
 
 # Looks up forsys generation parameters from DB.
@@ -316,27 +359,14 @@ class ForsysGenerationRequestParamsFromDb(
         ForsysGenerationRequestParamsFromUrlWithDefaults):
     def __init__(self, request: HttpRequest) -> None:
         ForsysGenerationRequestParams.__init__(self)
+
+        # TODO: pass cluster parameters via DB.
         self.cluster_params = ClusterAlgorithmRequestParams(request.GET)
-        self._read_db_params(request)
 
-    def _read_db_params(self, request: HttpRequest) -> None:
-        self.db_params = DbRequestParams(request, True, True)
-
-        scenario = self.db_params.scenario
-        self._validate_scenario(scenario)
-
-        project = scenario.project
-        plan = Plan.objects.get(id=project.plan_id)
-        self.region = plan.region_name
-        # TODO: the model for plan.geometry should be null=False.
-        self.planning_area = plan.geometry
-        if self.planning_area is None:
-            raise Exception(
-                "geometry missing for plan ID, %d, for scenario ID, %d" %
-                (plan.pk, self.db_write_params.scenario.pk))
-
-        self.priorities, self.priority_weights = self._get_weighted_priorities(
-            scenario)
+        self.db_params = DbRequestParamsForGenerationFromDb(request)
+        self._validate_scenario(self.db_params.scenario)
+        
+        self._read_db_params()
 
     def _validate_scenario(self, scenario: Scenario):
         status = scenario.status
@@ -351,6 +381,22 @@ class ForsysGenerationRequestParamsFromDb(
         if scenario.project is None:
             raise Exception(
                 "project is none for scenario ID, %d" % (scenario.pk))
+
+    def _read_db_params(self) -> None:
+        scenario = self.db_params.scenario
+
+        project = scenario.project
+        plan = Plan.objects.get(id=project.plan_id)
+        self.region = plan.region_name
+        # TODO: the model for plan.geometry should be null=False.
+        self.planning_area = plan.geometry
+        if self.planning_area is None:
+            raise Exception(
+                "geometry missing for plan ID, %d, for scenario ID, %d" %
+                (plan.pk, self.db_write_params.scenario.pk))
+
+        self.priorities, self.priority_weights = self._get_weighted_priorities(
+            scenario)
 
     def _get_weighted_priorities(
         self, scenario: Scenario

--- a/src/planscape/forsys/forsys_request_params_test.py
+++ b/src/planscape/forsys/forsys_request_params_test.py
@@ -12,7 +12,8 @@ from forsys.forsys_request_params import (ClusterAlgorithmType,
                                           ClusterAlgorithmRequestParams,
                                           get_generation_request_params,
                                           get_ranking_request_params)
-from plan.models import Plan, Project, ProjectArea
+from plan.models import (Plan, Project, ProjectArea,
+                         Scenario, ScenarioWeightedPriority)
 from planscape import settings
 
 
@@ -211,7 +212,7 @@ class TestForsysRankingRequestParamsFromDb(TestCase):
         self.assertRaises(Exception, get_ranking_request_params, qd)
 
     def test_nonexistent_project_id(self):
-        qd = QueryDict('project_id=10')
+        qd = QueryDict('project_id=99999')
         self.assertRaises(Exception, get_ranking_request_params, qd)
 
     def test_empty_project_areas(self):
@@ -263,6 +264,8 @@ class TestForsysGenerationRequestParamsFromUrlWithDefaults(TestCase):
         self.assertEqual(params.cluster_params.num_clusters, 500)
         self.assertEqual(
             params.cluster_params.pixel_index_weight, 0.01)
+        self.assertIsNone(params.db_params.scenario)
+        self.assertFalse(params.db_params.write_to_db)
 
     def test_reads_region_from_url_params(self):
         request = HttpRequest()
@@ -305,6 +308,8 @@ class TestForsysGenerationRequestParamsFromUrlWithDefaults(TestCase):
 
 class TestForsysGenerationRequestParamsFromDb(TestCase):
     def setUp(self) -> None:
+        self.region = 'sierra_cascade_inyo'
+
         self.user = User.objects.create(username='testuser')
         self.user.set_password('12345')
         self.user.save()
@@ -312,27 +317,56 @@ class TestForsysGenerationRequestParamsFromDb(TestCase):
         self.geometry = {'type': 'MultiPolygon',
                          'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
         self.stored_geometry = GEOSGeometry(json.dumps(self.geometry))
+
         self.plan_with_user = Plan.objects.create(
-            owner=self.user, name="plan", region_name='sierra_cascade_inyo',
+            owner=self.user, name="plan", region_name=self.region,
             geometry=self.stored_geometry)
+
+        self.project_with_user = Project.objects.create(
+            owner=self.user, plan=self.plan_with_user)
+
+        self.scenario_with_user = Scenario.objects.create(
+            owner=self.user, plan=self.plan_with_user,
+            project=self.project_with_user,
+            status=Scenario.ScenarioStatus.INITIALIZED)
+
+        weighted_priorities = {'foo': 1, 'bar': 5, 'baz': 3}
+        for condition_name in weighted_priorities.keys():
+            base_condition = BaseCondition.objects.create(
+                condition_name=condition_name, region_name=self.region,
+                condition_level=1)
+            condition = Condition.objects.create(
+                condition_dataset=base_condition)
+            ScenarioWeightedPriority.objects.create(
+                scenario=self.scenario_with_user, priority=condition,
+                weight=weighted_priorities[condition_name])
 
     def test_read_ok(self):
         request = HttpRequest()
-        request.GET = QueryDict('id=' + str(self.plan_with_user.pk))
+        request.GET = QueryDict(
+            'scenario_id=' + str(self.scenario_with_user.pk))
         request.user = self.user
         params = get_generation_request_params(request)
         self.assertEqual(params.region, 'sierra_cascade_inyo')
         self.assertEqual(params.planning_area.coords, ((
             ((1.0, 2.0), (2.0, 3.0), (3.0, 4.0), (1.0, 2.0)),),))
+        self.assertListEqual(params.priorities, ['foo', 'bar', 'baz'])
+        self.assertListEqual(params.priority_weights, [1, 5, 3])
+
         self.assertEqual(params.cluster_params.cluster_algorithm_type,
                          ClusterAlgorithmType.NONE)
         self.assertEqual(params.cluster_params.num_clusters, 500)
         self.assertEqual(
             params.cluster_params.pixel_index_weight, 0.01)
 
+        self.assertTrue(params.db_params.write_to_db)
+        self.assertEqual(params.db_params.scenario.pk,
+                         self.scenario_with_user.pk)
+
     def test_fails_on_no_user(self):
         request = HttpRequest()
-        request.GET = QueryDict('id=' + str(self.plan_with_user.pk))
+        request.GET = QueryDict(
+            'scenario_id=' + str(self.scenario_with_user.pk))
         with self.assertRaises(Exception) as context:
             get_generation_request_params(request)
         self.assertEquals(
@@ -345,31 +379,61 @@ class TestForsysGenerationRequestParamsFromDb(TestCase):
         wrong_user.save()
 
         request = HttpRequest()
-        request.GET = QueryDict('id=' + str(self.plan_with_user.pk))
+        request.GET = request.GET = QueryDict(
+            'scenario_id=' + str(self.scenario_with_user.pk))
         request.user = wrong_user
         with self.assertRaises(Exception) as context:
             get_generation_request_params(request)
         self.assertEquals(
             str(context.exception),
-            "You do not have permission to view this plan.")
+            "You do not have permission to view this scenario.")
 
-    def test_fails_no_plan(self):
+    def test_fails_no_scenario(self):
         request = HttpRequest()
         request.GET = QueryDict()
         request.user = self.user
         with self.assertRaises(Exception) as context:
             get_generation_request_params(request)
-        self.assertEquals(str(context.exception), "'id'")
+        self.assertEquals(str(context.exception), "'scenario_id'")
 
-    def test_fails_nonexistent_plan_id(self):
+    def test_fails_nonexistent_scenario_id(self):
         request = HttpRequest()
-        request.GET = QueryDict('id=' + str(125125))
+        request.GET = QueryDict('scenario_id=' + str(125125))
         request.user = self.user
         with self.assertRaises(Exception) as context:
             get_generation_request_params(request)
         self.assertEquals(
             str(context.exception),
-            "Plan matching query does not exist.")
+            "Scenario matching query does not exist.")
+
+    def test_fails_scenario_status(self):
+        self.scenario_with_user.status = Scenario.ScenarioStatus.PENDING
+        self.scenario_with_user.save()
+
+        request = HttpRequest()
+        request.GET = QueryDict(
+            'scenario_id=' + str(self.scenario_with_user.pk))
+        request.user = self.user
+
+        with self.assertRaises(Exception) as context:
+            get_generation_request_params(request)
+        self.assertEquals(
+            str(context.exception),
+            "scenario status for scenario ID, 5, is Pending (expected Initialized or Failed)")
+
+    def test_fails_zero_weighted_priorities(self):
+        ScenarioWeightedPriority.objects.all().delete()
+
+        request = HttpRequest()
+        request.GET = QueryDict(
+            'scenario_id=' + str(self.scenario_with_user.pk))
+        request.user = self.user
+
+        with self.assertRaises(Exception) as context:
+            get_generation_request_params(request)
+        self.assertEquals(
+            str(context.exception),
+            "no weighted priorities available for scenario ID, 6")
 
 
 class ForsysGenerationRequestParamsFromHuc12(TestCase):

--- a/src/planscape/forsys/parse_forsys_output.py
+++ b/src/planscape/forsys/parse_forsys_output.py
@@ -2,8 +2,10 @@ import rpy2
 
 import numpy as np
 
+from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 from forsys.merge_polygons import merge_polygons
+from planscape import settings
 from typing import TypedDict
 
 
@@ -431,8 +433,14 @@ class ForsysGenerationOutputForASingleScenario(
                     ) -> dict[int, Polygon | MultiPolygon]:
         merged_polygons = {}
         for id in project_area_geometries.keys():
-            merged_polygons[id] = merge_polygons(
+            geo = merge_polygons(
                 project_area_geometries[id], 0)
+            geo.transform(
+                CoordTransform(
+                    SpatialReference(settings.CRS_9822_PROJ4),
+                    SpatialReference(settings.DEFAULT_CRS)))
+            geo.srid = settings.DEFAULT_CRS
+            merged_polygons[id] = geo
         return merged_polygons
 
     def _populate_geo_wkt_in_ranked_projects(

--- a/src/planscape/forsys/views.py
+++ b/src/planscape/forsys/views.py
@@ -20,6 +20,8 @@ from forsys.parse_forsys_output import (
     ForsysGenerationOutputForASingleScenario,
     ForsysRankingOutputForASingleScenario,
     ForsysRankingOutputForMultipleScenarios)
+from forsys.write_forsys_output_to_db import (
+    create_plan_and_scenario, save_generation_output_to_db)
 from memory_profiler import profile
 from planscape import settings
 from pytz import timezone
@@ -250,6 +252,16 @@ def generate_project_areas_for_a_single_scenario(
         response['forsys'] = {}
         response['forsys']['input'] = forsys_input.forsys_input
         response['forsys']['output'] = forsys_output.scenario
+
+        if params.db_params.write_to_db:
+            scenario = create_plan_and_scenario(params) \
+                if params.db_params.scenario is None \
+                else params.db_params.scenario
+            save_generation_output_to_db(scenario, forsys_output.scenario)
+            response['db'] = {}
+            response['db']['scenario_id'] = str(scenario.pk)
+            response['db']['project_id'] = str(scenario.project.pk)
+            response['db']['plan_id'] = str(scenario.plan.pk)
 
         if settings.DEBUG:
             _tear_down_cprofiler(pr, 'output/cprofiler.log')

--- a/src/planscape/forsys/write_forsys_output_to_db.py
+++ b/src/planscape/forsys/write_forsys_output_to_db.py
@@ -1,22 +1,45 @@
+from datetime import datetime
+
 from base.condition_types import ConditionScoreType
 from conditions.models import Condition
-from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
 from forsys.forsys_request_params import ForsysGenerationRequestParams
-from forsys.parse_forsys_output import ForsysGenerationOutputForASingleScenario
 from plan.models import (
     Plan, Project, ProjectArea, RankedProjectArea, Scenario,
     ScenarioWeightedPriority)
+from pytz import timezone
 
 
+def _create_plan(params: ForsysGenerationRequestParams) -> Plan:
+    plan = Plan.objects.create(
+        owner=params.db_params.user, name=datetime.now().astimezone(
+            timezone('US/Pacific')
+        ).strftime("%Y%-m-%d-%H:%M"), region_name=params.region,
+        geometry=params.planning_area)
+    plan.save()
+    return plan
+
+
+def _create_weighted_priorities(
+        params: ForsysGenerationRequestParams, scenario: Scenario):
+    for i in range(len(params.priorities)):
+        condition = Condition.objects.select_related('condition_dataset').get(
+            condition_dataset__condition_name=params.priorities[i],
+            condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
+        weighted_priority = ScenarioWeightedPriority.objects.create(
+            scenario=scenario, priority=condition, weight=params.priority_weights[i])
+        weighted_priority.save()
+
+
+# Creates a plan, project, scenario, and the weighted priorities associated
+# with a scenario.
+# This is primarily used for debug purposes, when 
+# ForsysGenerationRequestParams.db_params is missing a scenario.
 def create_plan_and_scenario(
         params: ForsysGenerationRequestParams) -> Scenario:
     user = params.db_params.user
 
-    plan = Plan.objects.create(
-        owner=user, name="my new plan", region_name=params.region,
-        geometry=params.planning_area)
-    plan.save()
+    plan = _create_plan(params)
 
     project = Project.objects.create(owner=user, plan=plan)
     project.save()
@@ -26,38 +49,46 @@ def create_plan_and_scenario(
         status=Scenario.ScenarioStatus.SUCCESS)
     scenario.save()
 
-    for i in range(len(params.priorities)):
-        condition = Condition.objects.select_related('condition_dataset').get(
-            condition_dataset__condition_name=params.priorities[i],
-            condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
-        weighted_priority = ScenarioWeightedPriority.objects.create(
-            scenario=scenario, priority=condition, weight=params.priority_weights[i])
-        weighted_priority.save()
+    _create_weighted_priorities(params, scenario)
 
     return scenario
 
 
+# Given a WKT, returns a MultiPolygon.
 def _get_multipolygon(wkt: str):
     geo = GEOSGeometry(wkt)
     if geo.geom_typeid == 6:
         return geo
     elif geo.geom_typeid == 3:
         return MultiPolygon((geo))
-    
+
     raise Exception(
         "geometry, %s, is neither a polygon nor a multipolylgon" % (wkt))
 
 
-def write_to_db(scenario: Scenario,
-                output_scenario: dict):
+# Given a Scenario and Forsys output data, adds ProjectArea and 
+# RankedProjectArea objects to the DB.
+# Forsys output data, represented by output_scenario, is the dictionary in
+# ForsysGenerationOutputForASingleScenario.scenario.
+def save_generation_output_to_db(scenario: Scenario,
+                                 output_scenario: dict):
     owner = scenario.owner
     project = scenario.project
+
     for p in output_scenario['ranked_projects']:
+        # TODO: add scenario as an optional field in ProjectArea so that project areas previously-generated for a scenario can be deleted.
         project_area = ProjectArea.objects.create(
             owner=owner, project=project,
             project_area=_get_multipolygon(p['geo_wkt']))
         project_area.save()
+
         ranked_project_area = RankedProjectArea.objects.create(
             scenario=scenario, project_area=project_area,
             rank=p['rank'], weighted_score=p['total_score'])
         ranked_project_area.save()
+
+    scenario.status = Scenario.ScenarioStatus.SUCCESS
+    scenario.save()
+
+
+# TODO: add save_ranking_output_to_db.

--- a/src/planscape/forsys/write_forsys_output_to_db.py
+++ b/src/planscape/forsys/write_forsys_output_to_db.py
@@ -1,0 +1,63 @@
+from base.condition_types import ConditionScoreType
+from conditions.models import Condition
+from django.contrib.auth.models import User
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+from forsys.forsys_request_params import ForsysGenerationRequestParams
+from forsys.parse_forsys_output import ForsysGenerationOutputForASingleScenario
+from plan.models import (
+    Plan, Project, ProjectArea, RankedProjectArea, Scenario,
+    ScenarioWeightedPriority)
+
+
+def create_plan_and_scenario(
+        params: ForsysGenerationRequestParams) -> Scenario:
+    user = params.db_params.user
+
+    plan = Plan.objects.create(
+        owner=user, name="my new plan", region_name=params.region,
+        geometry=params.planning_area)
+    plan.save()
+
+    project = Project.objects.create(owner=user, plan=plan)
+    project.save()
+
+    scenario = Scenario.objects.create(
+        owner=user, plan=plan, project=project,
+        status=Scenario.ScenarioStatus.SUCCESS)
+    scenario.save()
+
+    for i in range(len(params.priorities)):
+        condition = Condition.objects.select_related('condition_dataset').get(
+            condition_dataset__condition_name=params.priorities[i],
+            condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
+        weighted_priority = ScenarioWeightedPriority.objects.create(
+            scenario=scenario, priority=condition, weight=params.priority_weights[i])
+        weighted_priority.save()
+
+    return scenario
+
+
+def _get_multipolygon(wkt: str):
+    geo = GEOSGeometry(wkt)
+    if geo.geom_typeid == 6:
+        return geo
+    elif geo.geom_typeid == 3:
+        return MultiPolygon((geo))
+    
+    raise Exception(
+        "geometry, %s, is neither a polygon nor a multipolylgon" % (wkt))
+
+
+def write_to_db(scenario: Scenario,
+                output_scenario: dict):
+    owner = scenario.owner
+    project = scenario.project
+    for p in output_scenario['ranked_projects']:
+        project_area = ProjectArea.objects.create(
+            owner=owner, project=project,
+            project_area=_get_multipolygon(p['geo_wkt']))
+        project_area.save()
+        ranked_project_area = RankedProjectArea.objects.create(
+            scenario=scenario, project_area=project_area,
+            rank=p['rank'], weighted_score=p['total_score'])
+        ranked_project_area.save()

--- a/src/planscape/forsys/write_forsys_output_to_db.py
+++ b/src/planscape/forsys/write_forsys_output_to_db.py
@@ -27,7 +27,8 @@ def _create_weighted_priorities(
             condition_dataset__condition_name=params.priorities[i],
             condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
         weighted_priority = ScenarioWeightedPriority.objects.create(
-            scenario=scenario, priority=condition, weight=params.priority_weights[i])
+            scenario=scenario, priority=condition, 
+            weight=params.priority_weights[i])
         weighted_priority.save()
 
 
@@ -35,6 +36,8 @@ def _create_weighted_priorities(
 # with a scenario.
 # This is primarily used for debug purposes, when 
 # ForsysGenerationRequestParams.db_params is missing a scenario.
+# TODO: this assumes ForsysGenerationRequestParams is well-formed; input 
+# validation logic needs to be added and tested.
 def create_plan_and_scenario(
         params: ForsysGenerationRequestParams) -> Scenario:
     user = params.db_params.user
@@ -45,8 +48,7 @@ def create_plan_and_scenario(
     project.save()
 
     scenario = Scenario.objects.create(
-        owner=user, plan=plan, project=project,
-        status=Scenario.ScenarioStatus.SUCCESS)
+        owner=user, plan=plan, project=project)
     scenario.save()
 
     _create_weighted_priorities(params, scenario)
@@ -70,6 +72,8 @@ def _get_multipolygon(wkt: str):
 # RankedProjectArea objects to the DB.
 # Forsys output data, represented by output_scenario, is the dictionary in
 # ForsysGenerationOutputForASingleScenario.scenario.
+# TODO: this assumes the input arguments are well-formed; input validation 
+# logic needs to be added and tested.
 def save_generation_output_to_db(scenario: Scenario,
                                  output_scenario: dict):
     owner = scenario.owner

--- a/src/planscape/forsys/write_forsys_output_to_db_test.py
+++ b/src/planscape/forsys/write_forsys_output_to_db_test.py
@@ -1,0 +1,132 @@
+from django.contrib.auth.models import User
+from forsys.forsys_request_params import (
+    ForsysGenerationRequestParams, DbRequestParams)
+from forsys.write_forsys_output_to_db import (
+    create_plan_and_scenario, save_generation_output_to_db)
+from conditions.models import BaseCondition, Condition
+from plan.models import ScenarioWeightedPriority, RankedProjectArea, Scenario
+from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.http import HttpRequest
+from planscape import settings
+from django.test import TestCase
+
+
+def _create_condition(name: str, region: str):
+    base_condition = BaseCondition.objects.create(
+        condition_name=name, region_name=region, condition_level=3)
+    Condition.objects.create(condition_dataset=base_condition,
+                             condition_score_type=0, is_raw=False)
+
+
+def _set_up_db(self):
+    self.region = 'sierra_cascade_inyo'
+
+    poly = Polygon(((-120.14015536869722, 39.05413814388948),
+                    (-120.18409937110482, 39.48622140686506),
+                    (-119.93422142411087, 39.48622140686506),
+                    (-119.93422142411087, 39.05413814388948),
+                    (-120.14015536869722, 39.05413814388948)))
+    self.geo = MultiPolygon((poly))
+    self.geo.srid = settings.DEFAULT_CRS
+
+    self.user = User.objects.create(username='testuser')
+    self.user.set_password('12345')
+    self.user.save()
+
+    _create_condition('foo', self.region)
+    _create_condition('bar', self.region)
+
+
+class CreatePlanAndScenarioTest(TestCase):
+    def setUp(self):
+        _set_up_db(self)
+
+    def test_creates_plan_and_scenario(self):
+        params = ForsysGenerationRequestParams()
+        params.region = self.region
+        params.priorities = ['foo', 'bar']
+        params.priority_weights = [1, 4]
+        params.planning_area = self.geo
+
+        req = HttpRequest()
+        params.db_params = DbRequestParams(req)
+        params.db_params.user = self.user
+        params.db_params.write_to_db = True
+
+        scenario = create_plan_and_scenario(params)
+        project = scenario.project
+        plan = scenario.plan
+
+        self.assertEqual(scenario.owner, params.db_params.user)
+
+        self.assertEqual(plan.owner, params.db_params.user)
+        self.assertEqual(plan.region_name, params.region)
+        self.assertEqual(plan.geometry, params.planning_area)
+
+        self.assertEqual(project.owner, params.db_params.user)
+        self.assertEqual(project.plan, plan)
+
+        weighted_priorities = {
+            wp.priority.condition_dataset.condition_name: wp.weight
+            for wp in ScenarioWeightedPriority.objects.filter(
+                scenario_id=scenario.pk)}
+        self.assertDictEqual(weighted_priorities, {'foo': 1, 'bar': 4})
+
+
+class SaveGenerationOutputToDbTest(TestCase):
+    def setUp(self):
+        _set_up_db(self)
+
+        params = ForsysGenerationRequestParams()
+        params.region = self.region
+        params.priorities = ['foo', 'bar']
+        params.priority_weights = [1, 4]
+        params.planning_area = self.geo
+
+        req = HttpRequest()
+        params.db_params = DbRequestParams(req)
+        params.db_params.user = self.user
+        params.db_params.write_to_db = True
+        self.scenario = create_plan_and_scenario(params)
+
+    def test_saves_generation_output_to_db(self):
+        poly1 = Polygon(((-120.14015536869722, 39.05413814388948),
+                      (-119.93422142411087, 39.48622140686506),
+                      (-119.93422142411087, 39.05413814388948),
+                      (-120.14015536869722, 39.05413814388948)))
+        poly1.srid = settings.DEFAULT_CRS
+        poly2 = Polygon(((-120.14015536869722, 39.05413814388948),
+                      (-120.18409937110482, 39.48622140686506),
+                      (-119.93422142411087, 39.05413814388948),
+                      (-120.14015536869722, 39.05413814388948)))
+        poly2.srid = settings.DEFAULT_CRS
+
+        save_generation_output_to_db(
+            self.scenario, {
+                'ranked_projects':
+                [{'id': 2,
+                  'weighted_priority_scores': {'foo': 0.1, 'bar': 0.8},
+                  'total_score': 0.9,
+                  'rank': 1,
+                  'geo_wkt': poly1.wkt},
+                 {'id': 1,
+                  'weighted_priority_scores': {'foo': 0.5, 'bar': 0.2},
+                    'total_score': 0.7,
+                    'rank': 2,
+                    'geo_wkt': poly2.wkt}]})
+
+        p1 = RankedProjectArea.objects.get(
+            scenario_id=self.scenario.pk, rank=1)
+        self.assertAlmostEqual(p1.weighted_score, 0.9)
+        self.assertEqual(p1.project_area.project_area.coords[0], poly1.coords)
+        self.assertEqual(p1.project_area.owner, self.user)
+        self.assertEqual(p1.project_area.project, self.scenario.project)
+
+        p2 = RankedProjectArea.objects.get(
+            scenario_id=self.scenario.pk, rank=2)
+        self.assertAlmostEqual(p2.weighted_score, 0.7)
+        self.assertEqual(p2.project_area.project_area.coords[0], poly2.coords)
+        self.assertEqual(p2.project_area.owner, self.user)
+        self.assertEqual(p2.project_area.project, self.scenario.project)
+
+        self.assertEqual(self.scenario.status, Scenario.ScenarioStatus.SUCCESS)

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -5,6 +5,7 @@ from base.condition_types import ConditionScoreType
 from base.region_name import display_name_to_region, region_to_display_name
 from conditions.models import BaseCondition, Condition
 from conditions.raster_utils import fetch_or_compute_condition_stats
+from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.db.models import Count
 from django.db.models.query import QuerySet
@@ -27,7 +28,7 @@ MAX_SLOPE = 'max_slope'
 PRIORITIES = 'priorities'
 
 
-def get_user(request: HttpRequest):
+def get_user(request: HttpRequest) -> User:
     user = None
     if request.user.is_authenticated:
         user = request.user
@@ -35,6 +36,28 @@ def get_user(request: HttpRequest):
         raise ValueError("Must be logged in")
     return user
 
+
+def get_scenario_by_id(
+        user: User, id_url_param: str, params: QueryDict) -> Scenario:
+    assert isinstance(params[id_url_param], str)
+    scenario_id = params.get(id_url_param, "0")
+    scenario = Scenario.objects.select_related(
+        'project').get(id=scenario_id)
+
+    if scenario.owner != user:
+        raise ValueError(
+            "You do not have permission to view this scenario.")
+    return scenario
+
+
+def get_project_by_id(user: User, id_url_param: str, 
+                      params: QueryDict) -> Project:
+    assert isinstance(params[id_url_param], str)
+    project_id = params.get(id_url_param, "0")
+    project = Project.objects.get(id=project_id)
+    if project.owner != user:
+        raise ValueError("You do not have permission to view this project.")
+    return project
 
 @csrf_exempt
 def create_plan(request: HttpRequest) -> HttpResponse:
@@ -195,7 +218,8 @@ def list_plans_by_owner(request: HttpRequest) -> HttpResponse:
 
 
 # TODO: add validation for requiring either max budget or max area to be set for a generation run
-def _validate_constraint_values(max_budget, max_treatment_area_ratio, max_road_distance, max_slope):
+def _validate_constraint_values(
+        max_budget, max_treatment_area_ratio, max_road_distance, max_slope):
     if max_budget is not None and not (isinstance(max_budget, (int, float))):
         raise ValueError("Max budget must be a number value")
 
@@ -204,7 +228,8 @@ def _validate_constraint_values(max_budget, max_treatment_area_ratio, max_road_d
         raise ValueError(
             "Max treatment must be a number value >= 0.0")
 
-    if max_road_distance is not None and not (isinstance(max_road_distance, (int, float))):
+    if max_road_distance is not None and not (
+            isinstance(max_road_distance, (int, float))):
         raise ValueError("Max distance from road must be a number value")
 
     if (max_slope is not None and
@@ -213,8 +238,9 @@ def _validate_constraint_values(max_budget, max_treatment_area_ratio, max_road_d
             "Max slope must be a number value >= 0.0")
 
 
-def _set_project_parameters(max_budget, max_treatment_area_ratio, max_road_distance,
-                            max_slope, project: Project):
+def _set_project_parameters(
+        max_budget, max_treatment_area_ratio, max_road_distance, max_slope,
+        project: Project):
     project.max_budget = float(max_budget) if max_budget else None
     project.max_treatment_area_ratio = float(
         max_treatment_area_ratio) if max_treatment_area_ratio else None
@@ -230,7 +256,8 @@ def _set_priorities(priorities, project: Project):
                 condition_name=priorities[i])
             # is_raw=False required because for metrics, we store both current raw and current normalized data.
             condition = Condition.objects.get(
-                condition_dataset=base_condition, condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
+                condition_dataset=base_condition,
+                condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
             project.priorities.add(condition)
 
 
@@ -337,23 +364,17 @@ def list_projects_for_plan(request: HttpRequest) -> HttpResponse:
 
         projects = Project.objects.filter(owner=user, plan=int(plan_id))
 
-        return JsonResponse([_serialize_project(project) for project in projects], safe=False)
+        return JsonResponse([_serialize_project(project)
+                             for project in projects],
+                            safe=False)
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 
 def get_project(request: HttpRequest) -> HttpResponse:
     try:
-        assert isinstance(request.GET['id'], str)
-        project_id = request.GET.get('id', "0")
-
         user = get_user(request)
-
-        project = Project.objects.get(id=project_id)
-        if project.owner != user:
-            raise ValueError(
-                "You do not have permission to view this project.")
-
+        project = get_project_by_id(user, 'id', request.GET)
         return JsonResponse(_serialize_project(project))
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
@@ -450,6 +471,8 @@ def create_project_area(request: HttpRequest) -> HttpResponse:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 # TODO: consolidate create_project_areas API to one call
+
+
 @csrf_exempt
 def create_project_areas_for_project(request: HttpRequest) -> HttpResponse:
     try:
@@ -506,17 +529,9 @@ def _serialize_project_areas(areas: QuerySet):
 
 def get_project_areas(request: HttpRequest) -> HttpResponse:
     try:
-        assert isinstance(request.GET['project_id'], str)
-        project_id = request.GET.get('project_id', "0")
-        project_exists = Project.objects.get(id=project_id)
-
         user = get_user(request)
-
-        if project_exists.owner != user:
-            raise ValueError(
-                "You do not have permission to view this project.")
-
-        project_areas = ProjectArea.objects.filter(project=project_id)
+        project = get_project_by_id(user, 'project_id', request.GET)
+        project_areas = ProjectArea.objects.filter(project=project.pk)
         response = _serialize_project_areas(project_areas)
         return JsonResponse(response)
     except Exception as e:
@@ -531,12 +546,15 @@ def _set_scenario_metadata(priorities, weights, notes, scenario: Scenario):
             condition_name=priorities[i])
         # is_raw=False required because for metrics, we store both current raw and current normalized data.
         condition = Condition.objects.get(
-            condition_dataset=base_condition, condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
+            condition_dataset=base_condition,
+            condition_score_type=ConditionScoreType.CURRENT, is_raw=False)
         weight = weights[i] if weights is not None else None
         weighted_pri = ScenarioWeightedPriority.objects.create(
             scenario=scenario, priority=condition, weight=weight)
 
 # TODO: create scenario for project instead of plan
+
+
 @csrf_exempt
 def create_scenario(request: HttpRequest) -> HttpResponse:
     try:
@@ -617,7 +635,8 @@ def update_scenario(request: HttpRequest) -> HttpResponse:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 
 
-def _serialize_scenario(scenario: Scenario, weights: QuerySet, areas: QuerySet, project: Project) -> dict:
+def _serialize_scenario(scenario: Scenario, weights: QuerySet, areas: QuerySet,
+                        project: Project) -> dict:
     result = ScenarioSerializer(scenario).data
 
     if 'creation_time' in result:
@@ -629,8 +648,9 @@ def _serialize_scenario(scenario: Scenario, weights: QuerySet, areas: QuerySet, 
     for weight in weights:
         serialized_weight = ScenarioWeightedPrioritySerializer(weight).data
         if 'priority' in serialized_weight and 'weight' in serialized_weight:
-            result['priorities'][Condition.objects.get(
-                pk=serialized_weight['priority']).condition_dataset.condition_name] = serialized_weight['weight']
+            result['priorities'][
+                Condition.objects.get(pk=serialized_weight['priority']).
+                condition_dataset.condition_name] = serialized_weight['weight']
 
     result['project_areas'] = _serialize_project_areas(areas)
     # TODO: project should be a required field
@@ -643,19 +663,15 @@ def _serialize_scenario(scenario: Scenario, weights: QuerySet, areas: QuerySet, 
 @csrf_exempt
 def get_scenario(request: HttpRequest) -> HttpResponse:
     try:
-        assert isinstance(request.GET['id'], str)
-        scenario_id = request.GET.get('id', "0")
-        scenario = Scenario.objects.select_related(
-            'project').get(id=scenario_id)
-
         user = get_user(request)
+        scenario = get_scenario_by_id(user, 'id', request.GET)
 
-        if scenario.owner != user:
-            raise ValueError(
-                "You do not have permission to view this scenario.")
         weights = ScenarioWeightedPriority.objects.filter(scenario=scenario)
         project_areas = ProjectArea.objects.filter(project=scenario.project.pk)
-        return JsonResponse(_serialize_scenario(scenario, weights, project_areas, scenario.project), safe=False)
+        return JsonResponse(
+            _serialize_scenario(
+                scenario, weights, project_areas, scenario.project),
+            safe=False)
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))
 

--- a/src/planscape/plan/views.py
+++ b/src/planscape/plan/views.py
@@ -670,11 +670,6 @@ def get_scenario(request: HttpRequest) -> HttpResponse:
         weights = ScenarioWeightedPriority.objects.filter(scenario=scenario)
         project_areas = ProjectArea.objects.filter(project=scenario.project.pk)
 
-        r = JsonResponse(
-            _serialize_scenario(
-                scenario, weights, project_areas, scenario.project),
-            safe=False)
-        
         return JsonResponse(
             _serialize_scenario(
                 scenario, weights, project_areas, scenario.project),


### PR DESCRIPTION
1) Adds DbRequestParams, which contains parameters, write_to_db (true/false), scenario (Scenario/None), and user (User/None).
2) Updates ForsysRankingRequestParamsFromDb (write_to_db is true by default, scenario is retrieved, user is optional) and ForsysRankingRequestParamsFromUrlWithDefaults ( write_to_db is false by default, scenario is null, user is optional).
3) Adds create_plan_and_scenario (to be used for test cases), write_to_db (to be used for actual data).
4) Updates the CRS of project area polygons in ForsysGenerationOutputForASingleScenario.

test url: http://localhost:8000/planscape-backend/forsys/generate_project_areas/single_scenario/?request_type=4&cluster_algorithm_type=0&write_to_db=1&debug_user_id=56

![image](https://user-images.githubusercontent.com/3720361/226841713-8351cdef-3a0a-4c21-b0a0-0911a59d0e66.png)

![image](https://user-images.githubusercontent.com/3720361/226841605-3217e6ba-26f0-4304-9d6b-2306ed9c641e.png)
