### PR TITLE
Revert "Boundary Config Update"

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -630,7 +630,7 @@ export class MapManager {
     map.boundaryLayerRef?.remove();
 
     const boundaryLayerName = map.config.boundaryLayerConfig.boundary_name;
-    const boundaryVectorName = map.config.dataLayerConfig.region_geoserver_name + map.config.boundaryLayerConfig.vector_name;
+    const boundaryVectorName = map.config.boundaryLayerConfig.vector_name;
     const boundaryShapeName = map.config.boundaryLayerConfig.shape_name;
     
     if (boundaryLayerName !== '') {

--- a/src/interface/src/app/services/map.service.spec.ts
+++ b/src/interface/src/app/services/map.service.spec.ts
@@ -65,7 +65,7 @@ describe('MapService', () => {
     // Must flush the requests in the constructor for httpTestingController.verify()
     // to pass in other tests.
     const req1 = httpTestingController.expectOne(
-      BackendConstants.END_POINT + '/boundary/config/'
+      BackendConstants.END_POINT + '/boundary/config/?region_name=sierra_cascade_inyo'
     );
     req1.flush(conditionsConfig);
     const req2 = httpTestingController.expectOne(
@@ -94,7 +94,7 @@ describe('MapService', () => {
       //   })
       //   });
       service
-        .getBoundaryShapes(":vector_huc12")
+        .getBoundaryShapes("sierra-nevada:vector_huc12")
         .subscribe((res) => { 
           expect(res).toBeTruthy();
         })

--- a/src/interface/src/app/services/map.service.ts
+++ b/src/interface/src/app/services/map.service.ts
@@ -47,7 +47,7 @@ export class MapService {
   constructor(private http: HttpClient, private sessionService: SessionService) {
 
     this.http
-      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/')
+      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/?region_name='+ `${this.regionToString(this.selectedRegion$.getValue())}`)
       .pipe(take(1))
       .subscribe((config: BoundaryConfig[]) => {
         this.boundaryConfig$.next(config);
@@ -89,7 +89,7 @@ export class MapService {
 
   setConfigs(){
     this.http
-      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/')
+      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/?region_name='+ `${this.regionToString(this.selectedRegion$.getValue())}`)
       .pipe(take(1))
       .subscribe((config: BoundaryConfig[]) => {
         this.boundaryConfig$.next(config);

--- a/src/planscape/boundary/views.py
+++ b/src/planscape/boundary/views.py
@@ -20,12 +20,17 @@ boundary_config = BoundaryConfig(
 
 def get_config(params: QueryDict):
 
+    assert isinstance(params['region_name'], str)
+    region_name = params['region_name']
+
     # Read from boundary config
     config_path = os.path.join(
         settings.BASE_DIR, 'config/boundary.json')
     boundary_config = json.load(open(config_path, 'r'))
 
-    return boundary_config['boundaries']
+    for region in boundary_config['regions']:
+        if region_name == region['region_name']:
+            return region['boundaries']
         
 
     return None

--- a/src/planscape/config/boundary.json
+++ b/src/planscape/config/boundary.json
@@ -1,18 +1,25 @@
 {
-    "boundaries": [
+    "__comment1": "TODO: replace filename for SoCal's HUC10 when it loses its dash.",
+    "regions": [
+      {
+        "region_name": "southern_california",
+        "display_name": "Southern California",
+        "boundaries": [
         {
-            "boundary_name": "counties",
+            "boundary_name": "southern_california-counties",
             "display_name": "Counties",
-            "vector_name": ":vector_county",
+            "vector_name": "southern-california:vector_county",
+            "region_name": "none",
             "filepath": "cnty19_1.shp",
             "source_srs": 3857,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "COUNTY_NAM"
         },
         {
-            "boundary_name": "huc12",
+            "boundary_name": "southern_california-huc12",
             "display_name": "HUC-12",
-            "vector_name": ":vector_huc12",
+            "vector_name": "southern-california:vector_huc12",
+            "region_name": "none",
             "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
             "source_srs": 4326,
             "geometry_type": "MULTIPOLYGON",
@@ -21,38 +28,177 @@
         {
             "boundary_name": "huc10",
             "display_name": "HUC-10",
-            "vector_name": ":vector_huc10",
+            "vector_name": "southern-california:vector_huc-10",
+            "region_name": "none",
             "filepath": "WBD_USGS_HUC10_CA.shp",
             "source_srs": 6414,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "Name"
         },
         {
-            "boundary_name": "USFS",
+            "boundary_name": "southern_california-USFS",
             "display_name": "National Forests",
-            "vector_name": ":vector_forests",
+            "vector_name": "southern-california:vector_forests",
+            "region_name": "none",
             "filepath": "California_USFS.shp",
             "source_srs": 4269,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "FORESTNAME"
         },
         {
-            "boundary_name": "RecentFires",
+            "boundary_name": "southern_california-RecentFires",
             "display_name": "Fires (1990 through 2021)",
-            "vector_name": ":vector_recent-fires",
+            "vector_name": "southern-california:vector_recent-fires",
+            "region_name": "none",
             "filepath": "recent-fires.shp",
             "source_srs": 3310,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "FIRE_NAME"
         },
         {
-            "boundary_name": "PrescribedBurns",
+            "boundary_name": "southern_california-PrescribedBurns",
             "display_name": "Prescribed Burns (through 2021)",
-            "vector_name": ":vector_prescribed-burns",
+            "vector_name": "southern-california:vector_prescribed-burns",
+            "region_name": "none",
             "filepath": "prescribed-burns.shp",
             "source_srs": 3310,
             "geometry_type": "MULTIPOLYGON",
             "shape_name": "TREATMEN_1"
         }
+        ]
+      },
+      {
+        "region_name": "sierra_cascade_inyo",
+        "display_name": "Sierra Nevada",
+        "boundaries": [
+        {
+            "boundary_name": "sierra-nevada-counties",
+            "display_name": "Counties",
+            "vector_name": "sierra-nevada:vector_county",
+            "region_name": "none",
+            "filepath": "cnty19_1.shp",
+            "source_srs": 3857,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "COUNTY_NAM"
+        },
+        {
+            "boundary_name": "sierra-nevada-huc12",
+            "display_name": "HUC-12",
+            "vector_name": "sierra-nevada:vector_huc12",
+            "region_name": "none",
+            "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+            "source_srs": 4326,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+        },
+        {
+            "boundary_name": "sierra-nevada-huc10",
+            "display_name": "HUC-10",
+            "vector_name": "sierra-nevada:vector_huc10",
+            "region_name": "none",
+            "filepath": "WBD_USGS_HUC10_CA.shp",
+            "source_srs": 6414,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+        },
+        {
+            "boundary_name": "sierra-nevada-USFS",
+            "display_name": "National Forests",
+            "vector_name": "sierra-nevada:vector_forests",
+            "region_name": "none",
+            "filepath": "California_USFS.shp",
+            "source_srs": 4269,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FORESTNAME"
+        },
+        {
+            "boundary_name": "sierra-nevada-RecentFires",
+            "display_name": "Fires (1990 through 2021)",
+            "vector_name": "sierra-nevada:vector_recent-fires",
+            "region_name": "none",
+            "filepath": "recent-fires.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FIRE_NAME"
+        },
+        {
+            "boundary_name": "sierra-nevada-PrescribedBurns",
+            "display_name": "Prescribed Burns (through 2021)",
+            "vector_name": "sierra-nevada:vector_prescribed-burns",
+            "region_name": "none",
+            "filepath": "prescribed-burns.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "TREATMEN_1"
+        }
+	]
+      },
+      {
+        "region_name": "central_coast",
+        "display_name": "Central Coast",
+        "boundaries": [
+        {
+            "boundary_name": "central-coast-counties",
+            "display_name": "Counties",
+            "vector_name": "central-coast:vector_county",
+            "region_name": "none",
+            "filepath": "cnty19_1.shp",
+            "source_srs": 3857,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "COUNTY_NAM"
+        },
+        {
+            "boundary_name": "central-coast-huc12",
+            "display_name": "HUC-12",
+            "vector_name": "central-coast:vector_huc12",
+            "region_name": "none",
+            "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+            "source_srs": 4326,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+        },
+        {
+            "boundary_name": "central-coast-huc10",
+            "display_name": "HUC-10",
+            "vector_name": "central-coast:vector_huc10",
+            "region_name": "none",
+            "filepath": "WBD_USGS_HUC10_CA.shp",
+            "source_srs": 6414,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "Name"
+        },
+        {
+            "boundary_name": "central-coast-USFS",
+            "display_name": "National Forests",
+            "vector_name": "central-coast:vector_forests",
+            "region_name": "none",
+            "filepath": "California_USFS.shp",
+            "source_srs": 4269,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FORESTNAME"
+        },
+        {
+            "boundary_name": "central-coast-RecentFires",
+            "display_name": "Fires (1990 through 2021)",
+            "vector_name": "central-coast:vector_recent-fires",
+            "region_name": "none",
+            "filepath": "recent-fires.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "FIRE_NAME"
+        },
+        {
+            "boundary_name": "central-coast-PrescribedBurns",
+            "display_name": "Prescribed Burns (through 2021)",
+            "vector_name": "central-coast:vector_prescribed-burns",
+            "region_name": "none",
+            "filepath": "prescribed-burns.shp",
+            "source_srs": 3310,
+            "geometry_type": "MULTIPOLYGON",
+            "shape_name": "TREATMEN_1"
+        }
+	]
+      }
     ]
 }
+

--- a/src/planscape/config/boundary_config.py
+++ b/src/planscape/config/boundary_config.py
@@ -35,9 +35,9 @@ class BoundaryConfig:
         """
 
 
-        def check_boundaries(boundarylist) -> bool:
-            return (isinstance(boundarylist, list) and
-                    all([check_boundary(boundary) for boundary in boundarylist]))
+        def check_regions(regionlist) -> bool:
+            return (isinstance(regionlist, list) and
+                    all([check_region(region) for region in regionlist]))
 
         def check_region(region) -> bool:
             return (isinstance(region, dict) and
@@ -53,15 +53,16 @@ class BoundaryConfig:
 
         def check_boundary(boundary) -> bool:
             return (isinstance(boundary, dict) and
-                    boundary.keys() <= set(['boundary_name', 'display_name', 'vector_name', 'filepath', 'source_srs', 
+                    boundary.keys() <= set(['boundary_name', 'display_name', 'vector_name', 'region_name', 'filepath', 'source_srs', 
                                             'geometry_type', 'shape_name']) and
                     isinstance(boundary['boundary_name'], str) and
                     isinstance(boundary.get('display_name', ''), str) and
                     isinstance(boundary['vector_name'], str) and
+                    isinstance(boundary['region_name'], str) and
                     isinstance(boundary['filepath'], str) and
                     isinstance(boundary['source_srs'], int) and
                     isinstance(GeometryType(boundary['geometry_type']), GeometryType) and 
                     isinstance(boundary['shape_name'], str))
 
 
-        return 'boundaries' in self._config and check_boundaries(self._config['boundaries'])
+        return 'regions' in self._config and check_regions(self._config['regions'])


### PR DESCRIPTION
- Reverts (https://github.com/OurPlanscape/Planscape/pull/865).
- Fixes bug where boundaries don't show up unless a condition layer is already applied
- Temporarily changes boundary config back to region based dictionary with workspace names hardcoded for vector layers to fix bug
- Updates corresponding tests
Future Todo: Find way to centralize workspace name configs — possibly give it its own config file that both conditions and boundaries pull from