### PR TITLE
Add the APIs for inserting, deleting, listing, and retrieving Planning Areas

### DIFF
--- a/src/planscape/planning/apps.py
+++ b/src/planscape/planning/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class PlanConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'planning'

--- a/src/planscape/planning/apps.py
+++ b/src/planscape/planning/apps.py
@@ -1,6 +1,5 @@
 from django.apps import AppConfig
 
 
-class PlanConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
+class PlanningConfig(AppConfig):
     name = 'planning'

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from rest_framework.serializers import IntegerField
 from rest_framework_gis import serializers as gis_serializers
 
-from .models import (PlanningArea, Scenario)
+from .models import (PlanningArea)
 
 
 class PlanningAreaSerializer(gis_serializers.GeoFeatureModelSerializer):
@@ -11,8 +11,3 @@ class PlanningAreaSerializer(gis_serializers.GeoFeatureModelSerializer):
         fields = ("id", "user", "name", "region_name")
         model = PlanningArea
         geo_field = "geometry"
-
-class ScenarioSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Scenario
-        fields = '__all__'

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -1,0 +1,18 @@
+from conditions.models import BaseCondition, Condition
+from rest_framework import serializers
+from rest_framework.serializers import IntegerField
+from rest_framework_gis import serializers as gis_serializers
+
+from .models import (PlanningArea, Scenario)
+
+
+class PlanningAreaSerializer(gis_serializers.GeoFeatureModelSerializer):
+    class Meta:
+        fields = ("id", "user", "name", "region_name")
+        model = PlanningArea
+        geo_field = "geometry"
+
+class ScenarioSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Scenario
+        fields = '__all__'

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -5,7 +5,7 @@ from rest_framework_gis import serializers as gis_serializers
 
 from .models import (PlanningArea)
 
-
+# TODO: flesh this out more for better maintainability.
 class PlanningAreaSerializer(gis_serializers.GeoFeatureModelSerializer):
     class Meta:
         fields = ("id", "user", "name", "region_name")

--- a/src/planscape/planning/tests.py
+++ b/src/planscape/planning/tests.py
@@ -1,0 +1,363 @@
+import datetime
+import json
+
+from base.condition_types import ConditionLevel, ConditionScoreType
+from conditions.models import BaseCondition, Condition, ConditionRaster
+from django.contrib.auth.models import User
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
+from django.db import connection
+from django.test import TransactionTestCase
+from django.urls import reverse
+from planscape import settings
+
+from .models import (PlanningArea, Scenario)
+
+
+# Create test plans.  These are going straight to the test DB without
+# normal parameter checking (e.g. if is there a real geometry).
+# Always use a Sierra Nevada region.
+def _create_plan(
+        user: User | None, name: str, geometry: GEOSGeometry | None):
+    """
+    Creates a plan with the given user, name, geometry.  All regions
+    are in Sierra Nevada.
+    """
+    plan = PlanningArea.objects.create(
+        user=user, name=name, region_name='sierra_cascade_inyo',
+        geometry=geometry)
+    plan.save()
+    return plan
+
+#### PLAN(NING AREA) Tests ####
+        
+class CreatePlanningAreaTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+        self.geometry = {'features': [
+                {'geometry': {'type': 'Polygon', 'coordinates': [[[1, 2], [2, 3], [3, 4], [1, 2]]]}}]}
+
+    def test_missing_user(self):
+        response = self.client.post(
+            reverse('planning:create_plan'), {'name': 'plan', 'region_name': 'Sierra Nevada', 'geometry': self.geometry},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_name(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'), {'region_name': 'Sierra Nevada', 'geometry': self.geometry},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_geometry(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'), {'name': 'plan', 'region_name': 'Sierra Nevada'},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_features(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'), {'name': 'plan', 'region_name': 'Sierra Nevada', 'geometry': {}},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_empty_features(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'plan', 'region_name': 'Sierra Nevada', 'geometry': {'features': []}},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_bad_geometry(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'plan', 'region_name': 'Sierra Nevada', 'geometry': {'features': [
+                {'type': 'Point', 'coordinates': [1, 2]}]}},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_bad_polygon(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'plan', 'region_name': 'Sierra Nevada', 'geometry': {'features': [
+                {'geometry': {'type': 'Polygon'}}]}},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_good_polygon(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'test plan', 'region_name': 'Sierra Nevada', 'geometry': self.geometry},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(PlanningArea.objects.count(), 1)
+
+    def test_good_multipolygon(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'plan', 'region_name': 'Sierra Nevada', 'geometry': {'features': [
+                {'geometry': {'type': 'MultiPolygon', 'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}}]}},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(PlanningArea.objects.count(), 1)
+
+    def test_bad_region_name(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'plan', 'region_name': 'north_coast_inland', 'geometry': {'features': [
+                {'geometry': {'type': 'MultiPolygon', 'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}}]}},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_good_region_name(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'plan', 'region_name': 'Sierra Nevada', 'geometry': {'features': [
+                {'geometry': {'type': 'MultiPolygon', 'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}}]}},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        plans = PlanningArea.objects.all()
+        self.assertEqual(plans.count(), 1)
+        plan = plans.first()
+        assert plan is not None
+        self.assertEqual(plan.region_name, 'sierra_cascade_inyo')
+
+
+class DeletePlanningAreaTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+
+        self.plan1 = _create_plan(self.user, "plan1", None)
+        self.plan2 = _create_plan(self.user, "plan2", None)
+
+        self.user2 = User.objects.create(username='testuser2')
+        self.user2.set_password('12345')
+        self.user2.save()
+
+        self.plan3 = _create_plan(self.user2, "plan3", None)
+        
+    def test_delete_user_not_logged_in(self):
+        response = self.client.post(
+            reverse('planning:delete_plan'), {'id': self.plan1.pk},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(PlanningArea.objects.count(), 3)
+
+    def test_delete_wrong_user(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse('planning:delete_plan'), {'id': self.plan3.pk},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(PlanningArea.objects.count(), 3)
+
+    def test_delete(self):
+        self.client.force_login(self.user)
+        self.assertEqual(PlanningArea.objects.count(), 3)
+        response = self.client.post(
+            reverse('planning:delete_plan'), {'id': self.plan2.pk},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, json.dumps(
+            {"id": [self.plan2.pk]}).encode())
+        self.assertEqual(PlanningArea.objects.count(), 2)
+
+    def test_delete_multiple_plans_fails_if_owner_mismatch(self):
+        self.client.force_login(self.user)
+        self.assertEqual(PlanningArea.objects.count(), 3)
+        plan_ids = [self.plan1.pk, self.plan3.pk]
+        response = self.client.post(
+            reverse('planning:delete_plan'), {'id': plan_ids},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(PlanningArea.objects.count(), 3)
+
+    def test_delete_multiple_plans(self):
+        self.client.force_login(self.user)
+        self.assertEqual(PlanningArea.objects.count(), 3)
+        plan_ids = [self.plan1.pk, self.plan2.pk]
+        response = self.client.post(
+            reverse('planning:delete_plan'), {'id': plan_ids},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, json.dumps(
+            {"id": plan_ids}).encode())
+        self.assertEqual(PlanningArea.objects.count(), 1)
+
+
+class GetPlanningAreaTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+        self.geometry = {'type': 'MultiPolygon',
+                         'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
+        storable_geometry = GEOSGeometry(json.dumps(self.geometry))
+        self.plan = _create_plan(self.user, 'test plan', storable_geometry)
+
+        self.user2 = User.objects.create(username='testuser2')
+        self.user2.set_password('12345')
+        self.user2.save()
+        self.plan2 = _create_plan(self.user2, 'test plan2', storable_geometry)
+
+    def test_get_plan(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('planning:get_plan_by_id'),
+            {'id': self.plan.pk},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['name'], 'test plan')
+        self.assertEqual(response.json()['region_name'], 'Sierra Nevada')
+
+    def test_get_nonexistent_plan(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('planning:get_plan_by_id'), {'id': 9999},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_plan_does_not_belong_to_user(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('planning:get_plan_by_id'),
+            {'id': self.plan2.pk},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_plan_not_logged_in(self):
+        response = self.client.get(
+            reverse('planning:get_plan_by_id'),
+            {'id': self.plan.pk},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+
+class ListPlanningAreaTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+        self.geometry = {'type': 'MultiPolygon',
+                         'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
+        stored_geometry = GEOSGeometry(json.dumps(self.geometry))
+        self.plan1 = _create_plan(self.user, 'plan1', stored_geometry)
+        self.plan2 = _create_plan(self.user, 'plan2', stored_geometry)
+
+        self.user2 = User.objects.create(username='testuser2')
+        self.user2.set_password('12345')
+        self.user2.save()
+        self.geometry = {'type': 'MultiPolygon',
+                         'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
+        stored_geometry = GEOSGeometry(json.dumps(self.geometry))
+        self.plan3 = _create_plan(self.user2, 'plan3', stored_geometry)
+
+        self.emptyuser = User.objects.create(username='emptyuser')
+        self.emptyuser.set_password('12345')
+        self.emptyuser.save()
+        
+    def test_list_plans_not_logged_in(self):
+        response = self.client.get(reverse('planning:list_plans'), {},
+                                   content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_plans_user_logged_in(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('planning:list_plans'),
+            {},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 2)
+
+    def test_list_plans_empty_user(self):
+        self.client.force_login(self.emptyuser)
+        response = self.client.get(
+            reverse('planning:list_plans'),
+            {},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 0)
+
+
+# EndtoEnd test that lists, creates a plan, tests what was stored,
+# and then deletes it.
+# This covers the basic happiest of cases and should not be a substitute
+# for the main unit tests.
+class EndtoEndPlanningAreaTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+        self.internal_geometry = {'type': 'MultiPolygon',
+                         'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
+        self.geometry = {'features': [{'geometry': self.internal_geometry}]}
+
+    def test_end_to_end(self):
+        self.client.force_login(self.user)
+
+        # List - returns 0
+        response = self.client.get(
+            reverse('planning:list_plans'),
+            {},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 0)
+
+        # insert one
+        response = self.client.post(
+            reverse('planning:create_plan'),
+            {'name': 'test plan', 'region_name': 'Sierra Nevada', 'geometry': self.geometry},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(PlanningArea.objects.count(), 1)
+
+        # is it there?
+        response = self.client.get(
+            reverse('planning:list_plans'),
+            {},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        plans = response.json()
+        listed_plan = plans[0]
+        
+        # get plan details
+        response = self.client.get(
+            reverse('planning:get_plan_by_id'),
+            {'id': listed_plan['id']},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        plan = response.json()
+        self.assertEqual(plan['name'], 'test plan')
+        self.assertEqual(plan['region_name'], 'Sierra Nevada')
+        self.assertEqual(plan['id'], listed_plan['id'])
+        self.assertEqual(plan['geometry'], self.internal_geometry)
+
+        # remove it
+        response = self.client.post(
+            reverse('planning:delete_plan'),
+            {'id': plan['id']},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        
+        # there should be no more plans
+        response = self.client.get(
+            reverse('planning:list_plans'),
+            {},
+            content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 0)

--- a/src/planscape/planning/urls.py
+++ b/src/planscape/planning/urls.py
@@ -1,0 +1,18 @@
+from django.urls import path
+from planning.views import (create_plan, delete_plan, get_plan_by_id, list_plans)
+
+app_name = 'planning'
+
+urlpatterns = [
+    # Plans / Planning Areas
+    path('create_plan/', create_plan, name='create_plan'),
+    path('delete_plan/', delete_plan, name='delete_plan'),
+    path('get_plan_by_id/', get_plan_by_id, name='get_plan_by_id'),
+    path('list_plans/', list_plans, name='list_plans'),
+
+    # Scenarios
+    # TODO
+
+    # Project Areas
+    # TODO
+]

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -144,7 +144,7 @@ def delete_plan(request: HttpRequest) -> HttpResponse:
         elif isinstance(plan_id, list):
             plan_ids = plan_id
         else:
-            raise ValueError("Bad plan id: " + plan_id)
+            raise ValueError("Plan ID must be an int or a list of ints.")
 
         # Get the plan; reject if the plan id is not found or if
         # the plan's user doesn't match the logged in user.

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -1,0 +1,203 @@
+import datetime
+import json
+
+import boto3
+from base.condition_types import ConditionScoreType
+from base.region_name import display_name_to_region, region_to_display_name
+from conditions.models import BaseCondition, Condition
+from conditions.raster_utils import fetch_or_compute_condition_stats
+from django.contrib.auth.models import User
+from django.contrib.gis.geos import GEOSGeometry
+from django.db.models import Count
+from django.db.models.query import QuerySet
+from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
+                         JsonResponse, QueryDict)
+from django.views.decorators.csrf import csrf_exempt
+from planning.models import (PlanningArea, Scenario)
+from planning.serializers import (PlanningAreaSerializer,ScenarioSerializer)
+from planscape import settings
+
+# TODO: disallow calls if not logged in as user
+
+MAX_BUDGET = 'max_budget'
+MAX_TREATMENT_AREA_RATIO = 'max_treatment_area_ratio'
+MAX_ROAD_DIST = 'max_road_distance'
+MAX_SLOPE = 'max_slope'
+PRIORITIES = 'priorities'
+
+# Retrieve the logged in user from the HTTP request.
+def _get_user(request: HttpRequest) -> User:
+    user = None
+    if hasattr(request, 'user') and request.user.is_authenticated:
+        user = request.user
+    return user
+
+
+# Retrieve a plan by its ID from a QueryDict.
+def _get_plan_by_id_from_query(user, params: QueryDict):
+    assert isinstance(params['id'], str)
+    plan_id = params.get('id')
+
+    if plan_id is None:
+        raise ValueError("No plan ID provided.")
+
+    plan = PlanningArea.objects.get(id=int(plan_id))
+    if plan is None:
+        raise ValueError("No plan found for this id.")
+
+    if plan.user != user:
+        raise ValueError("You do not have permission to view this plan.")
+    return plan
+
+
+# We always need to store multipolygons, so coerce a single polygon to
+# a multigolygon if needed.
+def _convert_polygon_to_multipolygon(geometry: dict):
+    features = geometry.get('features', [])
+    if len(features) > 1 or len(features) == 0:
+        raise ValueError("Must send exactly one feature.")
+    feature = features[0]
+    geom = feature['geometry']
+    if geom['type'] == 'Polygon':
+        geom['type'] = 'MultiPolygon'
+        geom['coordinates'] = [feature['geometry']['coordinates']]
+    actual_geometry = GEOSGeometry(json.dumps(geom))
+    if actual_geometry.geom_type != 'MultiPolygon':
+        raise ValueError("Could not parse geometry")
+    return actual_geometry
+
+
+def _serialize_plan(plan: PlanningArea, add_geometry: bool) -> dict:
+    """
+    Serializes a Plan into a dictionary.
+    1. Converts the Plan to a dictionary with fields 'id', 'geometry', and 'properties'
+       (the latter of which is a dictionary).
+    2. Creates the partial result from the properties and 'id' fields.
+    3. Adds the 'geometry' if requested.
+    4. Replaces the internal region_name with the display version.
+    """
+    data = PlanningAreaSerializer(plan).data
+    result = data['properties']
+    result['id'] = data['id']
+    if 'geometry' in data and add_geometry:
+        result['geometry'] = data['geometry']
+    if 'region_name' in result:
+        result['region_name'] = region_to_display_name(result['region_name'])
+    return result
+
+
+#### PLAN(NING AREA) Handlers ####
+
+# Requires a logged in user (from the session), a plan name, a region name, and a geometry.
+def create_plan(request: HttpRequest) -> HttpResponse:
+    try:
+        # Check that the user is logged in.
+        user = _get_user(request)
+        if user is None:
+            raise ValueError("User must be logged in.")
+        
+        # Get the name of the plan.
+        body = json.loads(request.body)
+        name = body.get('name')
+        if name is None:
+            raise ValueError("Must specify a plan name.")
+
+        # Get the region name; it should be in the human-readable display name format.
+        region_name_input = body.get('region_name')
+        if region_name_input is None:
+            raise ValueError("Region name must be specified.")
+        
+        region_name = display_name_to_region(region_name_input)
+        if region_name is None:
+            raise ValueError("Unknown region_name: " + region_name_input)
+
+        # Get the geometry of the plan.
+        geometry = body.get('geometry')
+        if geometry is None:
+            raise ValueError("Must specify the plan geometry.")
+
+        # Convert to a MultiPolygon if it is a simple Polygon, since the model column type is
+        # MultiPolygon.
+        geometry = _convert_polygon_to_multipolygon(geometry)
+
+        # Create the plan
+        plan = PlanningArea.objects.create(
+            user=user, name=name, region_name=region_name, geometry=geometry)
+        plan.save()
+        return HttpResponse(str(plan.pk))
+    except Exception as e:
+        return HttpResponseBadRequest("Error in create: " + str(e))
+
+
+# Supports deleting a whole list of plans.
+# Plans are deleteable only by their owners.  A list that only partially
+# matches the logged in user will result in no plans being deleted.
+def delete_plan(request: HttpRequest) -> HttpResponse:
+    try:
+        # Check that the user is logged in.
+        user = _get_user(request)
+        if user is None:
+            raise ValueError("User must be logged in.")
+        user_id = user.pk
+
+        # Get the plans                                                                                                                                 
+        body = json.loads(request.body)
+        plan_id = body.get('id', None)
+        plan_ids = []
+        if plan_id is None:
+            raise ValueError("Must specify plan id")
+        elif isinstance(plan_id, int):
+            plan_ids = [plan_id]
+        elif isinstance(plan_id, list):
+            plan_ids = plan_id
+        else:
+            raise ValueError("Bad plan id: " + plan_id)
+
+        # Get the plan; reject if the plan id is not found or if
+        # the plan's user doesn't match the logged in user.
+        plans = PlanningArea.objects.filter(pk__in=plan_ids)
+        for plan in plans:
+            if user_id != plan.user.pk:
+                raise ValueError(
+                    "Cannot delete plan " + str(plan.pk) + "; plan is not owned by user")
+        for plan in plans:
+            plan.delete()
+        response_data = {'id': plan_ids}
+
+        return HttpResponse(
+            json.dumps(response_data),
+            content_type="application/json")
+    except Exception as e:
+        return HttpResponseBadRequest("Error in delete: " + str(e))
+
+
+# User can see only their own plans.
+def get_plan_by_id(request: HttpRequest) -> HttpResponse:
+    try:
+        user = _get_user(request)
+        if user is None:
+            raise ValueError("User must be logged in.")
+        user_id = user.pk
+
+        return JsonResponse(
+            _serialize_plan(
+                _get_plan_by_id_from_query(user, request.GET),
+                True))
+    except Exception as e:
+        return HttpResponseBadRequest("Ill-formed request: " + str(e))
+
+
+# No Params expected, since we're always using the logged in user.
+def list_plans(request: HttpRequest) -> HttpResponse:
+    try:
+        user = _get_user(request)
+        if user is None:
+            raise ValueError("User must be logged in.")
+        user_id = user.pk
+        plans = PlanningArea.objects.filter(user=user_id)
+        return JsonResponse(
+            [_serialize_plan(plan, False) for plan in plans],
+            safe=False)
+    except Exception as e:
+        return HttpResponseBadRequest("Ill-formed request: " + str(e))
+

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -13,17 +13,10 @@ from django.db.models.query import QuerySet
 from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
                          JsonResponse, QueryDict)
 from django.views.decorators.csrf import csrf_exempt
-from planning.models import (PlanningArea, Scenario)
-from planning.serializers import (PlanningAreaSerializer,ScenarioSerializer)
+from planning.models import (PlanningArea)
+from planning.serializers import (PlanningAreaSerializer)
 from planscape import settings
 
-# TODO: disallow calls if not logged in as user
-
-MAX_BUDGET = 'max_budget'
-MAX_TREATMENT_AREA_RATIO = 'max_treatment_area_ratio'
-MAX_ROAD_DIST = 'max_road_distance'
-MAX_SLOPE = 'max_slope'
-PRIORITIES = 'priorities'
 
 # Retrieve the logged in user from the HTTP request.
 def _get_user(request: HttpRequest) -> User:

--- a/src/planscape/planscape/urls.py
+++ b/src/planscape/planscape/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('planscape-backend/conditions/', include('conditions.urls')),
     path('planscape-backend/forsys/', include('forsys.urls')),
     path('planscape-backend/plan/', include('plan.urls')),
+    path('planscape-backend/planning/', include('planning.urls')),
     path('planscape-backend/projects/', include('existing_projects.urls')),
     # Auth URLs
     path('planscape-backend/users/', include('users.urls')),


### PR DESCRIPTION
This covers only PlanningAreas.  Scenario logic will come later.

APIs require that a user is logged in.

This code is somewhat based on the old Plan code but reflects requirements and schema based on 2023H2.