### PR TITLE
fixes create_plan_and_scenario bugs

### DIFF
--- a/src/planscape/conditions/raster_utils.py
+++ b/src/planscape/conditions/raster_utils.py
@@ -97,12 +97,13 @@ def _append_to_list(
 def get_raster_geo(geo: GEOSGeometry) -> GEOSGeometry:
     if geo.srid == settings.CRS_FOR_RASTERS:
         return geo
-    geo.transform(
+    transformed_geo = geo.clone()
+    transformed_geo.transform(
         CoordTransform(
             SpatialReference(geo.srid),
             SpatialReference(settings.CRS_9822_PROJ4)))
-    geo.srid = settings.CRS_FOR_RASTERS
-    return geo
+    transformed_geo.srid = settings.CRS_FOR_RASTERS
+    return transformed_geo
 
 
 # Returns None if no intersection exists between a geometry and the condition

--- a/src/planscape/forsys/write_forsys_output_to_db.py
+++ b/src/planscape/forsys/write_forsys_output_to_db.py
@@ -10,7 +10,8 @@ from plan.models import (
 from pytz import timezone
 
 
-# Given a WKT, returns a MultiPolygon.
+# Given a WKT, validates that the WKT repreesents either a Polygon or 
+# MultiPolygon, then returns a MultiPolygon.
 def _get_multipolygon(wkt: str):
     geo = GEOSGeometry(wkt)
     if geo.geom_typeid == 6:
@@ -21,7 +22,7 @@ def _get_multipolygon(wkt: str):
         return multi
 
     raise Exception(
-        "geometry, %s, is neither a polygon nor a multipolylgon" % (wkt))
+        "geometry, %s, is neither a polygon nor a multipolygon" % (wkt))
 
 
 def _create_plan(params: ForsysGenerationRequestParams) -> Plan:

--- a/src/planscape/plan/geos_utils.py
+++ b/src/planscape/plan/geos_utils.py
@@ -1,0 +1,17 @@
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+
+_MULTIPOLYGON = 6
+_POLYGON = 3
+
+# Given a GEOSGeometry, validates that it represents either a Polygon or 
+# MultiPolygon, then returns a MultiPolygon.
+def get_multipolygon(geo: GEOSGeometry) -> MultiPolygon:
+    if geo.geom_typeid == _MULTIPOLYGON:
+        return geo
+    elif geo.geom_typeid == _POLYGON:
+        multi = MultiPolygon((geo))
+        multi.srid = geo.srid
+        return multi
+    
+    raise Exception(
+        "geometry, %s, is neither a polygon nor a multipolygon" % (geo.wkt))

--- a/src/planscape/plan/geos_utils_test.py
+++ b/src/planscape/plan/geos_utils_test.py
@@ -1,0 +1,42 @@
+from plan.geos_utils import get_multipolygon
+from django.test import TestCase
+from django.contrib.gis.geos import MultiPolygon, Point, Polygon
+
+
+class GetMultiPolygonTest(TestCase):
+    def test_multipolygon(self):
+        geo = MultiPolygon(
+            (Polygon(((-120.14015536869722, 39.05413814388948),
+                      (-119.93422142411087, 39.48622140686506),
+                      (-119.93422142411087, 39.05413814388948),
+                      (-120.14015536869722, 39.05413814388948))),
+             Polygon(((-120.14015536869722, 39.05413814388948),
+                      (-120.18409937110482, 39.48622140686506),
+                      (-119.93422142411087, 39.05413814388948),
+                      (-120.14015536869722, 39.05413814388948)))))
+        geo.srid = 4269
+        multi = get_multipolygon(geo)
+        self.assertEqual(multi.geom_type, 'MultiPolygon')
+        self.assertEqual(multi.coords, geo.coords)
+        self.assertEqual(multi.srid, geo.srid)
+
+    def test_polygon(self):
+        geo = Polygon(((-120.14015536869722, 39.05413814388948),
+                       (-120.18409937110482, 39.48622140686506),
+                       (-119.93422142411087, 39.48622140686506),
+                       (-119.93422142411087, 39.05413814388948),
+                       (-120.14015536869722, 39.05413814388948)))
+        geo.srid = 4269
+        multi = get_multipolygon(geo)
+        self.assertEqual(multi.geom_type, 'MultiPolygon')
+        self.assertEqual(multi.coords[0], geo.coords)
+        self.assertEqual(multi.srid, geo.srid)
+
+    def test_point(self):
+        geo = Point((-120.14015536869722, 39.05413814388948))
+        geo.srid = 4269
+        with self.assertRaises(Exception) as context:
+            get_multipolygon(geo)
+        self.assertEqual(
+            str(context.exception),
+            "geometry, POINT (-120.14015536869722 39.05413814388948), is neither a polygon nor a multipolygon")


### PR DESCRIPTION
1) in _create_plan, a MultiPolygon is expected, but sometimes the input is a Polygon. Adds logic for ensuring the Plan.geometry field is set with a MultiPolygon.
2) in get_raster_geo, a GEOSGeometry is passed by reference, which means it's transformed even when it shouldn't be. Adds logic for cloning the input before transforming it.

Tested on url, http://localhost:8000/planscape-backend/forsys/generate_project_areas/single_scenario/?request_type=5&cluster_algorithm_type=0&write_to_db=1&debug_user_id=57&priority_weights=1&priority_weights=1&priority_weights=4&priority_weights=3&priority_weights=5

![image](https://user-images.githubusercontent.com/3720361/227451012-68e1340d-19dd-4fc3-8648-6a3566e8a8c2.png)
