### PR TITLE
Boundary region switch fix

### DIFF
--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -230,24 +230,22 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
             if (regionMaps) {
               regionMaps.forEach((mapConfig, index) => {
                 this.maps[index].config = mapConfig;
+                this.boundaryConfig$
+                .pipe(filter((config) => !!config))
+                .subscribe((config) => {
+                // Ensure the radio button corresponding to the saved selection is selected.
+                  const boundaryConfig = config?.find(
+                  (boundary) =>
+                    boundary.boundary_name ===
+                    mapConfig.boundaryLayerConfig.boundary_name
+                  );
+                  this.maps[index].config.boundaryLayerConfig = boundaryConfig
+                  ? boundaryConfig
+                  : NONE_BOUNDARY_CONFIG;
+                });
               });
             }
           }
-          this.boundaryConfig$
-          .pipe(filter((config) => !!config))
-          .subscribe((config) => {
-            // Ensure the radio button corresponding to the saved selection is selected.
-            this.maps.forEach((map) => {
-              const boundaryConfig = config?.find(
-                (boundary) =>
-                  boundary.boundary_name ===
-                  map.config.boundaryLayerConfig.boundary_name
-              );
-              map.config.boundaryLayerConfig = boundaryConfig
-                ? boundaryConfig
-                : NONE_BOUNDARY_CONFIG;
-            });
-          });
         });
         this.maps.forEach((map: Map) => {
           this.initMap(map, map.id);

--- a/src/planscape/config/boundary.json
+++ b/src/planscape/config/boundary.json
@@ -6,7 +6,7 @@
         "boundaries": [
         
         {
-            "boundary_name": "counties",
+            "boundary_name": "sierra-nevada-counties",
             "display_name": "Counties",
             "vector_name": "sierra-nevada:vector_county",
             "region_name": "none",
@@ -17,7 +17,7 @@
             
         },
         {
-            "boundary_name": "huc12",
+            "boundary_name": "sierra-nevada-huc12",
             "display_name": "HUC-12",
             "vector_name": "sierra-nevada:vector_huc12",
             "region_name": "none",
@@ -28,7 +28,7 @@
             
         },
         {
-            "boundary_name": "huc10",
+            "boundary_name": "sierra-nevada-huc10",
             "display_name": "HUC-10",
             "vector_name": "sierra-nevada:vector_huc10",
             "region_name": "none",
@@ -39,7 +39,7 @@
             
         },
         {
-            "boundary_name": "USFS",
+            "boundary_name": "sierra-nevada-USFS",
             "display_name": "National Forests",
             "vector_name": "sierra-nevada:vector_forests",
             "region_name": "none",
@@ -50,7 +50,7 @@
             
         },
         {
-            "boundary_name": "RecentFires",
+            "boundary_name": "sierra-nevada-RecentFires",
             "display_name": "Fires (through 2021)",
             "vector_name": "sierra-nevada:vector_recent-fires", 
             "region_name": "none",
@@ -63,9 +63,84 @@
             
         },
         {
-            "boundary_name": "PrescribedBurns",
+            "boundary_name": "sierra-nevada-PrescribedBurns",
             "display_name": "Prescribed Burns (through 2021)",
             "vector_name": "sierra-nevada:vector_prescribed-burns",
+            "region_name": "none",
+            "filepath": "prescribed-burns.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "TREATMEN_1"
+           
+            
+        }
+    ]
+    },
+    {
+        "region_name": "southern_california",
+        "display_name": "Southern California",
+        "boundaries": [
+        
+        {
+            "boundary_name": "southern_california-counties",
+            "display_name": "Counties",
+            "vector_name": "southern-californiaa:vector_county",
+            "region_name": "none",
+            "filepath": "cnty19_1.shp",
+            "source_srs": 3857,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "COUNTY_NAM"
+            
+        },
+        {
+            "boundary_name": "southern_california-huc12",
+            "display_name": "HUC-12",
+            "vector_name": "southern-california:vector_huc12",
+            "region_name": "none",
+            "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+            "source_srs": 4326,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+            
+        },
+        {
+            "boundary_name": "southern_california-huc10",
+            "display_name": "HUC-10",
+            "vector_name": "southern-california:vector_huc10",
+            "region_name": "none",
+            "filepath": "WBD_USGS_HUC10_CA.shp",
+            "source_srs": 6414,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+            
+        },
+        {
+            "boundary_name": "southern_california-USFS",
+            "display_name": "National Forests",
+            "vector_name": "southern-california:vector_forests",
+            "region_name": "none",
+            "filepath": "California_USFS.shp",
+            "source_srs": 4269,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FORESTNAME"
+            
+        },
+        {
+            "boundary_name": "southern_california-RecentFires",
+            "display_name": "Fires (through 2021)",
+            "vector_name": "southern-california:vector_recent-fires", 
+            "region_name": "none",
+            "filepath": "recent-fires.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FIRE_NAME"
+            
+            
+        },
+        {
+            "boundary_name": "southern_california-PrescribedBurns",
+            "display_name": "Prescribed Burns (through 2021)",
+            "vector_name": "southern-california:vector_prescribed-burns",
             "region_name": "none",
             "filepath": "prescribed-burns.shp",
             "source_srs": 3310,

--- a/src/planscape/config/boundary.json
+++ b/src/planscape/config/boundary.json
@@ -6,7 +6,7 @@
         "display_name": "Southern California",
         "boundaries": [
         {
-            "boundary_name": "counties",
+            "boundary_name": "southern_california-counties",
             "display_name": "Counties",
             "vector_name": "southern-california:vector_county",
             "region_name": "none",
@@ -16,7 +16,7 @@
             "shape_name": "COUNTY_NAM"
         },
         {
-            "boundary_name": "huc12",
+            "boundary_name": "southern_california-huc12",
             "display_name": "HUC-12",
             "vector_name": "southern-california:vector_huc12",
             "region_name": "none",
@@ -36,7 +36,7 @@
             "shape_name": "Name"
         },
         {
-            "boundary_name": "USFS",
+            "boundary_name": "southern_california-USFS",
             "display_name": "National Forests",
             "vector_name": "southern-california:vector_forests",
             "region_name": "none",
@@ -46,7 +46,7 @@
             "shape_name": "FORESTNAME"
         },
         {
-            "boundary_name": "RecentFires",
+            "boundary_name": "southern_california-RecentFires",
             "display_name": "Fires (through 2021)",
             "vector_name": "southern-california:vector_recent-fires",
             "region_name": "none",
@@ -56,7 +56,7 @@
             "shape_name": "FIRE_NAME"
         },
         {
-            "boundary_name": "PrescribedBurns",
+            "boundary_name": "southern_california-PrescribedBurns",
             "display_name": "Prescribed Burns (through 2021)",
             "vector_name": "southern-california:vector_prescribed-burns",
             "region_name": "none",
@@ -130,81 +130,6 @@
             "source_srs": 3310,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "TREATMEN_1"
-        }
-    ]
-    },
-    {
-        "region_name": "southern_california",
-        "display_name": "Southern California",
-        "boundaries": [
-        
-        {
-            "boundary_name": "southern_california-counties",
-            "display_name": "Counties",
-            "vector_name": "southern-californiaa:vector_county",
-            "region_name": "none",
-            "filepath": "cnty19_1.shp",
-            "source_srs": 3857,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "COUNTY_NAM"
-            
-        },
-        {
-            "boundary_name": "southern_california-huc12",
-            "display_name": "HUC-12",
-            "vector_name": "southern-california:vector_huc12",
-            "region_name": "none",
-            "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
-            "source_srs": 4326,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "Name"
-            
-        },
-        {
-            "boundary_name": "southern_california-huc10",
-            "display_name": "HUC-10",
-            "vector_name": "southern-california:vector_huc10",
-            "region_name": "none",
-            "filepath": "WBD_USGS_HUC10_CA.shp",
-            "source_srs": 6414,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "Name"
-            
-        },
-        {
-            "boundary_name": "southern_california-USFS",
-            "display_name": "National Forests",
-            "vector_name": "southern-california:vector_forests",
-            "region_name": "none",
-            "filepath": "California_USFS.shp",
-            "source_srs": 4269,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "FORESTNAME"
-            
-        },
-        {
-            "boundary_name": "southern_california-RecentFires",
-            "display_name": "Fires (through 2021)",
-            "vector_name": "southern-california:vector_recent-fires", 
-            "region_name": "none",
-            "filepath": "recent-fires.shp",
-            "source_srs": 3310,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "FIRE_NAME"
-            
-            
-        },
-        {
-            "boundary_name": "southern_california-PrescribedBurns",
-            "display_name": "Prescribed Burns (through 2021)",
-            "vector_name": "southern-california:vector_prescribed-burns",
-            "region_name": "none",
-            "filepath": "prescribed-burns.shp",
-            "source_srs": 3310,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "TREATMEN_1"
-           
-            
         }
     ]
     }


### PR DESCRIPTION
- Fixes issue where boundary for previous region loads in on region switch 

Note: All boundaries need unique names across regions as they get added to boundary.json