### PR TITLE
Boundary Bug Patch 

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -630,7 +630,7 @@ export class MapManager {
     map.boundaryLayerRef?.remove();
 
     const boundaryLayerName = map.config.boundaryLayerConfig.boundary_name;
-    const boundaryVectorName = map.config.dataLayerConfig.region_geoserver_name + map.config.boundaryLayerConfig.vector_name;
+    const boundaryVectorName = map.config.boundaryLayerConfig.vector_name;
     const boundaryShapeName = map.config.boundaryLayerConfig.shape_name;
     
     if (boundaryLayerName !== '') {

--- a/src/interface/src/app/services/map.service.spec.ts
+++ b/src/interface/src/app/services/map.service.spec.ts
@@ -65,9 +65,9 @@ describe('MapService', () => {
     // Must flush the requests in the constructor for httpTestingController.verify()
     // to pass in other tests.
     const req1 = httpTestingController.expectOne(
-      BackendConstants.END_POINT + '/boundary/config/'
+      BackendConstants.END_POINT + '/boundary/config/?region_name=sierra_cascade_inyo'
     );
-    req1.flush(conditionsConfig);
+    req1.flush(boundaryConfigs);
     const req2 = httpTestingController.expectOne(
       BackendConstants.END_POINT +
         '/conditions/config/?region_name=sierra_cascade_inyo'

--- a/src/interface/src/app/services/map.service.ts
+++ b/src/interface/src/app/services/map.service.ts
@@ -47,7 +47,7 @@ export class MapService {
   constructor(private http: HttpClient, private sessionService: SessionService) {
 
     this.http
-      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/')
+      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/?region_name='+ `${this.regionToString(this.selectedRegion$.getValue())}`)
       .pipe(take(1))
       .subscribe((config: BoundaryConfig[]) => {
         this.boundaryConfig$.next(config);

--- a/src/planscape/boundary/views.py
+++ b/src/planscape/boundary/views.py
@@ -19,13 +19,17 @@ boundary_config = BoundaryConfig(
     os.path.join(settings.BASE_DIR, 'config/boundary.json'))
 
 def get_config(params: QueryDict):
+    assert isinstance(params['region_name'], str)
+    region_name = params['region_name']
 
     # Read from boundary config
     config_path = os.path.join(
         settings.BASE_DIR, 'config/boundary.json')
     boundary_config = json.load(open(config_path, 'r'))
 
-    return boundary_config['boundaries']
+    for region in boundary_config['regions']:
+        if region_name == region['region_name']:
+            return region['boundaries']
         
 
     return None

--- a/src/planscape/config/boundary.json
+++ b/src/planscape/config/boundary.json
@@ -1,58 +1,184 @@
 {
-    "boundaries": [
+    "regions": [
         {
-            "boundary_name": "counties",
-            "display_name": "Counties",
-            "vector_name": ":vector_county",
-            "filepath": "cnty19_1.shp",
-            "source_srs": 3857,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "COUNTY_NAM"
+          "region_name": "southern_california",
+          "display_name": "Southern California",
+          "boundaries": [
+          {
+              "boundary_name": "southern_california-counties",
+              "display_name": "Counties",
+              "vector_name": "southern-california:vector_county",
+              "filepath": "cnty19_1.shp",
+              "source_srs": 3857,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "COUNTY_NAM"
+          },
+          {
+              "boundary_name": "southern_california-huc12",
+              "display_name": "HUC-12",
+              "vector_name": "southern-california:vector_huc12",
+              "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+              "source_srs": 4326,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "Name"
+          },
+          {
+              "boundary_name": "huc10",
+              "display_name": "HUC-10",
+              "vector_name": "southern-california:vector_huc-10",
+              "filepath": "WBD_USGS_HUC10_CA.shp",
+              "source_srs": 6414,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "Name"
+          },
+          {
+              "boundary_name": "southern_california-USFS",
+              "display_name": "National Forests",
+              "vector_name": "southern-california:vector_forests",
+              "filepath": "California_USFS.shp",
+              "source_srs": 4269,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "FORESTNAME"
+          },
+          {
+              "boundary_name": "southern_california-RecentFires",
+              "display_name": "Fires (through 2021)",
+              "vector_name": "southern-california:vector_recent-fires",
+              "filepath": "recent-fires.shp",
+              "source_srs": 3310,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "FIRE_NAME"
+          },
+          {
+              "boundary_name": "southern_california-PrescribedBurns",
+              "display_name": "Prescribed Burns (through 2021)",
+              "vector_name": "southern-california:vector_prescribed-burns",
+              "filepath": "prescribed-burns.shp",
+              "source_srs": 3310,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "TREATMEN_1"
+          }
+          ]
         },
         {
-            "boundary_name": "huc12",
-            "display_name": "HUC-12",
-            "vector_name": ":vector_huc12",
-            "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
-            "source_srs": 4326,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "Name"
+          "region_name": "sierra_cascade_inyo",
+          "display_name": "Sierra Nevada",
+          "boundaries": [
+          {
+              "boundary_name": "sierra-nevada-counties",
+              "display_name": "Counties",
+              "vector_name": "sierra-nevada:vector_county",
+              "filepath": "cnty19_1.shp",
+              "source_srs": 3857,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "COUNTY_NAM"
+          },
+          {
+              "boundary_name": "sierra-nevada-huc12",
+              "display_name": "HUC-12",
+              "vector_name": "sierra-nevada:vector_huc12",
+              "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+              "source_srs": 4326,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "Name"
+          },
+          {
+              "boundary_name": "sierra-nevada-huc10",
+              "display_name": "HUC-10",
+              "vector_name": "sierra-nevada:vector_huc10",
+              "filepath": "WBD_USGS_HUC10_CA.shp",
+              "source_srs": 6414,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "Name"
+          },
+          {
+              "boundary_name": "sierra-nevada-USFS",
+              "display_name": "National Forests",
+              "vector_name": "sierra-nevada:vector_forests",
+              "filepath": "California_USFS.shp",
+              "source_srs": 4269,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "FORESTNAME"
+          },
+          {
+              "boundary_name": "sierra-nevada-RecentFires",
+              "display_name": "Fires (through 2021)",
+              "vector_name": "sierra-nevada:vector_recent-fires",
+              "filepath": "recent-fires.shp",
+              "source_srs": 3310,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "FIRE_NAME"
+          },
+          {
+              "boundary_name": "sierra-nevada-PrescribedBurns",
+              "display_name": "Prescribed Burns (through 2021)",
+              "vector_name": "sierra-nevada:vector_prescribed-burns",
+              "filepath": "prescribed-burns.shp",
+              "source_srs": 3310,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "TREATMEN_1"
+          }
+      ]
         },
         {
-            "boundary_name": "huc10",
-            "display_name": "HUC-10",
-            "vector_name": ":vector_huc10",
-            "filepath": "WBD_USGS_HUC10_CA.shp",
-            "source_srs": 6414,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "Name"
-        },
-        {
-            "boundary_name": "USFS",
-            "display_name": "National Forests",
-            "vector_name": ":vector_forests",
-            "filepath": "California_USFS.shp",
-            "source_srs": 4269,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "FORESTNAME"
-        },
-        {
-            "boundary_name": "RecentFires",
-            "display_name": "Fires (1990 through 2021)",
-            "vector_name": ":vector_recent-fires",
-            "filepath": "recent-fires.shp",
-            "source_srs": 3310,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "FIRE_NAME"
-        },
-        {
-            "boundary_name": "PrescribedBurns",
-            "display_name": "Prescribed Burns (through 2021)",
-            "vector_name": ":vector_prescribed-burns",
-            "filepath": "prescribed-burns.shp",
-            "source_srs": 3310,
-            "geometry_type": "MULTIPOLYGON",
-            "shape_name": "TREATMEN_1"
+          "region_name": "central_coast",
+          "display_name": "Central Coast",
+          "boundaries": [
+          {
+              "boundary_name": "central-coast-counties",
+              "display_name": "Counties",
+              "vector_name": "central-coast:vector_county",
+              "filepath": "cnty19_1.shp",
+              "source_srs": 3857,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "COUNTY_NAM"
+          },
+          {
+              "boundary_name": "central-coast-huc12",
+              "display_name": "HUC-12",
+              "vector_name": "central-coast:vector_huc12",
+              "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+              "source_srs": 4326,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "Name"
+          },
+          {
+              "boundary_name": "central-coast-huc10",
+              "display_name": "HUC-10",
+              "vector_name": "central-coast:vector_huc10",
+              "filepath": "WBD_USGS_HUC10_CA.shp",
+              "source_srs": 6414,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "Name"
+          },
+          {
+              "boundary_name": "central-coast-USFS",
+              "display_name": "National Forests",
+              "vector_name": "central-coast:vector_forests",
+              "filepath": "California_USFS.shp",
+              "source_srs": 4269,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "FORESTNAME"
+          },
+          {
+              "boundary_name": "central-coast-RecentFires",
+              "display_name": "Fires (through 2021)",
+              "vector_name": "central-coast:vector_recent-fires",
+              "filepath": "recent-fires.shp",
+              "source_srs": 3310,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "FIRE_NAME"
+          },
+          {
+              "boundary_name": "central-coast-PrescribedBurns",
+              "display_name": "Prescribed Burns (through 2021)",
+              "vector_name": "central-coast:vector_prescribed-burns",
+              "filepath": "prescribed-burns.shp",
+              "source_srs": 3310,
+              "geometry_type": "MULTIPOLYGON",
+              "shape_name": "TREATMEN_1"
+          }
+      ]
         }
-    ]
+      ]
 }

--- a/src/planscape/config/boundary_config.py
+++ b/src/planscape/config/boundary_config.py
@@ -35,15 +35,14 @@ class BoundaryConfig:
         """
 
 
-        def check_boundaries(boundarylist) -> bool:
-            return (isinstance(boundarylist, list) and
-                    all([check_boundary(boundary) for boundary in boundarylist]))
+        def check_regions(regionlist) -> bool:
+            return (isinstance(regionlist, list) and
+                    all([check_region(region) for region in regionlist]))
 
         def check_region(region) -> bool:
             return (isinstance(region, dict) and
                     region.keys() <= set(['region_name', 'display_name', 'boundaries']) and
                     isinstance(RegionName(region['region_name']), RegionName) and
-                    isinstance(region['display_name'], str) and
                     isinstance(region['display_name'], str) and
                     isinstance(region['boundaries'], list) and
                     all([check_boundary(boundary) for boundary in region['boundaries']]))
@@ -64,4 +63,4 @@ class BoundaryConfig:
                     isinstance(boundary['shape_name'], str))
 
 
-        return 'boundaries' in self._config and check_boundaries(self._config['boundaries'])
+        return 'regions' in self._config and check_regions(self._config['regions'])


### PR DESCRIPTION
- Fixes bug where boundaries don't show up unless a condition layer is already applied
- Temporarily changes boundary config back to region based dictionary with workspace names hardcoded for vector layers to fix bug
- Updates corresponding tests
- Future Todo: Find way to centralize workspace name configs — possibly give it its own config file that both conditions and boundaries pull from 