### PR TITLE
Add dev-level google analytics ID location, which can be manually updated on the actual dev/prod boxes.

### DIFF
--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { SignupComponent } from './signup/signup.component';
 import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
 import { DeleteAccountDialogComponent } from './account-dialog/delete-account-dialog/delete-account-dialog.component';
+import { environment } from "src/environments/environment";
 
 @NgModule({
   declarations: [
@@ -80,7 +81,7 @@ import { DeleteAccountDialogComponent } from './account-dialog/delete-account-di
     }),
     LayoutModule,
     MaterialModule,
-    NgxGoogleAnalyticsModule,
+    NgxGoogleAnalyticsModule.forRoot(environment.google_analytics_id),
     NgxGoogleAnalyticsRouterModule,
     PlanModule,
     SharedModule,

--- a/src/interface/src/environments/environment.prod.ts
+++ b/src/interface/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   backend_endpoint: 'http://localhost/planscape-backend'
-  google_analytics_id: 'G-4XVSK5FG2M' // TODO: replace with the real prod ID
+  google_analytics_id: '' // Replace with actual ID for prod.
 };

--- a/src/interface/src/environments/environment.prod.ts
+++ b/src/interface/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   backend_endpoint: 'http://localhost/planscape-backend'
+  google_analytics_id: 'G-4XVSK5FG2M' // TODO: replace with the real prod ID
 };

--- a/src/interface/src/environments/environment.ts
+++ b/src/interface/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  backend_endpoint: 'http://localhost:8000/planscape-backend'
+  backend_endpoint: 'http://localhost:8000/planscape-backend',
+  google_analytics_id: 'G-4XVSK5FG2M' // This is a just a dev-only GA ID
 };
 
 /*

--- a/src/interface/src/environments/environment.ts
+++ b/src/interface/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   backend_endpoint: 'http://localhost:8000/planscape-backend',
-  google_analytics_id: 'G-4XVSK5FG2M' // This is a just a dev-only GA ID
+  google_analytics_id: '' // Replace with actual ID.
 };
 
 /*


### PR DESCRIPTION
This sends all GA traffic to my personal GA account.  This will be later replaced with a real GA account.