### PR TITLE
Add account management dialog

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -1,3 +1,22 @@
-<p>
-  You are logged in as {{ (user$ | async) ? displayName((user$ | async)!) : 'Guest' }}.
-</p>
+<div class="account-dialog">
+  <h1>
+    Welcome, {{ (user$ | async) ? displayName((user$ | async)!) : 'Guest' }}
+  </h1>
+
+  <div *ngIf="(user$ | async) as user">
+    <h3>Account Name</h3>
+    <h2>{{ displayName(user) }}</h2>
+
+    <h3>Email</h3>
+    <h2>{{ user.email }}</h2>
+
+    <h3>Password</h3>
+    <h2>••••••••••••••••••••••••••</h2>
+  </div>
+
+  <div class="button-row" *ngIf="user$ | async">
+    <button mat-raised-button color="primary">EDIT ACCOUNT</button>
+
+    <button mat-raised-button (click)="logout()">SIGN OUT</button>
+  </div>
+</div>

--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -95,8 +95,8 @@
           <mat-label>Email</mat-label>
           <input
             type="text"
-            required
-            formControlName="email"
+            disabled
+            [value]="editAccountForm.get('email')?.value"
             matInput>
         </mat-form-field>
 

--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -1,22 +1,120 @@
 <div class="account-dialog">
-  <h1>
-    Welcome, {{ (user$ | async) ? displayName((user$ | async)!) : 'Guest' }}
-  </h1>
+  <!-- Account details -->
+  <ng-container *ngIf="!editingAccount && !changingPassword; else form">
+    <h1>
+      Welcome, {{ (user$ | async) ? displayName((user$ | async)!) : 'Guest' }}
+    </h1>
 
-  <div *ngIf="(user$ | async) as user">
-    <h3>Account Name</h3>
-    <h2>{{ displayName(user) }}</h2>
+    <div *ngIf="(user$ | async) as user">
+      <h3>Account Name</h3>
+      <h2>{{ displayName(user) }}</h2>
 
-    <h3>Email</h3>
-    <h2>{{ user.email }}</h2>
+      <h3>Email</h3>
+      <h2>{{ user.email }}</h2>
 
-    <h3>Password</h3>
-    <h2>••••••••••••••••••••••••••</h2>
-  </div>
+      <h3>Password</h3>
+      <h2>••••••••••••••••••••••••••</h2>
+    </div>
 
-  <div class="button-row" *ngIf="user$ | async">
-    <button mat-raised-button color="primary">EDIT ACCOUNT</button>
+    <div class="button-row" *ngIf="user$ | async">
+      <button mat-raised-button color="primary" (click)="editAccount()">EDIT ACCOUNT</button>
 
-    <button mat-raised-button (click)="logout()">SIGN OUT</button>
-  </div>
+      <button mat-raised-button color="primary" (click)="changePassword()">CHANGE PASSWORD</button>
+
+      <button mat-raised-button (click)="logout()">SIGN OUT</button>
+    </div>
+  </ng-container>
+
+  <ng-template #form>
+    <!-- Change password -->
+    <ng-container *ngIf="changingPassword">
+      <form [formGroup]="changePasswordForm" (ngSubmit)="savePassword()">
+        <mat-form-field>
+          <mat-label>Password</mat-label>
+          <input
+            type="password"
+            required
+            formControlName="password1"
+            matInput>
+          <mat-error *ngIf="changePasswordForm.get('password1')?.hasError('minlength')">
+            Password must contain at least 8 characters.
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Confirm new password</mat-label>
+          <input
+            type="password"
+            required
+            formControlName="password2"
+            matInput>
+          <mat-error *ngIf="changePasswordForm.hasError('passwordsNotEqual')">
+            Passwords must match.
+          </mat-error>
+        </mat-form-field>
+
+        <div class="button-row">
+          <button
+            mat-raised-button
+            color="primary"
+            [disabled]="changePasswordForm.invalid || disableChangeButton"
+            (click)="savePassword()">
+            {{ disableEditButton ? 'SAVING...' : 'SAVE CHANGES' }}
+          </button>
+
+          <button mat-raised-button (click)="changingPassword = false">CANCEL</button>
+        </div>
+
+        <p>{{ error?.message }}</p>
+        <p *ngIf="error">{{ error?.error | json }}</p>
+      </form>
+    </ng-container>
+
+    <!-- Edit account details -->
+    <ng-container *ngIf="editingAccount">
+      <form [formGroup]="editAccountForm" (ngSubmit)="saveEdits()">
+        <mat-form-field>
+          <mat-label>First name</mat-label>
+          <input
+            type="text"
+            required
+            formControlName="firstName"
+            matInput>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Last name</mat-label>
+          <input
+            type="text"
+            required
+            formControlName="lastName"
+            matInput>
+        </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Email</mat-label>
+          <input
+            type="text"
+            required
+            formControlName="email"
+            matInput>
+        </mat-form-field>
+
+        <div class="button-row">
+          <button
+            mat-raised-button
+            color="primary"
+            [disabled]="editAccountForm.invalid || disableEditButton"
+            (click)="saveEdits()">
+            {{ disableEditButton ? 'SAVING...' : 'SAVE CHANGES' }}
+          </button>
+
+          <button mat-raised-button (click)="editingAccount = false">CANCEL</button>
+        </div>
+
+        <p>{{ error?.message }}</p>
+        <p *ngIf="error">{{ error?.error | json }}</p>
+      </form>
+    </ng-container>
+  </ng-template>
 </div>

--- a/src/interface/src/app/account-dialog/account-dialog.component.scss
+++ b/src/interface/src/app/account-dialog/account-dialog.component.scss
@@ -1,0 +1,39 @@
+.account-dialog {
+  align-items: stretch;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  justify-content: center;
+  padding: 48px 78px 24px;
+  width: 500px;
+}
+
+h1 {
+  font-family: 'Roboto';
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 32px;
+}
+
+h2 {
+  font-family: 'Public Sans';
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 24px;
+  margin-bottom: 24px;
+}
+
+h3 {
+  font-family: 'Public Sans';
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+  margin-bottom: 8px;
+}
+
+.button-row {
+  display: flex;
+  gap: 40px;
+  justify-content: start;
+}

--- a/src/interface/src/app/account-dialog/account-dialog.component.scss
+++ b/src/interface/src/app/account-dialog/account-dialog.component.scss
@@ -6,7 +6,7 @@
   gap: 48px;
   justify-content: center;
   padding: 48px 78px 24px;
-  width: 500px;
+  width: 600px;
 }
 
 h1 {
@@ -32,8 +32,13 @@ h3 {
   margin-bottom: 8px;
 }
 
+form {
+  display: flex;
+  flex-direction: column;
+}
+
 .button-row {
   display: flex;
-  gap: 40px;
+  gap: 12px;
   justify-content: start;
 }

--- a/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BehaviorSubject, of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
 
@@ -15,14 +16,20 @@ describe('AccountDialogComponent', () => {
     fakeAuthService = jasmine.createSpyObj<AuthService>(
       'AuthService',
       {
+        changePassword: of(),
         logout: of(),
+        updateUser: of(),
       },
       {
-        loggedInUser$: new BehaviorSubject<User | null>(null),
+        loggedInUser$: new BehaviorSubject<User | null>({
+          firstName: 'Foo',
+          lastName: 'Bar',
+          email: 'test@test.com',
+        }),
       }
     );
     TestBed.configureTestingModule({
-      imports: [MaterialModule],
+      imports: [FormsModule, MaterialModule, ReactiveFormsModule],
       declarations: [AccountDialogComponent],
       providers: [{ provide: AuthService, useValue: fakeAuthService }],
     });
@@ -39,5 +46,53 @@ describe('AccountDialogComponent', () => {
     component.logout();
 
     expect(fakeAuthService.logout).toHaveBeenCalledOnceWith();
+  });
+
+  it('editing prefills form and clears error', () => {
+    component.error = 'err';
+
+    component.editAccount();
+
+    expect(component.editingAccount).toBeTrue();
+    expect(component.error).toBeNull();
+    expect(component.editAccountForm.value).toEqual({
+      firstName: 'Foo',
+      lastName: 'Bar',
+      email: 'test@test.com',
+    });
+  });
+
+  it('changing password clears error', () => {
+    component.error = 'err';
+
+    component.changePassword();
+
+    expect(component.changingPassword).toBeTrue();
+    expect(component.error).toBeNull();
+  });
+
+  it('saving user changes calls AuthService', () => {
+    component.editAccount();
+    component.saveEdits();
+
+    expect(fakeAuthService.updateUser).toHaveBeenCalledOnceWith({
+      firstName: 'Foo',
+      lastName: 'Bar',
+      email: 'test@test.com',
+    });
+  });
+
+  it('saving new password calls AuthService', () => {
+    component.changePasswordForm.setValue({
+      password1: 'testpass',
+      password2: 'testpass',
+    });
+
+    component.savePassword();
+
+    expect(fakeAuthService.changePassword).toHaveBeenCalledOnceWith(
+      'testpass',
+      'testpass'
+    );
   });
 });

--- a/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
 
 import { AuthService } from '../services';
@@ -9,11 +9,14 @@ import { AccountDialogComponent } from './account-dialog.component';
 describe('AccountDialogComponent', () => {
   let component: AccountDialogComponent;
   let fixture: ComponentFixture<AccountDialogComponent>;
+  let fakeAuthService: AuthService;
 
   beforeEach(() => {
-    const fakeAuthService = jasmine.createSpyObj<AuthService>(
+    fakeAuthService = jasmine.createSpyObj<AuthService>(
       'AuthService',
-      {},
+      {
+        logout: of(),
+      },
       {
         loggedInUser$: new BehaviorSubject<User | null>(null),
       }
@@ -30,5 +33,11 @@ describe('AccountDialogComponent', () => {
 
   it('can load instance', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('logs user out', () => {
+    component.logout();
+
+    expect(fakeAuthService.logout).toHaveBeenCalledOnceWith();
   });
 });

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -5,6 +5,7 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable, take } from 'rxjs';
 
 import { AuthService } from '../services';
@@ -25,7 +26,11 @@ export class AccountDialogComponent implements OnInit {
   error: any;
   user$!: Observable<User | null>;
 
-  constructor(private authService: AuthService, private fb: FormBuilder) {
+  constructor(
+    private authService: AuthService,
+    private fb: FormBuilder,
+    private snackbar: MatSnackBar
+  ) {
     this.changePasswordForm = this.fb.group(
       {
         password1: this.fb.control('', [
@@ -88,6 +93,9 @@ export class AccountDialogComponent implements OnInit {
           this.changingPassword = false;
           this.disableChangeButton = false;
           this.error = null;
+          this.snackbar.open('Updated password successfully', undefined, {
+            duration: 3000,
+          });
         },
         (err) => {
           this.error = err;
@@ -113,6 +121,9 @@ export class AccountDialogComponent implements OnInit {
           this.editingAccount = false;
           this.disableEditButton = false;
           this.error = null;
+          this.snackbar.open('Updated account successfully', undefined, {
+            duration: 3000,
+          });
         },
         (err) => {
           this.error = err;

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, take } from 'rxjs';
 
 import { AuthService } from '../services';
 import { User } from '../types';
@@ -21,5 +21,9 @@ export class AccountDialogComponent implements OnInit {
   displayName(user: User): string {
     if (user.firstName) return user.firstName.concat(' ', user.lastName ?? '');
     else return user.username ?? user.email!;
+  }
+
+  logout(): void {
+    this.authService.logout().pipe(take(1)).subscribe();
   }
 }

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -132,6 +132,34 @@ export class AuthService {
         })
       );
   }
+
+  changePassword(password1: string, password2: string): Observable<any> {
+    return this.http.post(this.API_ROOT.concat('password/change/'), {
+      new_password1: password1,
+      new_password2: password2,
+    }, {
+      withCredentials: true,
+    });
+  }
+
+  updateUser(newUser: User): Observable<User> {
+    return this.http.patch(this.API_ROOT.concat('user/'), {
+      ...newUser,
+      first_name: newUser.firstName,
+      last_name: newUser.lastName,
+    }, {
+      withCredentials: true
+    }).pipe(map((response: any) => {
+      const user: User = {
+        email: response.email,
+        username: response.username,
+        firstName: response.first_name,
+        lastName: response.last_name,
+      };
+      this.loggedInUser$.next(user);
+      return user;
+    }));
+  }
 }
 
 /** An AuthGuard used to prevent access to pages that require sign-in. If the user is not signed

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -134,31 +134,44 @@ export class AuthService {
   }
 
   changePassword(password1: string, password2: string): Observable<any> {
-    return this.http.post(this.API_ROOT.concat('password/change/'), {
-      new_password1: password1,
-      new_password2: password2,
-    }, {
-      withCredentials: true,
-    });
+    return this.http.post(
+      this.API_ROOT.concat('password/change/'),
+      {
+        new_password1: password1,
+        new_password2: password2,
+      },
+      {
+        withCredentials: true,
+      }
+    );
   }
 
   updateUser(newUser: User): Observable<User> {
-    return this.http.patch(this.API_ROOT.concat('user/'), {
-      ...newUser,
-      first_name: newUser.firstName,
-      last_name: newUser.lastName,
-    }, {
-      withCredentials: true
-    }).pipe(map((response: any) => {
-      const user: User = {
-        email: response.email,
-        username: response.username,
-        firstName: response.first_name,
-        lastName: response.last_name,
-      };
-      this.loggedInUser$.next(user);
-      return user;
-    }));
+    return this.http
+      .patch(
+        this.API_ROOT.concat('user/'),
+        {
+          email: newUser.email,
+          username: newUser.username,
+          first_name: newUser.firstName,
+          last_name: newUser.lastName,
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .pipe(
+        map((response: any) => {
+          const user: User = {
+            email: response.email,
+            username: response.username,
+            firstName: response.first_name,
+            lastName: response.last_name,
+          };
+          this.loggedInUser$.next(user);
+          return user;
+        })
+      );
   }
 }
 

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -222,6 +222,7 @@ ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_LOGOUT_ON_GET = True
 ACCOUNT_USERNAME_REQUIRED = False
+LOGOUT_ON_PASSWORD_CHANGE = False
 
 # PostGIS constants. All raster data should be ingested with a common
 # Coordinate Reference System (CRS).  The values below are those for the


### PR DESCRIPTION
## Changes
- Part of #3 
- Replaces the stub account dialog
- New dialog displays user's account information, as well as buttons to edit account, change password, or log out (note: we cannot actually retrieve the user's password from the backend for security reasons, so the "password" shown is fake)
- User can edit select account details (first and last name) and save the changes
- User can update their password to a new one

## Todos
- Django-rest-auth doesn't support email change by default--will need to write a custom view for this
- Account deletion not supported yet
- Account recovery not supported yet
- Account avatars not supported yet

## Account details
![image](https://user-images.githubusercontent.com/10444733/227375031-f06e0f1c-b7e3-4e1c-a5b3-b283e0de8046.png)

## Updating account information
![image](https://user-images.githubusercontent.com/10444733/227375144-229c9c5b-1a4e-47a4-b280-3a8517b63d6e.png)

## Changing password
![image](https://user-images.githubusercontent.com/10444733/227375188-e44cb2fc-3c53-4133-b61f-07acdee9e673.png)
