### PR TITLE
Ability to Enable/Disable raw/translated/future data, slight top bar UI tweak

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -136,8 +136,64 @@
           </div>
         </mat-expansion-panel>
 
-        <!-- Ecosystem scores controls -->
-        <ng-container *featureFlag="'unlaunched_layers'">
+        <div *ngIf="rawDataEnabled">
+         <!-- Current condition controls -->
+         <app-condition-tree
+         #conditionTreeRaw
+         [conditionsData$]="conditionDataRaw$"
+         [header]="'Current Condition (Raw)'"
+         [map]="map"
+         (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(1)">
+       </app-condition-tree>
+      </div>
+
+        <div *ngIf="translatedDataEnabled">
+
+        <!-- Normalized current condition controls -->
+        <app-condition-tree
+          #conditionTreeNormalized
+          [conditionsData$]="conditionDataNormalized$"
+          [header]="'Current Condition'"
+          [map]="map"
+          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
+        </app-condition-tree>
+        </div>
+
+      <div *ngIf="futureDataEnabled">
+        <!-- Future condition controls -->
+        <app-condition-tree
+          #conditionTreeNormalized
+          [conditionsData$]="conditionDataFuture$"
+          [header]="'Future Climate Stability'"
+          [map]="map"
+          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
+        </app-condition-tree>
+      </div>
+
+        <!-- No Data Region controls -->
+        <div *ngIf="!translatedDataEnabled">
+          <mat-expansion-panel disabled="true">
+            <mat-expansion-panel-header class="layer-panel-header">
+              <mat-panel-title>
+                Current Conditions (coming soon)
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+          </mat-expansion-panel>
+        </div>
+          
+        <div *ngIf="!futureDataEnabled">
+          <mat-expansion-panel disabled="true">
+            <mat-expansion-panel-header class="layer-panel-header">
+              <mat-panel-title>
+                Future Climate Stability (coming soon)
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+          </mat-expansion-panel>
+        </div>
+
+
+                <!-- Ecosystem scores controls -->
+        <!-- <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel expanded="false">
             <mat-expansion-panel-header class="layer-panel-header">
               <mat-panel-title>
@@ -155,35 +211,8 @@
               </mat-radio-group>
             </div>
           </mat-expansion-panel>
-        </ng-container>
-
-        <!-- Current condition controls -->
-        <app-condition-tree
-          #conditionTreeRaw
-          [conditionsData$]="conditionDataRaw$"
-          [header]="'Current Condition (Raw)'"
-          [map]="map"
-          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(1)">
-        </app-condition-tree>
-
-        <!-- Normalized current condition controls -->
-        <app-condition-tree
-          #conditionTreeNormalized
-          [conditionsData$]="conditionDataNormalized$"
-          [header]="'Current Condition'"
-          [map]="map"
-          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
-        </app-condition-tree>
-
-        <!-- Future condition controls -->
-        <app-condition-tree
-          #conditionTreeNormalized
-          [conditionsData$]="conditionDataFuture$"
-          [header]="'Future Climate Stability'"
-          [map]="map"
-          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
-        </app-condition-tree>
-
+        </ng-container> -->
+        
         <!-- Disturbances controls -->
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -171,6 +171,15 @@
       </div>
 
         <!-- No Data Region controls -->
+        <div *ngIf="!rawDataEnabled">
+          <mat-expansion-panel disabled="true">
+            <mat-expansion-panel-header class="layer-panel-header">
+              <mat-panel-title>
+                Current Conditions (coming soon)
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+          </mat-expansion-panel>
+        </div>
         <div *ngIf="!translatedDataEnabled">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -7,7 +7,7 @@ import {
   QueryList,
   ViewChildren,
 } from '@angular/core';
-import { BehaviorSubject, filter, map, Observable } from 'rxjs';
+import { BehaviorSubject, Subject, filter, map, Observable, takeUntil } from 'rxjs';
 import {
   BaseLayerType,
   BoundaryConfig,
@@ -66,6 +66,12 @@ export class MapControlPanelComponent implements OnInit {
   readonly noneBoundaryConfig = NONE_BOUNDARY_CONFIG;
   readonly noneDataLayerConfig = NONE_DATA_LAYER_CONFIG;
 
+
+  private readonly destroy$ = new Subject<void>();
+  rawDataEnabled: boolean | null = null;
+  translatedDataEnabled: boolean | null = null;
+  futureDataEnabled: boolean | null = null;
+
   conditionDataRaw$ = new BehaviorSubject<ConditionsNode[]>([]);
   conditionDataNormalized$ = new BehaviorSubject<ConditionsNode[]>([]);
   conditionDataFuture$ = new BehaviorSubject<ConditionsNode[]>([]);
@@ -73,6 +79,13 @@ export class MapControlPanelComponent implements OnInit {
   constructor() {}
 
   ngOnInit(): void {
+    this.conditionsConfig$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((config: ConditionsConfig | null) => {
+        this.rawDataEnabled = config?.raw_data!;
+        this.translatedDataEnabled = config?.translated_data!;
+        this.futureDataEnabled = config?.future_data!;
+      });
     this.conditionsConfig$
       .pipe(
         filter((config) => !!config),

--- a/src/interface/src/app/top-bar/top-bar.component.scss
+++ b/src/interface/src/app/top-bar/top-bar.component.scss
@@ -63,8 +63,9 @@ select.region-dropdown {
   background: none;
   border: none;
   outline: none;
-  width: fit-content;
-  margin-right: 15px;
+  text-align: left;
+  width: 140px;
+  margin-right: 5px;
 
   cursor: pointer;
   color: #ffffff;

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -11,6 +11,9 @@ export interface ConditionsConfig extends DataLayerConfig {
   region_name?: string;
   region_geoserver_name?: string;
   pillars?: PillarConfig[];
+  raw_data?: boolean;
+  translated_data?: boolean;
+  future_data?: boolean;
 }
 
 export interface ConditionsMetadata {

--- a/src/interface/src/app/types/region.types.ts
+++ b/src/interface/src/app/types/region.types.ts
@@ -22,13 +22,13 @@ const regions: Region[] = [
 
 const availableRegions = new Set([
   Region.SIERRA_NEVADA,
+  features.show_socal ? Region.SOUTHERN_CALIFORNIA : null
 ])
 
 export const regionOptions = regions.map((region) => {
   return {
     type: region,
     name: region,
-    available: new Set([...availableRegions,
-      features.show_socal ? Region.SOUTHERN_CALIFORNIA : null]).has(region),
+    available: availableRegions.has(region),
   }
 });

--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -6,6 +6,9 @@
       "region_name": "southern_california",
       "display_name": "Southern California",
       "region_geoserver_name": "southern-california",
+      "raw_data": true,
+      "translated_data": false,
+      "future_data": false,
       "pillars": [
         {
           "pillar_name": "fire_adapted_communities",
@@ -76,6 +79,9 @@
       "filepath": "sierra_nevada",
       "region_geoserver_name": "sierra-nevada",
       "display_name": "Sierra Nevada",
+      "raw_data": true,
+      "translated_data": true,
+      "future_data": true,
       "pillars": [
         {
           "pillar_name": "air_quality",

--- a/src/planscape/config/conditions_config.py
+++ b/src/planscape/config/conditions_config.py
@@ -25,7 +25,7 @@ class PillarConfig:
     # Keys in the dictionaries.
     COMMON_METADATA = {'filepath', 'display_name', 'data_provider', 
                        'colormap', 'max_value', 'min_value','layer', 'normalized_layer', 'normalized_data_download_path'}
-    REGION_KEYS = {'region_name', 'pillars', 'region_geoserver_name'}.union(COMMON_METADATA)
+    REGION_KEYS = {'region_name', 'pillars', 'region_geoserver_name', 'raw_data', 'translated_data', 'future_data'}.union(COMMON_METADATA)
     PILLAR_KEYS = {'pillar_name',
                    'elements',
                    'operation',
@@ -112,6 +112,9 @@ class PillarConfig:
                     region.keys() <= PillarConfig.REGION_KEYS and
                     isinstance(RegionName(region['region_name']), RegionName) and
                     isinstance(region['pillars'], list) and
+                    isinstance(region['raw_data'], bool) and
+                    isinstance(region['translated_data'], bool) and
+                    isinstance(region['future_data'], bool) and
                     isinstance(region['region_geoserver_name'], str) and 
                     all([check_pillar(pillar) for pillar in region['pillars']]))
 


### PR DESCRIPTION
- Slightly edited top bar html so that drop down arrow both doesn't overlap with "Southern California" text and is still clickable
- Added rawData, translatedData, and futureData values to regionOptions to use to toggle data option in map control panel
<img width="410" alt="Screenshot 2023-06-12 at 12 26 40 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/88b3b877-174f-4119-8c1f-da74b4962c4a">
<img width="190" alt="Screenshot 2023-06-12 at 12 31 52 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/0a12f1c8-44dd-4ecc-9b79-eaa177ce5d47">
