### PR TITLE
Change Structure Exposure and Damage Potential Layers to point to the new reclassified layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules
 src/interface/src/environments/environment.ts
 src/interface/src/environments/environment.prod.ts
 src/interface/src/app/features/features.json
+
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true
-}


### PR DESCRIPTION
I've added new layers to GeoServer to represent these raw metrics for three workspaces (Sierra, SoCal and Central). I'm updating the files and the layers these are pointing to, so we can display them correctly over the UI.