### PR TITLE
Displays Future legend name in the legend box in the map control panel

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -47,7 +47,7 @@
     </button>
     <button mat-button class="map-count-button" (click)="changeMapCount.emit(4)"
       aria-label="Show 4 maps"
-      [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 4}">1
+      [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 4}">
     <div class="map-count-button-grid-row">
       <div class="map-count-button-grid-cell"></div>
       <div class="map-count-button-grid-cell"></div>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -4,7 +4,8 @@
     <h1><b>Map {{selectedMap?.name}}</b> Legend</h1>
 
     <div class="legend-box">
-      <h3>Current Condition {{selectedMap?.config?.dataLayerConfig?.normalized ? '(Normalized)' : ''}}</h3>
+      <!-- Name of the kind of data -->
+      <h3>{{selectedMap?.config?.dataLayerConfig?.legend_name}}</h3>
 
       <div class="legend-title">
         <h2>{{selectedMap?.config?.dataLayerConfig?.display_name}}</h2>
@@ -46,7 +47,7 @@
     </button>
     <button mat-button class="map-count-button" (click)="changeMapCount.emit(4)"
       aria-label="Show 4 maps"
-      [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 4}">
+      [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 4}">1
     <div class="map-count-button-grid-row">
       <div class="map-count-button-grid-cell"></div>
       <div class="map-count-button-grid-cell"></div>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -56,7 +56,6 @@ export class MapControlPanelComponent implements OnInit {
   @Output() selectMap = new EventEmitter<number>();
   @Output() toggleExistingProjectsLayer = new EventEmitter<Map>();
 
-
   readonly baseLayerTypes: number[] = [
     BaseLayerType.Road,
     BaseLayerType.Terrain,
@@ -146,7 +145,7 @@ export class MapControlPanelComponent implements OnInit {
               ...pillar,
               disableSelect: true,
               disableInfoCard: true,
-	      legend_name: CURRENT_CONDITIONS_RAW_LEGEND,
+              legend_name: CURRENT_CONDITIONS_RAW_LEGEND,
               children: pillar.elements
                 ?.filter((element) => element.display)
                 .map((element): ConditionsNode => {
@@ -159,7 +158,7 @@ export class MapControlPanelComponent implements OnInit {
                       return {
                         ...metric,
                         layer:metric.raw_layer,
-			legend_name: CURRENT_CONDITIONS_RAW_LEGEND,
+                        legend_name: CURRENT_CONDITIONS_RAW_LEGEND,
                         data_download_link: metric.raw_data_download_path ?
 	                      BackendConstants.DOWNLOAD_END_POINT + '/' + metric.raw_data_download_path :
                         metric.data_download_link,

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -25,6 +25,11 @@ import {
 
 import { BackendConstants } from './../../backend-constants';
 
+/** Map Legend Display Strings */
+  const CURRENT_CONDITIONS_RAW_LEGEND = "Current Condition (Raw)";
+  const CURRENT_CONDITIONS_NORMALIZED_LEGEND = "Current Condition (Normalized)";
+  const FUTURE_CONDITIONS_LEGEND = "Future Climate Stability (Normalized)";
+
 @Component({
   selector: 'app-map-control-panel',
   templateUrl: './map-control-panel.component.html',
@@ -50,6 +55,7 @@ export class MapControlPanelComponent implements OnInit {
   @Output() changeOpacity = new EventEmitter<number>();
   @Output() selectMap = new EventEmitter<number>();
   @Output() toggleExistingProjectsLayer = new EventEmitter<Map>();
+
 
   readonly baseLayerTypes: number[] = [
     BaseLayerType.Road,
@@ -140,6 +146,7 @@ export class MapControlPanelComponent implements OnInit {
               ...pillar,
               disableSelect: true,
               disableInfoCard: true,
+	      legend_name: CURRENT_CONDITIONS_RAW_LEGEND,
               children: pillar.elements
                 ?.filter((element) => element.display)
                 .map((element): ConditionsNode => {
@@ -147,10 +154,12 @@ export class MapControlPanelComponent implements OnInit {
                     ...element,
                     disableSelect: true,
                     disableInfoCard: true,
+                    legend_name: CURRENT_CONDITIONS_RAW_LEGEND,
                     children: element.metrics?.map((metric): ConditionsNode=> {
                       return {
                         ...metric,
                         layer:metric.raw_layer,
+			legend_name: CURRENT_CONDITIONS_RAW_LEGEND,
                         data_download_link: metric.raw_data_download_path ?
 	                      BackendConstants.DOWNLOAD_END_POINT + '/' + metric.raw_data_download_path :
                         metric.data_download_link,
@@ -179,6 +188,7 @@ export class MapControlPanelComponent implements OnInit {
               data_download_link: pillar.normalized_data_download_path ?
 	              BackendConstants.DOWNLOAD_END_POINT + '/' + pillar.normalized_data_download_path :
                 undefined,
+              legend_name: CURRENT_CONDITIONS_NORMALIZED_LEGEND,
               normalized: true,
               children: pillar.elements?.map((element): ConditionsNode => {
                 return {
@@ -187,6 +197,7 @@ export class MapControlPanelComponent implements OnInit {
                   data_download_link: element.normalized_data_download_path ?
                   BackendConstants.DOWNLOAD_END_POINT + '/' + element.normalized_data_download_path :
                   undefined,
+                  legend_name: CURRENT_CONDITIONS_NORMALIZED_LEGEND,
                   normalized: true,
                   min_value: undefined,
                   max_value: undefined,
@@ -197,6 +208,7 @@ export class MapControlPanelComponent implements OnInit {
                       data_download_link: metric.normalized_data_download_path ?
 	                    BackendConstants.DOWNLOAD_END_POINT + '/' + metric.normalized_data_download_path :
                       metric.data_download_link,
+                      legend_name: CURRENT_CONDITIONS_NORMALIZED_LEGEND,
                       normalized: true,
                       min_value: undefined,
                       max_value: undefined,
@@ -224,6 +236,7 @@ export class MapControlPanelComponent implements OnInit {
 	      BackendConstants.DOWNLOAD_END_POINT + '/' + pillar.future_data_download_path :
               pillar.data_download_link,
             layer: pillar.future_layer,
+            legend_name: FUTURE_CONDITIONS_LEGEND,
             normalized: true,
             children: []
 	  };

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -23,6 +23,7 @@ export interface ConditionsMetadata {
 
 export interface DataLayerConfig extends ConditionsMetadata {
   display_name?: string;
+  legend_name?: string;
   filepath?: string;
   normalized_data_download_path?: string;
   layer?: string;


### PR DESCRIPTION
Add "legend_name" to the data layer config, at every level.

Displays the actual primary data type in the legend box near the top of the map control panel.
![AKBC2guqdSoB6VC](https://github.com/OurPlanscape/Planscape/assets/125416076/0269c0da-399f-4b79-884a-0746e8768c3b)

Other data types will result in a display of
"Current Condition (Raw)"
and
"Current Condition (Normalized)"