### PR TITLE
make sure DEBUG defaults to FALSE

### DIFF
--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -37,7 +37,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = config("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config("PLANSCAPE_DEBUG", default=True)
+DEBUG = config("PLANSCAPE_DEBUG", default=False, cast=bool)
 
 ALLOWED_HOSTS: list[str] = str(config("PLANSCAPE_ALLOWED_HOSTS", default="*")).split(
     ","


### PR DESCRIPTION
DEBUG defaulted to TRUE, which is a security concern. Already changed this to FALSE on production and development.