### PR TITLE
Edit drawing disable tooltip message

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -28,7 +28,7 @@
       </div>
 
       <!-- Draw a planning area -->
-      <div matTooltip="This item is disabled as you are not logged in." [matTooltipDisabled]="login_enabled">
+      <div matTooltip="This item is not available in this version." [matTooltipDisabled]="login_enabled">
       <button mat-button
       [disabled]="!login_enabled"
         class="draw-area-button"
@@ -41,7 +41,7 @@
 
       <!-- Upload a planning area -->
       <div class="upload-wrapper">
-        <div matTooltip="This item is disabled as you are not logged in." [matTooltipDisabled]="login_enabled">
+        <div matTooltip="This item is not available in this version." [matTooltipDisabled]="login_enabled">
           <button mat-button
           [disabled]="!login_enabled"
             class="upload-area-button"


### PR DESCRIPTION
Changed drawing disable tooltip message from "This item is disabled as you are not logged in." to "This item is not available in this version."
<img width="478" alt="Screenshot 2023-05-19 at 9 18 27 AM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/8e0d41be-7c46-468f-8a18-40774359b87e">
