### PR TITLE
Move evaluate_scenario out of the command object and make it a standalone exportable routine

### DIFF
--- a/src/planscape/forsys/management/commands/evaluate_scenario.py
+++ b/src/planscape/forsys/management/commands/evaluate_scenario.py
@@ -9,8 +9,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from planning.models import (Scenario, ScenarioResultStatus, ScenarioResult)
-
-#TODO: Move evaluate_scenario() outside of the command directory.
+from forsys.services import run_scenario
 
 class Command(BaseCommand):
     help = "Evaluates a specific scenario."
@@ -40,126 +39,10 @@ class Command(BaseCommand):
         fake_run_failure_rate = options['fake_run_failure_rate']
 
         try:
-            self.evaluate_scenario(scenario_id, dry_run, fake_run, fake_run_time,
-                                   fake_run_failure_rate)
+            run_scenario(scenario_id, dry_run, fake_run, fake_run_time,
+                         fake_run_failure_rate)
             self.logger.info('Successfully evaluated scenario %d' % scenario_id)
         except Exception as e:
             # Log any exception, but then throw it again to generate a failed exit code.
             self.logger.critical(str(e))
             raise e
-
-    def _evaluate_fake(self, scenario: Scenario, scenario_result: ScenarioResult,
-                       dry_run: bool, fake_run_time: int, fake_run_failure_rate: int):
-        """
-        Fakes a scenario evaluation.
-        Allows for a chance of a simulated failure.
-        """
-        self.logger.debug("Fake-evaluating %d" % scenario.pk)
-        scenario_result.status = ScenarioResultStatus.RUNNING
-        scenario_result.save()
-        time.sleep(fake_run_time)
-        self.logger.debug("sleeping %d" % fake_run_time)
-
-        if fake_run_failure_rate > 0:
-            random.seed()
-            if random.randrange(100) < fake_run_failure_rate:
-                self.logger.info("faking a failure")
-                return {
-                    'new_status': ScenarioResultStatus.FAILURE,
-                    'new_result': {
-                        'comment': 'Inconcievable!'
-                    },
-                    'new_run_details': {
-                        'comment': 'You’ve fell victim to one of the classic blunders! '\
-                                   'The most famous is never get involved in a land war in Asia, '\
-                                   'but only slightly less well known is this; never go in '\
-                                   'against a Sicilian, when death is on the line!'
-                    }
-                }
-
-        return {
-            'new_status': ScenarioResultStatus.SUCCESS,
-            'new_result': {
-                'comment': "We'll never succeed."
-            },
-            'new_run_details': {
-                'comment': "No, no. We have already succeeded. I mean, what are the three terrors "\
-                           "of the Fire Swamp? One, the flame spurt — no problem. There's a "\
-                           "popping sound preceding each; we can avoid that. Two, the lightning "\
-                           "sand, which you were clever enough to discover what that looks like, "\
-                           "so in the future we can avoid that too."
-            }
-        }
-
-    def _evaluate_scenario(self, scenario: Scenario, scenario_results: ScenarioResult,
-                           dry_run: bool):
-        """
-        TODO: Read all map data for scenario from DB
-        Run Forsys
-        Write full results (e.g. project areas) to DB
-        """
-
-        self._run_forsys()
-
-        return {
-            'new_status': ScenarioResultStatus.SUCCESS,
-            'new_result': {
-                'comment': 'TODO'
-            },
-            'new_run_details': {
-                'comment': 'TODO'
-            }
-        }
-
-    def evaluate_scenario(self, scenario_id: int, dry_run: bool, fake_run: bool,
-                          fake_run_time: int, fake_run_failure_rate: int):
-        scenario_result = ScenarioResult.objects.filter(
-            status=ScenarioResultStatus.PENDING).select_related('scenario').get(scenario__pk=scenario_id)
-        scenario = Scenario.objects.select_related('planning_area').get(id=scenario_id)
-
-        if scenario_result is None:
-            raise ValueError("No eligible scenario (e.g. in a PENDING state) found")
-
-        # TODO: Make a real class out of the output instead of toting around dictionaries
-        run_output = {}
-        run_starting_time = datetime.now()
-        output_start_time = run_starting_time.strftime("%x %X")
-
-        with transaction.atomic():
-            scenario_result.status = ScenarioResultStatus.RUNNING
-            scenario_result.run_details = json.dumps({'start_time': output_start_time})
-            scenario_result.save()
-
-            if fake_run:
-                run_output = self._evaluate_fake(scenario, scenario_result, dry_run, fake_run_time,
-                                                 fake_run_failure_rate)
-            else:
-                try:
-                    run_output = self._evaluate_scenario(scenario, scenario_result, dry_run)
-                    #TODO: Save project areas to DB, etc.
-                except Exception as e:
-                    run_output['new_status'] = ScenarioResultStatus.FAILURE
-                    run_output['new_run_details']['error_details'] = str(e)
-
-            run_output['new_run_details']['start_time'] = output_start_time
-            run_ending_time = datetime.now()
-            elapsed_time = run_ending_time - run_starting_time
-            run_output['new_run_details']['end_time'] = run_ending_time.strftime("%x %X")
-            run_output['new_run_details']['elapsed_time'] = elapsed_time.total_seconds()
-
-            scenario_result.status = run_output['new_status']
-            scenario_result.result = json.dumps(run_output['new_result'])
-            scenario_result.run_details = json.dumps(run_output['new_run_details'])
-            scenario_result.save()
-
-            if dry_run:
-                self.logger.info(json.dumps(run_output))
-                transaction.set_rollback(True)
-            else:
-                self.logger.debug(json.dumps(run_output))
-
-    def _run_forsys(self):
-        """
-        This is where the fun happens.
-        """
-        pass

--- a/src/planscape/forsys/services.py
+++ b/src/planscape/forsys/services.py
@@ -1,0 +1,128 @@
+import argparse
+import json
+import logging
+import random
+import time
+
+from datetime import datetime
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from planning.models import (Scenario, ScenarioResultStatus, ScenarioResult)
+
+def run_scenario(scenario_id: int, dry_run: bool, fake_run: bool,
+                 fake_run_time: int, fake_run_failure_rate: int):
+    logger = logging.getLogger(__name__)
+    scenario_result = ScenarioResult.objects.filter(
+        status=ScenarioResultStatus.PENDING).select_related('scenario').get(scenario__pk=scenario_id)
+    scenario = Scenario.objects.select_related('planning_area').get(id=scenario_id)
+
+    if scenario_result is None:
+        raise ValueError("No eligible scenario (e.g. in a PENDING state) found")
+
+    # TODO: Make a real class out of the output instead of toting around dictionaries
+    run_output = {}
+    run_starting_time = datetime.now()
+    output_start_time = run_starting_time.strftime("%x %X")
+
+    with transaction.atomic():
+        scenario_result.status = ScenarioResultStatus.RUNNING
+        scenario_result.run_details = json.dumps({'start_time': output_start_time})
+        scenario_result.save()
+
+        if fake_run:
+            run_output = _run_fake_scenario(scenario, scenario_result, dry_run, fake_run_time,
+                                            fake_run_failure_rate)
+        else:
+            try:
+                run_output = _run_scenario(scenario, scenario_result, dry_run)
+                #TODO: Save project areas to DB, etc.
+            except Exception as e:
+                run_output['new_status'] = ScenarioResultStatus.FAILURE
+                run_output['new_run_details']['error_details'] = str(e)
+                
+        run_output['new_run_details']['start_time'] = output_start_time
+        run_ending_time = datetime.now()
+        elapsed_time = run_ending_time - run_starting_time
+        run_output['new_run_details']['end_time'] = run_ending_time.strftime("%x %X")
+        run_output['new_run_details']['elapsed_time'] = elapsed_time.total_seconds()
+
+        scenario_result.status = run_output['new_status']
+        scenario_result.result = json.dumps(run_output['new_result'])
+        scenario_result.run_details = json.dumps(run_output['new_run_details'])
+        scenario_result.save()
+
+        if dry_run:
+            logger.info(json.dumps(run_output))
+            transaction.set_rollback(True)
+        else:
+            logger.debug(json.dumps(run_output))
+
+
+def _run_scenario(scenario: Scenario, scenario_results: ScenarioResult,
+                      dry_run: bool):
+    """
+    TODO: Read all map data for scenario from DB
+    Run Forsys
+    Write full results (e.g. project areas) to DB
+    """
+
+    # TODO: Run forsys here.
+
+    return {
+        'new_status': ScenarioResultStatus.SUCCESS,
+        'new_result': {
+            'comment': 'TODO'
+        },
+        'new_run_details': {
+            'comment': 'TODO'
+        }
+    }
+
+
+def _run_fake_scenario(scenario: Scenario, scenario_result: ScenarioResult,
+                       dry_run: bool, fake_run_time: int, fake_run_failure_rate: int):
+    """
+    Fakes a scenario evaluation.
+    Allows for a chance of a simulated failure.
+    Should return the same information that process_scenario does.
+    """
+
+    logger = logging.getLogger(__name__)
+    logger.debug("Fake-evaluating %d" % scenario.pk)
+    scenario_result.status = ScenarioResultStatus.RUNNING
+    scenario_result.save()
+    time.sleep(fake_run_time)
+    logger.debug("sleeping %d" % fake_run_time)
+
+    if fake_run_failure_rate > 0:
+        random.seed()
+        if random.randrange(100) < fake_run_failure_rate:
+            logger.info("faking a failure")
+            return {
+                'new_status': ScenarioResultStatus.FAILURE,
+                'new_result': {
+                    'comment': 'Inconcievable!'
+                },
+                'new_run_details': {
+                    'comment': 'You’ve fell victim to one of the classic blunders! '\
+                    'The most famous is never get involved in a land war in Asia, '\
+                    'but only slightly less well known is this; never go in '\
+                    'against a Sicilian, when death is on the line!'
+                }
+            }
+
+    return {
+        'new_status': ScenarioResultStatus.SUCCESS,
+        'new_result': {
+            'comment': "We'll never succeed."
+        },
+        'new_run_details': {
+            'comment': "No, no. We have already succeeded. I mean, what are the three terrors "\
+                       "of the Fire Swamp? One, the flame spurt — no problem. There's a "\
+                       "popping sound preceding each; we can avoid that. Two, the lightning "\
+                       "sand, which you were clever enough to discover what that looks like, "\
+                       "so in the future we can avoid that too."
+        }
+    }
+


### PR DESCRIPTION
Note that the standalone routine is now called run_scenario

Kept fake run logic inside so that the output of run_scenario is consistent with fake or real runs.

Kept other changes minimal for this PR.