### PR TITLE
Fix Max SDI raw download path

### DIFF
--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -572,7 +572,7 @@
                   "metric_name": "max_sdi",
                   "filepath": "sierra_nevada/forest_resilience/forest_structure/proportion_of_SDI_83_Max_300m",
                   "raw_layer": "sierra-nevada:forestShrubResil_Tier2_proportion_of_SDI_33_Max_30m", 
-                  "raw_data_download_path": "sierra-nevada/forestShrubResilTranslate/Tier2/BASATOT_2021_scored.tif",
+                  "raw_data_download_path": "sierra-nevada/forestShrubResil/Tier2/proportion_of_SDI_33_Max_30m.tif",
                   "normalized_layer": "sierra-nevada:forestShrubResilTranslate_Tier2_proportion_of_SDI_33_Max_scored",
                   "normalized_data_download_path": "sierra-nevada/forestShrubResilTranslate/Tier2/proportion_of_SDI_33_Max_scored.tif",
                   "display_name": "Max SDI",


### PR DESCRIPTION
Changed from sierra-nevada/forestShrubResilTranslate/Tier2/BASATOT_2021_scored.tif to sierra-nevada/forestShrubResil/Tier2/proportion_of_SDI_33_Max_30m.tif