### PR TITLE
Default geoserver query to sierra-nevada region

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -691,7 +691,7 @@ export class MapManager {
       region = 'sierra-nevada';
     }
     map.dataLayerRef = L.tileLayer.wms(
-      BackendConstants.TILES_END_POINT + map.config.dataLayerConfig.region_geoserver_name + "/wms?" ,
+      BackendConstants.TILES_END_POINT + region + "/wms?" ,
       {
         layers: layer,
         minZoom: 7,

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -686,6 +686,10 @@ export class MapManager {
       colormap = DEFAULT_COLORMAP;
     }
 
+    var region = map.config.dataLayerConfig.region_geoserver_name;
+    if(region == null){
+      region = 'sierra-nevada';
+    }
     map.dataLayerRef = L.tileLayer.wms(
       BackendConstants.TILES_END_POINT + map.config.dataLayerConfig.region_geoserver_name + "/wms?" ,
       {


### PR DESCRIPTION
When the map loads in with layers from a previous session, queries are made to the geoserver before the region is set by the session service. The region will default to sierra-nevada when undefined for now. 