### PR TITLE
Legend Bottom Border Bug

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -716,6 +716,9 @@ export class MapManager {
               htmlContent += '<div class="legendline" '+ lastChild+ '><i style="background:'+ entry['color'] + '"> &emsp; &hairsp;</i> &nbsp;<label>'
               + entry['label'] + '<br/></label></div>';
             } 
+            else if (lastChild != "") {
+              htmlContent += '<div class="legendline"' + lastChild + '></div>';
+            }
           } else {
             htmlContent += '<div class="legendline" '+ lastChild+ '><i style="background:'+ entry['color'] + '"> &emsp; &hairsp;</i> &nbsp; <br/></div>';
           }


### PR DESCRIPTION
- Fixes bug where bottom spacing on some legends wasn't consistent due to the last value being nodata (which is filtered out)

Before: 
<img width="662" alt="Screenshot 2023-07-25 at 4 04 06 PM" src="https://github.com/PatManley/Planscape/assets/18537927/5802978e-f2d3-4f1f-bc22-d9b46e225f92">

After: 
<img width="652" alt="Screenshot 2023-07-25 at 3 10 42 PM" src="https://github.com/PatManley/Planscape/assets/18537927/a4cf99cb-2387-4e26-aa06-4da4fe9ae2bf">
