### PR TITLE
style changes to map layer panel

### DIFF
--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -16,20 +16,21 @@
           <div [class.disabled]="node.styleDisabled">
             <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
               (change)="onSelect(node)">
-              {{node.display_name}}
+              <span class="condition-label">{{node.display_name}}</span>
             </mat-radio-button>
             <span *ngIf="node.disableSelect">
               {{node.display_name}}
             </span>
-            <button mat-icon-button
-              [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
-              (menuClosed)="node.infoMenuOpen = false">
-              <mat-icon color="primary">info_outline</mat-icon>
-            </button>
-            <mat-menu #popoverMenu="matMenu">
-              <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
-            </mat-menu>
           </div>
+          <button mat-icon-button
+            class="info-button"
+            [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+            (menuClosed)="node.infoMenuOpen = false">
+            <mat-icon color="primary">info_outline</mat-icon>
+          </button>
+          <mat-menu #popoverMenu="matMenu">
+            <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+          </mat-menu>
         </div>
       </mat-tree-node>
       <!-- This is the tree node template for expandable nodes -->

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -6,20 +6,20 @@
   <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
     color="primary"
     [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionLayer.emit(map)">
-    <mat-tree [dataSource]="conditionDataSource" [treeControl]="conditionTreeControl"
+    <mat-tree [dataSource]="conditionDataSource" [treeControl]="treeControl"
       class="condition-tree">
       <!-- This is the tree node template for leaf nodes -->
       <!-- There is inline padding applied to this node using styles.
         This padding value depends on the mat-icon-button width. -->
-      <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+      <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
         <div class="mat-tree-node">
           <div [class.disabled]="node.styleDisabled">
-            <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+            <mat-radio-button [value]="node.condition" *ngIf="!node.condition.disableSelect"
               (change)="onSelect(node)">
-              <span class="condition-label">{{node.display_name}}</span>
+              <span class="condition-label">{{node.condition.display_name}}</span>
             </mat-radio-button>
-            <span *ngIf="node.disableSelect">
-              {{node.display_name}}
+            <span *ngIf="node.condition.disableSelect">
+              {{node.condition.display_name}}
             </span>
           </div>
           <button mat-icon-button
@@ -29,36 +29,30 @@
             <mat-icon color="primary">info_outline</mat-icon>
           </button>
           <mat-menu #popoverMenu="matMenu">
-            <app-layer-info-card [dataLayerConfig]="node"></app-layer-info-card>
+            <app-layer-info-card [dataLayerConfig]="node.condition"></app-layer-info-card>
           </mat-menu>
         </div>
       </mat-tree-node>
       <!-- This is the tree node template for expandable nodes -->
-      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+      <mat-tree-node  *matTreeNodeDef="let node;when: hasChild" matTreeNodePadding>
         <div class="mat-tree-node expandable-condition-node">
           <div [class.disabled]="node.styleDisabled">
-            <mat-radio-button [value]="node" *ngIf="!node.disableSelect"
+            <mat-radio-button [value]="node.condition" *ngIf="!node.condition.disableSelect"
               (change)="onSelect(node)">
-              {{node.display_name}}
+              {{node.condition.display_name}}
             </mat-radio-button>
-            <span *ngIf="node.disableSelect">
-              {{node.display_name}}
+            <span *ngIf="node.condition.disableSelect">
+              {{node.condition.display_name}}
             </span>
           </div>
-            <button mat-icon-button matTreeNodeToggle
-                    [attr.aria-label]="'Toggle ' + node.display_name">
-              <mat-icon class="mat-icon-rtl-mirror">
-                {{conditionTreeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
-              </mat-icon>
-            </button>
+          <button mat-icon-button matTreeNodeToggle
+                  [attr.aria-label]="'Toggle ' + node.condition.display_name">
+            <mat-icon class="mat-icon-rtl-mirror">
+              {{treeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
+            </mat-icon>
+          </button>
         </div>
-        <!-- There is inline padding applied to this div using styles.
-            This padding value depends on the mat-icon-button width.  -->
-        <div [class.condition-tree-invisible]="!conditionTreeControl.isExpanded(node)"
-            role="group">
-            <ng-container matTreeNodeOutlet></ng-container>
-        </div>
-      </mat-nested-tree-node>
+      </mat-tree-node>
     </mat-tree>
   </mat-radio-group>
 </mat-expansion-panel>

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -11,10 +11,16 @@
       <!-- This is the tree node template for leaf nodes -->
       <!-- There is inline padding applied to this node using styles.
         This padding value depends on the mat-icon-button width. -->
-      <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
+      <mat-tree-node
+        *matTreeNodeDef="let node"
+        [class.selected]="node.styleSelected">
         <div class="mat-tree-node">
+          <div class="selected-dot" [class.hidden]="!node.styleDescendantSelected"></div>
           <div [class.disabled]="node.styleDisabled">
-            <mat-radio-button [value]="node.condition" *ngIf="!node.condition.disableSelect"
+            <mat-radio-button
+              [value]="node.condition"
+              *ngIf="!node.condition.disableSelect"
+              class="white"
               (change)="onSelect(node)">
               <span class="condition-label">{{node.condition.display_name}}</span>
             </mat-radio-button>
@@ -34,10 +40,16 @@
         </div>
       </mat-tree-node>
       <!-- This is the tree node template for expandable nodes -->
-      <mat-tree-node  *matTreeNodeDef="let node;when: hasChild" matTreeNodePadding>
+      <mat-tree-node
+        *matTreeNodeDef="let node;when: hasChild"
+        [class.selected]="node.styleSelected">
         <div class="mat-tree-node expandable-condition-node">
+          <div class="selected-dot" [class.hidden]="!node.styleDescendantSelected"></div>
           <div [class.disabled]="node.styleDisabled">
-            <mat-radio-button [value]="node.condition" *ngIf="!node.condition.disableSelect"
+            <mat-radio-button
+              [value]="node.condition"
+              *ngIf="!node.condition.disableSelect"
+              class="white"
               (change)="onSelect(node)">
               {{node.condition.display_name}}
             </mat-radio-button>
@@ -45,8 +57,10 @@
               {{node.condition.display_name}}
             </span>
           </div>
-          <button mat-icon-button matTreeNodeToggle
-                  [attr.aria-label]="'Toggle ' + node.condition.display_name">
+          <button
+            mat-icon-button
+            matTreeNodeToggle
+            [attr.aria-label]="'Toggle ' + node.condition.display_name">
             <mat-icon class="mat-icon-rtl-mirror">
               {{treeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
             </mat-icon>

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -13,7 +13,7 @@
         This padding value depends on the mat-icon-button width. -->
       <mat-tree-node
         *matTreeNodeDef="let node"
-        [class.selected]="node.styleSelected">
+        [class.selected]="map.config.dataLayerConfig === node.condition">
         <div class="mat-tree-node">
           <div class="selected-dot" [class.hidden]="!node.styleDescendantSelected"></div>
           <div [class.disabled]="node.styleDisabled">
@@ -42,7 +42,7 @@
       <!-- This is the tree node template for expandable nodes -->
       <mat-tree-node
         *matTreeNodeDef="let node;when: hasChild"
-        [class.selected]="node.styleSelected">
+        [class.selected]="map.config.dataLayerConfig === node.condition">
         <div class="mat-tree-node expandable-condition-node">
           <div class="selected-dot" [class.hidden]="!node.styleDescendantSelected"></div>
           <div [class.disabled]="node.styleDisabled">

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -41,14 +41,15 @@ mat-tree-node {
 
   &[aria-level='1'] {
     background-color: #F5F5F5;
-  }
-
-  &[aria-level='2'] {
     padding-left: 28px;
   }
 
-  &[aria-level='3'] {
+  &[aria-level='2'] {
     padding-left: 44px;
+  }
+
+  &[aria-level='3'] {
+    padding-left: 60px;
   }
 
   .disabled {

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -1,11 +1,3 @@
-@use 'sass:map';
-@use '@angular/material' as mat;
-
-@import "../../../../styles.scss";
-
-$color-config:    mat.get-color-config($planscape-frontend-theme);
-$primary-palette: map.get($color-config, 'primary');
-
 .layer-panel-header {
   background-color: #D8D8D8 !important;
   font-size: 14px;
@@ -42,20 +34,55 @@ $primary-palette: map.get($color-config, 'primary');
   padding-left: 20px;
 }
 
-.mat-tree-node {
+mat-tree-node {
   box-sizing: border-box;
   border-top: 1px solid #F5F5F5;
-  padding: 0px 4px 0px 24px;
+  padding: 0px 8px 0px 12px;
 
-  > .disabled {
+  &[aria-level='2'] {
+    padding-left: 28px;
+  }
+
+  &[aria-level='3'] {
+    padding-left: 44px;
+  }
+
+  .disabled {
     opacity: 0.5;
   }
+
+  &.selected {
+    background-color: #3367D6;
+
+    span {
+      color: white;
+    }
+
+    mat-icon {
+      color: white;
+    }
+  }
+
+  button {
+    margin-left: auto;
+  }
+}
+
+::ng-deep .mat-radio-button.mat-primary.mat-radio-checked.white .mat-radio-outer-circle {
+  border-color: white !important;
+}
+
+::ng-deep .mat-radio-button.mat-primary.mat-radio-checked.white .mat-radio-inner-circle {
+  background-color: white !important;
+}
+
+::ng-deep .mat-radio-button.mat-primary.mat-radio-checked.white .mat-radio-label-content {
+  color: white !important;
 }
 
 .expandable-condition-node {
   align-items: center;
   display: flex;
-  justify-content: space-between;
 }
 
 .condition-label {
@@ -67,7 +94,14 @@ $primary-palette: map.get($color-config, 'primary');
   margin-right: 24px;
 }
 
-.mat-expansion-panel-body {
-  margin: 0px -24px;
-  padding: 0px 24px;
+.selected-dot {
+  background-color: #3367D6;
+  border-radius: 4px;
+  height: 8px;
+  margin-right: 4px;
+  width: 8px;
+
+  &.hidden {
+    visibility: hidden;
+  }
 }

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -59,6 +59,15 @@ $primary-palette: map.get($color-config, 'primary');
   justify-content: space-between;
 }
 
+.condition-label {
+  white-space: normal;
+}
+
+.info-button {
+  margin-left: auto;
+  margin-right: 45px;
+}
+
 .mat-expansion-panel-body {
   margin: 0px -24px;
   padding: 0px 24px;

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -39,6 +39,10 @@ mat-tree-node {
   border-top: 1px solid #F5F5F5;
   padding: 0px 8px 0px 12px;
 
+  &[aria-level='1'] {
+    background-color: #F5F5F5;
+  }
+
   &[aria-level='2'] {
     padding-left: 28px;
   }

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -18,6 +18,10 @@ $primary-palette: map.get($color-config, 'primary');
   padding-bottom: 0px !important;
 }
 
+.condition-tree {
+  margin: 0px -24px;
+}
+
 .condition-tree-invisible {
   display: none;
 }
@@ -30,13 +34,6 @@ $primary-palette: map.get($color-config, 'primary');
 }
 
 /*
- * This padding sets alignment of the nested nodes.
- */
-.condition-tree .mat-nested-tree-node div[role=group] {
-  padding-left: 20px;
-}
-
-/*
  * Padding for leaf nodes.
  * Leaf nodes need to have padding so as to align with other non-leaf nodes
  * under the same parent.
@@ -46,7 +43,9 @@ $primary-palette: map.get($color-config, 'primary');
 }
 
 .mat-tree-node {
-  margin: 0px -16px 0px 0px;
+  box-sizing: border-box;
+  border-top: 1px solid #F5F5F5;
+  padding: 0px 4px 0px 24px;
 
   > .disabled {
     opacity: 0.5;
@@ -65,7 +64,7 @@ $primary-palette: map.get($color-config, 'primary');
 
 .info-button {
   margin-left: auto;
-  margin-right: 45px;
+  margin-right: 24px;
 }
 
 .mat-expansion-panel-body {

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
@@ -55,24 +55,23 @@ describe('ConditionTreeComponent', () => {
     });
 
     it('styles children of a selected node and unstyles all other nodes', () => {
-      const nodeWithChildren = component.conditionDataSource.data[0];
-      const nodeWithoutChildren = component.conditionDataSource.data[1];
+      const nodeWithChildren = component.treeControl.dataNodes[0];
+      const nodeWithoutChildren = component.treeControl.dataNodes[4];
 
       component.onSelect(nodeWithChildren);
 
-      nodeWithChildren.children?.forEach((child) => {
-        expect(child.styleDisabled).toBeTrue();
-      });
+      component.treeControl
+        .getDescendants(nodeWithChildren)
+        .forEach((descendant) => {
+          expect(descendant.styleDisabled).toBeTrue();
+        });
       expect(nodeWithChildren.styleDisabled).toBeFalse();
       expect(nodeWithoutChildren.styleDisabled).toBeFalse();
 
       component.onSelect(nodeWithoutChildren);
 
-      component.conditionDataSource.data.forEach((node) => {
+      component.treeControl.dataNodes.forEach((node) => {
         expect(node.styleDisabled).toBeFalse();
-        node.children?.forEach((child) => {
-          expect(child.styleDisabled).toBeFalse();
-        });
       });
     });
   });

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
@@ -75,4 +75,24 @@ describe('ConditionTreeComponent', () => {
       });
     });
   });
+
+  it('styles ancestors of a selected node and unstyles all other nodes', () => {
+    const childNode = component.treeControl.dataNodes[1];
+    const parentNode = component.treeControl.dataNodes[0];
+
+    component.onSelect(childNode);
+
+    expect(childNode.styleSelected).toBeTrue();
+    expect(parentNode.styleDescendantSelected).toBeTrue();
+
+    component.treeControl.dataNodes
+      .filter((node) => {
+        return node !== childNode && node !== parentNode;
+      })
+      .forEach((node) => {
+        expect(node.styleDisabled).toBeFalse();
+        expect(node.styleSelected).toBeFalse();
+        expect(node.styleDescendantSelected).toBeFalse();
+      });
+  });
 });

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
@@ -82,7 +82,6 @@ describe('ConditionTreeComponent', () => {
 
     component.onSelect(childNode);
 
-    expect(childNode.styleSelected).toBeTrue();
     expect(parentNode.styleDescendantSelected).toBeTrue();
 
     component.treeControl.dataNodes
@@ -91,7 +90,6 @@ describe('ConditionTreeComponent', () => {
       })
       .forEach((node) => {
         expect(node.styleDisabled).toBeFalse();
-        expect(node.styleSelected).toBeFalse();
         expect(node.styleDescendantSelected).toBeFalse();
       });
   });

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
@@ -19,7 +19,6 @@ interface ConditionFlatNode {
   infoMenuOpen?: boolean;
   styleDisabled?: boolean; // Node should be greyed out but still selectable
   styleDescendantSelected?: boolean;  // Node should have a dot indicator
-  styleSelected?: boolean; // Node should have a colored background
 }
 
 @Component({
@@ -87,16 +86,14 @@ export class ConditionTreeComponent implements OnInit {
   onSelect(node: ConditionFlatNode): void {
     this.unstyleAndDeselectAllNodes();
     this.styleDescendantsDisabled(node);
-    node.styleSelected = true;
     this.styleAncestorsSelected(node);
   }
 
   /** Unstyles and deselects all nodes. */
-  private unstyleAndDeselectAllNodes(): void {
+  unstyleAndDeselectAllNodes(): void {
     this.treeControl.dataNodes.forEach((dataNode) => {
       dataNode.styleDisabled = false;
       dataNode.styleDescendantSelected = false;
-      dataNode.styleSelected = false;
     });
   }
 

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -159,7 +159,7 @@
           [conditionsData$]="conditionDataRaw$"
           [header]="'Current Condition'"
           [map]="map"
-          (changeConditionLayer)="changeConditionLayer.emit($event)">
+          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(1)">
         </app-condition-tree>
 
         <!-- Normalized current condition controls -->
@@ -168,7 +168,7 @@
           [conditionsData$]="conditionDataNormalized$"
           [header]="'Current Condition (Normalized)'"
           [map]="map"
-          (changeConditionLayer)="changeConditionLayer.emit($event)">
+          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
         </app-condition-tree>
 
         <!-- Disturbances controls -->

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -1,4 +1,12 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  QueryList,
+  ViewChildren,
+} from '@angular/core';
 import { BehaviorSubject, filter, map, Observable } from 'rxjs';
 import {
   BaseLayerType,
@@ -10,7 +18,10 @@ import {
 
 import { NONE_DATA_LAYER_CONFIG } from './../../types/data.types';
 import { Map, MapViewOptions } from './../../types/map.types';
-import { ConditionsNode } from './condition-tree/condition-tree.component';
+import {
+  ConditionsNode,
+  ConditionTreeComponent,
+} from './condition-tree/condition-tree.component';
 
 @Component({
   selector: 'app-map-control-panel',
@@ -18,6 +29,9 @@ import { ConditionsNode } from './condition-tree/condition-tree.component';
   styleUrls: ['./map-control-panel.component.scss'],
 })
 export class MapControlPanelComponent implements OnInit {
+  @ViewChildren(ConditionTreeComponent)
+  conditionTrees?: QueryList<ConditionTreeComponent>;
+
   @Input() boundaryConfig: BoundaryConfig[] | null = null;
   @Input() conditionsConfig$!: Observable<ConditionsConfig | null>;
   @Input() loadingIndicators: { [layerName: string]: boolean } = {};
@@ -96,6 +110,10 @@ export class MapControlPanelComponent implements OnInit {
     this.toggleExistingProjectsLayer.emit(map);
     map.config.dataLayerConfig = NONE_DATA_LAYER_CONFIG;
     this.changeConditionLayer.emit(map);
+  }
+
+  unstyleConditionTree(index: number): void {
+    this.conditionTrees?.get(index)?.unstyleAndDeselectAllNodes();
   }
 
   private conditionsConfigToDataRaw(


### PR DESCRIPTION
## Changes
- Fixes #498 
- Add the blue background to the selected item
- Shift the info icon all the way to the right of the box
- Add the blue dot to the left of all ancestors of a selected item
- Add borders to items
- Add shading to Tier 2 items

![image](https://user-images.githubusercontent.com/10444733/226734265-227eb9b5-59dc-4032-8faf-2cc48bd48d2e.png)
