### PR TITLE
Delete account UI + functionality

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -72,6 +72,8 @@
 
     <!-- Edit account details -->
     <ng-container *ngIf="editingAccount">
+      <button mat-button color="primary" (click)="openDeleteAccountDialog()">DELETE ACCOUNT</button>
+
       <form [formGroup]="editAccountForm" (ngSubmit)="saveEdits()">
         <mat-form-field>
           <mat-label>First name</mat-label>

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -1,3 +1,4 @@
+import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-account-dialog.component';
 import { Component, OnInit } from '@angular/core';
 import {
   AbstractControl,
@@ -5,6 +6,7 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable, take } from 'rxjs';
 
@@ -28,6 +30,7 @@ export class AccountDialogComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
+    private dialog: MatDialog,
     private fb: FormBuilder,
     private snackbar: MatSnackBar
   ) {
@@ -136,5 +139,9 @@ export class AccountDialogComponent implements OnInit {
     const password1 = group.get('password1')?.value;
     const password2 = group.get('password2')?.value;
     return password1 === password2 ? null : { passwordsNotEqual: true };
+  }
+
+  openDeleteAccountDialog(): void {
+    this.dialog.open(DeleteAccountDialogComponent);
   }
 }

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -1,4 +1,3 @@
-import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-account-dialog.component';
 import { Component, OnInit } from '@angular/core';
 import {
   AbstractControl,
@@ -8,10 +7,12 @@ import {
 } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 import { Observable, take } from 'rxjs';
 
 import { AuthService } from '../services';
 import { User } from '../types';
+import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-account-dialog.component';
 
 @Component({
   selector: 'app-account-dialog',
@@ -31,7 +32,9 @@ export class AccountDialogComponent implements OnInit {
   constructor(
     private authService: AuthService,
     private dialog: MatDialog,
+    private dialogRef: MatDialogRef<AccountDialogComponent>,
     private fb: FormBuilder,
+    private router: Router,
     private snackbar: MatSnackBar
   ) {
     this.changePasswordForm = this.fb.group(
@@ -142,6 +145,18 @@ export class AccountDialogComponent implements OnInit {
   }
 
   openDeleteAccountDialog(): void {
-    this.dialog.open(DeleteAccountDialogComponent);
+    this.dialog
+      .open(DeleteAccountDialogComponent, {
+        data: {
+          user: this.authService.loggedInUser$.value,
+        },
+      })
+      .afterClosed()
+      .subscribe((data) => {
+        if (data.deletedAccount) {
+          this.dialogRef.close();
+          this.router.navigate(['login']);
+        }
+      });
   }
 }

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
@@ -9,6 +9,14 @@
   <div class="button-row">
     <button mat-raised-button (click)="cancel()">CANCEL</button>
 
-    <button mat-raised-button color="warn">DELETE</button>
+    <button
+      mat-raised-button
+      color="warn"
+      (click)="deleteAccount()"
+      [disabled]="disableDeleteButton">
+      DELETE
+    </button>
   </div>
+
+  <p *ngIf="error">{{ error }}</p>
 </div>

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
@@ -1,0 +1,14 @@
+<div class="delete-account-dialog">
+  <mat-icon class="warning-icon">warning</mat-icon>
+
+  <p>
+    <b>Are you sure you want to delete your account?</b>
+    <br>This will permanently erase your account.
+  </p>
+
+  <div class="button-row">
+    <button mat-raised-button (click)="cancel()">CANCEL</button>
+
+    <button mat-raised-button color="warn">DELETE</button>
+  </div>
+</div>

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.scss
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.scss
@@ -1,0 +1,27 @@
+.delete-account-dialog {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+}
+
+.warning-icon {
+  color: #F3B300;
+  font-size: 60px;
+  height: 60px;
+  width: 60px;
+}
+
+p {
+  font-family: 'Roboto';
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 32px;
+  text-align: center;
+}
+
+.button-row {
+  display: flex;
+  gap: 24px;
+}

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteAccountDialogComponent } from './delete-account-dialog.component';
+
+describe('DeleteAccountDialogComponent', () => {
+  let component: DeleteAccountDialogComponent;
+  let fixture: ComponentFixture<DeleteAccountDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeleteAccountDialogComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeleteAccountDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.spec.ts
@@ -1,23 +1,106 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { MaterialModule } from 'src/app/material/material.module';
+import { AuthService } from 'src/app/services';
 
 import { DeleteAccountDialogComponent } from './delete-account-dialog.component';
 
 describe('DeleteAccountDialogComponent', () => {
   let component: DeleteAccountDialogComponent;
   let fixture: ComponentFixture<DeleteAccountDialogComponent>;
+  let loader: HarnessLoader;
+  let fakeAuthService: AuthService;
 
   beforeEach(async () => {
+    fakeAuthService = jasmine.createSpyObj(
+      'AuthService',
+      {
+        deleteUser: of(true),
+      },
+      {}
+    );
+    const fakeData = {
+      user: {
+        email: 'test@test.com',
+      },
+    };
+    const fakeDialog = jasmine.createSpyObj(
+      'MatDialog',
+      {
+        open: undefined,
+      },
+      {}
+    );
+    const fakeDialogRef = jasmine.createSpyObj(
+      'MatDialogRef',
+      {
+        close: undefined,
+      },
+      {}
+    );
     await TestBed.configureTestingModule({
-      declarations: [ DeleteAccountDialogComponent ]
-    })
-    .compileComponents();
+      imports: [MaterialModule],
+      declarations: [DeleteAccountDialogComponent],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: fakeAuthService,
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: fakeData,
+        },
+        {
+          provide: MatDialog,
+          useValue: fakeDialog,
+        },
+        {
+          provide: MatDialogRef<DeleteAccountDialogComponent>,
+          useValue: fakeDialogRef,
+        },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(DeleteAccountDialogComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('cancel button should close dialog', async () => {
+    const dialogRef = fixture.debugElement.injector.get(MatDialogRef);
+    const cancelButton: MatButtonHarness = await loader.getHarness(
+      MatButtonHarness.with({ text: /CANCEL/ })
+    );
+
+    await cancelButton.click();
+
+    expect(dialogRef.close).toHaveBeenCalledOnceWith();
+  });
+
+  it('delete button should call AuthService and close dialog', async () => {
+    const dialogRef = fixture.debugElement.injector.get(MatDialogRef);
+    const deleteButton: MatButtonHarness = await loader.getHarness(
+      MatButtonHarness.with({ text: /DELETE/ })
+    );
+
+    await deleteButton.click();
+
+    expect(fakeAuthService.deleteUser).toHaveBeenCalledOnceWith({
+      email: 'test@test.com',
+    });
+    expect(dialogRef.close).toHaveBeenCalledOnceWith({ deletedAccount: true });
   });
 });

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.ts
@@ -1,17 +1,39 @@
-import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { AuthService } from 'src/app/services';
+import { User } from 'src/app/types';
 
 @Component({
   selector: 'app-delete-account-dialog',
   templateUrl: './delete-account-dialog.component.html',
-  styleUrls: ['./delete-account-dialog.component.scss']
+  styleUrls: ['./delete-account-dialog.component.scss'],
 })
 export class DeleteAccountDialogComponent {
+  disableDeleteButton: boolean = false;
+  error: any;
 
-  constructor(private dialogRef: MatDialogRef<DeleteAccountDialogComponent>) { }
+  constructor(
+    private authService: AuthService,
+    @Inject(MAT_DIALOG_DATA) private data: { user: User },
+    private dialogRef: MatDialogRef<DeleteAccountDialogComponent>
+  ) {}
 
   cancel(): void {
     this.dialogRef.close();
   }
 
+  deleteAccount(): void {
+    this.disableDeleteButton = true;
+    this.authService.deleteUser(this.data.user).subscribe(
+      (_) => {
+        this.dialogRef.close({
+          deletedAccount: true,
+        });
+      },
+      (err) => {
+        this.error = err.error;
+        this.disableDeleteButton = false;
+      }
+    );
+  }
 }

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-delete-account-dialog',
+  templateUrl: './delete-account-dialog.component.html',
+  styleUrls: ['./delete-account-dialog.component.scss']
+})
+export class DeleteAccountDialogComponent {
+
+  constructor(private dialogRef: MatDialogRef<DeleteAccountDialogComponent>) { }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+
+}

--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { SharedModule } from './shared/shared.module';
 import { SignupComponent } from './signup/signup.component';
 import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
+import { DeleteAccountDialogComponent } from './account-dialog/delete-account-dialog/delete-account-dialog.component';
 
 @NgModule({
   declarations: [
@@ -63,6 +64,7 @@ import { TopBarComponent } from './top-bar/top-bar.component';
     HomeComponent,
     PlanTableComponent,
     SignInDialogComponent,
+    DeleteAccountDialogComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -379,6 +379,49 @@ describe('AuthService', () => {
         .flush(backendUser);
     });
   });
+
+  describe('deleteUser', () => {
+    it('makes request to backend', (done) => {
+      const user = {
+        firstName: 'Foo',
+        lastName: 'Bar',
+        username: 'test',
+        email: 'test@test.com',
+      };
+
+      service.deleteUser(user).subscribe((res) => {
+        expect(res).toBeTrue();
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        BackendConstants.END_POINT + '/users/delete/'
+      );
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ email: 'test@test.com' });
+      req.flush({ deleted: true });
+      httpTestingController.verify();
+    });
+  });
+
+  it('logs out user if successful', (done) => {
+    const user = {
+      firstName: 'Foo',
+      lastName: 'Bar',
+      username: 'test',
+      email: 'test@test.com',
+    };
+
+    service.deleteUser(user).subscribe((res) => {
+      expect(service.loggedInStatus$.value).toBeFalse();
+      expect(service.loggedInUser$.value).toBeNull();
+      done();
+    });
+
+    httpTestingController
+      .expectOne(BackendConstants.END_POINT + '/users/delete/')
+      .flush({ deleted: true });
+  });
 });
 
 describe('AuthGuard', () => {

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -173,6 +173,30 @@ export class AuthService {
         })
       );
   }
+
+  /** "Deletes" user from backend. The behavior of this command is to disable the user account,
+   *  not fully delete it, so data can be restored later if necessary.
+   */
+  deleteUser(user: User): Observable<boolean> {
+    return this.http
+      .post(
+        BackendConstants.END_POINT.concat('/users/delete/'),
+        {
+          email: user.email,
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .pipe(
+        take(1),
+        map((result: any) => {
+          this.loggedInStatus$.next(false);
+          this.loggedInUser$.next(null);
+          return result.deleted;
+        })
+      );
+  }
 }
 
 /** An AuthGuard used to prevent access to pages that require sign-in. If the user is not signed

--- a/src/planscape/planscape/urls.py
+++ b/src/planscape/planscape/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('planscape-backend/plan/', include('plan.urls')),
     path('planscape-backend/projects/', include('existing_projects.urls')),
     # Auth URLs
+    path('planscape-backend/users/', include('users.urls')),
     path('planscape-backend/dj-rest-auth/', include('dj_rest_auth.urls')),
     path('planscape-backend/dj-rest-auth/registration/',
          include('dj_rest_auth.registration.urls')),

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -1,3 +1,39 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.test import TransactionTestCase
+from django.urls import reverse
 
 # Create your tests here.
+
+class DeleteUserTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create(email='testuser@test.com')
+        self.user.set_password('12345')
+        self.user.save()
+    
+    def test_missing_user(self):
+        response = self.client.post(
+            reverse('users:delete'), {'email': 'testuser@test.com'},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+    
+    def test_missing_email(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('users:delete'), {},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+    
+    def test_different_user(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('users:delete'), {'email': 'diffuser@test.com'},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+    
+    def test_same_user(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('users:delete'), {'email': 'testuser@test.com'},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(User.objects.get(pk=self.user.pk).is_active)

--- a/src/planscape/users/urls.py
+++ b/src/planscape/users/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+
+app_name = 'users'
+
+urlpatterns = [
+    path('delete/', views.delete_user, name='delete'),
+]

--- a/src/planscape/users/views.py
+++ b/src/planscape/users/views.py
@@ -1,3 +1,31 @@
-from django.shortcuts import render
+import json
 
-# Create your views here.
+from django.contrib.auth.models import User
+from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
+                         JsonResponse)
+
+def get_user(request: HttpRequest) -> User:
+    user = None
+    if hasattr(request, 'user') and request.user.is_authenticated:
+        user = request.user
+    return user
+
+def delete_user(request: HttpRequest) -> HttpResponse:
+    try:
+        logged_in_user = get_user(request)
+        if logged_in_user is None:
+            raise ValueError("Must be logged in")
+        body = json.loads(request.body)
+        user_email_to_delete = body.get('email', None)
+        if user_email_to_delete is None or not isinstance(user_email_to_delete, str):
+            raise ValueError("User email must be provided as a string")
+        if user_email_to_delete != logged_in_user.email:
+            raise ValueError("Cannot delete another user account")
+
+        # Deactivate user account
+        logged_in_user.is_active = False
+        logged_in_user.save()
+
+        return JsonResponse({"deleted": True})
+    except Exception as e:
+        return HttpResponseBadRequest("Ill-formed request: " + str(e))


### PR DESCRIPTION
## Changes
- Part of #3 
- Adds a "DELETE ACCOUNT" button to the user account dialog
- Adds a confirmation screen for the user to confirm they want to delete their account
- Redirects user to login if they successfully delete their account
- Adds a `/users/delete` backend API which allows the currently logged in user to disable their account (note: the account is not permanently deleted, but cannot be logged into or accessed in any way unless re-enabled by an admin)
- Adds a `deleteUser()` method to the `AuthService`

## Delete account button
![image](https://user-images.githubusercontent.com/10444733/227660351-44ff7639-3baa-4ffe-a501-da132a74ae94.png)

## Delete account confirmation dialog
![image](https://user-images.githubusercontent.com/10444733/227660372-27868d63-f875-420d-937e-d058afa44df6.png)
