### PR TITLE
Expand selected node after loaded in from history fix

### DIFF
--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.ts
@@ -166,7 +166,7 @@ export class ConditionTreeComponent implements OnInit {
       if (node.condition.region_geoserver_name) {
         node_layer = node.condition.region_geoserver_name + node.condition.layer;
       } 
-      if (node_layer === config.layer) {
+      if (node_layer === node.condition.region_geoserver_name + config.layer) {
         this.expandAncestors(node);
         this.onSelect(node);
         return node.condition;


### PR DESCRIPTION
- Fixes bug where node loaded in from local session history doesn't get selected in map control panel 