### PR TITLE
Add a new label "Transparency" but only for the map control panel.

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -22,7 +22,8 @@
       <app-legend [legend]="getSelectedLegend()"></app-legend>
 
       <!-- Opacity controls for the currently shown data layer -->
-      <app-opacity-slider (change)="changeOpacity.emit($event)" [opacity]="selectedMapOpacity">
+      <app-opacity-slider (change)="changeOpacity.emit($event)" [opacity]="selectedMapOpacity"
+			  label="Transparency">
       </app-opacity-slider>
     </div>
 

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.html
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.html
@@ -1,5 +1,6 @@
 <div class="root-container">
   <div class="opacity-slider-wrapper">
+    {{label}}
     <mat-slider
       class="opacity-slider"
       color="primary"

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.scss
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.scss
@@ -9,6 +9,7 @@
 .opacity-slider-wrapper {
   align-items: center;
   display: flex;
+  font-size: 12px;
   justify-content: stretch;
   width: 100%;
 }

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.ts
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.ts
@@ -10,6 +10,7 @@ import { filter } from 'rxjs/operators';
 })
 export class OpacitySliderComponent implements OnInit, OnChanges {
   @Input() opacity: number | null | undefined = FrontendConstants.MAP_DATA_LAYER_OPACITY;
+  @Input() label: string | null = "";
   @Output() change = new EventEmitter<number>();
 
   opacityPercentage: number = FrontendConstants.MAP_DATA_LAYER_OPACITY * 100;


### PR DESCRIPTION
Also: add an optional label field for all sliders.

The label is 12px, same size as the label data type (e.g. "Future Climate Stability (Normalized)").
![8RdTBZzUtX72dPr](https://github.com/OurPlanscape/Planscape/assets/125416076/db4fa5a7-42c2-491b-b74b-774d26149aaf)
