### PR TITLE
Create new show_centralcoast feature flag for displaying Central Coast as an available region

### DIFF
--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -19,6 +19,10 @@ features that require login to use (e.g planning) when set to false. When login
 is disabled it also replaces the plans on the homepage with a message
 explaining that some buttons and features are disabled.  
 
+### show_centralcoast
+This flag will display the option to switch to the Central Coast region,
+and therefore allow for the display of Central Coast data.
+
 ### show_socal
 This flag will display the option to switch to the Southern California region,
 and therefore allow for the display of Southern California data.

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,5 +1,6 @@
 {
   "login": true,
+  "show_centralcoast": false,
   "show_socal": true,
   "testFalseFeature": false,
   "testTrueFeature": true,

--- a/src/interface/src/app/home/region-selection/region-selection.component.html
+++ b/src/interface/src/app/home/region-selection/region-selection.component.html
@@ -2,8 +2,8 @@
   <!-- Content text -->
   <section class="content-section">
     <span *ngIf="!hasPlans || !(loggedIn$ | async)">Welcome to Planscape preview! </span>
-    <span *ngIf="socal_enabled; else socalNotEnabled" >Choose a region to explore </span>
-    <ng-template #socalNotEnabled>
+    <span *ngIf="multiple_regions_enabled; else singleRegionEnabled">Choose a region to explore </span>
+    <ng-template #singleRegionEnabled>
       Click Sierra Nevada to explore 
     </ng-template>
   </section>

--- a/src/interface/src/app/home/region-selection/region-selection.component.ts
+++ b/src/interface/src/app/home/region-selection/region-selection.component.ts
@@ -20,7 +20,9 @@ export class RegionSelectionComponent implements OnInit {
   hasPlans: boolean = false;
   loggedIn$ = this.authService.isLoggedIn$;
   readonly regionOptions: RegionOption[] = regionOptions;
-  socal_enabled = features.show_socal;
+
+  /** We assume that Sierra Nevada is always enabled.  */
+  multiple_regions_enabled = features.show_socal || features.show_centralcoast;
   constructor(
     private authService: AuthService,
     private planService: PlanService,

--- a/src/interface/src/app/types/region.types.ts
+++ b/src/interface/src/app/types/region.types.ts
@@ -22,7 +22,8 @@ const regions: Region[] = [
 
 const availableRegions = new Set([
   Region.SIERRA_NEVADA,
-  features.show_socal ? Region.SOUTHERN_CALIFORNIA : null
+  features.show_socal ? Region.SOUTHERN_CALIFORNIA : null,
+  features.show_centralcoast ? Region.CENTRAL_COAST : null
 ])
 
 export const regionOptions = regions.map((region) => {


### PR DESCRIPTION
Defaults to off.

Updates logic for the front page to display slightly different wording when either SoCal or CentralCoast is enabled.

No metric data is available for CC yet, but this allows for CC development now.

![Screenshot 2023-07-17 at 6 58 32 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/8e5cf361-b1a1-4b88-84d0-0e77e983303a)
![Screenshot 2023-07-17 at 6 58 21 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/6e68ac70-cf60-4dff-8694-0d03240ceb99)

