### PR TITLE
Appends "(Raw)" to the raw data section header in the map control panel.

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -159,7 +159,7 @@
         <app-condition-tree
           #conditionTreeRaw
           [conditionsData$]="conditionDataRaw$"
-          [header]="'Current Condition'"
+          [header]="'Current Condition (Raw)'"
           [map]="map"
           (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(1)">
         </app-condition-tree>
@@ -168,7 +168,7 @@
         <app-condition-tree
           #conditionTreeNormalized
           [conditionsData$]="conditionDataNormalized$"
-          [header]="'Current Condition (Normalized)'"
+          [header]="'Current Condition'"
           [map]="map"
           (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
         </app-condition-tree>


### PR DESCRIPTION
Appends "(Raw)" to the raw data section header in the map control panel.
Removes "(Normalized)" from the normalized data section header in the map control panel.

We are doing this as most data is normalized, and the raw data is considered to be the unusual kind of data.