### PR TITLE
Allow for lower-left-corner map labels to appear for newly added metrics

### DIFF
--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -19,7 +19,7 @@ describe('StringifyMapConfigPipe', () => {
       expect(transformedStr).toEqual('');
     });
 
-    it('should still return empty string due to lack of a dataLayerConfig's display_name and the lack of a boundary's boundary_name', () => {
+    it('should still return empty string due to lack of dataLayerConfig::display_name and the lack of boundary::boundary_name', () => {
       let mapConfig: MapConfig = {
         baseLayerType: BaseLayerType.Road,
         boundaryLayerConfig: {

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -19,7 +19,89 @@ describe('StringifyMapConfigPipe', () => {
       expect(transformedStr).toEqual('');
     });
 
-    it('should return formatted config string', () => {
+    it('should still return empty string due to lack of a display name and boundary name', () => {
+      let mapConfig: MapConfig = {
+        baseLayerType: BaseLayerType.Road,
+	boundaryLayerConfig: {
+          display_name: 'HUC-12',
+          boundary_name: '',
+          vector_name: 'sierra-nevada:vector_huc12',
+          shape_name: 'Name",'
+	},
+        dataLayerConfig: {
+        },
+        showExistingProjectsLayer: false,
+      };
+
+      let transformedStr = pipe.transform(mapConfig);
+
+      expect(transformedStr).toEqual('');
+    });
+
+    it('should return just the boundary name', () => {
+      let mapConfig: MapConfig = {
+        baseLayerType: BaseLayerType.Road,
+	boundaryLayerConfig: {
+          display_name: 'HUC-12',
+          boundary_name: 'huc12',
+          vector_name: 'sierra-nevada:vector_huc12',
+          shape_name: 'Name",'
+	},
+        dataLayerConfig: {
+        },
+        showExistingProjectsLayer: false,
+      };
+      let mapConfigStr = 'HUC-12';
+
+      let transformedStr = pipe.transform(mapConfig);
+
+      expect(transformedStr).toEqual(mapConfigStr);
+    });
+
+    it('should return just the existing projects', () => {
+      let mapConfig: MapConfig = {
+        baseLayerType: BaseLayerType.Road,
+	boundaryLayerConfig: {
+          display_name: 'HUC-12',
+          boundary_name: '',
+          vector_name: 'sierra-nevada:vector_huc12',
+          shape_name: 'Name",'
+	},
+        dataLayerConfig: {
+        },
+        showExistingProjectsLayer: true,
+      };
+      let mapConfigStr = 'Existing Projects';
+
+      let transformedStr = pipe.transform(mapConfig);
+
+      expect(transformedStr).toEqual(mapConfigStr);
+    });
+
+    it('should return only the data layer name', () => {
+      let mapConfig: MapConfig = {
+        baseLayerType: BaseLayerType.Road,
+        boundaryLayerConfig: {
+          display_name: 'HUC-12',
+          boundary_name: '',
+          vector_name: 'sierra-nevada:vector_huc12',
+          shape_name: 'Name",'
+        },
+        dataLayerConfig: {
+          display_name: 'Habitat Connectivity',
+          normalized: false,
+        },
+        showExistingProjectsLayer: false,
+      };
+      let mapConfigStr =
+        'Habitat Connectivity';
+
+      let transformedStr = pipe.transform(mapConfig);
+
+      expect(transformedStr).toEqual(mapConfigStr);
+    });
+
+    it('should return a fully formatted config string', () => {
       let mapConfig: MapConfig = {
         baseLayerType: BaseLayerType.Road,
         boundaryLayerConfig: {
@@ -30,7 +112,6 @@ describe('StringifyMapConfigPipe', () => {
         },
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',
-          filepath: 'habitat_connectivity',
           normalized: true,
         },
         showExistingProjectsLayer: true,

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -19,15 +19,15 @@ describe('StringifyMapConfigPipe', () => {
       expect(transformedStr).toEqual('');
     });
 
-    it('should still return empty string due to lack of a display name and boundary name', () => {
+    it('should still return empty string due to lack of a dataLayerConfig's display_name and the lack of a boundary's boundary_name', () => {
       let mapConfig: MapConfig = {
         baseLayerType: BaseLayerType.Road,
-	boundaryLayerConfig: {
+        boundaryLayerConfig: {
           display_name: 'HUC-12',
           boundary_name: '',
           vector_name: 'sierra-nevada:vector_huc12',
           shape_name: 'Name",'
-	},
+        },
         dataLayerConfig: {
         },
         showExistingProjectsLayer: false,
@@ -41,12 +41,12 @@ describe('StringifyMapConfigPipe', () => {
     it('should return just the boundary name', () => {
       let mapConfig: MapConfig = {
         baseLayerType: BaseLayerType.Road,
-	boundaryLayerConfig: {
+        boundaryLayerConfig: {
           display_name: 'HUC-12',
           boundary_name: 'huc12',
           vector_name: 'sierra-nevada:vector_huc12',
           shape_name: 'Name",'
-	},
+        },
         dataLayerConfig: {
         },
         showExistingProjectsLayer: false,
@@ -61,12 +61,12 @@ describe('StringifyMapConfigPipe', () => {
     it('should return just the existing projects', () => {
       let mapConfig: MapConfig = {
         baseLayerType: BaseLayerType.Road,
-	boundaryLayerConfig: {
+        boundaryLayerConfig: {
           display_name: 'HUC-12',
           boundary_name: '',
           vector_name: 'sierra-nevada:vector_huc12',
           shape_name: 'Name",'
-	},
+        },
         dataLayerConfig: {
         },
         showExistingProjectsLayer: true,

--- a/src/interface/src/app/stringify-map-config.pipe.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.ts
@@ -18,13 +18,11 @@ export class StringifyMapConfigPipe implements PipeTransform {
 
     let str: string = '';
     let labels: string[] = [];
-    if (
-      !!mapConfig.dataLayerConfig.filepath &&
-      mapConfig.dataLayerConfig.filepath.length > 0
-    ) {
-      let dataLabel = mapConfig.dataLayerConfig.display_name
-        ? mapConfig.dataLayerConfig.display_name
-        : mapConfig.dataLayerConfig.filepath;
+
+    if (!!mapConfig.dataLayerConfig.display_name &&
+      mapConfig.dataLayerConfig.display_name.length > 0 &&
+      mapConfig.dataLayerConfig.display_name != "None") {
+      let dataLabel = mapConfig.dataLayerConfig.display_name;
       if (mapConfig.dataLayerConfig.normalized) {
         dataLabel = dataLabel.concat(' (Normalized)');
       }

--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -1,5 +1,5 @@
 {
-  "__comment1": "TODO: reorder lines (first by name, then alphabetically)",
+  "__comment1": "TODO: add validation that each layer type has minimally-viable data, e.g. a display_name",
   "__comment_socal_source": "https://docs.google.com/spreadsheets/d/1Fvx8DBUq-hrU6yd7Q4iP9g4f7s7TGVl6/edit#gid=283454101",
   "regions": [
     {


### PR DESCRIPTION
filepath is deprecated as part of the conditions.json config, and new metrics don't have it.  However, this was preventing the map labels for new metrics from showing up.

Remove filepath as part of the equation for lower-left-corner map labels.

Update test for map label generation to reflect the removal of filepath and include more test cases.