### PR TITLE
Updated Home Page Text Release Notes url 

### DIFF
--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -137,7 +137,7 @@
       <b>How do I learn more?<br></b>
         
       <p>Click on the <a routerLink="/help" target="_blank" rel="noopener noreferrer"> Help</a> icon on the top right corner of the tool to read the user guide or check out the <a href="https://www.planscape.org/faqs" target="_blank" rel="noopener noreferrer">FAQ</a> for commonly asked questions and answers. You can also visit <a href="https://www.planscape.org/" target= "_blank" rel="noopener noreferrer">Planscape.org</a> for more information about the tool, to sign up for regular updates as we release new versions, and to receive our newsletter.</p>
-      <p>See the <a href="https://github.com/OurPlanscape/Planscape/wiki/2023.05.31-Release-Notes">Planscape 2023.05.31-Release-Notes</a> for additional information on this release.</p>
+      <p>See the <a href="https://github.com/OurPlanscape/Planscape/wiki/Release-Notes" target="_blank" rel="noopener noreferrer">Planscape Release Notes</a> for additional information on this release.</p>
 
       <b>Conditions of Use<br></b>
       <p>Please read our <a href="https://www.planscape.org/conditions-of-use/" target="_blank">Conditions of Use</a> for information regarding usage of this tool.</p>


### PR DESCRIPTION
Updated linked Release Notes link from https://github.com/OurPlanscape/Planscape/wiki/2023.05.31-Release-Notes to https://github.com/OurPlanscape/Planscape/wiki/Release-Notes