### PR TITLE
Fix the range of Species Diversity::Species Richness to 1->93.

### DIFF
--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -198,7 +198,7 @@
                   "data_year": "2021",
                   "reference_link": "https://data.fs.usda.gov/geodata/rastergateway/regional-resource-kit/docs/RRK_Metric_Dictionary_v2.pdf#page=25",
                   "min_value": 1,
-                  "max_value": 7,
+                  "max_value": 93,
                   "data_units": "Number of species"
                 },
                 {


### PR DESCRIPTION
This fixes the range of Species Diversity::Species Richness to 1->93, which was previously incorrect.