### PR TITLE
Create Future data section in map control panel, showing Pillars only.

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -171,6 +171,15 @@
           (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
         </app-condition-tree>
 
+        <!-- Future condition controls -->
+        <app-condition-tree
+          #conditionTreeNormalized
+          [conditionsData$]="conditionDataFuture$"
+          [header]="'Future Climate Stability'"
+          [map]="map"
+          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
+        </app-condition-tree>
+
         <!-- Disturbances controls -->
         <mat-expansion-panel disabled="true">
           <mat-expansion-panel-header class="layer-panel-header">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -61,6 +61,7 @@ export class MapControlPanelComponent implements OnInit {
 
   conditionDataRaw$ = new BehaviorSubject<ConditionsNode[]>([]);
   conditionDataNormalized$ = new BehaviorSubject<ConditionsNode[]>([]);
+  conditionDataFuture$ = new BehaviorSubject<ConditionsNode[]>([]);
 
   constructor() {}
 
@@ -80,6 +81,14 @@ export class MapControlPanelComponent implements OnInit {
       )
       .subscribe((data) => {
         this.conditionDataNormalized$.next(data);
+      });
+    this.conditionsConfig$
+      .pipe(
+        filter((config) => !!config),
+        map((config) => this.conditionsConfigToDataFuture(config!))
+      )
+      .subscribe((data) => {
+        this.conditionDataFuture$.next(data);
       });
   }
 
@@ -116,6 +125,8 @@ export class MapControlPanelComponent implements OnInit {
     this.conditionTrees?.get(index)?.unstyleAndDeselectAllNodes();
   }
 
+  /** Raw data is selectable only at the metric level.
+   */
   private conditionsConfigToDataRaw(
     config: ConditionsConfig
   ): ConditionsNode[] {
@@ -140,6 +151,8 @@ export class MapControlPanelComponent implements OnInit {
       : [];
   }
 
+  /** Normalized configs are selectable at every level (pillar, element, metric).
+   */
   private conditionsConfigToDataNormalized(
     config: ConditionsConfig
   ): ConditionsNode[] {
@@ -171,4 +184,23 @@ export class MapControlPanelComponent implements OnInit {
           })
       : [];
   }
+
+  /** Future configs are selectable and viewable only at the pillar level.
+   */
+  private conditionsConfigToDataFuture(
+    config: ConditionsConfig
+  ): ConditionsNode[] {
+    return config.pillars
+      ? config.pillars
+        ?.filter((pillar) => pillar.display)
+	.map((pillar): ConditionsNode => {
+          return {
+ 	    ...pillar,
+              filepath: pillar.filepath?.concat('_normalized'),
+	      children: []
+	  };
+        })
+    : [];
+  }
+
 }


### PR DESCRIPTION
This does not assume any particular Future data is available yet; this only shows the Pillar-level options in a new section in the control panel named "Future Climate Stability".  Any changes to display as a result of selecting a Future pillar should be ignored.
![Screenshot 2023-05-01 at 5 54 13 PM](https://user-images.githubusercontent.com/125416076/235556825-6e852e02-b5dd-420b-b7fd-a418baaff126.png)
