### PR TITLE
Add Access-Control-Headers to nginx.conf

### DIFF
--- a/src/interface/nginx/nginx.conf
+++ b/src/interface/nginx/nginx.conf
@@ -12,6 +12,7 @@ server {
 
   location /planscape-backend/ {
     add_header Access-Control-Allow-Origin "$http_origin";
+    add_header Access-Control-Allow-Headers "content-type";
     uwsgi_pass django;
     include uwsgi_params;
   }


### PR DESCRIPTION
Update nginx.conf with content-type Access-Control-Allow-Header