### PR TITLE
hacky fix to drawProjectAreas

### DIFF
--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
@@ -113,9 +113,11 @@ export class ScenarioDetailsComponent implements OnInit {
     this.planService.updateStateWithPanelState(this.panelExpanded);
   }
 
-  private drawProjectAreas(projectAreas: ProjectArea[]): void {
+  private drawProjectAreas(projectAreas: ProjectArea[]): void {   
+    var areas: any[] = []
     projectAreas.forEach((projectArea) => {
-      this.planService.updateStateWithShapes(projectArea.projectArea);
+      areas.push(projectArea.projectArea)
     });
+    this.planService.updateStateWithShapes(areas);
   }
 }


### PR DESCRIPTION
Drawing project areas one at a time via updateStateWithShapes caused only the last shape to be shown. This change enables project areas to be drawn together.

Before:
![image](https://user-images.githubusercontent.com/3720361/226742475-311d79e5-1b6f-419e-9c1b-1bac5d844d44.png)

After:
![image](https://user-images.githubusercontent.com/3720361/226742528-2aac8da4-09e8-4f0e-9172-d85719cc1a38.png)
