### PR TITLE
Boundary name and Condition unit update

### DIFF
--- a/src/planscape/config/boundary.json
+++ b/src/planscape/config/boundary.json
@@ -47,7 +47,7 @@
         },
         {
             "boundary_name": "southern_california-RecentFires",
-            "display_name": "Fires (through 2021)",
+            "display_name": "Fires (1990 through 2021)",
             "vector_name": "southern-california:vector_recent-fires",
             "region_name": "none",
             "filepath": "recent-fires.shp",
@@ -113,7 +113,7 @@
         },
         {
             "boundary_name": "sierra-nevada-RecentFires",
-            "display_name": "Fires (through 2021)",
+            "display_name": "Fires (1990 through 2021)",
             "vector_name": "sierra-nevada:vector_recent-fires",
             "region_name": "none",
             "filepath": "recent-fires.shp",
@@ -179,7 +179,7 @@
         },
         {
             "boundary_name": "central-coast-RecentFires",
-            "display_name": "Fires (through 2021)",
+            "display_name": "Fires (1990 through 2021)",
             "vector_name": "central-coast:vector_recent-fires",
             "region_name": "none",
             "filepath": "recent-fires.shp",

--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -372,7 +372,7 @@
                 {
                   "display_name": "Cost of Potential Treatments",
                   "data_provider": "CALFIRE",
-                  "data_units": "Dollars/Acre",
+                  "data_units": "Dollars/Acre Index",
                   "max_value": 13,
                   "metric_name": "cost_of_potential_treatments",
                   "min_value": 1,
@@ -1448,7 +1448,7 @@
                 {
                   "display_name": "Cost of Potential Treatments",
                   "data_provider": "CAL FIRE, USDA Forest Service",
-                  "data_units": "Dollars/Acre",
+                  "data_units": "Dollars/Acre Index",
                   "max_value": 15,
                   "metric_name": "cost_of_potential_treatments",
                   "min_value": 0,


### PR DESCRIPTION
- Changed Fires boundary display_name from  "Fires (through 2021)" to "Fires (1990 through 2021)"
- Changed data_units for Cost of Potential Treatments from "Dollars/Acre" to "Dollars/Acre Index"