### PR TITLE
EP functionality to unblock FE

### DIFF
--- a/src/planscape/forsys/management/commands/evaluate_scenario.py
+++ b/src/planscape/forsys/management/commands/evaluate_scenario.py
@@ -1,35 +1,163 @@
 import argparse
+import json
+import logging
+import random
+import time
+from datetime import datetime
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand, CommandParser
+from planning.models import (Scenario, ScenarioResultStatus, ScenarioResult)
+
 
 class Command(BaseCommand):
     help = "Evaluates a specific scenario."
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser):
         parser.add_argument("scenario_id", type=int)
         parser.add_argument('--dry_run',
                             type=bool, default=False, action=argparse.BooleanOptionalAction,
-                            help='Show the commands to be run but do not run them.')
+                            help='Show the commands to be run but do not run them.' \
+                                 'Makes no changes to the database and does not call forsys.')
+        parser.add_argument('--fake_run',
+                            type=bool, default=False, action=argparse.BooleanOptionalAction,
+                            help='Fake an evaluation and write dummy data for a scenario.')
+        parser.add_argument('--fake_run_time', type=int, default=60, required=False,
+                            help='Sets the run duration in seconds for a fake run')
+        parser.add_argument('--fake_run_failure_rate', type=int, default=0, required=False,
+                            help='During a fake run, set the failure rate (0-100).')
 
     def handle(self, *args, **options):
         scenario_id = options["scenario_id"]
+        dry_run = options['dry_run']
+        fake_run = options['fake_run']
+        fake_run_time = options['fake_run_time']
+        fake_run_failure_rate = options['fake_run_failure_rate']
 
-        self._evaluate_scenario(scenario_id)
-        self.stdout.write(
-            self.style.SUCCESS('Successfully evaluated "%d"' % scenario_id)
-        )
+        try:
+            self.evaluate_scenario(scenario_id, dry_run, fake_run, fake_run_time,
+                                   fake_run_failure_rate)
+            self.logger.info('Successfully evaluated scenario %d' % scenario_id)
+        except Exception as e:
+            # Log any exception, but then throw it again to generate a failed exit code.
+            self.logger.critical(str(e))
+            raise e
 
-    def _evaluate_scenario(self, scenario_id: int):
-                
+    def _evaluate_fake(self, scenario: Scenario, scenario_result: ScenarioResult,
+                       dry_run: bool, fake_run_time: int, fake_run_failure_rate: int):
         """
-        TODO:
-        Read from DB
-        Write faked result to DB
-        Sanity-check scenario correctness
-        
-        Update DB with run information (pid, start time)
+        Fakes a scenario evaluation.
+        Allows for a chance of a simulated failure.
+        """
+        self.logger.debug("Fake-evaluating %d" % scenario.pk)
+        scenario_result.status = ScenarioResultStatus.RUNNING
+        scenario_result.save()
+        time.sleep(fake_run_time)
+        self.logger.debug("sleeping %d" % fake_run_time)
+
+        if fake_run_failure_rate > 0:
+            random.seed()
+            if random.randrange(100) < fake_run_failure_rate:
+                self.logger.info("faking a failure")
+                return {
+                    'new_status': ScenarioResultStatus.FAILURE,
+                    'new_result': {
+                        'comment': 'Inconcievable!'
+                    },
+                    'new_run_details': {
+                        'comment': 'You’ve fell victim to one of the classic blunders! '\
+                                   'The most famous is never get involved in a land war in Asia, '\
+                                   'but only slightly less well known is this; never go in '\
+                                   'against a Sicilian, when death is on the line!'
+                    }
+                }
+
+        return {
+            'new_status': ScenarioResultStatus.SUCCESS,
+            'new_result': {
+                'comment': "We'll never succeed."
+            },
+            'new_run_details': {
+                'comment': "No, no. We have already succeeded. I mean, what are the three terrors "\
+                           "of the Fire Swamp? One, the flame spurt — no problem. There's a "\
+                           "popping sound preceding each; we can avoid that. Two, the lightning "\
+                           "sand, which you were clever enough to discover what that looks like, "\
+                           "so in the future we can avoid that too."
+            }
+        }
+
+    def _evaluate_scenario(self, scenario: Scenario, scenario_results: ScenarioResult,
+                           dry_run: bool):
+        """
+        TODO: Read all map data for scenario from DB
         Run Forsys
-        Write to DB
-
+        Write full results (e.g. project areas) to DB
         """
+
+        self._run_forsys()
+
+        return {
+            'new_status': ScenarioResultStatus.SUCCESS,
+            'new_result': {
+                'comment': 'TODO'
+            },
+            'new_run_details': {
+                'comment': 'TODO'
+            }
+        }
+
+    def evaluate_scenario(self, scenario_id: int, dry_run: bool, fake_run: bool,
+                          fake_run_time: int, fake_run_failure_rate: int):
+        scenario_result = ScenarioResult.objects.filter(
+            status=ScenarioResultStatus.PENDING).select_related('scenario').get(scenario__pk=scenario_id)
+        scenario = Scenario.objects.select_related('planning_area').get(id=scenario_id)
+
+        if scenario_result is None:
+            self.logger.debug('Scenarios need to be in a PENDING state in order to be evaluated.')
+            raise ValueError("No eligible scenario found")
+
+        # TODO: Make a real class out of the output instead of toting around dictionaries
+        run_output = {}
+        run_starting_time = datetime.now()
+        output_start_time = run_starting_time.strftime("%x %X")
+
+        # Update the status to running.
+        if dry_run:
+            run_output['dry_run'] = 'Dry run enabled.  Would have changed the status to Running.'
+        else:
+            scenario_result.status = ScenarioResultStatus.RUNNING
+            scenario_result.run_details = json.dumps({'start_time': output_start_time})
+            scenario_result.save()
+
+        if fake_run:
+            run_output = self._evaluate_fake(scenario, scenario_result, dry_run, fake_run_time,
+                                             fake_run_failure_rate)
+        else:
+            try:
+                run_output = self._evaluate_scenario(scenario, scenario_result, dry_run)
+            except Exception as e:
+                run_output['new_status'] = ScenarioResultStatus.FAILURE
+                run_output['new_run_details']['error_details'] = str(e)
+
+        run_output['new_run_details']['start_time'] = output_start_time
+        run_ending_time = datetime.now()
+        elapsed_time = run_ending_time - run_starting_time
+        run_output['new_run_details']['end_time'] = run_ending_time.strftime("%x %X")
+        run_output['new_run_details']['elapsed_time'] = elapsed_time.total_seconds()
+
+        if dry_run:
+            self.logger.info(json.dumps(run_output))
+        else:
+            scenario_result.status = run_output['new_status']
+            scenario_result.result = json.dumps(run_output['new_result'])
+            scenario_result.run_details = json.dumps(run_output['new_run_details'])
+            scenario_result.save()
+            self.logger.debug(json.dumps(run_output))
         return True
+
+    def _run_forsys(self):
+        """
+        This is where the fun happens.
+        """
+        pass

--- a/src/planscape/forsys/management/commands/evaluate_scenario.py
+++ b/src/planscape/forsys/management/commands/evaluate_scenario.py
@@ -118,8 +118,7 @@ class Command(BaseCommand):
         scenario = Scenario.objects.select_related('planning_area').get(id=scenario_id)
 
         if scenario_result is None:
-            self.logger.debug('Scenarios need to be in a PENDING state in order to be evaluated.')
-            raise ValueError("No eligible scenario found")
+            raise ValueError("No eligible scenario (e.g. in a PENDING state) found")
 
         # TODO: Make a real class out of the output instead of toting around dictionaries
         run_output = {}

--- a/src/planscape/forsys/management/commands/evaluate_scenario.py
+++ b/src/planscape/forsys/management/commands/evaluate_scenario.py
@@ -1,12 +1,13 @@
 import argparse
-from datetime import datetime
-from django.db import transaction
 import json
 import logging
 import random
 import time
 
-from django.core.management.base import BaseCommand, CommandParser
+from datetime import datetime
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
 from planning.models import (Scenario, ScenarioResultStatus, ScenarioResult)
 
 #TODO: Move evaluate_scenario() outside of the command directory.
@@ -157,7 +158,6 @@ class Command(BaseCommand):
                 transaction.set_rollback(True)
             else:
                 self.logger.debug(json.dumps(run_output))
-        return True
 
     def _run_forsys(self):
         """

--- a/src/planscape/forsys/management/commands/evaluate_scenario.py
+++ b/src/planscape/forsys/management/commands/evaluate_scenario.py
@@ -9,9 +9,12 @@ import time
 from django.core.management.base import BaseCommand, CommandParser
 from planning.models import (Scenario, ScenarioResultStatus, ScenarioResult)
 
+#TODO: Move evaluate_scenario() outside of the command directory.
 
 class Command(BaseCommand):
     help = "Evaluates a specific scenario."
+
+    # TODO: configure a dedicated logger in settings.py for this command.
     logger = logging.getLogger(__name__)
 
     def add_arguments(self, parser):

--- a/src/planscape/forsys/tests/test_evaluate_scenario.py
+++ b/src/planscape/forsys/tests/test_evaluate_scenario.py
@@ -1,0 +1,166 @@
+from io import StringIO
+import json
+
+from django.contrib.auth.models import User
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
+from django.core.management import call_command
+from django.test import TestCase
+
+from planning.models import (PlanningArea, Scenario, ScenarioResult, ScenarioResultStatus)
+
+# TODO: Refactor into a test utility file.
+# Create test plans.  These are going straight to the test DB without
+# normal parameter checking (e.g. if is there a real geometry).
+# Always use a Sierra Nevada region.
+def _create_planning_area(
+        user: User | None, name: str, geometry: GEOSGeometry | None) -> PlanningArea:
+    """
+    Creates a planning_area with the given user, name, geometry.  All regions
+    are in Sierra Nevada.
+    """
+    planning_area = PlanningArea.objects.create(
+        user=user, name=name, region_name='sierra_cascade_inyo', geometry=geometry)
+    planning_area.save()
+    return planning_area
+
+
+# Blindly create a scenario and a scenario result in its default (pending) state.
+# Note that this does no deduplication, which our APIs may eventually do.
+def _create_scenario(planning_area: PlanningArea,
+                     scenario_name: str, configuration: str) -> Scenario:
+    scenario = Scenario.objects.create(
+        planning_area=planning_area, name=scenario_name, configuration=configuration)
+    scenario.save()
+
+    scenario_result = ScenarioResult.objects.create(
+        scenario=scenario)
+    scenario_result.save()
+
+    return scenario
+
+
+class ShouldHaveFailedException(Exception):
+    """ Specific new exception to be uncaught. """
+    pass
+
+class EvaluateScenarioTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.user.set_password('12345')
+        self.user.save()
+        self.geometry = {'type': 'MultiPolygon',
+                         'coordinates': [[[[1, 2], [2, 3], [3, 4], [1, 2]]]]}
+        self.storable_geometry = GEOSGeometry(json.dumps(self.geometry))
+        self.planning_area = _create_planning_area(self.user, 'test plan', self.storable_geometry)
+        self.scenario = _create_scenario(self.planning_area, 'test scenario', '{}')
+        self.scenario2 = _create_scenario(self.planning_area, 'test scenario2', '{}')
+        self.scenario3 = _create_scenario(self.planning_area, 'test scenario3', '{}')
+
+        self.user2 = User.objects.create(username='testuser2')
+        self.user2.set_password('12345')
+        self.user2.save()
+        self.planning_area2 = _create_planning_area(self.user2, 'test plan2', self.storable_geometry)
+        self.user2scenario = _create_scenario(self.planning_area2, 'test user2scenario', '{}')
+
+        self.assertEqual(Scenario.objects.count(), 4)
+        self.assertEqual(ScenarioResult.objects.count(), 4)
+
+    def _call_command(self, *args, **kwargs) -> str:
+        out = StringIO()
+        call_command('evaluate_scenario', *args, stdout=out,
+                     stderr=StringIO(), **kwargs)
+        return out.getvalue()
+
+    # TODO: update this when we really trigger a forsys call
+    def test_evaluate_scenario(self):
+        output = self._call_command(self.scenario.pk)
+        scenario_result = ScenarioResult.objects.get(scenario__id=self.scenario.pk)
+        self.assertEquals(scenario_result.status, ScenarioResultStatus.SUCCESS)
+
+    def test_evaluate_scenario_dry_run(self):
+        output = self._call_command(self.scenario.pk, '--dry_run')
+        scenario_result = ScenarioResult.objects.get(scenario__id=self.scenario.pk)
+        self.assertEquals(scenario_result.status, ScenarioResultStatus.PENDING)
+
+    def test_evaluate_scenario_fake_run(self):
+        output = self._call_command(self.scenario.pk, '--fake_run', '--fake_run_time=1')
+        scenario_result = ScenarioResult.objects.get(scenario__id=self.scenario.pk)
+        self.assertEquals(scenario_result.status, ScenarioResultStatus.SUCCESS)
+        details = json.loads(scenario_result.run_details)
+        self.assertRegex(details['comment'], r'Fire Swamp')
+        self.assertTrue('start_time' in details)
+        self.assertTrue('end_time' in details)
+        self.assertTrue(details['elapsed_time'] > 1.0)
+
+    def test_evaluate_scenario_fake_run_with_failure(self):
+        output = self._call_command(self.scenario.pk, '--fake_run', '--fake_run_time=2', '--fake_run_failure_rate=100')
+        scenario_result = ScenarioResult.objects.get(scenario__id=self.scenario.pk)
+        self.assertEquals(scenario_result.status, ScenarioResultStatus.FAILURE)
+        details = json.loads(scenario_result.run_details)
+        self.assertRegex(details['comment'], r'land war in Asia')
+        self.assertTrue('start_time' in details)
+        self.assertTrue('end_time' in details)
+        self.assertTrue(details['elapsed_time'] > 1.0)
+
+    def test_missing_scenario_id(self):
+        try:
+            output = self._call_command()
+            raise ShouldHaveFailedException(output)
+        except ShouldHaveFailedException as e:
+            raise ShouldHaveFailedException(e)
+        except Exception as e:
+            self.assertRegex(str(e), r'the following arguments are required: scenario_id')
+
+    def test_nonexistent_scenario_id(self):
+        try:
+            output = self._call_command(999999)
+            raise ShouldHaveFailedException(output)
+        except ShouldHaveFailedException as e:
+            raise ShouldHaveFailedException(e)
+        except Exception as e:
+            self.assertRegex(str(e), r'ScenarioResult matching query does not exist')
+
+    def test_garbage_scenario_id(self):
+        try:
+            output = self._call_command('abcdef')
+            raise ShouldHaveFailedException(output)
+        except ShouldHaveFailedException as e:
+            raise ShouldHaveFailedException(e)
+        except Exception as e:
+            self.assertRegex(str(e), r'argument scenario_id: invalid int value')
+
+    def test_evaluate_scenario_ineligible_scenario_running(self):
+        scenario_result = ScenarioResult.objects.get(scenario__id=self.scenario.pk)
+        scenario_result.status = ScenarioResultStatus.RUNNING
+        scenario_result.save()
+        try:
+            output = self._call_command(self.scenario.pk, '--fake_run', '--fake_run_time=1')
+            raise ShouldHaveFailedException(output)
+        except ShouldHaveFailedException as e:
+            raise ShouldHaveFailedException(e)
+        except Exception as e:
+            self.assertRegex(str(e), r'ScenarioResult matching query does not exist')
+
+    def test_evaluate_scenario_ineligible_scenario_success(self):
+        scenario_result = ScenarioResult.objects.get(scenario__id=self.scenario.pk)
+        scenario_result.status = ScenarioResultStatus.SUCCESS
+        scenario_result.save()
+        try:
+            output = self._call_command(self.scenario.pk, '--fake_run', '--fake_run_time=1')
+            raise ShouldHaveFailedException(output)
+        except ShouldHaveFailedException as e:
+            raise ShouldHaveFailedException(e)
+        except Exception as e:
+            self.assertRegex(str(e), r'ScenarioResult matching query does not exist')
+
+    def test_evaluate_scenario_ineligible_scenario_failure(self):
+        scenario_result = ScenarioResult.objects.get(scenario__id=self.scenario.pk)
+        scenario_result.status = ScenarioResultStatus.FAILURE
+        scenario_result.save()
+        try:
+            output = self._call_command(self.scenario.pk, '--fake_run', '--fake_run_time=1')
+            raise ShouldHaveFailedException(output)
+        except ShouldHaveFailedException as e:
+            raise ShouldHaveFailedException(e)
+        except Exception as e:
+            self.assertRegex(str(e), r'ScenarioResult matching query does not exist')


### PR DESCRIPTION
Add fetching scenario and scenario status.
Writes (on non-dry-run) to DB, updating status as expected. Writes placeholder run details.
Add dry run support.
Add fake run support with switches to simulate an evaluation delay and occasional failures.

Does not call forsys yet.
Additional refinements around output are expected in the future.