### PR TITLE
Updating Update Explore Navigation to `Regional Resource Kit Data`

### DIFF
--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -121,13 +121,13 @@
           <app-condition-tree
           #conditionTreeRaw
           [conditionsConfig$]="conditionsConfig$"
-          [header]="'Current Condition (Raw)'"
+          [header]="'Regional Resource Kit Data'"
           [map]="map"
           [dataType]="dataTypeEnum.RAW"
           (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(1)">
         </app-condition-tree>
        </div>
-        
+
         <!-- Normalized current condition controls -->
          <div *ngIf="translated_control_panel_enabled && translatedDataEnabled">
          <app-condition-tree
@@ -138,7 +138,7 @@
            [dataType]="dataTypeEnum.TRANSLATED"
            (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
          </app-condition-tree>
-         </div> 
+         </div>
 
         <!-- Future condition controls -->
          <div *ngIf="future_control_panel_enabled && futureDataEnabled">
@@ -162,7 +162,7 @@
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </div>
-          
+
         <div *ngIf="future_control_panel_enabled && !futureDataEnabled">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
@@ -193,7 +193,7 @@
             </div>
           </mat-expansion-panel>
         </ng-container> -->
-        
+
         <!-- Disturbances controls -->
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">


### PR DESCRIPTION
PLAN-323

Updates the title over the explore navigation menu

<img width="581" alt="Screen Shot 2023-08-24 at 11 02 06" src="https://github.com/OurPlanscape/Planscape/assets/358892/7e759454-a266-46e2-b237-1e62d16c9caf">
