### PR TITLE
Hide the info icon for raw pillar and raw element entries in the map control panel

### DIFF
--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -29,6 +29,7 @@
             </span>
           </div>
           <button mat-icon-button
+            *ngIf="!node.condition.disableInfoCard"
             class="info-button"
             [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
             (menuClosed)="node.infoMenuOpen = false">
@@ -57,7 +58,9 @@
               {{node.condition.display_name}}
             </span>
           </div>
+          <!-- TODO: remove disableInfoCard if it is no longer needed -->
           <button mat-icon-button
+            *ngIf="!node.condition.disableInfoCard"
             class="info-button"
             [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
             (menuClosed)="node.infoMenuOpen = false">

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
@@ -10,6 +10,7 @@ import { DataLayerConfig, Map, NONE_DATA_LAYER_CONFIG } from 'src/app/types';
 export interface ConditionsNode extends DataLayerConfig {
   children?: ConditionsNode[];
   disableSelect?: boolean; // Node should not include a radio button
+  disableInfoCard?: boolean; // Node should not have an info button
 }
 
 interface ConditionFlatNode {

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -139,12 +139,14 @@ export class MapControlPanelComponent implements OnInit {
             return {
               ...pillar,
               disableSelect: true,
+              disableInfoCard: true,
               children: pillar.elements
                 ?.filter((element) => element.display)
                 .map((element): ConditionsNode => {
                   return {
                     ...element,
                     disableSelect: true,
+                    disableInfoCard: true,
                     children: element.metrics?.map((metric): ConditionsNode=> {
                       return {
                         ...metric,


### PR DESCRIPTION
This hides the info icon in the raw pillar and raw element entries in the map control panel, as the icons and resulting popup do not add much value today.  The icons are still present for other entries, including normalized pillar and normalized element entries.

<img width="404" alt="Screenshot 2023-05-15 at 6 39 34 PM" src="https://github.com/OurPlanscape/Planscape/assets/125416076/662d678a-019a-49fa-9e1c-459651a0c1bf">
