### PR TITLE
Legend Header 

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -699,11 +699,16 @@ export class MapManager {
       }
 
       const div = L.DomUtil.create('div', 'legend');
+      // htmlContent of HTMLDivElement must be directly added here to add to leaflet map
+      // Creating a string and then assigning to div.innerHTML to allow for class encapsulation 
+      // (otherwise div tags are automatically closed before they should be)
       var htmlContent = '';
       htmlContent += '<div class=parentlegend>';
-      if (dataUnit) {
+      if (dataUnit && colormap['type'] == 'ramp') {
+        // For legends with numerical labels make header the corresponding data units
         htmlContent += '<div><b>' + dataUnit + '</b></div>';
       } else {
+        // For legends with categorical labels make header 'Legend'
         htmlContent += '<div><b>Legend</b></div>';
       }
         // Reversing order to present legend values from high to low (default is low to high)

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -13,13 +13,12 @@ import {
 import * as L from 'leaflet';
 import '@geoman-io/leaflet-geoman-free';
 import 'leaflet.sync';
-import { BehaviorSubject, Observable, last, take } from 'rxjs';
+import { BehaviorSubject, Observable, take } from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
 import { PopupService, SessionService } from '../services';
 import {
   BaseLayerType,
-  BoundaryConfig,
   DEFAULT_COLORMAP,
   FrontendConstants,
   Map,
@@ -725,9 +724,6 @@ export class MapManager {
               htmlContent += '<div class="legendline" '+ lastChild+ '><i style="background:'+ entry['color'] + '"> &emsp; &hairsp;</i> &nbsp;<label>'
               + entry['label'] + '<br/></label></div>';
             } 
-            else if (lastChild != "") {
-              htmlContent += '<div class="legendline"' + lastChild + '></div>';
-            }
           } else {
             htmlContent += '<div class="legendline" '+ lastChild+ '><i style="background:'+ entry['color'] + '"> &emsp; &hairsp;</i> &nbsp; <br/></div>';
           }

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -30,6 +30,7 @@ export interface ConditionsMetadata {
 export interface DataLayerConfig extends ConditionsMetadata {
   display_name?: string;
   legend_name?: string;
+  data_units?: string;
   region_geoserver_name?: string;
   filepath?: string;
   normalized_data_download_path?: string;


### PR DESCRIPTION
- Change legend header to data units for numerical (ramp) legends
- Keep legend header as 'Legend' for categorical (value) legends
- Add dataunit value to DataLayerConfig
Numerical Before: 
<img width="661" alt="Screenshot 2023-07-25 at 3 58 26 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/6ea595de-2b44-4cac-b06a-a99f416c51b1">


Numerical After: 
<img width="652" alt="Screenshot 2023-07-25 at 3 10 42 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/94b3151b-996f-4055-8adb-094cfefa7026">
