### PR TITLE
Add link to the Conditions of Use (aka the legal disclaimer) to the front page

### DIFF
--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -139,6 +139,9 @@
       <b>How do I learn more?<br></b>
         
       <p>Click on the <a routerLink="/help" target="_blank" rel="noopener noreferrer"> Help</a> icon on the top right corner of the tool to read the user guide or check out the <a href="https://www.planscape.org/faqs" target="_blank" rel="noopener noreferrer">FAQ</a> for commonly asked questions and answers. You can also visit <a href="https://www.planscape.org/" target= "_blank" rel="noopener noreferrer">Planscape.org</a> for more information about the tool, to sign up for regular updates as we release new versions, and to receive our newsletter.</p>
+
+      <b>Conditions of Use<br></b>
+      <p>Please read our <a href="https://www.planscape.org/conditions-of-use/" target="_blank">Conditions of Use</a> for information regarding usage of this tool.
     </div>
     </ng-template>
     <ng-template #noplans class="no-saved-plans">


### PR DESCRIPTION
The new link will pop up a new tab and send the user to https://www.planscape.org/conditions-of-use/
![56kCpncJYdm5ktT](https://github.com/OurPlanscape/Planscape/assets/125416076/5f2cfcec-b9f4-496a-a37f-cacf7df98ff0)
