### PR TITLE
Add new use_its feature flag to use ITS instead of Calmapper data.

### DIFF
--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -31,6 +31,10 @@ This flag will hide map layers that are not currently launched or implemented
 when set to false. Once layers are launched in prod, they should be changed in
 map-control-panel.component.html so they are no longer affected by this flag.
 
+### use_its
+This flag will enable use of ITS data for past resilience projects rather than
+Calmapper.
+
 ### Other flags
 There are two other flags, testFalseFeature and testTrueFeature created just for
 automated testing.  Their values should be kept to "false" and "true" for
@@ -46,6 +50,7 @@ for angular tests to pass.  You can start with this, but later enable settings.
   "testFalseFeature": false,
   "testTrueFeature": true,
   "top_percent_slider": true,
-  "unlaunched_layers": false
+  "unlaunched_layers": false,
+  "use_its": false
 }
 ```

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -4,5 +4,6 @@
   "testFalseFeature": false,
   "testTrueFeature": true,
   "top_percent_slider": true,
-  "unlaunched_layers": false
+  "unlaunched_layers": false,
+  "use_its": false
 }

--- a/src/interface/src/app/services/map.service.ts
+++ b/src/interface/src/app/services/map.service.ts
@@ -13,6 +13,7 @@ import {
   Region,
 } from '../types';
 
+import features from '../features/features.json'
 
 /** A map of Region to static assets for that region. */
 const regionToGeojsonMap: Record<Region, Record<string, string>> = {
@@ -141,7 +142,8 @@ export class MapService {
 
   // Queries the CalMAPPER ArcGIS Web Feature Service for known land management projects without filtering.
   getExistingProjects(): Observable<GeoJSON.GeoJSON> {
-    return this.http.get<string>(BackendConstants.END_POINT + '/projects/calmapper').pipe(
+    return this.http.get<string>(BackendConstants.END_POINT +
+      (features.use_its ? '/projects/its' : '/projects/calmapper')).pipe(
       map((response: string) => {
         return JSON.parse(response);
       })

--- a/src/planscape/existing_projects/views.py
+++ b/src/planscape/existing_projects/views.py
@@ -29,7 +29,8 @@ class MillionAcres_ITS(APIView):
         }
         # URL for treatment polygons
         # TODO: include line and points
-        url_final = "https://gsal.sig-gis.com/server/rest/services/Hosted/Million_Acres_Flat_File_2020_2021/FeatureServer/645/query?" + \
+        # TODO: get a stable URL without a version number
+        url_final = "https://gsal.sig-gis.com/server/rest/services/Hosted/Million_Acres_Flat_File_2020_2021/FeatureServer/736/query?" + \
             urllib.parse.urlencode(params)
         response = requests.get(url=url_final)
         return Response(response.text)


### PR DESCRIPTION
Add new use_its feature flag to use ITS instead of Calmapper data.  Defaults to false (use calmapper).
Update the ITS API version number.

Note that pulling from ITS doesn't work properly yet; this is just to get the flag in place.