### PR TITLE
Fix for incorrect priority weights

### DIFF
--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
@@ -35,8 +35,8 @@
             <div class="flex-row space-between">
               <h2>{{ priority.name | titlecase  }}</h2>
               <div class="flex-row">
-                <mat-slider [disabled]=true [min]="1" [max]="5" [thumbLabel]="true" [value]="priority.weight"
-                  color="primary" [step]="1">
+                <mat-slider [disabled]=true [min]="0" [max]="5" [thumbLabel]="true" [value]="priority.weight"
+                  color="primary">
                   <input matSliderThumb>
                 </mat-slider>
                 <div class="slider-label">{{priority.weight}}</div>

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -392,7 +392,6 @@ export class PlanService {
   }
 
   private convertBackendScenarioToScenario(scenario: any): Scenario {
-    console.log(scenario);
     return {
       id: scenario.id,
       planId: scenario.plan,

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -392,6 +392,7 @@ export class PlanService {
   }
 
   private convertBackendScenarioToScenario(scenario: any): Scenario {
+    console.log(scenario);
     return {
       id: scenario.id,
       planId: scenario.plan,
@@ -436,16 +437,13 @@ export class PlanService {
       return [];
     }
 
-    let priorities: Priority[] = [];
-    Object.keys(scenarioPriorities).forEach((priority, weight) => {
-      priorities.push({
+    return Object.entries(scenarioPriorities).map(([priority, weight]) => {
+      return {
         id: priority,
         name: priority.replace(/_/g, " "),
         weight: weight,
-      });
+      }
     });
-
-    return priorities;
   }
 
   private convertConfigToScenario(config: ProjectConfig): any {


### PR DESCRIPTION
Bug:
Was showing incorrect weights in the Scenario Details priorities sliders because index was being used instead of the object value. 😅

Note that angular material default styles the first slider value black instead of grayed out when disabled. Changed the min to 0 instead of 1.

<img width="417" alt="Screenshot 2023-03-22 at 3 52 18 PM" src="https://user-images.githubusercontent.com/114368235/227056164-f095b770-3314-44a2-ac25-7ee6667765da.png">


