### PR TITLE
Patch for region-switch map centering bug

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -467,6 +467,8 @@ export class MapManager {
   private setUpPanHandler(map: L.Map) {
     if (!this.mapViewOptions$.getValue().center) return;
 
+    // Temporarily disabling to patch region-switch centering bug
+    // TODO: Either get rid of locally stored center or change to region-based dictionary
     // map.panTo(this.mapViewOptions$.getValue().center);
 
     map.addEventListener('moveend', (e) => {

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -467,7 +467,7 @@ export class MapManager {
   private setUpPanHandler(map: L.Map) {
     if (!this.mapViewOptions$.getValue().center) return;
 
-    map.panTo(this.mapViewOptions$.getValue().center);
+    // map.panTo(this.mapViewOptions$.getValue().center);
 
     map.addEventListener('moveend', (e) => {
       const mapViewOptions = this.mapViewOptions$.getValue();


### PR DESCRIPTION
- Comments out line that re-centers map based on locally saved center history (incorrectly centers map to previous region area when navigating to a new region from the home page)

Future fix: Either completely remove locally stored center, or change to region-based dictionary 