### PR TITLE
Save user uploaded shapefile as multiple project areas

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -56,7 +56,7 @@
         <app-generate-scenarios
           [formGroup]="formGroups[3]"
           (formBackEvent)="stepper.previous()"
-          (createScenarioEvent)="createScenarioAndProjectArea()">
+          (createScenarioEvent)="createScenarioAndProjectAreas()">
         </app-generate-scenarios>
       </mat-step>
     </mat-stepper>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -30,6 +30,7 @@ describe('CreateScenariosComponent', () => {
           maxBudget: 100,
         }),
         updateProject: of(1),
+        bulkCreateProjectAreas: of(null),
         createProjectArea: of(1),
         createScenario: of('1'),
         updateStateWithShapes: undefined,
@@ -147,7 +148,7 @@ describe('CreateScenariosComponent', () => {
     const router = fixture.debugElement.injector.get(Router);
     spyOn(router, 'navigate');
 
-    component.createScenarioAndProjectArea();
+    component.createScenarioAndProjectAreas();
 
     expect(fakePlanService.createScenario).toHaveBeenCalledOnceWith({
       id: 1,
@@ -164,18 +165,148 @@ describe('CreateScenariosComponent', () => {
     ]);
   });
 
-  it('creates uploaded project area when event is emitted', () => {
+  it('creates uploaded project areas when event is emitted', () => {
     component.scenarioConfigId = 1;
     component.formGroups[0].get('priorities')?.setValue(['test']);
     component.formGroups[2].get('uploadedArea')?.setValue(fakeGeoJson);
     const router = fixture.debugElement.injector.get(Router);
     spyOn(router, 'navigate');
 
-    component.createScenarioAndProjectArea();
+    component.createScenarioAndProjectAreas();
 
-    expect(fakePlanService.createProjectArea).toHaveBeenCalledOnceWith(
+    expect(fakePlanService.bulkCreateProjectAreas).toHaveBeenCalledOnceWith(
       component.scenarioConfigId,
-      fakeGeoJson
+      []
     );
+  });
+
+  describe('convertSingleGeoJsonToGeoJsonArray', () => {
+    it('converts a geojson with multiple multipolygons into geojsons', () => {
+      const testMultiGeoJson: GeoJSON.GeoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'MultiPolygon',
+              coordinates: [
+                [
+                  [
+                    [-120.48760442258875, 38.86069261999541],
+                    [-120.25134738486939, 38.63563031791014],
+                    [-120.68265831280989, 38.65924332885403],
+                    [-120.48760442258875, 38.86069261999541],
+                  ],
+                ],
+                [
+                  [
+                    [-120.08926185006236, 38.70429439806091],
+                    [-119.83102710804575, 38.575493119820806],
+                    [-120.02882494064228, 38.56474992770867],
+                    [-120.12497630750148, 38.59268150226389],
+                    [-120.08926185006236, 38.70429439806091],
+                  ],
+                ],
+                [
+                  [
+                    [-120.32277500514876, 38.59483057427002],
+                    [-120.19090826710838, 38.65494898256424],
+                    [-120.1947892445163, 38.584354895060606],
+                    [-120.25934844928075, 38.55964521088927],
+                    [-120.32277500514876, 38.59483057427002],
+                  ],
+                ],
+              ],
+            },
+            properties: {},
+          },
+          {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [-120.399442, 38.957252],
+                  [-120.646674, 38.631876],
+                  [-120.020352, 38.651183],
+                  [-120.07804, 38.818293],
+                  [-120.306043, 38.79689],
+                  [-120.399442, 38.957252],
+                ],
+              ],
+            },
+          },
+        ],
+      };
+
+      const result =
+        component.convertSingleGeoJsonToGeoJsonArray(testMultiGeoJson);
+
+      expect(result).toEqual([
+        {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                  [
+                    [
+                      [-120.48760442258875, 38.86069261999541],
+                      [-120.25134738486939, 38.63563031791014],
+                      [-120.68265831280989, 38.65924332885403],
+                      [-120.48760442258875, 38.86069261999541],
+                    ],
+                  ],
+                  [
+                    [
+                      [-120.08926185006236, 38.70429439806091],
+                      [-119.83102710804575, 38.575493119820806],
+                      [-120.02882494064228, 38.56474992770867],
+                      [-120.12497630750148, 38.59268150226389],
+                      [-120.08926185006236, 38.70429439806091],
+                    ],
+                  ],
+                  [
+                    [
+                      [-120.32277500514876, 38.59483057427002],
+                      [-120.19090826710838, 38.65494898256424],
+                      [-120.1947892445163, 38.584354895060606],
+                      [-120.25934844928075, 38.55964521088927],
+                      [-120.32277500514876, 38.59483057427002],
+                    ],
+                  ],
+                ],
+              },
+              properties: {},
+            },
+          ],
+        },
+        {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              properties: {},
+              geometry: {
+                type: 'Polygon',
+                coordinates: [
+                  [
+                    [-120.399442, 38.957252],
+                    [-120.646674, 38.631876],
+                    [-120.020352, 38.651183],
+                    [-120.07804, 38.818293],
+                    [-120.306043, 38.79689],
+                    [-120.399442, 38.957252],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      ]);
+    });
   });
 });

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -215,6 +215,25 @@ describe('PlanService', () => {
     });
   });
 
+  describe('bulkCreateProjectAreas', () => {
+    it('should make HTTP request to backend', () => {
+      service.bulkCreateProjectAreas(1, [fakeGeoJson]).subscribe((res) => {
+        expect(res).toEqual(null);
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT.concat('/plan/create_project_areas_for_project/')
+      );
+      expect(req.request.body).toEqual({
+        project_id: 1,
+        geometries: [fakeGeoJson],
+      });
+      expect(req.request.method).toEqual('POST');
+      req.flush(1);
+      httpTestingController.verify();
+    });
+  });
+
   describe('updateProject', () => {
     it('should make HTTP request to backend', () => {
       const projectConfig: ProjectConfig = {

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -195,6 +195,23 @@ export class PlanService {
       );
   }
 
+  /** Creates multiple project areas for a project. */
+  bulkCreateProjectAreas(projectId: number, projectAreas: GeoJSON.GeoJSON[]) {
+    const url = BackendConstants.END_POINT.concat('/plan/create_project_areas_for_project/');
+    return this.http
+      .post<number>(
+        url,
+        {
+          project_id: Number(projectId),
+          geometries: projectAreas,
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .pipe(take(1), map(() => null));
+  }
+
   /** Updates a project with new parameters. */
   updateProject(projectConfig: ProjectConfig): Observable<number> {
     const url = BackendConstants.END_POINT.concat('/plan/update_project/');


### PR DESCRIPTION
Shapefiles can contain multiple polygons, and when it's converted to a GeoJSON file, MultiPolygon is used for each feature to ensure the geometry can be correctly saved (polygons can have coordinates to indicate cutouts in the polygon). This change parses the converted GeoJSON from the uploaded shapefile into individual GeoJSONs, each feature as its own project area, to be used to call bulkCreateProjectAreas.