### PR TITLE
Remove 'coming soon' options

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -153,17 +153,6 @@
             (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
           </app-condition-tree>
         </div>
-
-        <!-- No Data Region controls -->
-        <div *ngIf="!rawDataEnabled">
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Current Conditions (coming soon)
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
-        </div>
   
         <!-- Ecosystem scores controls -->
         <!-- <ng-container *featureFlag="'unlaunched_layers'">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -164,26 +164,7 @@
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </div>
-        <div *ngIf="!translatedDataEnabled">
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Current Conditions (coming soon)
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
-        </div>
-          
-        <div *ngIf="!futureDataEnabled">
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Future Climate Stability (coming soon)
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
-        </div>
-
+  
         <!-- Ecosystem scores controls -->
         <!-- <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel expanded="false">


### PR DESCRIPTION
- Removed 'coming soon' options from the map control panel for raw, translated, and future data
(Example picture has translated and future data disabled)
<img width="405" alt="Screenshot 2023-07-17 at 10 55 22 AM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/e287636f-cd3a-4ca0-8987-6220ff7ebb0b">
