### PR TITLE
Add Scenario Config Excluded Areas Panel + Small Styling Updates

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -58,5 +58,18 @@
         </div>
       </div>
     </div>
+    <div class="constraints-content">
+      <div formGroupName="excludedAreasForm" class="flex-column">
+        <div class="top-label">
+          <label class="form-label">EXCLUDE AREAS</label>
+        </div>
+        <section class="area-selection">
+          <div class="checkbox-column">
+            <mat-checkbox [color]="'primary'" *ngFor="let item of excludedAreasOptions;" [formControlName]="item"
+              [value]="item">{{item}}</mat-checkbox>
+          </div>
+        </section>
+      </div>
+    </div>
   </form>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
@@ -1,3 +1,22 @@
+.area-selection {
+  columns: 2;
+  -webkit-columns: 2;
+  overflow: hidden;
+  margin-top: 10px;
+  gap: 10px;
+  margin-bottom: 20px;
+  margin-left: 30px;
+}
+
+.area-column {
+  display: inline-block;
+  flex-direction: column;
+}
+
+.checkbox-column {
+  max-width: 50%;
+}
+
 .constraints-panel {
   display: flex;
   flex-direction: column;
@@ -152,7 +171,7 @@
 
 .mat-button-toggle-group {
   width: fit-content;
-  margin-right:60px;
+  margin-right: 60px;
 
 }
 
@@ -165,5 +184,9 @@
 ::ng-deep .mat-button-toggle-appearance-standard .mat-button-toggle-label-content {
   line-height: 20px;
   top: 5px;
-  width:60px;
+  width: 60px;
+}
+
+.mat-grid-tile-content {
+  width: fit-content;
 }

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
@@ -37,6 +37,12 @@ describe('ConstraintsPanelComponent', () => {
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
 
+    var excludedAreasOptions = ["Private Land", "National Forests and Parks",
+      "Wilderness Area", "Tribal Lands"];
+    var excludedAreasChosen: { [key: string]: (boolean | Validators)[] } = {};
+    excludedAreasOptions.forEach((area: string) => {
+      excludedAreasChosen[area] = [false, Validators.required];
+    });
     const fb = fixture.componentRef.injector.get(FormBuilder);
     component.constraintsForm = fb.group({
       treatmentForm: fb.group({
@@ -56,6 +62,7 @@ describe('ConstraintsPanelComponent', () => {
         maxRoadDistance: ['', Validators.min(0)],
         standSize: ['Large', Validators.required],
       }),
+      excludedAreasForm: fb.group(excludedAreasChosen),
       excludeAreasByDegrees: [false],
       excludeAreasByDistance: [false],
       excludeSlope: [''],

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -8,5 +8,6 @@ import { FormGroup, Validators } from '@angular/forms';
 })
 export class ConstraintsPanelComponent {
   @Input() constraintsForm: FormGroup | undefined;
+  @Input() excludedAreasOptions: Array<string> | undefined;
   standSizeOptions: Array<String> = ["Small", "Medium", "Large"];
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -9,7 +9,7 @@
           </app-set-priorities>
           <app-identify-project-areas *ngIf="project_area_upload_enabled" [formGroup]="formGroups[2]">
           </app-identify-project-areas>
-          <app-constraints-panel [constraintsForm]="formGroups[1]"> </app-constraints-panel>
+          <app-constraints-panel [constraintsForm]="formGroups[1]" [excludedAreasOptions]="excludedAreasOptions"> </app-constraints-panel>
         </div>
       </mat-tab>
       <mat-tab label="Outcome">

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -31,7 +31,7 @@
   top: 0;
   left: 0;
   background-color: #E6e9f4;
-  background-image: linear-gradient(to bottom, white 7%, rgba(0, 0, 0, 0) 7%);
+  background-image: linear-gradient(to bottom, white 64px, rgba(0, 0, 0, 0) 64px);
 }
 
 /** Always show scrollbar. */

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -71,9 +71,12 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     priorities: [''],
     weights: [0]
   }
+  excludedAreasOptions: Array<string> = ["Private Land", "National Forests and Parks",
+    "Wilderness Area", "Tribal Lands"];
+
   private readonly destroy$ = new Subject<void>();
   project_area_upload_enabled = features.upload_project_area;
-  
+
   constructor(
     private fb: FormBuilder,
     private matSnackBar: MatSnackBar,
@@ -83,6 +86,11 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     this.treatmentGoals = this.planService.treatmentGoalsConfig$.pipe(
       takeUntil(this.destroy$)
     );
+
+    var excludedAreasChosen: { [key: string]: (boolean | Validators)[] } = {};
+    this.excludedAreasOptions.forEach((area: string) => {
+      excludedAreasChosen[area] = [false, Validators.required];
+    });
     // Initialize empty form
     this.formGroups = [
       // Step 1: Select priorities
@@ -109,6 +117,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
             // TODO validate to make sure standSize is only 'Small', 'Medium', or 'Large'
             standSize: ['Large', Validators.required],
           }),
+          excludedAreasForm: this.fb.group(excludedAreasChosen),
           excludeAreasByDegrees: [true],
           excludeAreasByDistance: [true],
         },

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
@@ -7,10 +7,10 @@
       <div class="top-label">
         <label class="form-label">PROJECT AREAS</label>
       </div>
-      <mat-radio-button [value]="true">
+      <mat-radio-button [color]="'primary'" [value]="true">
         Define them for me
       </mat-radio-button>
-      <mat-radio-button [value]="false">
+      <mat-radio-button [color]="'primary'" [value]="false">
         Upload exising areas
         <button mat-stroked-button color="primary" (click)="showUploader = true">
           <mat-icon color="primary">upload</mat-icon>

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.scss
@@ -79,18 +79,6 @@
   margin-bottom: 1px;
 }
 
-// Makes radio button blue (default is pink)
-::ng-deep .mat-radio-button.mat-accent.mat-radio-checked .mat-radio-outer-circle {
-  border-color: #3f51b5;
-}
-
-::ng-deep .mat-radio-button.mat-accent .mat-radio-inner-circle,
-.mat-radio-button.mat-accent .mat-radio-ripple .mat-ripple-element:not(.mat-radio-persistent-ripple),
-.mat-radio-button.mat-accent.mat-radio-checked .mat-radio-persistent-ripple,
-.mat-radio-button.mat-accent:active .mat-radio-persistent-ripple {
-  background-color: #3f51b5;
-}
-
 ::ng-deep .mat-radio-label {
   width: fit-content;
 }


### PR DESCRIPTION
- Add Excluded Areas panel to Scenario config page
- Fix background color styling on scenario config page (would shift on window resize)
- Simplify radio button color styling for project area upload panel
<img width="698" alt="Screenshot 2023-08-17 at 3 24 23 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/46570af1-6a74-4782-a586-e77c1fe3ec77">
