### PR TITLE
Add support for downloading future metrics from the map control panel's info popup

### DIFF
--- a/src/interface/src/app/backend-constants.ts
+++ b/src/interface/src/app/backend-constants.ts
@@ -3,5 +3,6 @@ import { environment  } from "src/environments/environment";
 export const BackendConstants = {
   END_POINT: environment.backend_endpoint,
   TILES_END_POINT: environment.tile_endpoint,
+  DOWNLOAD_END_POINT: environment.download_endpoint,
 } as const;
  

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -23,6 +23,8 @@ import {
   ConditionTreeComponent,
 } from './condition-tree/condition-tree.component';
 
+import { BackendConstants } from './../../backend-constants';
+
 @Component({
   selector: 'app-map-control-panel',
   templateUrl: './map-control-panel.component.html',
@@ -205,8 +207,13 @@ export class MapControlPanelComponent implements OnInit {
 	.map((pillar): ConditionsNode => {
           return {
  	    ...pillar,
-        layer: pillar.future_layer,
-	      children: []
+            data_download_link: pillar.future_data_download_path ?
+	      BackendConstants.DOWNLOAD_END_POINT + '/' + pillar.future_data_download_path :
+              pillar.data_download_link,
+            layer: pillar.future_layer,
+            min_value: -1,
+            max_value: 1,
+            children: []
 	  };
         })
     : [];

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -27,7 +27,6 @@ export interface DataLayerConfig extends ConditionsMetadata {
   layer?: string;
   raw_layer?: string;
   normalized_layer?: string;
-  future_layer?: string;
   colormap?: string;
   normalized?: boolean;
   opacity?: number;
@@ -48,7 +47,10 @@ export interface PillarConfig extends DataLayerConfig {
   display?: boolean;
   pillar_name?: string;
   elements?: ElementConfig[];
+  future_layer?: string;
+  future_data_download_path?: string;
 }
+
 
 export const NONE_BOUNDARY_CONFIG: BoundaryConfig = {
   boundary_name: '',

--- a/src/interface/src/environments/environment.prod.ts
+++ b/src/interface/src/environments/environment.prod.ts
@@ -2,5 +2,6 @@ export const environment = {
   production: true,
   backend_endpoint: 'http://localhost/planscape-backend',
   google_analytics_id: '', // Replace with actual ID for prod.
-  tile_endpoint: '' //Replace with actual URL for prod.
+  tile_endpoint: '', //Replace with actual URL for prod.
+  download_endpoint: '', // Replace with actual URL for prod.
 };

--- a/src/interface/src/environments/environment.ts
+++ b/src/interface/src/environments/environment.ts
@@ -6,7 +6,8 @@ export const environment = {
   production: false,
   backend_endpoint: 'http://localhost:8000/planscape-backend',
   google_analytics_id: '',  // Replace with actual ID.
-  tile_endpoint: '' // Replace with actual URL
+  tile_endpoint: '', // Replace with actual URL
+  download_endpoint: '', // Replace with actual URL
 };
 
 /*

--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -12,6 +12,8 @@
           "filepath": "sierra_nevada/air_quality",
           "normalized_layer":  "sierra-nevada:airQualityTranslate_airQuality",
           "future_layer": "sierra-nevada:airQualityTranslate_airQuality030_future",
+          "future_data_download_path": "sierra-nevada/airQualityTranslate/airQuality030_future.tif",
+          "data_provider": "USDA Forest Service, Region 5",
           "display_name": "Air Quality",
           "display": true,
           "elements": [

--- a/src/planscape/config/conditions_config.py
+++ b/src/planscape/config/conditions_config.py
@@ -23,12 +23,14 @@ class PillarConfig:
     """
 
     # Keys in the dictionaries.
-    COMMON_METADATA = {'filepath', 'display_name',
-                       'colormap', 'max_value', 'min_value','layer', 'raw_layer', 'normalized_layer', 'future_layer'}
+    COMMON_METADATA = {'filepath', 'display_name', 'data_provider',
+                       'colormap', 'max_value', 'min_value','layer', 'raw_layer', 'normalized_layer'}
     REGION_KEYS = {'region_name', 'pillars'}.union(COMMON_METADATA)
     PILLAR_KEYS = {'pillar_name',
                    'elements',
                    'operation',
+                   'future_layer',
+                   'future_data_download_path',
                    'display'}.union(COMMON_METADATA)
     ELEMENT_KEYS = {'element_name',
                     'metrics',
@@ -39,7 +41,6 @@ class PillarConfig:
                    'ignore',
                    'source',
                    'source_link',
-                   'data_provider',
                    'data_download_link',
                    'data_year',
                    'reference_link',


### PR DESCRIPTION
This adds future data only for Air Quality as an initial example.
This will also set values for future data from -1 to 1, to be displayed in the info popup.
Assume that future metrics only exist for pillars, and not any other level; future-data-related fields are only available at the pillar level.
<img width="637" alt="Screenshot 2023-05-07 at 11 34 32 PM" src="https://user-images.githubusercontent.com/125416076/236751697-67195a40-3cbb-41a3-b466-b781baace78f.png">

The download link on my dev box resolves to
   http://dev-geo.planscape.org/sierra-nevada/airQualityTranslate/airQuality030_future.tif
... with environment.ts's download_endpoint set to "http://dev-geo.planscape.org".