### PR TITLE
add explicit versions to auth pkgs in requirements.txt

### DIFF
--- a/src/planscape/requirements.txt
+++ b/src/planscape/requirements.txt
@@ -1,12 +1,12 @@
-dj-rest-auth
+dj-rest-auth~=2.2.5
 django~=4.1.1
-django-allauth
+django-allauth~=0.53.1
 django-cors-headers
 django-filter~=21.1.0
 django-leaflet
-djangorestframework~=3.13.0
+djangorestframework~=3.13.1
 djangorestframework-gis~=0.18.0
-djangorestframework-simplejwt
+djangorestframework-simplejwt~=5.2.2
 numpy
 pandas
 psycopg2>=2.9.3


### PR DESCRIPTION
Explicitly set version numbers for all our auth-related Python dependencies. The important one is setting `dj-rest-auth` to <3.0.0 which will temporarily fix #745.

The long-term fix is to update the config settings so we can migrate to `dj-rest-auth` v3.0.0 without breaking login.