### PR TITLE
Stop displaying a year in the layer info cards.

### DIFF
--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
@@ -13,9 +13,6 @@
     <span *ngIf="hasSource()">
       SOURCE: <a [href]="dataLayerConfig?.source_link" target="_blank">{{dataLayerConfig?.source}}</a>
     </span>
-    <span *ngIf="hasYear()">
-      ({{dataLayerConfig?.data_year}})
-    </span>
   </p>
 
   <div *ngIf="hasDownloadLink()">

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
@@ -32,10 +32,6 @@ export class LayerInfoCardComponent {
     return !!this.dataLayerConfig?.source && !!this.dataLayerConfig.source_link;
   }
 
-  hasYear(): boolean {
-    return !!this.dataLayerConfig?.data_year;
-  }
-
   computeMinMax(): number[] {
     if (this.dataLayerConfig?.normalized) {
       return [-1, 1];


### PR DESCRIPTION
With this CL:
![Screenshot 2023-07-06 at 5 18 48 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/426c561d-ee20-4b93-a1e3-7ebeaca3d5b3)


Previous:
![Screenshot 2023-07-06 at 3 53 49 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/d616700f-7501-4735-a1a1-f660620b50d4)
