### PR TITLE
Translated/Future data flags

### DIFF
--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -35,6 +35,12 @@ map-control-panel.component.html so they are no longer affected by this flag.
 This flag will enable use of ITS data for past resilience projects rather than
 Calmapper.
 
+### show_future_control_panel
+This flag will enable future condition options in the map control panel for all regions. A region-specific flag, "future_data", can be found for each region in Planscape/src/planscape/config/conditions.json. When "show_future_control_panel" is set to true and "future_data" is set to true for a region, the future condition layers will appear in the map control panel. When "show_future_control_panel" is set to true and "future_data" is set to false for a region, "Future Climate Stability (coming soon)" will appear in the map control panel. 
+
+### show_translated_control_panel
+This flag will enable translated condition options in the map control panel for all regions. A region-specific flag, "translated_data", can be found for each region in Planscape/src/planscape/config/conditions.json. When "show_translated_control_panel" is set to true and "translated_data" is set to true for a region, the translated condition layers will appear in the map control panel. When "show_translated_control_panel" is set to true and "translated_data" is set to false for a region, "Current Conditions (coming soon)" will appear in the map control panel. 
+
 ### Other flags
 There are two other flags, testFalseFeature and testTrueFeature created just for
 automated testing.  Their values should be kept to "false" and "true" for
@@ -51,6 +57,8 @@ for angular tests to pass.  You can start with this, but later enable settings.
   "testTrueFeature": true,
   "top_percent_slider": true,
   "unlaunched_layers": false,
-  "use_its": false
+  "use_its": false,
+  "show_future_control_panel": false,
+  "show_translated_control_panel": false
 }
 ```

--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -23,9 +23,15 @@ explaining that some buttons and features are disabled.
 This flag will display the option to switch to the Central Coast region,
 and therefore allow for the display of Central Coast data.
 
+### show_future_control_panel
+This flag will enable future condition options in the map control panel for all regions. A region-specific flag, "future_data", can be found for each region in Planscape/src/planscape/config/conditions.json. When "show_future_control_panel" is set to true and "future_data" is set to true for a region, the future condition layers will appear in the map control panel. When "show_future_control_panel" is set to true and "future_data" is set to false for a region, "Future Climate Stability (coming soon)" will appear in the map control panel. 
+
 ### show_socal
 This flag will display the option to switch to the Southern California region,
 and therefore allow for the display of Southern California data.
+
+### show_translated_control_panel
+This flag will enable translated condition options in the map control panel for all regions. A region-specific flag, "translated_data", can be found for each region in Planscape/src/planscape/config/conditions.json. When "show_translated_control_panel" is set to true and "translated_data" is set to true for a region, the translated condition layers will appear in the map control panel. When "show_translated_control_panel" is set to true and "translated_data" is set to false for a region, "Current Conditions (coming soon)" will appear in the map control panel. 
 
 ### top_percent_slider
 This flag shows the slider displayed in the scenario generator UI (plan phase).
@@ -39,12 +45,6 @@ map-control-panel.component.html so they are no longer affected by this flag.
 This flag will enable use of ITS data for past resilience projects rather than
 Calmapper.
 
-### show_future_control_panel
-This flag will enable future condition options in the map control panel for all regions. A region-specific flag, "future_data", can be found for each region in Planscape/src/planscape/config/conditions.json. When "show_future_control_panel" is set to true and "future_data" is set to true for a region, the future condition layers will appear in the map control panel. When "show_future_control_panel" is set to true and "future_data" is set to false for a region, "Future Climate Stability (coming soon)" will appear in the map control panel. 
-
-### show_translated_control_panel
-This flag will enable translated condition options in the map control panel for all regions. A region-specific flag, "translated_data", can be found for each region in Planscape/src/planscape/config/conditions.json. When "show_translated_control_panel" is set to true and "translated_data" is set to true for a region, the translated condition layers will appear in the map control panel. When "show_translated_control_panel" is set to true and "translated_data" is set to false for a region, "Current Conditions (coming soon)" will appear in the map control panel. 
-
 ### Other flags
 There are two other flags, testFalseFeature and testTrueFeature created just for
 automated testing.  Their values should be kept to "false" and "true" for
@@ -57,13 +57,13 @@ for angular tests to pass.  You can start with this, but later enable settings.
 {
   "login": true,
   "show_centralcoast": false,
+  "show_future_control_panel": false,
   "show_socal": false,
+  "show_translated_control_panel": false
   "testFalseFeature": false,
   "testTrueFeature": true,
   "top_percent_slider": true,
   "unlaunched_layers": false,
-  "use_its": false,
-  "show_future_control_panel": false,
-  "show_translated_control_panel": false
+  "use_its": false
 }
 ```

--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -56,6 +56,7 @@ for angular tests to pass.  You can start with this, but later enable settings.
 ```
 {
   "login": true,
+  "show_centralcoast": false,
   "show_socal": false,
   "testFalseFeature": false,
   "testTrueFeature": true,

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,12 +1,12 @@
 {
   "login": true,
   "show_centralcoast": false,
+  "show_future_control_panel": false,
   "show_socal": true,
+  "show_translated_control_panel": false,
   "testFalseFeature": false,
   "testTrueFeature": true,
   "top_percent_slider": true,
   "unlaunched_layers": false,
-  "use_its": false,
-  "show_future_control_panel": false,
-  "show_translated_control_panel": false
+  "use_its": false
 }

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -5,5 +5,7 @@
   "testTrueFeature": true,
   "top_percent_slider": true,
   "unlaunched_layers": false,
-  "use_its": false
+  "use_its": false,
+  "show_future_control_panel": false,
+  "show_translated_control_panel": false
 }

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -116,8 +116,8 @@
           </div>
         </mat-expansion-panel>
 
+        <!-- Current condition controls -->
         <div *ngIf="rawDataEnabled">
-          <!-- Current condition controls -->
           <app-condition-tree
           #conditionTreeRaw
           [conditionsConfig$]="conditionsConfig$"
@@ -127,10 +127,9 @@
           (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(1)">
         </app-condition-tree>
        </div>
- 
-         <div *ngIf="translatedDataEnabled">
- 
-         <!-- Normalized current condition controls -->
+        
+        <!-- Normalized current condition controls -->
+         <div *ngIf="translated_control_panel_enabled && translatedDataEnabled">
          <app-condition-tree
            #conditionTreeNormalized
            [conditionsConfig$]="conditionsConfig$"
@@ -141,9 +140,8 @@
          </app-condition-tree>
          </div> 
 
-
-         <div *ngIf="futureDataEnabled">
-          <!-- Future condition controls -->
+        <!-- Future condition controls -->
+         <div *ngIf="future_control_panel_enabled && futureDataEnabled">
           <app-condition-tree
             #conditionTreeNormalized
             [conditionsConfig$]="conditionsConfig$"
@@ -153,7 +151,28 @@
             (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
           </app-condition-tree>
         </div>
-  
+
+        <!-- No Data Region controls -->
+        <div *ngIf="translated_control_panel_enabled && !translatedDataEnabled">
+          <mat-expansion-panel disabled="true">
+            <mat-expansion-panel-header class="layer-panel-header">
+              <mat-panel-title>
+                Current Conditions (coming soon)
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+          </mat-expansion-panel>
+        </div>
+          
+        <div *ngIf="future_control_panel_enabled && !futureDataEnabled">
+          <mat-expansion-panel disabled="true">
+            <mat-expansion-panel-header class="layer-panel-header">
+              <mat-panel-title>
+                Future Climate Stability (coming soon)
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+          </mat-expansion-panel>
+        </div>
+
         <!-- Ecosystem scores controls -->
         <!-- <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel expanded="false">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -153,17 +153,6 @@
             (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
           </app-condition-tree>
         </div>
-
-        <!-- No Data Region controls -->
-        <div *ngIf="!rawDataEnabled">
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Current Conditions (coming soon)
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
-        </div>
   
         <!-- Ecosystem scores controls -->
         <!-- <ng-container *featureFlag="'unlaunched_layers'">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -164,26 +164,7 @@
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </div>
-        <div *ngIf="!translatedDataEnabled">
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Current Conditions (coming soon)
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
-        </div>
-          
-        <div *ngIf="!futureDataEnabled">
-          <mat-expansion-panel disabled="true">
-            <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Future Climate Stability (coming soon)
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-          </mat-expansion-panel>
-        </div>
-
+  
         <!-- Ecosystem scores controls -->
         <!-- <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel expanded="false">

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -21,6 +21,7 @@ import {
   ConditionsNode,
   ConditionTreeComponent,
 } from './condition-tree/condition-tree.component';
+import features from '../../features/features.json';
 
 
 /** Map Legend Display Strings */
@@ -72,6 +73,9 @@ export class MapControlPanelComponent implements OnInit {
   conditionDataRaw$ = new BehaviorSubject<ConditionsNode[]>([]);
   conditionDataNormalized$ = new BehaviorSubject<ConditionsNode[]>([]);
   conditionDataFuture$ = new BehaviorSubject<ConditionsNode[]>([]);
+
+  future_control_panel_enabled = features.show_future_control_panel;
+  translated_control_panel_enabled = features.show_translated_control_panel;
 
   constructor() {}
 

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -64,18 +64,20 @@ export class MapControlPanelComponent implements OnInit {
 
 
   private readonly destroy$ = new Subject<void>();
+  // Region-specific data flags
   rawDataEnabled: boolean | null = null;
   translatedDataEnabled: boolean | null = null;
   futureDataEnabled: boolean | null = null;
+
+  // General data flags
+  future_control_panel_enabled = features.show_future_control_panel;
+  translated_control_panel_enabled = features.show_translated_control_panel;
   
   public dataTypeEnum = ConditionTreeType;
 
   conditionDataRaw$ = new BehaviorSubject<ConditionsNode[]>([]);
   conditionDataNormalized$ = new BehaviorSubject<ConditionsNode[]>([]);
   conditionDataFuture$ = new BehaviorSubject<ConditionsNode[]>([]);
-
-  future_control_panel_enabled = features.show_future_control_panel;
-  translated_control_panel_enabled = features.show_translated_control_panel;
 
   constructor() {}
 


### PR DESCRIPTION
- Add "show_future_control_panel" and "show_translated_control_panel" flags to features.json to toggle future and translated options in map control panel
- Created option to toggle future/translated options between actual data or 'coming soon' message based on region-specific flag values in conditions.json
- Updated features.json README