### PR TITLE
Different OS Dropdown Region Bug Fix 

### DIFF
--- a/src/interface/src/app/top-bar/top-bar.component.scss
+++ b/src/interface/src/app/top-bar/top-bar.component.scss
@@ -60,7 +60,7 @@ select.region-dropdown {
   -moz-appearance:none; /* Firefox */
   -webkit-appearance:none; /* Safari and Chrome */
   appearance:none;
-  background: none;
+  background: #494949;
   border: none;
   outline: none;
   text-align: left;


### PR DESCRIPTION
- Explicitly set background color for region drop down to account for native widget defaults for different OS's
- Previously default background color was white (e.g on Linux), making the selectable region options seem invisible 

Before: 
<img width="188" alt="Screenshot 2023-08-01 at 8 28 37 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/d45d11b4-c399-4836-97d1-d6d18cbfb380">

After: 
<img width="187" alt="Screenshot 2023-08-01 at 8 28 46 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/41966064-939d-4c9c-8671-8acfd7c3a2df">


