### PR TITLE
Show Southern California options in the home page and region dropdown when enabled

### DIFF
--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -2,7 +2,7 @@ Feature flags are set in features.json and will hide certain features if the cor
 
 features.json should be gitignored in the future once prod build is rolled out.
 
-By default, set the values of new fields to match what prod should be so that we do not risk releasing something unexpected.
+By default, set the values of new fields to match what prod should be so that we do not risk releasing something unexpected.  The exception is "login", which is left on so that automated tests run properly.
 
 login: This flag will hide the login/account signup buttons and will disable any features that require login to use (e.g planning) when set to false. When login is disabled it also replaces the plans on the homepage with a message explaining that some buttons and features are disabled.  
 

--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -5,3 +5,5 @@ features.json should be gitignored in the future once prod build is rolled out.
 login: This flag will hide the login/account signup buttons and will disable any features that require login to use (e.g planning) when set to false. When login is disabled it also replaces the plans on the homepage with a message explaining that some buttons and features are disabled.  
 
 unlaunched_layers: This flag will hide map layers that are not currently launched or implemented when set to false. Once layers are launched in prod, they should be changed in map-control-panel.component.html so they are no longer affected by this flag.
+
+show_socal: This flag will display the option to switch to the Southern California region, and therefore allow for the display of Southern California data.

--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -2,7 +2,7 @@ Feature flags are set in features.json and will hide certain features if the cor
 
 features.json should be gitignored in the future once prod build is rolled out.
 
-By default, set the values of new fields to match what prod should be so that we do not risk releasing something unexpected.  The exception is "login", which is left on so that automated tests run properly.
+By default, set the values of new fields to match what prod should be so that we do not risk releasing something unexpected.  The exceptions are for "login" and "top_percent_silder", both of which need to be enabled for tests to run properly.
 
 login: This flag will hide the login/account signup buttons and will disable any features that require login to use (e.g planning) when set to false. When login is disabled it also replaces the plans on the homepage with a message explaining that some buttons and features are disabled.  
 

--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -1,9 +1,14 @@
 Feature flags are set in features.json and will hide certain features if the corresponding flag is set to false. 
 
-features.json should be gitignored in the future once prod build is rolled out.  
+features.json should be gitignored in the future once prod build is rolled out.
+
+By default, set the values of new fields to match what prod should be so that we do not risk releasing something unexpected.
 
 login: This flag will hide the login/account signup buttons and will disable any features that require login to use (e.g planning) when set to false. When login is disabled it also replaces the plans on the homepage with a message explaining that some buttons and features are disabled.  
 
+show_socal: This flag will display the option to switch to the Southern California region, and therefore allow for the display of Southern California data.
+
+top_percent_slider: This flag shows the slider displayed in the scenario generator UI (plan phase).
+
 unlaunched_layers: This flag will hide map layers that are not currently launched or implemented when set to false. Once layers are launched in prod, they should be changed in map-control-panel.component.html so they are no longer affected by this flag.
 
-show_socal: This flag will display the option to switch to the Southern California region, and therefore allow for the display of Southern California data.

--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -2,7 +2,7 @@ Feature flags are set in features.json and will hide certain features if the cor
 
 features.json should be gitignored in the future once prod build is rolled out.
 
-By default, set the values of new fields to match what prod should be so that we do not risk releasing something unexpected.  The exceptions are for "login" and "top_percent_silder", both of which need to be enabled for tests to run properly.
+By default, set the values of new fields to match what prod should be so that we do not risk releasing something unexpected.  The exceptions are for "login" and "top_percent_slider", both of which need to be enabled for tests to run properly.
 
 login: This flag will hide the login/account signup buttons and will disable any features that require login to use (e.g planning) when set to false. When login is disabled it also replaces the plans on the homepage with a message explaining that some buttons and features are disabled.  
 

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,8 +1,8 @@
 {
-  "login": true,
+  "login": false,
   "show_socal": false,
   "testFalseFeature": false,
   "testTrueFeature": true,
-  "top_percent_slider":true,
-  "unlaunched_layers": true
+  "top_percent_slider": false,
+  "unlaunched_layers": false
 }

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,5 +1,5 @@
 {
-  "login": false,
+  "login": true,
   "show_socal": false,
   "testFalseFeature": false,
   "testTrueFeature": true,

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,7 +1,8 @@
 {
   "login": true,
-  "unlaunched_layers": true,
-  "top_percent_slider":true,
+  "show_socal": false,
   "testFalseFeature": false,
-  "testTrueFeature": true
+  "testTrueFeature": true,
+  "top_percent_slider":true,
+  "unlaunched_layers": true
 }

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -3,6 +3,6 @@
   "show_socal": false,
   "testFalseFeature": false,
   "testTrueFeature": true,
-  "top_percent_slider": false,
+  "top_percent_slider": true,
   "unlaunched_layers": false
 }

--- a/src/interface/src/app/types/region.types.ts
+++ b/src/interface/src/app/types/region.types.ts
@@ -1,3 +1,5 @@
+import features from '../features/features.json'
+
 export enum Region {
   SIERRA_NEVADA = 'Sierra Nevada',
   SOUTHERN_CALIFORNIA = 'Southern California',
@@ -26,6 +28,7 @@ export const regionOptions = regions.map((region) => {
   return {
     type: region,
     name: region,
-    available: availableRegions.has(region),
+    available: new Set([...availableRegions,
+      features.show_socal ? Region.SOUTHERN_CALIFORNIA : null]).has(region),
   }
 });


### PR DESCRIPTION
This introduces a new feature flag, show_socal, that can be used to display (or hide) the Southern California region from the region dropdown or the home page region buttons.

When show_socal=false (which is the default setting), Southern California is not an option.
![Screenshot 2023-05-17 at 10 58 51 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/54a726cc-cb9f-4570-b021-af96e0eb185d)

Note that this does not introduce any real data for SoCal.  There are no guarantees on the explore page when in SoCal mode.