### PR TITLE
Add SoCal boundary data.

### DIFF
--- a/src/planscape/config/boundary.json
+++ b/src/planscape/config/boundary.json
@@ -1,10 +1,76 @@
 {
+    "__comment1": "TODO: replace filename for SoCal's HUC10 when it loses its dash.",
     "regions": [
+      {
+        "region_name": "southern_california",
+        "display_name": "Southern California",
+        "boundaries": [
+        {
+            "boundary_name": "counties",
+            "display_name": "Counties",
+            "vector_name": "southern-california:vector_county",
+            "region_name": "none",
+            "filepath": "cnty19_1.shp",
+            "source_srs": 3857,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "COUNTY_NAM"
+        },
+        {
+            "boundary_name": "huc12",
+            "display_name": "HUC-12",
+            "vector_name": "southern-california:vector_huc12",
+            "region_name": "none",
+            "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+            "source_srs": 4326,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+        },
+        {
+            "boundary_name": "huc10",
+            "display_name": "HUC-10",
+            "vector_name": "southern-california:vector_huc-10",
+            "region_name": "none",
+            "filepath": "WBD_USGS_HUC10_CA.shp",
+            "source_srs": 6414,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+        },
+        {
+            "boundary_name": "USFS",
+            "display_name": "National Forests",
+            "vector_name": "southern-california:vector_forests",
+            "region_name": "none",
+            "filepath": "California_USFS.shp",
+            "source_srs": 4269,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FORESTNAME"
+        },
+        {
+            "boundary_name": "RecentFires",
+            "display_name": "Fires (through 2021)",
+            "vector_name": "southern-california:vector_recent-fires",
+            "region_name": "none",
+            "filepath": "recent-fires.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FIRE_NAME"
+        },
+        {
+            "boundary_name": "PrescribedBurns",
+            "display_name": "Prescribed Burns (through 2021)",
+            "vector_name": "southern-california:vector_prescribed-burns",
+            "region_name": "none",
+            "filepath": "prescribed-burns.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "TREATMEN_1"
+        }
+        ]
+      },
       {
         "region_name": "sierra_cascade_inyo",
         "display_name": "Sierra Nevada",
         "boundaries": [
-        
         {
             "boundary_name": "counties",
             "display_name": "Counties",
@@ -14,7 +80,6 @@
             "source_srs": 3857,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "COUNTY_NAM"
-            
         },
         {
             "boundary_name": "huc12",
@@ -25,7 +90,6 @@
             "source_srs": 4326,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "Name"
-            
         },
         {
             "boundary_name": "huc10",
@@ -36,7 +100,6 @@
             "source_srs": 6414,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "Name"
-            
         },
         {
             "boundary_name": "USFS",
@@ -47,20 +110,16 @@
             "source_srs": 4269,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "FORESTNAME"
-            
         },
         {
             "boundary_name": "RecentFires",
             "display_name": "Fires (through 2021)",
-            "vector_name": "sierra-nevada:vector_recent-fires", 
+            "vector_name": "sierra-nevada:vector_recent-fires",
             "region_name": "none",
             "filepath": "recent-fires.shp",
             "source_srs": 3310,
             "geometry_type": "MULTIPOLYGON",
-            
             "shape_name": "FIRE_NAME"
-            
-            
         },
         {
             "boundary_name": "PrescribedBurns",
@@ -71,8 +130,6 @@
             "source_srs": 3310,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "TREATMEN_1"
-           
-            
         }
     ]
     }


### PR DESCRIPTION
The config change to enable SoCal boundaries was missing.

![Screenshot 2023-07-24 at 6 50 01 PM](https://github.com/OurPlanscape/Planscape/assets/125416076/23e8be90-ad05-4737-beaa-9494ec6fdfe1)
