### PR TITLE
Allow viewing of metrics in old plan-priority page

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -116,7 +116,9 @@ export class SetPrioritiesComponent implements OnInit {
             };
             data.push(elementRow);
             pillarRow.children.push(elementRow);
-            element.metrics?.forEach((metric) => {
+            element.metrics
+	      ?.filter((metric) => !!metric.filepath)
+	      .forEach((metric) => {
               let metricRow: PriorityRow = {
                 conditionName: metric.metric_name!,
                 displayName: metric.display_name,

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -117,8 +117,8 @@ export class SetPrioritiesComponent implements OnInit {
             data.push(elementRow);
             pillarRow.children.push(elementRow);
             element.metrics
-	      ?.filter((metric) => !!metric.filepath)
-	      .forEach((metric) => {
+              ?.filter((metric) => !!metric.filepath)
+              .forEach((metric) => {
               let metricRow: PriorityRow = {
                 conditionName: metric.metric_name!,
                 displayName: metric.display_name,


### PR DESCRIPTION
In the (arguably deprecated) Plan / priority page, exclude metrics that lack a filepath. which is the majority of newly added metrics. This allows older metrics to still appear in the list of priorities, and thus allows the some progression of the plan - priority page today, even if complete planning doesn't work any longer.

Current:
![Screenshot 2023-07-18 at 3 10 29 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/73b5b2ef-c938-4f72-a8cc-fe65ecb44bde)

After this change:
![Screenshot 2023-07-18 at 3 04 44 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/8d77aaa6-3515-4d25-ba25-73b27020d4a1)
