### PR TITLE
Populate one SoCal metric so that it shows up in the SoCal map control panel

### DIFF
--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,6 +1,6 @@
 {
   "login": true,
-  "show_socal": false,
+  "show_socal": true,
   "testFalseFeature": false,
   "testTrueFeature": true,
   "top_percent_slider": true,

--- a/src/interface/src/app/home/region-selection/region-selection.component.spec.ts
+++ b/src/interface/src/app/home/region-selection/region-selection.component.spec.ts
@@ -55,7 +55,7 @@ describe('RegionSelectionComponent', () => {
     );
 
     for (let regionButton of regionButtons) {
-      if ((await regionButton.getText()).match(/SIERRA NEVADA/)) {
+      if ((await regionButton.getText()).match(/(SIERRA NEVADA)|(SOUTHERN CALIFORNIA)/)) {
         expect(await regionButton.isDisabled()).toBeFalse();
       } else {
         expect(await regionButton.isDisabled()).toBeTrue();

--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -3,6 +3,34 @@
   "__comment2": "TODO: update metrics and element entries to reflect 30m when available",
   "regions": [
     {
+      "region_name": "southern_california",
+      "display_name": "Southern California",
+      "pillars": [
+        {
+          "pillar_name": "fire_adapted_communities",
+	  "display": true,
+	  "display_name": "Fire Adapted Communities",
+	  "elements": [
+	    {
+	      "element_name": "hazard",
+	      "display": true,
+	      "display_name": "Hazard",
+              "metrics": [
+	        {
+		  "metric_name": "structure_exposure_score",
+		  "raw_layer": "southern-california:StructureExposureScore_WUI_2022",
+		  "raw_data_download_path": "southern-california/fireAdaptedCommunities/Tier2/StructureExposureScore_WUI_2022.tif",
+		  "display_name": "Structure Exposure Score",
+		  "source": "Southern California Resource Kit",
+		  "source_link": "https://data.fs.usda.gov/geodata/rastergateway/regional-resource-kit/index.php"
+		}
+	      ]
+	    }
+	  ]
+	}
+      ]
+    },
+    {
       "region_name": "sierra_cascade_inyo",
       "filepath": "sierra_nevada",
       "display_name": "Sierra Nevada",


### PR DESCRIPTION
No actual data is expected to appear in the maps.
<img width="441" alt="Screenshot 2023-05-26 at 2 25 58 PM" src="https://github.com/OurPlanscape/Planscape/assets/125416076/8d4ef339-af3b-45f6-8602-e5de88e9bcdc">

The bug where maps don't fully update after a region switch still persists.
