### PR TITLE
lint and prettier for angular app

### DIFF
--- a/src/interface/.eslintrc.json
+++ b/src/interface/.eslintrc.json
@@ -1,0 +1,61 @@
+{
+  "root": true,
+  "ignorePatterns": [
+    "projects/**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts"
+      ],
+      "parserOptions": {
+        "project": [
+          "tsconfig.json"
+        ],
+        "createDefaultProgram": true
+      },
+      "extends": [
+        "plugin:@angular-eslint/recommended",
+        "plugin:@angular-eslint/template/process-inline-templates",
+        "plugin:prettier/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "warn",
+          {
+            "type": "attribute",
+            "prefix": "app",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "warn",
+          {
+            "type": "element",
+            "prefix": "app",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.html"
+      ],
+      "extends": [
+        "plugin:@angular-eslint/template/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/template/no-negated-async": ["warn"]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "excludedFiles": ["*inline-template-*.component.html"],
+      "extends": ["plugin:prettier/recommended"],
+      "rules": {
+        "prettier/prettier": ["error", { "parser": "angular" }]
+      }
+    }
+  ]
+}

--- a/src/interface/.prettierignore
+++ b/src/interface/.prettierignore
@@ -1,0 +1,42 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# Compiled output
+/dist
+/tmp
+/out-tsc
+/bazel-out
+
+# Node
+/node_modules
+npm-debug.log
+yarn-error.log
+
+# IDEs and editors
+.idea/
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
+# Miscellaneous
+/.angular/cache
+.sass-cache/
+/connect.lock
+/coverage
+/libpeerconnection.log
+testem.log
+/typings
+
+# System files
+.DS_Store
+Thumbs.db

--- a/src/interface/.prettierrc
+++ b/src/interface/.prettierrc
@@ -1,0 +1,3 @@
+bracketSameLine: true
+trailingComma: "es5"
+singleQuote: true

--- a/src/interface/.prettierrc
+++ b/src/interface/.prettierrc
@@ -1,3 +1,4 @@
 bracketSameLine: true
+htmlWhitespaceSensitivity: "ignore"
 trailingComma: "es5"
 singleQuote: true

--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -65,7 +65,7 @@
                 {
                   "replace": "src/app/features/features.json",
                   "with": "src/app/features/features.prod.json"
-                }       
+                }
               ],
               "outputHashing": "all"
             },
@@ -122,11 +122,23 @@
             ],
             "scripts": []
           }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
+          }
         }
       }
     }
   },
   "cli": {
-    "analytics": "3301f864-55c8-45dc-ab8d-8c347e5f9b66"
+    "analytics": "3301f864-55c8-45dc-ab8d-8c347e5f9b66",
+    "schematicCollections": [
+      "@angular-eslint/schematics"
+    ]
   }
 }

--- a/src/interface/package-lock.json
+++ b/src/interface/package-lock.json
@@ -8,7 +8,6 @@
       "name": "interface",
       "version": "0.0.0",
       "dependencies": {
-        "@angular-eslint/schematics": "^1.0.0",
         "@angular/animations": "^14.2.0",
         "@angular/cdk": "^14.2.2",
         "@angular/common": "^14.2.0",
@@ -40,6 +39,11 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^14.2.3",
+        "@angular-eslint/builder": "14.4.0",
+        "@angular-eslint/eslint-plugin": "14.4.0",
+        "@angular-eslint/eslint-plugin-template": "14.4.0",
+        "@angular-eslint/schematics": "14.4.0",
+        "@angular-eslint/template-parser": "14.4.0",
         "@angular/cli": "~14.2.3",
         "@angular/compiler-cli": "^14.2.0",
         "@mapbox/vector-tile": "^1.3.1",
@@ -48,13 +52,29 @@
         "@types/leaflet": "^1.9.0",
         "@types/leaflet-draw": "^1.0.4",
         "@types/shpjs": "^3.4.2",
+        "@typescript-eslint/eslint-plugin": "5.43.0",
+        "@typescript-eslint/parser": "5.43.0",
+        "eslint": "^8.28.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-prettier": "^5.0.0",
         "jasmine-core": "~4.3.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
+        "prettier": "^3.0.2",
+        "prettier-eslint": "^15.0.1",
         "typescript": "~4.7.2"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -272,6 +292,7 @@
     },
     "node_modules/@angular-devkit/core": {
       "version": "14.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "8.11.0",
@@ -296,6 +317,7 @@
     },
     "node_modules/@angular-devkit/core/node_modules/rxjs": {
       "version": "6.6.7",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.9.0"
@@ -306,14 +328,16 @@
     },
     "node_modules/@angular-devkit/core/node_modules/tslib": {
       "version": "1.14.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.10.tgz",
-      "integrity": "sha512-MMp31KpJTwKHisXOq+6VOXYApq97hZxFaFmZk396X5aIFTCELUwjcezQDk+u2nEs5iK/COUfnN3plGcfJxYhQA==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.12.tgz",
+      "integrity": "sha512-MN5yGR+SSSPPBBVMf4cifDJn9u0IYvxiHst+HWokH2AkBYy+vB1x8jYES2l1wkiISD7nvjTixfqX+Y95oMBoLg==",
+      "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.10",
+        "@angular-devkit/core": "14.2.12",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -326,9 +350,10 @@
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.10.tgz",
-      "integrity": "sha512-K4AO7mROTdbhQ7chtyQd6oPwmuL+BPUh+wn6Aq1qrmYJK4UZYFOPp8fi/Ehs8meCEeywtrssOPfrOE4Gsre9dg==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.12.tgz",
+      "integrity": "sha512-tg1+deEZdm3fgk2BQ6y7tujciL6qhtN5Ums266lX//kAZeZ4nNNXTBT+oY5xgfjvmLbW+xKg0XZrAS0oIRKY5g==",
+      "dev": true,
       "dependencies": {
         "ajv": "8.11.0",
         "ajv-formats": "2.1.1",
@@ -354,6 +379,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -364,93 +390,136 @@
     "node_modules/@angular-devkit/schematics/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@angular-eslint/builder": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-14.4.0.tgz",
+      "integrity": "sha512-AhAUFvSg0urtb6Lsowvuxwu6DMXUy0BPwrnfNOBGjRt9vG7F9kgXXAsm5DnIS0GNy/mLZ9mSfa86fv++1e0KUA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "*"
+      }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-15.1.0.tgz",
-      "integrity": "sha512-zcOx+PnYuVDIG3wd/JVzCYdEUarKGtgIcN4iU9ZF+BVk5e8i9cbD3U8U3EDJKbrrokbFl9GBBJMCOa6XYTGJwQ==",
-      "peer": true
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-14.4.0.tgz",
+      "integrity": "sha512-KMHPHd24s0HVvAP/DxSSqhYBWhwW8FgS/r0Uwv8eWpsIdc/z/Chd2ush2SgPchmmquAXTgOZsbEY7ZmW+XkJfQ==",
+      "dev": true
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-1.2.0.tgz",
-      "integrity": "sha512-HxSDdAS2/lbwYBJmRVRKlx5wjiKdeBPl7JJlciwhrP7QR01a66AWun+fW1ZpMnnqivkF+D5sISsoedRLthRcwA==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-14.4.0.tgz",
+      "integrity": "sha512-2rZQ4mt7tEUW+lI5jjuj3HWaT4VQtWTG6+LDnmuUmx76m8hqQ7NvFUpOcNDofu5KbEVBP+oF2DA6wjoZOIuSOA==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.3.0"
+        "@angular-eslint/utils": "14.4.0",
+        "@typescript-eslint/utils": "5.43.0"
       },
       "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-jsdoc": "*",
-        "eslint-plugin-prefer-arrow": "*",
+        "eslint": "^7.0.0 || ^8.0.0",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-1.2.0.tgz",
-      "integrity": "sha512-Oi/y+N/FETuyhbVuFxbkCqSfLo61CAvIPwnQQCfDku/IsCSTI1SjW+B2xO9thDI5po7t5V+3n26uMLQsWNZmlw==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-14.4.0.tgz",
+      "integrity": "sha512-d3GM/EU2iWzr+BrITwO4gBf9WfDfuOdTjfinV/zN84oXMFaK2ENo+IP6OEsD9hh36rdPps+m2gFGDdx+rTzBpg==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.3.0",
-        "aria-query": "^4.2.2",
-        "axobject-query": "^2.2.0"
+        "@angular-eslint/bundled-angular-compiler": "14.4.0",
+        "@angular-eslint/utils": "14.4.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
+        "aria-query": "5.1.3",
+        "axobject-query": "3.1.1"
       },
       "peerDependencies": {
-        "@angular-eslint/template-parser": "*",
-        "eslint": "*",
+        "eslint": "^7.0.0 || ^8.0.0",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-1.0.0.tgz",
-      "integrity": "sha512-5xdUjLrSi6Jis3Cd7Z7/+/Q5K2mKNMDD9fU7pjIEPZhxXNl0wrOMGLdoYvvWq69f8x5y9wlPCnWCSZK+kW0NFQ==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-14.4.0.tgz",
+      "integrity": "sha512-BrGkPug+CZQWOfmNRsJDrEtYJcxvzF/kLlV7RjvIN9Ky5TjUiJVCeafl3VY6COSY32tjlh2GvBdl1AQKWWovbA==",
+      "dev": true,
       "dependencies": {
-        "@angular-eslint/eslint-plugin": "^1.0.0",
-        "@angular-eslint/eslint-plugin-template": "^1.0.0",
+        "@angular-eslint/eslint-plugin": "14.4.0",
+        "@angular-eslint/eslint-plugin-template": "14.4.0",
+        "ignore": "5.2.0",
         "strip-json-comments": "3.1.1",
-        "tslint-to-eslint-config": "2.0.1"
+        "tmp": "0.2.1"
       },
       "peerDependencies": {
-        "@angular-devkit/core": "*",
-        "@angular-devkit/schematics": "*"
+        "@angular/cli": ">= 14.0.0 < 15.0.0"
+      }
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
       }
     },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-15.1.0.tgz",
-      "integrity": "sha512-ctcA7OAV1wwFByW1te3uZwzySuIRlo8NblG5yUtgU5BXt3nXwIDwoSr3tvI2dRHobNHcXVQcOFVzyOdXD/vsIg==",
-      "peer": true,
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-14.4.0.tgz",
+      "integrity": "sha512-zq888KpQB0YTEK26mkKcT4fs8LDWWT1oAEXU8DrXhvkikS8XavTSHOWJye/bVZR4oJRFCF5YTJV75DEMcGNIpQ==",
+      "dev": true,
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "15.1.0",
+        "@angular-eslint/bundled-angular-compiler": "14.4.0",
         "eslint-scope": "^7.0.0"
       },
       "peerDependencies": {
-        "eslint": "^7.20.0 || ^8.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/template-parser/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "peer": true,
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@angular-eslint/template-parser/node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/@angular-eslint/utils": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-14.4.0.tgz",
+      "integrity": "sha512-dPHklAVfh+JfueDfXre9Xooq7p5bFyKO2Z6y1agYeofAgHCPIJOPx2AhtFPrOtsc4VXFFiyE9XbowlXh4ogoKQ==",
+      "dev": true,
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "14.4.0",
+        "@typescript-eslint/utils": "5.43.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "*"
       }
     },
     "node_modules/@angular/animations": {
@@ -487,15 +556,15 @@
       "optional": true
     },
     "node_modules/@angular/cli": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.10.tgz",
-      "integrity": "sha512-gX9sAKOwq4lKdPWeABB7TzKDHdjQXvkUU8NmPJA6mEAVXvm3lhQtFvHDalZstwK8au2LY0LaXTcEtcKYOt3AXQ==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.12.tgz",
+      "integrity": "sha512-G/785b6jIIX7J+zS8RHaCT1OYzqANw5hJlnLf8tLgmaadLMVNQvIrvHTYtmD86pbqCYyVDLoMxefxRIwMHJuqw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1402.10",
-        "@angular-devkit/core": "14.2.10",
-        "@angular-devkit/schematics": "14.2.10",
-        "@schematics/angular": "14.2.10",
+        "@angular-devkit/architect": "0.1402.12",
+        "@angular-devkit/core": "14.2.12",
+        "@angular-devkit/schematics": "14.2.12",
+        "@schematics/angular": "14.2.12",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -508,7 +577,7 @@
         "ora": "5.4.1",
         "pacote": "13.6.2",
         "resolve": "1.22.1",
-        "semver": "7.3.7",
+        "semver": "7.5.3",
         "symbol-observable": "4.0.0",
         "uuid": "8.3.2",
         "yargs": "17.5.1"
@@ -523,12 +592,12 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/architect": {
-      "version": "0.1402.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.10.tgz",
-      "integrity": "sha512-/6YmPrgataj1jD2Uqd1ED+CG4DaZGacoeZd/89hH7hF76Nno8K18DrSOqJAEmDnOWegpSRGVLd0qP09IHmaG5w==",
+      "version": "0.1402.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.12.tgz",
+      "integrity": "sha512-LuK26pyaqyClEbY0n4/WIh3irUuA8wwmMmEj8uW4boziuJWv7U42lJJRF3VwkchiyOIp8qiKg995K6IoeXkWgA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.10",
+        "@angular-devkit/core": "14.2.12",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -538,9 +607,9 @@
       }
     },
     "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.10.tgz",
-      "integrity": "sha512-K4AO7mROTdbhQ7chtyQd6oPwmuL+BPUh+wn6Aq1qrmYJK4UZYFOPp8fi/Ehs8meCEeywtrssOPfrOE4Gsre9dg==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.12.tgz",
+      "integrity": "sha512-tg1+deEZdm3fgk2BQ6y7tujciL6qhtN5Ums266lX//kAZeZ4nNNXTBT+oY5xgfjvmLbW+xKg0XZrAS0oIRKY5g==",
       "dev": true,
       "dependencies": {
         "ajv": "8.11.0",
@@ -563,6 +632,18 @@
         }
       }
     },
+    "node_modules/@angular/cli/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@angular/cli/node_modules/rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -573,6 +654,21 @@
       },
       "engines": {
         "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@angular/cli/node_modules/tslib": {
@@ -747,6 +843,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
@@ -793,9 +890,10 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -867,9 +965,10 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -926,9 +1025,10 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1109,6 +1209,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.19.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1151,6 +1252,7 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -2010,9 +2112,10 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2206,9 +2309,10 @@
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2230,6 +2334,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.18.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -2237,23 +2342,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz",
-      "integrity": "sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==",
-      "dependencies": {
-        "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.11"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/@babel/template": {
       "version": "7.18.10",
@@ -2609,30 +2697,40 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
-      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
-      "peer": true,
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
       "dependencies": {
-        "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
-      "peer": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
-        "globals": "^13.15.0",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -2650,7 +2748,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2666,23 +2764,23 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
-      "peer": true,
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2697,7 +2795,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2709,13 +2807,13 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2727,12 +2825,21 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -2757,10 +2864,10 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
-      "peer": true,
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -2774,7 +2881,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2784,7 +2891,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2796,7 +2903,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2809,7 +2916,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2935,6 +3042,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2946,6 +3054,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2953,6 +3062,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3082,14 +3192,70 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@schematics/angular": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.10.tgz",
-      "integrity": "sha512-YFTc/9QJdx422XcApizEcVLKoyknu8b9zHIlAepZCu7WkV8GPT0hvVEHQ7KBWys5aQ7pPZMT0JpZLeAz0F2xYQ==",
+    "node_modules/@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "14.2.10",
-        "@angular-devkit/schematics": "14.2.10",
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@schematics/angular": {
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.12.tgz",
+      "integrity": "sha512-nCxoFzH/uh5vqhaAjAfQIBgGuCdV3RMjdSwD0VQ+GFiFvTe8rqFyDl+qpNCgETz4LwmGHb5HNjDH9+VyVLgfZQ==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "14.2.12",
+        "@angular-devkit/schematics": "14.2.12",
         "jsonc-parser": "3.1.0"
       },
       "engines": {
@@ -3099,9 +3265,9 @@
       }
     },
     "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.10.tgz",
-      "integrity": "sha512-K4AO7mROTdbhQ7chtyQd6oPwmuL+BPUh+wn6Aq1qrmYJK4UZYFOPp8fi/Ehs8meCEeywtrssOPfrOE4Gsre9dg==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.12.tgz",
+      "integrity": "sha512-tg1+deEZdm3fgk2BQ6y7tujciL6qhtN5Ums266lX//kAZeZ4nNNXTBT+oY5xgfjvmLbW+xKg0XZrAS0oIRKY5g==",
       "dev": true,
       "dependencies": {
         "ajv": "8.11.0",
@@ -3144,8 +3310,9 @@
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -3475,13 +3642,18 @@
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
     },
     "node_modules/@types/cors": {
-      "version": "2.8.12",
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
@@ -3547,13 +3719,8 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "peer": true
     },
     "node_modules/@types/leaflet": {
       "version": "1.9.0",
@@ -3586,6 +3753,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true
+    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "dev": true,
@@ -3600,6 +3773,12 @@
       "version": "0.12.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
+      "dev": true
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -3644,20 +3823,96 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.3.0.tgz",
-      "integrity": "sha512-cmmIK8shn3mxmhpKfzMMywqiEheyfXLV/+yPDnOTvQX/ztngx7Lg/OD26J8gTZfkLKUmaEBxO2jYP3keV7h2OQ==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
+      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
+      "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.3.0",
-        "@typescript-eslint/types": "4.3.0",
-        "@typescript-eslint/typescript-estree": "4.3.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^2.0.0"
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
+        "debug": "^4.3.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
+      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
+      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
+      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3665,30 +3920,20 @@
       },
       "peerDependencies": {
         "eslint": "*"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.3.0.tgz",
-      "integrity": "sha512-cTeyP5SCNE8QBRfc+Lgh4Xpzje46kNUhXYfc3pQWmJif92sjrFuHT9hH4rtOkDTo/si9Klw53yIr+djqGZS1ig==",
-      "dependencies": {
-        "@typescript-eslint/types": "4.3.0",
-        "@typescript-eslint/visitor-keys": "4.3.0"
       },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.3.0.tgz",
-      "integrity": "sha512-Cx9TpRvlRjOppGsU6Y6KcJnUDOelja2NNCX6AZwtVHRzaJkdytJWMuYiqi8mS35MRNA3cJSwDzXePfmhU6TANw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
+      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
+      "dev": true,
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3696,21 +3941,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.3.0.tgz",
-      "integrity": "sha512-ZAI7xjkl+oFdLV/COEz2tAbQbR3XfgqHEGy0rlUXzfGQic6EBCR4s2+WS3cmTPG69aaZckEucBoTxW9PhzHxxw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
+      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.3.0",
-        "@typescript-eslint/visitor-keys": "4.3.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3726,6 +3971,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -3745,20 +3991,48 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.3.0.tgz",
-      "integrity": "sha512-xZxkuR7XLM6RhvLkgv9yYlTcBHnTULzfnw4i6+z2TGBLy9yljAypQaZl9c3zFvy7PNI7fYWyvKYtohyF8au3cw==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
+      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.3.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
+      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.43.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3934,8 +4208,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "license": "MIT",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3955,7 +4231,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -4031,6 +4307,7 @@
     },
     "node_modules/ajv": {
       "version": "8.11.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4045,6 +4322,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -4104,6 +4382,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4111,6 +4390,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -4121,7 +4401,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4150,21 +4430,32 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
       },
-      "engines": {
-        "node": ">=6.0"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-flatten": {
@@ -4172,49 +4463,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/array-includes": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/autoprefixer": {
@@ -4249,10 +4504,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axobject-query": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
-      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
+      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
     },
     "node_modules/babel-loader": {
       "version": "8.2.5",
@@ -4322,9 +4593,10 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4354,10 +4626,12 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4376,8 +4650,9 @@
     },
     "node_modules/base64id": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
@@ -4386,6 +4661,15 @@
       "version": "0.6.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -4397,7 +4681,7 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4405,6 +4689,7 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -4464,6 +4749,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "dev": true,
@@ -4474,6 +4771,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -4511,6 +4809,7 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4536,20 +4835,27 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.0.0"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bytes": {
@@ -4590,6 +4896,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -4601,6 +4908,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4631,6 +4939,7 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -4648,7 +4957,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4698,6 +5007,7 @@
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -4708,6 +5018,7 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.7.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4736,6 +5047,7 @@
     },
     "node_modules/clone": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -4754,20 +5066,9 @@
         "node": ">=6"
       }
     },
-    "node_modules/coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -4775,6 +5076,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -4794,13 +5096,13 @@
       "version": "2.20.3",
       "license": "MIT"
     },
-    "node_modules/comment-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-      "peer": true,
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=4.0.0"
       }
     },
     "node_modules/commondir": {
@@ -4859,6 +5161,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/connect": {
@@ -4949,8 +5252,9 @@
     },
     "node_modules/cookie": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5035,24 +5339,15 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
-      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -5155,6 +5450,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5167,6 +5463,7 @@
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5176,17 +5473,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/cson-parser": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.7.tgz",
-      "integrity": "sha512-BSnAl0gllETWjU9/lb8MmeqhsGaRINPwhoPiBjI/TJBRvKf/24I9EVqnwvmk6R3Gt66cMRSGVktl6QicxIb72g==",
-      "dependencies": {
-        "coffeescript": "1.12.7"
-      },
-      "engines": {
-        "node": ">=10.13"
       }
     },
     "node_modules/css-blank-pseudo": {
@@ -5323,6 +5609,7 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -5336,11 +5623,190 @@
         }
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.1",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.0",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "peer": true
+      "dev": true
+    },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-browser/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-browser/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/default-gateway": {
       "version": "6.0.3",
@@ -5355,6 +5821,7 @@
     },
     "node_modules/defaults": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
@@ -5369,8 +5836,10 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -5422,16 +5891,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -5439,6 +5901,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -5460,7 +5928,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -5583,9 +6051,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
+      "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -5596,17 +6064,18 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.0.4",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -5669,74 +6138,36 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
-      "peer": true,
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.4.3",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-get-iterator/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-      "peer": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "peer": true,
-      "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.15.5",
@@ -5815,55 +6246,54 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/eslint": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
-      "peer": true,
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
-        "grapheme-splitter": "^1.0.4",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -5877,211 +6307,49 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
-      "dependencies": {
-        "get-stdin": "^6.0.0"
-      },
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "dev": true,
       "bin": {
-        "eslint-config-prettier-check": "bin/cli.js"
+        "eslint-config-prettier": "bin/cli.js"
       },
       "peerDependencies": {
-        "eslint": ">=3.14.1"
+        "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
-      "peer": true,
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+      "dev": true,
       "dependencies": {
-        "debug": "^3.2.7",
-        "resolve": "^1.20.0"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-module-utils": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
-      "peer": true,
-      "dependencies": {
-        "debug": "^3.2.7"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=4"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
-        "eslint": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
           "optional": true
         }
       }
     },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
-      "peer": true,
-      "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "peer": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "peer": true
-    },
-    "node_modules/eslint-plugin-jsdoc": {
-      "version": "39.6.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
-      "integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
-      "peer": true,
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.36.1",
-        "comment-parser": "1.3.1",
-        "debug": "^4.3.4",
-        "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "semver": "^7.3.8",
-        "spdx-expression-parse": "^3.0.1"
-      },
-      "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-prefer-arrow": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-      "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-      "peer": true,
-      "peerDependencies": {
-        "eslint": ">=2.0.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -6092,40 +6360,49 @@
       }
     },
     "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
       "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
       }
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6141,7 +6418,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -6156,13 +6433,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6172,7 +6449,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -6188,7 +6465,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -6200,13 +6477,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6215,59 +6492,26 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "peer": true,
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "peer": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6276,7 +6520,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -6292,7 +6536,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -6301,10 +6545,10 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
-      "peer": true,
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -6319,7 +6563,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6328,7 +6572,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6340,13 +6584,13 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -6361,7 +6605,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6373,7 +6617,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -6388,7 +6632,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -6403,7 +6647,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6415,7 +6659,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6424,14 +6668,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-      "peer": true,
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
       "dependencies": {
-        "acorn": "^8.8.0",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6440,17 +6684,9 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -6461,10 +6697,10 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "peer": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -6476,13 +6712,14 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -6493,6 +6730,7 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -6500,6 +6738,7 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -6507,6 +6746,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6691,11 +6931,20 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
+    },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "license": "MIT",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -6709,16 +6958,18 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6753,7 +7004,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -6763,6 +7014,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6841,20 +7093,22 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "peer": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
+      "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flatted": {
       "version": "3.2.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -6874,6 +7128,15 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
       }
     },
     "node_modules/forwarded": {
@@ -6935,6 +7198,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -6951,31 +7215,14 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "peer": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7032,11 +7279,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -7051,14 +7301,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "dev": true,
@@ -7068,22 +7310,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -7106,6 +7332,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7145,16 +7372,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "peer": true
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -7163,6 +7402,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -7171,17 +7411,39 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "peer": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7189,6 +7451,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
@@ -7197,8 +7460,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7211,7 +7487,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -7297,9 +7573,10 @@
       "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "dev": true
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -7452,6 +7729,7 @@
     },
     "node_modules/ignore": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7492,6 +7770,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -7506,6 +7785,7 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7513,6 +7793,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -7533,6 +7814,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -7641,12 +7923,12 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "peer": true,
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -7667,6 +7949,36 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "dev": true,
@@ -7676,7 +7988,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -7686,7 +7998,7 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -7699,7 +8011,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -7715,7 +8027,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7725,6 +8037,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.10.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
@@ -7737,7 +8050,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7764,6 +8077,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7779,6 +8093,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7787,8 +8102,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7799,20 +8148,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-negative-zero": {
+    "node_modules/is-map": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7822,7 +8169,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7837,7 +8184,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7868,7 +8215,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -7880,11 +8227,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
       "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -7907,7 +8263,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7922,7 +8278,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -7933,8 +8289,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7943,13 +8315,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "peer": true,
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7988,6 +8370,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -8022,9 +8405,10 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8134,22 +8518,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-sdsl": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
-      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -8157,15 +8533,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdoc-type-pratt-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-      "peer": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -8179,6 +8546,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "dev": true,
@@ -8186,18 +8559,20 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8207,6 +8582,7 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -8465,6 +8841,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "dev": true,
@@ -8494,7 +8879,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/leaflet.vectorgrid/-/leaflet.vectorgrid-1.3.0.tgz",
       "integrity": "sha512-kWmj1pKM+MVdo/7Mg5zsB3YrGZvo/uIuiANV9MvWUFOG+Y2xAJzrteDhoIcCgTjHSSRJ36xdeGdIQVhuWjnCZw==",
-      "dev": true,
       "dependencies": {
         "pbf": "^3.0.2",
         "topojson-client": "^2.1.0",
@@ -8584,9 +8968,10 @@
       }
     },
     "node_modules/less/node_modules/semver": {
-      "version": "5.7.1",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "license": "ISC",
       "optional": true,
       "bin": {
         "semver": "bin/semver"
@@ -8605,7 +8990,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -8683,10 +9068,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -8701,6 +9087,7 @@
     },
     "node_modules/log-symbols/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -8714,6 +9101,7 @@
     },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -8728,6 +9116,7 @@
     },
     "node_modules/log-symbols/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -8738,10 +9127,12 @@
     },
     "node_modules/log-symbols/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8749,6 +9140,7 @@
     },
     "node_modules/log-symbols/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8772,6 +9164,84 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/loglevel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha512-u45Wcxxc+SdAlh4yeF/uKlC1SPUPCy0gullSNKXod5I4bmifzk+Q4lSLExNEVn19tGaJipbZ4V4jbFn79/6mVA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "7.14.0",
       "dev": true,
@@ -8782,6 +9252,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.26.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
@@ -8805,9 +9276,10 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8873,6 +9345,7 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -8893,6 +9366,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
@@ -8934,6 +9408,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8993,6 +9468,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/minipass": {
@@ -9107,6 +9583,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -9141,7 +9618,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "peer": true
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "node_modules/needle": {
       "version": "3.1.0",
@@ -9380,7 +9863,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9537,21 +10020,40 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
       "version": "1.12.2",
+      "dev": true,
       "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9559,29 +10061,13 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9616,6 +10102,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9623,6 +10110,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -9651,17 +10139,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "peer": true,
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -9669,6 +10157,7 @@
     },
     "node_modules/ora": {
       "version": "5.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
@@ -9690,6 +10179,7 @@
     },
     "node_modules/ora/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -9703,6 +10193,7 @@
     },
     "node_modules/ora/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -9717,6 +10208,7 @@
     },
     "node_modules/ora/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -9727,10 +10219,12 @@
     },
     "node_modules/ora/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ora/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9738,6 +10232,7 @@
     },
     "node_modules/ora/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9861,6 +10356,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -9943,6 +10439,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9950,6 +10447,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9957,6 +10455,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9964,6 +10463,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
@@ -9973,6 +10473,7 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9982,7 +10483,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -9998,6 +10498,7 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10042,8 +10543,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/point-geometry/-/point-geometry-0.0.0.tgz",
       "integrity": "sha512-tXK8bY2l3/CPkyO7+UbOWbVjCpKoYY4t6uY3AYYy4Bagd4Z942gLeQOgtHICwBwgPf8dI6fw4VqKwzSNgvlw4A==",
-      "deprecated": "This module has moved: please install @mapbox/point-geometry instead",
-      "dev": true
+      "deprecated": "This module has moved: please install @mapbox/point-geometry instead"
     },
     "node_modules/polygon-clipping": {
       "version": "0.15.3",
@@ -10689,9 +11189,76 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-eslint": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-15.0.1.tgz",
+      "integrity": "sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.4.2",
+        "@types/prettier": "^2.6.0",
+        "@typescript-eslint/parser": "^5.10.0",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^8.7.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^2.5.1",
+        "pretty-format": "^23.0.1",
+        "require-relative": "^0.8.7",
+        "typescript": "^4.5.4",
+        "vue-eslint-parser": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -10703,6 +11270,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/proc-log": {
@@ -10746,8 +11332,7 @@
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "dev": true
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -10777,6 +11362,7 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10806,6 +11392,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10909,6 +11496,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -10921,7 +11509,7 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -10953,6 +11541,7 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {
@@ -10969,14 +11558,14 @@
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "peer": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10989,7 +11578,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -11046,10 +11635,17 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==",
+      "dev": true
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -11058,6 +11654,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.9.0",
@@ -11083,7 +11680,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -11126,6 +11722,7 @@
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -11145,6 +11742,7 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -11158,6 +11756,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -11171,6 +11770,7 @@
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11179,6 +11779,7 @@
     },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -11197,12 +11798,28 @@
     },
     "node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-async": {
@@ -11215,6 +11832,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11244,20 +11862,6 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "license": "MIT"
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -11384,6 +11988,7 @@
     },
     "node_modules/semver": {
       "version": "7.3.7",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11397,6 +12002,7 @@
     },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -11577,6 +12183,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -11587,6 +12194,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11611,6 +12219,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -11623,6 +12232,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/slash": {
@@ -11646,30 +12256,37 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.5.2",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+      "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.0",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.2.0"
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=10.2.0"
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.4.0",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "ws": "~8.11.0"
+      }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.1",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -11716,6 +12333,7 @@
     },
     "node_modules/source-map": {
       "version": "0.7.4",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
@@ -11779,6 +12397,7 @@
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/spdx-correct": {
@@ -11792,10 +12411,12 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
+      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -11804,6 +12425,7 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.12",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/spdy": {
@@ -11841,6 +12463,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
@@ -11862,6 +12485,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/streamroller": {
       "version": "3.1.2",
       "dev": true,
@@ -11877,6 +12512,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -11884,6 +12520,7 @@
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11913,51 +12550,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/strip-final-newline": {
@@ -11972,6 +12573,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -12062,6 +12664,7 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -12072,6 +12675,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12087,6 +12691,28 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -12266,6 +12892,7 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through": {
@@ -12277,6 +12904,18 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -12299,6 +12938,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -12319,7 +12959,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
       "integrity": "sha512-mxXNa6imbsrWXqUKF7iwGl2TkrshZ7dwQF+KuAB4hX9wTmfecNzqSjMmQZNhP2Ztvfwx8rKt0BfQfHF+ki6hQw==",
-      "dev": true,
       "dependencies": {
         "commander": "2"
       },
@@ -12337,307 +12976,15 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "peer": true,
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "license": "0BSD"
-    },
-    "node_modules/tslint": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-      "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.13.0",
-        "tsutils": "^2.29.0"
-      },
-      "bin": {
-        "tslint": "bin/tslint"
-      },
-      "engines": {
-        "node": ">=4.8.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
-      }
-    },
-    "node_modules/tslint-to-eslint-config": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslint-to-eslint-config/-/tslint-to-eslint-config-2.0.1.tgz",
-      "integrity": "sha512-RURU/zcBQpW9jKS7H2J6of4+64npTb0nrH7ND8tNhagMwryVjVnUDcucsl8DQuD7tO9RgjFO9bmJfDhyP0yV1w==",
-      "dependencies": {
-        "chalk": "4.1.0",
-        "commander": "6.2.0",
-        "cson-parser": "4.0.7",
-        "eslint-config-prettier": "6.15.0",
-        "glob": "7.1.6",
-        "json5": "2.1.3",
-        "lodash": "4.17.20",
-        "minimatch": "3.0.4",
-        "tslint": "6.1.3",
-        "typescript": "4.1.2"
-      },
-      "bin": {
-        "tslint-to-eslint-config": "bin/tslint-to-eslint-config"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tslint-to-eslint-config/node_modules/typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/tslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/tslint/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tslint/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/tslint/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/tslint/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/tslint/node_modules/tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
-      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -12651,13 +12998,14 @@
     "node_modules/tsutils/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -12695,6 +13043,7 @@
     },
     "node_modules/typescript": {
       "version": "4.7.4",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12705,7 +13054,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.31",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
       "dev": true,
       "funding": [
         {
@@ -12717,24 +13068,8 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -12805,6 +13140,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.9",
       "dev": true,
@@ -12832,6 +13176,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -12890,7 +13235,6 @@
       "resolved": "https://registry.npmjs.org/vector-tile/-/vector-tile-1.3.0.tgz",
       "integrity": "sha512-ECpYpDhbgTSGIRwaf4bLbiDHcUHDM+LGrBOmV1tdG+Lde8vajJtywP5vGFmMj0Z3cApTV0+9sLWgBCVsRuoAKQ==",
       "deprecated": "This module has moved: please install @mapbox/vector-tile instead",
-      "dev": true,
       "dependencies": {
         "point-geometry": "0.0.0"
       }
@@ -12901,6 +13245,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz",
+      "integrity": "sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.2",
+        "eslint-scope": "^7.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.0.0",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/watchpack": {
@@ -12925,6 +13318,7 @@
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
@@ -13088,26 +13482,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.9.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-merge": {
       "version": "5.8.0",
       "dev": true,
@@ -13217,8 +13591,7 @@
     "node_modules/whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -13235,13 +13608,47 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13264,15 +13671,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.2.tgz",
       "integrity": "sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ=="
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -13322,12 +13720,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.2.3",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13354,6 +13754,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -13393,7 +13794,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13410,6 +13811,12 @@
     }
   },
   "dependencies": {
+    "@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true
+    },
     "@adobe/css-tools": {
       "version": "4.0.1",
       "dev": true
@@ -13556,6 +13963,7 @@
     },
     "@angular-devkit/core": {
       "version": "14.2.3",
+      "dev": true,
       "requires": {
         "ajv": "8.11.0",
         "ajv-formats": "2.1.1",
@@ -13566,21 +13974,24 @@
       "dependencies": {
         "rxjs": {
           "version": "6.6.7",
+          "dev": true,
           "requires": {
             "tslib": "^1.9.0"
           }
         },
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "dev": true
         }
       }
     },
     "@angular-devkit/schematics": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.10.tgz",
-      "integrity": "sha512-MMp31KpJTwKHisXOq+6VOXYApq97hZxFaFmZk396X5aIFTCELUwjcezQDk+u2nEs5iK/COUfnN3plGcfJxYhQA==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.2.12.tgz",
+      "integrity": "sha512-MN5yGR+SSSPPBBVMf4cifDJn9u0IYvxiHst+HWokH2AkBYy+vB1x8jYES2l1wkiISD7nvjTixfqX+Y95oMBoLg==",
+      "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.10",
+        "@angular-devkit/core": "14.2.12",
         "jsonc-parser": "3.1.0",
         "magic-string": "0.26.2",
         "ora": "5.4.1",
@@ -13588,9 +13999,10 @@
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "14.2.10",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.10.tgz",
-          "integrity": "sha512-K4AO7mROTdbhQ7chtyQd6oPwmuL+BPUh+wn6Aq1qrmYJK4UZYFOPp8fi/Ehs8meCEeywtrssOPfrOE4Gsre9dg==",
+          "version": "14.2.12",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.12.tgz",
+          "integrity": "sha512-tg1+deEZdm3fgk2BQ6y7tujciL6qhtN5Ums266lX//kAZeZ4nNNXTBT+oY5xgfjvmLbW+xKg0XZrAS0oIRKY5g==",
+          "dev": true,
           "requires": {
             "ajv": "8.11.0",
             "ajv-formats": "2.1.1",
@@ -13603,6 +14015,7 @@
           "version": "6.6.7",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
           "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
           "requires": {
             "tslib": "^1.9.0"
           }
@@ -13610,60 +14023,87 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
+    "@angular-eslint/builder": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-14.4.0.tgz",
+      "integrity": "sha512-AhAUFvSg0urtb6Lsowvuxwu6DMXUy0BPwrnfNOBGjRt9vG7F9kgXXAsm5DnIS0GNy/mLZ9mSfa86fv++1e0KUA==",
+      "dev": true,
+      "requires": {}
+    },
     "@angular-eslint/bundled-angular-compiler": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-15.1.0.tgz",
-      "integrity": "sha512-zcOx+PnYuVDIG3wd/JVzCYdEUarKGtgIcN4iU9ZF+BVk5e8i9cbD3U8U3EDJKbrrokbFl9GBBJMCOa6XYTGJwQ==",
-      "peer": true
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-14.4.0.tgz",
+      "integrity": "sha512-KMHPHd24s0HVvAP/DxSSqhYBWhwW8FgS/r0Uwv8eWpsIdc/z/Chd2ush2SgPchmmquAXTgOZsbEY7ZmW+XkJfQ==",
+      "dev": true
     },
     "@angular-eslint/eslint-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-1.2.0.tgz",
-      "integrity": "sha512-HxSDdAS2/lbwYBJmRVRKlx5wjiKdeBPl7JJlciwhrP7QR01a66AWun+fW1ZpMnnqivkF+D5sISsoedRLthRcwA==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-14.4.0.tgz",
+      "integrity": "sha512-2rZQ4mt7tEUW+lI5jjuj3HWaT4VQtWTG6+LDnmuUmx76m8hqQ7NvFUpOcNDofu5KbEVBP+oF2DA6wjoZOIuSOA==",
+      "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.3.0"
+        "@angular-eslint/utils": "14.4.0",
+        "@typescript-eslint/utils": "5.43.0"
       }
     },
     "@angular-eslint/eslint-plugin-template": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-1.2.0.tgz",
-      "integrity": "sha512-Oi/y+N/FETuyhbVuFxbkCqSfLo61CAvIPwnQQCfDku/IsCSTI1SjW+B2xO9thDI5po7t5V+3n26uMLQsWNZmlw==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-14.4.0.tgz",
+      "integrity": "sha512-d3GM/EU2iWzr+BrITwO4gBf9WfDfuOdTjfinV/zN84oXMFaK2ENo+IP6OEsD9hh36rdPps+m2gFGDdx+rTzBpg==",
+      "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.3.0",
-        "aria-query": "^4.2.2",
-        "axobject-query": "^2.2.0"
+        "@angular-eslint/bundled-angular-compiler": "14.4.0",
+        "@angular-eslint/utils": "14.4.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
+        "aria-query": "5.1.3",
+        "axobject-query": "3.1.1"
       }
     },
     "@angular-eslint/schematics": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-1.0.0.tgz",
-      "integrity": "sha512-5xdUjLrSi6Jis3Cd7Z7/+/Q5K2mKNMDD9fU7pjIEPZhxXNl0wrOMGLdoYvvWq69f8x5y9wlPCnWCSZK+kW0NFQ==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-14.4.0.tgz",
+      "integrity": "sha512-BrGkPug+CZQWOfmNRsJDrEtYJcxvzF/kLlV7RjvIN9Ky5TjUiJVCeafl3VY6COSY32tjlh2GvBdl1AQKWWovbA==",
+      "dev": true,
       "requires": {
-        "@angular-eslint/eslint-plugin": "^1.0.0",
-        "@angular-eslint/eslint-plugin-template": "^1.0.0",
+        "@angular-eslint/eslint-plugin": "14.4.0",
+        "@angular-eslint/eslint-plugin-template": "14.4.0",
+        "ignore": "5.2.0",
         "strip-json-comments": "3.1.1",
-        "tslint-to-eslint-config": "2.0.1"
+        "tmp": "0.2.1"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        }
       }
     },
     "@angular-eslint/template-parser": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-15.1.0.tgz",
-      "integrity": "sha512-ctcA7OAV1wwFByW1te3uZwzySuIRlo8NblG5yUtgU5BXt3nXwIDwoSr3tvI2dRHobNHcXVQcOFVzyOdXD/vsIg==",
-      "peer": true,
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-14.4.0.tgz",
+      "integrity": "sha512-zq888KpQB0YTEK26mkKcT4fs8LDWWT1oAEXU8DrXhvkikS8XavTSHOWJye/bVZR4oJRFCF5YTJV75DEMcGNIpQ==",
+      "dev": true,
       "requires": {
-        "@angular-eslint/bundled-angular-compiler": "15.1.0",
+        "@angular-eslint/bundled-angular-compiler": "14.4.0",
         "eslint-scope": "^7.0.0"
       },
       "dependencies": {
         "eslint-scope": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-          "peer": true,
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+          "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
@@ -13673,8 +14113,18 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "peer": true
+          "dev": true
         }
+      }
+    },
+    "@angular-eslint/utils": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-14.4.0.tgz",
+      "integrity": "sha512-dPHklAVfh+JfueDfXre9Xooq7p5bFyKO2Z6y1agYeofAgHCPIJOPx2AhtFPrOtsc4VXFFiyE9XbowlXh4ogoKQ==",
+      "dev": true,
+      "requires": {
+        "@angular-eslint/bundled-angular-compiler": "14.4.0",
+        "@typescript-eslint/utils": "5.43.0"
       }
     },
     "@angular/animations": {
@@ -13697,15 +14147,15 @@
       }
     },
     "@angular/cli": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.10.tgz",
-      "integrity": "sha512-gX9sAKOwq4lKdPWeABB7TzKDHdjQXvkUU8NmPJA6mEAVXvm3lhQtFvHDalZstwK8au2LY0LaXTcEtcKYOt3AXQ==",
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-14.2.12.tgz",
+      "integrity": "sha512-G/785b6jIIX7J+zS8RHaCT1OYzqANw5hJlnLf8tLgmaadLMVNQvIrvHTYtmD86pbqCYyVDLoMxefxRIwMHJuqw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1402.10",
-        "@angular-devkit/core": "14.2.10",
-        "@angular-devkit/schematics": "14.2.10",
-        "@schematics/angular": "14.2.10",
+        "@angular-devkit/architect": "0.1402.12",
+        "@angular-devkit/core": "14.2.12",
+        "@angular-devkit/schematics": "14.2.12",
+        "@schematics/angular": "14.2.12",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "debug": "4.3.4",
@@ -13718,26 +14168,26 @@
         "ora": "5.4.1",
         "pacote": "13.6.2",
         "resolve": "1.22.1",
-        "semver": "7.3.7",
+        "semver": "7.5.3",
         "symbol-observable": "4.0.0",
         "uuid": "8.3.2",
         "yargs": "17.5.1"
       },
       "dependencies": {
         "@angular-devkit/architect": {
-          "version": "0.1402.10",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.10.tgz",
-          "integrity": "sha512-/6YmPrgataj1jD2Uqd1ED+CG4DaZGacoeZd/89hH7hF76Nno8K18DrSOqJAEmDnOWegpSRGVLd0qP09IHmaG5w==",
+          "version": "0.1402.12",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1402.12.tgz",
+          "integrity": "sha512-LuK26pyaqyClEbY0n4/WIh3irUuA8wwmMmEj8uW4boziuJWv7U42lJJRF3VwkchiyOIp8qiKg995K6IoeXkWgA==",
           "dev": true,
           "requires": {
-            "@angular-devkit/core": "14.2.10",
+            "@angular-devkit/core": "14.2.12",
             "rxjs": "6.6.7"
           }
         },
         "@angular-devkit/core": {
-          "version": "14.2.10",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.10.tgz",
-          "integrity": "sha512-K4AO7mROTdbhQ7chtyQd6oPwmuL+BPUh+wn6Aq1qrmYJK4UZYFOPp8fi/Ehs8meCEeywtrssOPfrOE4Gsre9dg==",
+          "version": "14.2.12",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.12.tgz",
+          "integrity": "sha512-tg1+deEZdm3fgk2BQ6y7tujciL6qhtN5Ums266lX//kAZeZ4nNNXTBT+oY5xgfjvmLbW+xKg0XZrAS0oIRKY5g==",
           "dev": true,
           "requires": {
             "ajv": "8.11.0",
@@ -13747,6 +14197,15 @@
             "source-map": "0.7.4"
           }
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "rxjs": {
           "version": "6.6.7",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -13754,6 +14213,15 @@
           "dev": true,
           "requires": {
             "tslib": "^1.9.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         },
         "tslib": {
@@ -13834,6 +14302,7 @@
     },
     "@babel/code-frame": {
       "version": "7.18.6",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -13864,7 +14333,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -13915,7 +14386,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -13954,7 +14427,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -14071,7 +14546,8 @@
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.19.1"
+      "version": "7.19.1",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -14098,6 +14574,7 @@
     },
     "@babel/highlight": {
       "version": "7.18.6",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -14573,7 +15050,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -14711,7 +15190,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -14729,24 +15210,9 @@
     },
     "@babel/runtime": {
       "version": "7.18.9",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "@babel/runtime-corejs3": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz",
-      "integrity": "sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==",
-      "requires": {
-        "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.11"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-        }
       }
     },
     "@babel/template": {
@@ -14917,27 +15383,31 @@
       "version": "0.5.7",
       "dev": true
     },
-    "@es-joy/jsdoccomment": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
-      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
-      "peer": true,
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
       "requires": {
-        "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@eslint-community/regexpp": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
-      "peer": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
-        "globals": "^13.15.0",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -14949,7 +15419,7 @@
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -14961,23 +15431,23 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "peer": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "globals": {
-          "version": "13.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
-          "peer": true,
+          "version": "13.21.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+          "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -14986,7 +15456,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "argparse": "^2.0.1"
           }
@@ -14995,13 +15465,13 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "peer": true
+          "dev": true
         },
         "minimatch": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -15010,9 +15480,15 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "peer": true
+          "dev": true
         }
       }
+    },
+    "@eslint/js": {
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "dev": true
     },
     "@gar/promisify": {
       "version": "1.1.3",
@@ -15032,10 +15508,10 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
-      "peer": true,
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -15046,7 +15522,7 @@
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -15056,7 +15532,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -15067,13 +15543,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "peer": true
+      "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "peer": true
+      "dev": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -15163,16 +15639,19 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
+      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -15257,21 +15736,61 @@
         }
       }
     },
-    "@schematics/angular": {
-      "version": "14.2.10",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.10.tgz",
-      "integrity": "sha512-YFTc/9QJdx422XcApizEcVLKoyknu8b9zHIlAepZCu7WkV8GPT0hvVEHQ7KBWys5aQ7pPZMT0JpZLeAz0F2xYQ==",
+    "@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "14.2.10",
-        "@angular-devkit/schematics": "14.2.10",
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "dependencies": {
+        "define-lazy-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+          "dev": true
+        },
+        "open": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+          "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+          "dev": true,
+          "requires": {
+            "default-browser": "^4.0.0",
+            "define-lazy-prop": "^3.0.0",
+            "is-inside-container": "^1.0.0",
+            "is-wsl": "^2.2.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@schematics/angular": {
+      "version": "14.2.12",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.2.12.tgz",
+      "integrity": "sha512-nCxoFzH/uh5vqhaAjAfQIBgGuCdV3RMjdSwD0VQ+GFiFvTe8rqFyDl+qpNCgETz4LwmGHb5HNjDH9+VyVLgfZQ==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "14.2.12",
+        "@angular-devkit/schematics": "14.2.12",
         "jsonc-parser": "3.1.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "14.2.10",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.10.tgz",
-          "integrity": "sha512-K4AO7mROTdbhQ7chtyQd6oPwmuL+BPUh+wn6Aq1qrmYJK4UZYFOPp8fi/Ehs8meCEeywtrssOPfrOE4Gsre9dg==",
+          "version": "14.2.12",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.2.12.tgz",
+          "integrity": "sha512-tg1+deEZdm3fgk2BQ6y7tujciL6qhtN5Ums266lX//kAZeZ4nNNXTBT+oY5xgfjvmLbW+xKg0XZrAS0oIRKY5g==",
           "dev": true,
           "requires": {
             "ajv": "8.11.0",
@@ -15300,6 +15819,8 @@
     },
     "@socket.io/component-emitter": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -15556,11 +16077,18 @@
     },
     "@types/cookie": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
     "@types/cors": {
-      "version": "2.8.12",
-      "dev": true
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/eslint": {
       "version": "8.4.6",
@@ -15617,13 +16145,8 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.11"
-    },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "peer": true
+      "version": "7.0.11",
+      "dev": true
     },
     "@types/leaflet": {
       "version": "1.9.0",
@@ -15651,6 +16174,12 @@
       "version": "4.0.0",
       "dev": true
     },
+    "@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true
+    },
     "@types/qs": {
       "version": "6.9.7",
       "dev": true
@@ -15661,6 +16190,12 @@
     },
     "@types/retry": {
       "version": "0.12.0",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "@types/serve-index": {
@@ -15702,52 +16237,83 @@
         "@types/node": "*"
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.3.0.tgz",
-      "integrity": "sha512-cmmIK8shn3mxmhpKfzMMywqiEheyfXLV/+yPDnOTvQX/ztngx7Lg/OD26J8gTZfkLKUmaEBxO2jYP3keV7h2OQ==",
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
+      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
+      "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.3.0",
-        "@typescript-eslint/types": "4.3.0",
-        "@typescript-eslint/typescript-estree": "4.3.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^2.0.0"
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
+        "debug": "^4.3.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
+      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.3.0.tgz",
-      "integrity": "sha512-cTeyP5SCNE8QBRfc+Lgh4Xpzje46kNUhXYfc3pQWmJif92sjrFuHT9hH4rtOkDTo/si9Klw53yIr+djqGZS1ig==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
+      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
+      "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.3.0",
-        "@typescript-eslint/visitor-keys": "4.3.0"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
+      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.3.0.tgz",
-      "integrity": "sha512-Cx9TpRvlRjOppGsU6Y6KcJnUDOelja2NNCX6AZwtVHRzaJkdytJWMuYiqi8mS35MRNA3cJSwDzXePfmhU6TANw=="
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
+      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
+      "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.3.0.tgz",
-      "integrity": "sha512-ZAI7xjkl+oFdLV/COEz2tAbQbR3XfgqHEGy0rlUXzfGQic6EBCR4s2+WS3cmTPG69aaZckEucBoTxW9PhzHxxw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
+      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
+      "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.3.0",
-        "@typescript-eslint/visitor-keys": "4.3.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "dependencies": {
         "globby": {
           "version": "11.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
           "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
           "requires": {
             "array-union": "^2.1.0",
             "dir-glob": "^3.0.1",
@@ -15760,17 +16326,35 @@
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
         }
       }
     },
-    "@typescript-eslint/visitor-keys": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.3.0.tgz",
-      "integrity": "sha512-xZxkuR7XLM6RhvLkgv9yYlTcBHnTULzfnw4i6+z2TGBLy9yljAypQaZl9c3zFvy7PNI7fYWyvKYtohyF8au3cw==",
+    "@typescript-eslint/utils": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
+      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
+      "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.3.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
+      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.43.0",
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -15918,7 +16502,10 @@
       }
     },
     "acorn": {
-      "version": "8.8.0"
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -15929,7 +16516,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "adjust-sourcemap-loader": {
@@ -15983,6 +16570,7 @@
     },
     "ajv": {
       "version": "8.11.0",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -15992,6 +16580,7 @@
     },
     "ajv-formats": {
       "version": "2.1.1",
+      "dev": true,
       "requires": {
         "ajv": "^8.0.0"
       }
@@ -16019,17 +16608,19 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -16049,52 +16640,39 @@
     },
     "argparse": {
       "version": "1.0.10",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
       }
     },
     "array-flatten": {
       "version": "2.1.2",
       "dev": true
     },
-    "array-includes": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
-        "is-string": "^1.0.7"
-      }
-    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-    },
-    "array.prototype.flat": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0"
-      }
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "autoprefixer": {
       "version": "10.4.12",
@@ -16108,10 +16686,20 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
+    },
     "axobject-query": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
-      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
+      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "^2.0.5"
+      }
     },
     "babel-loader": {
       "version": "8.2.5",
@@ -16162,7 +16750,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -16183,17 +16773,27 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "dev": true
     },
     "base64id": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true
     },
     "batch": {
       "version": "0.6.1",
+      "dev": true
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "dev": true
     },
     "big.js": {
@@ -16202,10 +16802,11 @@
     },
     "binary-extensions": {
       "version": "2.2.0",
-      "devOptional": true
+      "dev": true
     },
     "bl": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -16257,6 +16858,15 @@
       "version": "1.0.0",
       "dev": true
     },
+    "bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.44"
+      }
+    },
     "brace-expansion": {
       "version": "2.0.1",
       "dev": true,
@@ -16266,6 +16876,7 @@
     },
     "braces": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -16282,6 +16893,7 @@
     },
     "buffer": {
       "version": "5.7.1",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -16291,16 +16903,20 @@
       "version": "1.1.2",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ=="
-    },
     "builtins": {
       "version": "5.0.1",
       "dev": true,
       "requires": {
         "semver": "^7.0.0"
+      }
+    },
+    "bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "requires": {
+        "run-applescript": "^5.0.0"
       }
     },
     "bytes": {
@@ -16333,13 +16949,15 @@
     },
     "call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -16351,6 +16969,7 @@
     },
     "chalk": {
       "version": "2.4.2",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -16363,7 +16982,7 @@
     },
     "chokidar": {
       "version": "3.5.3",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -16389,12 +17008,14 @@
     },
     "cli-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
     },
     "cli-spinners": {
-      "version": "2.7.0"
+      "version": "2.7.0",
+      "dev": true
     },
     "cli-width": {
       "version": "3.0.0",
@@ -16410,7 +17031,8 @@
       }
     },
     "clone": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -16421,19 +17043,16 @@
         "shallow-clone": "^3.0.0"
       }
     },
-    "coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
-    },
     "color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -16446,11 +17065,11 @@
     "commander": {
       "version": "2.20.3"
     },
-    "comment-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-      "peer": true
+    "common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -16494,7 +17113,8 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "connect": {
       "version": "3.7.0",
@@ -16553,6 +17173,8 @@
     },
     "cookie": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
     "cookie-signature": {
@@ -16604,16 +17226,13 @@
         "browserslist": "^4.21.4"
       }
     },
-    "core-js-pure": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
-      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ=="
-    },
     "core-util-is": {
       "version": "1.0.3"
     },
     "cors": {
       "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "requires": {
         "object-assign": "^4",
@@ -16684,6 +17303,7 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -16692,18 +17312,11 @@
       "dependencies": {
         "which": {
           "version": "2.0.2",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         }
-      }
-    },
-    "cson-parser": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.7.tgz",
-      "integrity": "sha512-BSnAl0gllETWjU9/lb8MmeqhsGaRINPwhoPiBjI/TJBRvKf/24I9EVqnwvmk6R3Gt66cMRSGVktl6QicxIb72g==",
-      "requires": {
-        "coffeescript": "1.12.7"
       }
     },
     "css-blank-pseudo": {
@@ -16772,15 +17385,139 @@
     },
     "debug": {
       "version": "4.3.4",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
+      }
+    },
+    "deep-equal": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "dev": true,
+      "requires": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.1",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.0",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
       }
     },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "peer": true
+      "dev": true
+    },
+    "default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "requires": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^4.3.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+          "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        }
+      }
+    },
+    "default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "requires": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      }
     },
     "default-gateway": {
       "version": "6.0.3",
@@ -16791,6 +17528,7 @@
     },
     "defaults": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "clone": "^1.0.2"
       }
@@ -16800,7 +17538,10 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.4",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -16830,16 +17571,18 @@
       "version": "0.0.1",
       "dev": true
     },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-    },
     "dir-glob": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -16856,7 +17599,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -16939,9 +17682,9 @@
       }
     },
     "engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
+      "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",
@@ -16952,12 +17695,14 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0"
       }
     },
     "engine.io-parser": {
-      "version": "5.0.4",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
       "dev": true
     },
     "enhanced-resolve": {
@@ -16999,61 +17744,34 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
-      "peer": true,
+    "es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.4.3",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
       }
     },
     "es-module-lexer": {
       "version": "0.9.3",
       "dev": true
-    },
-    "es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-      "peer": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "peer": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
     },
     "esbuild": {
       "version": "0.15.5",
@@ -17101,52 +17819,51 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "dev": true
     },
     "eslint": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
-      "peer": true,
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
-        "grapheme-splitter": "^1.0.4",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "dependencies": {
@@ -17154,7 +17871,7 @@
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -17166,7 +17883,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -17175,13 +17892,13 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "peer": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -17191,7 +17908,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -17201,7 +17918,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -17210,58 +17927,35 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "peer": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "peer": true
+          "dev": true
         },
         "eslint-scope": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-          "peer": true,
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+          "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
           }
         },
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "peer": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          },
-          "dependencies": {
-            "eslint-visitor-keys": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-              "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-              "peer": true
-            }
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "peer": true
-        },
         "estraverse": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "peer": true
+          "dev": true
         },
         "find-up": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
           "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
@@ -17271,16 +17965,16 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
           }
         },
         "globals": {
-          "version": "13.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
-          "peer": true,
+          "version": "13.21.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+          "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -17289,13 +17983,13 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "peer": true
+          "dev": true
         },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "argparse": "^2.0.1"
           }
@@ -17304,13 +17998,13 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "peer": true
+          "dev": true
         },
         "locate-path": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
           "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
           }
@@ -17319,7 +18013,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -17328,7 +18022,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
           "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "yocto-queue": "^0.1.0"
           }
@@ -17337,7 +18031,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
           "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "p-limit": "^3.0.2"
           }
@@ -17346,7 +18040,7 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -17355,227 +18049,78 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "peer": true
+          "dev": true
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
-      "peer": true,
-      "requires": {
-        "debug": "^3.2.7",
-        "resolve": "^1.20.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
-      "peer": true,
-      "requires": {
-        "debug": "^3.2.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
-      "peer": true,
-      "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "peer": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "peer": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "peer": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "peer": true
-        }
-      }
-    },
-    "eslint-plugin-jsdoc": {
-      "version": "39.6.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
-      "integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
-      "peer": true,
-      "requires": {
-        "@es-joy/jsdoccomment": "~0.36.1",
-        "comment-parser": "1.3.1",
-        "debug": "^4.3.4",
-        "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "semver": "^7.3.8",
-        "spdx-expression-parse": "^3.0.1"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "peer": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "peer": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "peer": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-prefer-arrow": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-      "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-      "peer": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-prettier": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",
+      "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
         }
       }
     },
     "eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true
     },
     "espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-      "peer": true,
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
       "requires": {
-        "acorn": "^8.8.0",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "peer": true
-        }
+        "eslint-visitor-keys": "^3.4.1"
       }
     },
     "esprima": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "dev": true
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "peer": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       },
@@ -17584,26 +18129,30 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "peer": true
+          "dev": true
         }
       }
     },
     "esrecurse": {
       "version": "4.3.0",
+      "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.3.0"
+          "version": "5.3.0",
+          "dev": true
         }
       }
     },
     "estraverse": {
-      "version": "4.3.0"
+      "version": "4.3.0",
+      "dev": true
     },
     "esutils": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -17729,10 +18278,20 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
     },
     "fast-glob": {
-      "version": "3.2.12",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -17742,16 +18301,18 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "peer": true
+      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
+      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -17774,13 +18335,14 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
     },
     "fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -17836,21 +18398,32 @@
       }
     },
     "flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "peer": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
+      "dev": true,
       "requires": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "3.2.7"
+      "version": "3.2.7",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.15.2",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -17885,7 +18458,8 @@
       "dev": true
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -17893,25 +18467,14 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1"
-    },
-    "function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      }
+      "version": "1.1.1",
+      "dev": true
     },
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "peer": true
+      "dev": true
     },
     "gauge": {
       "version": "4.0.4",
@@ -17955,10 +18518,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.3",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -17966,24 +18533,9 @@
       "version": "0.1.0",
       "dev": true
     },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
-    },
     "get-stream": {
       "version": "6.0.1",
       "dev": true
-    },
-    "get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      }
     },
     "glob": {
       "version": "8.0.3",
@@ -17998,6 +18550,7 @@
     },
     "glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -18021,15 +18574,24 @@
         "slash": "^4.0.0"
       }
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "dev": true
     },
-    "grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "peer": true
+    "graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -18037,33 +18599,60 @@
     },
     "has": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        }
       }
     },
     "has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "peer": true
+      "dev": true
     },
     "has-flag": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "has-property-descriptors": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
     },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
+    },
     "has-symbols": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -18133,7 +18722,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-deceiver": {
@@ -18224,7 +18815,8 @@
       "version": "1.2.1"
     },
     "ignore": {
-      "version": "5.2.0"
+      "version": "5.2.0",
+      "dev": true
     },
     "ignore-walk": {
       "version": "5.0.1",
@@ -18249,18 +18841,21 @@
     },
     "import-fresh": {
       "version": "3.3.0",
+      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       },
       "dependencies": {
         "resolve-from": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
     "imurmurhash": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -18272,6 +18867,7 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18345,12 +18941,12 @@
       }
     },
     "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "peer": true,
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "dev": true,
       "requires": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
@@ -18363,6 +18959,27 @@
       "version": "2.0.1",
       "dev": true
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "dev": true
@@ -18371,14 +18988,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -18387,7 +19004,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18397,10 +19014,11 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "peer": true
+      "dev": true
     },
     "is-core-module": {
       "version": "2.10.0",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -18409,7 +19027,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18419,7 +19037,8 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -18427,31 +19046,51 @@
     },
     "is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
     },
+    "is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^3.0.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+          "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+          "dev": true
+        }
+      }
+    },
     "is-interactive": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "is-lambda": {
       "version": "1.0.1",
       "dev": true
     },
-    "is-negative-zero": {
+    "is-map": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true
     },
     "is-number": {
-      "version": "7.0.0"
+      "version": "7.0.0",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18460,7 +19099,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "peer": true
+      "dev": true
     },
     "is-plain-obj": {
       "version": "3.0.0",
@@ -18477,17 +19116,23 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true
+    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
       "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -18500,7 +19145,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18509,21 +19154,38 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
     },
-    "is-unicode-supported": {
-      "version": "0.1.0"
-    },
-    "is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "peer": true,
+    "is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
       "requires": {
-        "call-bind": "^1.0.2"
+        "which-typed-array": "^1.1.11"
+      }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "dev": true
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true
+    },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "is-what": {
@@ -18545,7 +19207,8 @@
       "dev": true
     },
     "isexe": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -18567,7 +19230,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -18643,30 +19308,26 @@
         }
       }
     },
-    "js-sdsl": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
-      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
-      "peer": true
-    },
     "js-tokens": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
-    "jsdoc-type-pratt-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-      "peer": true
-    },
     "jsesc": {
       "version": "2.5.2",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
     "json-parse-even-better-errors": {
@@ -18674,20 +19335,24 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "peer": true
+      "dev": true
     },
     "json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonc-parser": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -18884,6 +19549,15 @@
         "source-map-support": "^0.5.5"
       }
     },
+    "keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "dev": true
@@ -18904,7 +19578,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/leaflet.vectorgrid/-/leaflet.vectorgrid-1.3.0.tgz",
       "integrity": "sha512-kWmj1pKM+MVdo/7Mg5zsB3YrGZvo/uIuiANV9MvWUFOG+Y2xAJzrteDhoIcCgTjHSSRJ36xdeGdIQVhuWjnCZw==",
-      "dev": true,
       "requires": {
         "pbf": "^3.0.2",
         "topojson-client": "^2.1.0",
@@ -18948,7 +19621,9 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.1",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true,
           "optional": true
         },
@@ -18970,7 +19645,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -19022,10 +19697,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "peer": true
+      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -19033,12 +19709,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -19046,18 +19724,22 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -19075,12 +19757,71 @@
         "streamroller": "^3.1.2"
       }
     },
+    "loglevel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+      "dev": true
+    },
+    "loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha512-u45Wcxxc+SdAlh4yeF/uKlC1SPUPCy0gullSNKXod5I4bmifzk+Q4lSLExNEVn19tGaJipbZ4V4jbFn79/6mVA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+          "dev": true
+        }
+      }
+    },
     "lru-cache": {
       "version": "7.14.0",
       "dev": true
     },
     "magic-string": {
       "version": "0.26.2",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
@@ -19093,7 +19834,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -19143,7 +19886,8 @@
       "dev": true
     },
     "merge2": {
-      "version": "1.4.1"
+      "version": "1.4.1",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -19156,6 +19900,7 @@
     },
     "micromatch": {
       "version": "4.0.5",
+      "dev": true,
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -19177,7 +19922,8 @@
       }
     },
     "mimic-fn": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "2.6.1",
@@ -19210,7 +19956,8 @@
       }
     },
     "minimist": {
-      "version": "1.2.6"
+      "version": "1.2.6",
+      "dev": true
     },
     "minipass": {
       "version": "3.3.4",
@@ -19281,7 +20028,8 @@
       "version": "2.29.4"
     },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -19303,7 +20051,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "peer": true
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "needle": {
       "version": "3.1.0",
@@ -19457,7 +20211,7 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "devOptional": true
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -19563,32 +20317,36 @@
     },
     "object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2"
+      "version": "1.12.2",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
     },
     "object-keys": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
-      }
-    },
-    "object.values": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
       }
     },
     "obuf": {
@@ -19608,12 +20366,14 @@
     },
     "once": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
     },
     "onetime": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -19628,21 +20388,22 @@
       }
     },
     "optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "peer": true,
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
       "requires": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       }
     },
     "ora": {
       "version": "5.4.1",
+      "dev": true,
       "requires": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -19657,12 +20418,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -19670,18 +20433,22 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -19763,6 +20530,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -19821,29 +20589,33 @@
       "dev": true
     },
     "path-exists": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "path-key": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "path-parse": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "dev": true
     },
     "path-type": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "pbf": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
       "requires": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -19854,7 +20626,8 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1"
+      "version": "2.3.1",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -19880,8 +20653,7 @@
     "point-geometry": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/point-geometry/-/point-geometry-0.0.0.tgz",
-      "integrity": "sha512-tXK8bY2l3/CPkyO7+UbOWbVjCpKoYY4t6uY3AYYy4Bagd4Z942gLeQOgtHICwBwgPf8dI6fw4VqKwzSNgvlw4A==",
-      "dev": true
+      "integrity": "sha512-tXK8bY2l3/CPkyO7+UbOWbVjCpKoYY4t6uY3AYYy4Bagd4Z942gLeQOgtHICwBwgPf8dI6fw4VqKwzSNgvlw4A=="
     },
     "polygon-clipping": {
       "version": "0.15.3",
@@ -20199,11 +20971,74 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "peer": true
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "dev": true
+    },
+    "prettier-eslint": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-15.0.1.tgz",
+      "integrity": "sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^8.4.2",
+        "@types/prettier": "^2.6.0",
+        "@typescript-eslint/parser": "^5.10.0",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^8.7.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^2.5.1",
+        "pretty-format": "^23.0.1",
+        "require-relative": "^0.8.7",
+        "typescript": "^4.5.4",
+        "vue-eslint-parser": "^8.0.1"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true
+        }
+      }
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "5.6.0",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+          "dev": true
+        }
+      }
     },
     "proc-log": {
       "version": "2.0.1",
@@ -20236,8 +21071,7 @@
     "protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "dev": true
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -20259,7 +21093,8 @@
       "optional": true
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "qjobs": {
       "version": "1.2.0",
@@ -20273,7 +21108,8 @@
       }
     },
     "queue-microtask": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "dev": true
     },
     "quickselect": {
       "version": "2.0.0",
@@ -20342,6 +21178,7 @@
     },
     "readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -20350,7 +21187,7 @@
     },
     "readdirp": {
       "version": "3.6.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -20371,7 +21208,8 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9"
+      "version": "0.13.9",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -20385,21 +21223,21 @@
       "dev": true
     },
     "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "peer": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       }
     },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "peer": true
+      "dev": true
     },
     "regexpu-core": {
       "version": "5.2.1",
@@ -20435,7 +21273,14 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -20443,6 +21288,7 @@
     },
     "resolve": {
       "version": "1.22.1",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
@@ -20457,7 +21303,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -20490,6 +21335,7 @@
     },
     "restore-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -20500,7 +21346,8 @@
       "dev": true
     },
     "reusify": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "dev": true
     },
     "rfdc": {
       "version": "1.3.0",
@@ -20508,12 +21355,14 @@
     },
     "rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       },
       "dependencies": {
         "brace-expansion": {
           "version": "1.1.11",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -20521,6 +21370,7 @@
         },
         "glob": {
           "version": "7.2.3",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -20532,10 +21382,20 @@
         },
         "minimatch": {
           "version": "3.1.2",
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         }
+      }
+    },
+    "run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0"
       }
     },
     "run-async": {
@@ -20544,6 +21404,7 @@
     },
     "run-parallel": {
       "version": "1.2.0",
+      "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
@@ -20556,17 +21417,6 @@
     },
     "safe-buffer": {
       "version": "5.1.2"
-    },
-    "safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
-      }
     },
     "safer-buffer": {
       "version": "2.1.2"
@@ -20635,12 +21485,14 @@
     },
     "semver": {
       "version": "7.3.7",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -20780,12 +21632,14 @@
     },
     "shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "shpjs": {
       "version": "4.0.4",
@@ -20808,6 +21662,7 @@
     },
     "side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -20815,7 +21670,8 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.7"
+      "version": "3.0.7",
+      "dev": true
     },
     "slash": {
       "version": "4.0.0",
@@ -20826,23 +21682,33 @@
       "dev": true
     },
     "socket.io": {
-      "version": "4.5.2",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+      "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.0",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.2.0"
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
       }
     },
     "socket.io-adapter": {
-      "version": "2.4.0",
-      "dev": true
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "dev": true,
+      "requires": {
+        "ws": "~8.11.0"
+      }
     },
     "socket.io-parser": {
-      "version": "4.2.1",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -20876,7 +21742,8 @@
       }
     },
     "source-map": {
-      "version": "0.7.4"
+      "version": "0.7.4",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.0.2",
@@ -20915,7 +21782,8 @@
       }
     },
     "sourcemap-codec": {
-      "version": "1.4.8"
+      "version": "1.4.8",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -20926,17 +21794,20 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.12"
+      "version": "3.0.12",
+      "dev": true
     },
     "spdy": {
       "version": "4.0.2",
@@ -20967,7 +21838,8 @@
       "integrity": "sha512-9FaQ18FF0+sZc/ieEeXHt+Jw2eSpUgUtTLDYB/HXKWvhYVyOc7h1hzkn5MMO3GPib9MmXG1go8+OsBBzs/NMww=="
     },
     "sprintf-js": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "ssri": {
       "version": "9.0.1",
@@ -20980,6 +21852,15 @@
       "version": "1.5.0",
       "dev": true
     },
+    "stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "requires": {
+        "internal-slot": "^1.0.4"
+      }
+    },
     "streamroller": {
       "version": "3.1.2",
       "dev": true,
@@ -20991,12 +21872,14 @@
     },
     "string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.1"
+          "version": "5.2.1",
+          "dev": true
         }
       }
     },
@@ -21009,39 +21892,12 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      }
-    },
     "strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "peer": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -21050,7 +21906,8 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
     },
     "stylus": {
       "version": "0.59.0",
@@ -21103,16 +21960,36 @@
     },
     "supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
     },
     "supports-preserve-symlinks-flag": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "symbol-observable": {
       "version": "4.0.0",
       "dev": true
+    },
+    "synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "requires": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
     },
     "tapable": {
       "version": "2.2.1",
@@ -21225,7 +22102,8 @@
       "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
     },
     "text-table": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -21233,6 +22111,12 @@
     },
     "thunky": {
       "version": "1.1.0",
+      "dev": true
+    },
+    "titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
       "dev": true
     },
     "tmp": {
@@ -21248,6 +22132,7 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -21260,7 +22145,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
       "integrity": "sha512-mxXNa6imbsrWXqUKF7iwGl2TkrshZ7dwQF+KuAB4hX9wTmfecNzqSjMmQZNhP2Ztvfwx8rKt0BfQfHF+ki6hQw==",
-      "dev": true,
       "requires": {
         "commander": "2"
       }
@@ -21269,229 +22153,14 @@
       "version": "1.2.2",
       "dev": true
     },
-    "tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "peer": true,
-      "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
-    },
     "tslib": {
       "version": "2.4.0"
-    },
-    "tslint": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.13.0",
-        "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "tsutils": {
-          "version": "2.29.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
-      }
-    },
-    "tslint-to-eslint-config": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslint-to-eslint-config/-/tslint-to-eslint-config-2.0.1.tgz",
-      "integrity": "sha512-RURU/zcBQpW9jKS7H2J6of4+64npTb0nrH7ND8tNhagMwryVjVnUDcucsl8DQuD7tO9RgjFO9bmJfDhyP0yV1w==",
-      "requires": {
-        "chalk": "4.1.0",
-        "commander": "6.2.0",
-        "cson-parser": "4.0.7",
-        "eslint-config-prettier": "6.15.0",
-        "glob": "7.1.6",
-        "json5": "2.1.3",
-        "lodash": "4.17.20",
-        "minimatch": "3.0.4",
-        "tslint": "6.1.3",
-        "typescript": "4.1.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "commander": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "typescript": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-          "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ=="
-        }
-      }
     },
     "tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.1"
       },
@@ -21499,7 +22168,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -21507,7 +22177,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -21529,23 +22199,14 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4"
-    },
-    "ua-parser-js": {
-      "version": "0.7.31",
+      "version": "4.7.4",
       "dev": true
     },
-    "unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      }
+    "ua-parser-js": {
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -21589,6 +22250,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true
+    },
     "update-browserslist-db": {
       "version": "1.0.9",
       "dev": true,
@@ -21599,6 +22266,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -21637,7 +22305,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/vector-tile/-/vector-tile-1.3.0.tgz",
       "integrity": "sha512-ECpYpDhbgTSGIRwaf4bLbiDHcUHDM+LGrBOmV1tdG+Lde8vajJtywP5vGFmMj0Z3cApTV0+9sLWgBCVsRuoAKQ==",
-      "dev": true,
       "requires": {
         "point-geometry": "0.0.0"
       }
@@ -21645,6 +22312,39 @@
     "void-elements": {
       "version": "2.0.1",
       "dev": true
+    },
+    "vue-eslint-parser": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz",
+      "integrity": "sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.2",
+        "eslint-scope": "^7.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.0.0",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+          "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
     },
     "watchpack": {
       "version": "2.4.0",
@@ -21663,6 +22363,7 @@
     },
     "wcwidth": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "defaults": "^1.0.3"
       }
@@ -21794,11 +22495,6 @@
             "ajv-formats": "^2.1.1",
             "ajv-keywords": "^5.0.0"
           }
-        },
-        "ws": {
-          "version": "8.9.0",
-          "dev": true,
-          "requires": {}
         }
       }
     },
@@ -21837,8 +22533,7 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
       "version": "1.3.1",
@@ -21851,13 +22546,38 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "wide-align": {
@@ -21875,12 +22595,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.2.tgz",
       "integrity": "sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ=="
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "peer": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -21912,10 +22626,13 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "ws": {
-      "version": "8.2.3",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
       "requires": {}
     },
@@ -21924,7 +22641,8 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",
@@ -21951,7 +22669,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "peer": true
+      "dev": true
     },
     "zone.js": {
       "version": "0.11.8",

--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -8,12 +8,12 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
+    "lint:fix": "ng lint --fix",
     "build:prod": "ng build --configuration production",
     "test:prod": "ng test --browsers=ChromeHeadless --watch=false --code-coverage"
   },
   "private": true,
   "dependencies": {
-    "@angular-eslint/schematics": "^1.0.0",
     "@angular/animations": "^14.2.0",
     "@angular/cdk": "^14.2.2",
     "@angular/common": "^14.2.0",
@@ -45,6 +45,11 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.2.3",
+    "@angular-eslint/builder": "14.4.0",
+    "@angular-eslint/eslint-plugin": "14.4.0",
+    "@angular-eslint/eslint-plugin-template": "14.4.0",
+    "@angular-eslint/schematics": "14.4.0",
+    "@angular-eslint/template-parser": "14.4.0",
     "@angular/cli": "~14.2.3",
     "@angular/compiler-cli": "^14.2.0",
     "@mapbox/vector-tile": "^1.3.1",
@@ -53,12 +58,19 @@
     "@types/leaflet": "^1.9.0",
     "@types/leaflet-draw": "^1.0.4",
     "@types/shpjs": "^3.4.2",
+    "@typescript-eslint/eslint-plugin": "5.43.0",
+    "@typescript-eslint/parser": "5.43.0",
+    "eslint": "^8.28.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "jasmine-core": "~4.3.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
+    "prettier": "^3.0.2",
+    "prettier-eslint": "^15.0.1",
     "typescript": "~4.7.2"
   }
 }

--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -5,7 +5,7 @@
       Welcome, {{ (user$ | async) ? displayName((user$ | async)!) : 'Guest' }}
     </h1>
 
-    <div *ngIf="(user$ | async) as user">
+    <div *ngIf="user$ | async as user">
       <h3>Account Name</h3>
       <h2>{{ displayName(user) }}</h2>
 
@@ -17,9 +17,13 @@
     </div>
 
     <div class="button-row" *ngIf="user$ | async">
-      <button mat-raised-button color="primary" (click)="editAccount()">EDIT ACCOUNT</button>
+      <button mat-raised-button color="primary" (click)="editAccount()">
+        EDIT ACCOUNT
+      </button>
 
-      <button mat-raised-button color="primary" (click)="changePassword()">CHANGE PASSWORD</button>
+      <button mat-raised-button color="primary" (click)="changePassword()">
+        CHANGE PASSWORD
+      </button>
 
       <button mat-raised-button (click)="logout()">SIGN OUT</button>
     </div>
@@ -35,8 +39,9 @@
             type="password"
             required
             formControlName="password1"
-            matInput>
-          <mat-error *ngIf="changePasswordForm.get('password1')?.hasError('minlength')">
+            matInput />
+          <mat-error
+            *ngIf="changePasswordForm.get('password1')?.hasError('minlength')">
             Password must contain at least 8 characters.
           </mat-error>
         </mat-form-field>
@@ -47,7 +52,7 @@
             type="password"
             required
             formControlName="password2"
-            matInput>
+            matInput />
           <mat-error *ngIf="changePasswordForm.hasError('passwordsNotEqual')">
             Passwords must match.
           </mat-error>
@@ -62,7 +67,9 @@
             {{ disableEditButton ? 'SAVING...' : 'SAVE CHANGES' }}
           </button>
 
-          <button mat-raised-button (click)="changingPassword = false">CANCEL</button>
+          <button mat-raised-button (click)="changingPassword = false">
+            CANCEL
+          </button>
         </div>
 
         <p>{{ error?.message }}</p>
@@ -72,25 +79,19 @@
 
     <!-- Edit account details -->
     <ng-container *ngIf="editingAccount">
-      <button mat-button color="primary" (click)="openDeleteAccountDialog()">DELETE ACCOUNT</button>
+      <button mat-button color="primary" (click)="openDeleteAccountDialog()">
+        DELETE ACCOUNT
+      </button>
 
       <form [formGroup]="editAccountForm" (ngSubmit)="saveEdits()">
         <mat-form-field>
           <mat-label>First name</mat-label>
-          <input
-            type="text"
-            required
-            formControlName="firstName"
-            matInput>
+          <input type="text" required formControlName="firstName" matInput />
         </mat-form-field>
 
         <mat-form-field>
           <mat-label>Last name</mat-label>
-          <input
-            type="text"
-            required
-            formControlName="lastName"
-            matInput>
+          <input type="text" required formControlName="lastName" matInput />
         </mat-form-field>
 
         <mat-form-field>
@@ -99,7 +100,7 @@
             type="text"
             disabled
             [value]="editAccountForm.get('email')?.value"
-            matInput>
+            matInput />
         </mat-form-field>
 
         <div class="button-row">
@@ -111,7 +112,9 @@
             {{ disableEditButton ? 'SAVING...' : 'SAVE CHANGES' }}
           </button>
 
-          <button mat-raised-button (click)="editingAccount = false">CANCEL</button>
+          <button mat-raised-button (click)="editingAccount = false">
+            CANCEL
+          </button>
         </div>
 
         <p>{{ error?.message }}</p>

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
@@ -3,7 +3,8 @@
 
   <p>
     <b>Are you sure you want to delete your account?</b>
-    <br />This will permanently erase your account.
+    <br />
+    This will permanently erase your account.
   </p>
 
   <div class="button-row">

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
@@ -3,7 +3,7 @@
 
   <p>
     <b>Are you sure you want to delete your account?</b>
-    <br>This will permanently erase your account.
+    <br />This will permanently erase your account.
   </p>
 
   <div class="button-row">

--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -42,17 +42,17 @@ const routes: Routes = [
         component: SignupComponent,
         canActivate: [createFeatureGuard('login')],
       },
-      { 
-        path: 'map', 
-        title: 'Explore', 
-        component: MapComponent 
+      {
+        path: 'map',
+        title: 'Explore',
+        component: MapComponent,
       },
       {
         path: 'feedback',
         canActivate: [RedirectGuard],
         component: RedirectGuard,
         data: {
-          externalUrl: 'https://share.hsforms.com/1xXehW6VrR0WskbHhqxsrrw3atqe'
+          externalUrl: 'https://share.hsforms.com/1xXehW6VrR0WskbHhqxsrrw3atqe',
         },
       },
       {
@@ -60,7 +60,8 @@ const routes: Routes = [
         canActivate: [RedirectGuard],
         component: RedirectGuard,
         data: {
-          externalUrl: 'https://github.com/OurPlanscape/Planscape/wiki/Planscape-User-Guide'
+          externalUrl:
+            'https://github.com/OurPlanscape/Planscape/wiki/Planscape-User-Guide',
         },
       },
       {
@@ -105,8 +106,6 @@ export class PlanscapeTitleStrategy extends TitleStrategy {
     }
   }
 }
-
-
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/interface/src/app/app.component.html
+++ b/src/interface/src/app/app.component.html
@@ -1,3 +1,3 @@
 <!-- Toolbar -->
-<top-bar (toggleEvent)="toggleSidebar($event)"></top-bar>
+<app-top-bar (toggleEvent)="toggleSidebar($event)"></app-top-bar>
 <app-navigation [sidebarOpen]="sidebarOpen"></app-navigation>

--- a/src/interface/src/app/app.component.ts
+++ b/src/interface/src/app/app.component.ts
@@ -21,5 +21,4 @@ export class AppComponent implements OnInit {
     // Refresh the user's logged in status when the app initializes.
     this.authService.refreshLoggedInUser().pipe(take(1)).subscribe();
   }
-
 }

--- a/src/interface/src/app/app.module.ts
+++ b/src/interface/src/app/app.module.ts
@@ -44,7 +44,7 @@ import { SignupComponent } from './signup/signup.component';
 import { StringifyMapConfigPipe } from './stringify-map-config.pipe';
 import { TopBarComponent } from './top-bar/top-bar.component';
 import { DeleteAccountDialogComponent } from './account-dialog/delete-account-dialog/delete-account-dialog.component';
-import { environment } from "src/environments/environment";
+import { environment } from 'src/environments/environment';
 
 @NgModule({
   declarations: [

--- a/src/interface/src/app/backend-constants.ts
+++ b/src/interface/src/app/backend-constants.ts
@@ -1,8 +1,7 @@
-import { environment  } from "src/environments/environment";
+import { environment } from 'src/environments/environment';
 
 export const BackendConstants = {
   END_POINT: environment.backend_endpoint,
   TILES_END_POINT: environment.tile_endpoint,
   DOWNLOAD_END_POINT: environment.download_endpoint,
 } as const;
- 

--- a/src/interface/src/app/features/feature-flag.directive.spec.ts
+++ b/src/interface/src/app/features/feature-flag.directive.spec.ts
@@ -54,10 +54,12 @@ describe('FeatureFlagDirective', () => {
 });
 
 @Component({
-  template: ` <h2 *featureFlag="'false'">False</h2>
+  template: `
+    <h2 *featureFlag="'false'">False</h2>
     <h2 *featureFlag="'undefined'">Undefined</h2>
     <h2 *featureFlag="'true'">True</h2>
     <h3 *featureFlag="'true'; hide: true">Hidden</h3>
-    <h4 *featureFlag="'true'; hide: false">Visible</h4>`,
+    <h4 *featureFlag="'true'; hide: false">Visible</h4>
+  `,
 })
 class TestComponent {}

--- a/src/interface/src/app/features/feature-flag.directive.spec.ts
+++ b/src/interface/src/app/features/feature-flag.directive.spec.ts
@@ -57,7 +57,7 @@ describe('FeatureFlagDirective', () => {
   template: ` <h2 *featureFlag="'false'">False</h2>
     <h2 *featureFlag="'undefined'">Undefined</h2>
     <h2 *featureFlag="'true'">True</h2>
-    <h3 *featureFlag="'true'; hide:true">Hidden</h3>
-    <h4 *featureFlag="'true'; hide:false">Visible</h4>`,
+    <h3 *featureFlag="'true'; hide: true">Hidden</h3>
+    <h4 *featureFlag="'true'; hide: false">Visible</h4>`,
 })
 class TestComponent {}

--- a/src/interface/src/app/features/feature-flag.directive.ts
+++ b/src/interface/src/app/features/feature-flag.directive.ts
@@ -6,7 +6,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 
-import {FeatureService} from './feature.service';
+import { FeatureService } from './feature.service';
 
 /** Directive to show or hide a DOM element based on whether a feature flag is enabled. */
 @Directive({
@@ -15,7 +15,7 @@ import {FeatureService} from './feature.service';
 export class FeatureFlagDirective implements OnInit {
   @Input() featureFlag!: string;
   // if provided as true, will hide the content when the flag is true
-  @Input() featureFlagHide= false;
+  @Input() featureFlagHide = false;
 
   constructor(
     private featureService: FeatureService,

--- a/src/interface/src/app/features/features.module.ts
+++ b/src/interface/src/app/features/features.module.ts
@@ -5,9 +5,7 @@ import { FeatureFlagDirective } from './feature-flag.directive';
 import { FeatureService } from './feature.service';
 
 @NgModule({
-  declarations: [
-    FeatureFlagDirective
-  ],
+  declarations: [FeatureFlagDirective],
   imports: [CommonModule],
   providers: [FeatureService],
   exports: [FeatureFlagDirective],

--- a/src/interface/src/app/home/home.component.spec.ts
+++ b/src/interface/src/app/home/home.component.spec.ts
@@ -8,9 +8,8 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
-    })
-    .compileComponents();
+      declarations: [HomeComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/home/home.component.ts
+++ b/src/interface/src/app/home/home.component.ts
@@ -3,13 +3,6 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  styleUrls: ['./home.component.scss'],
 })
-export class HomeComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
-}
+export class HomeComponent {}

--- a/src/interface/src/app/home/plan-table/delete-plan-dialog/delete-plan-dialog.component.html
+++ b/src/interface/src/app/home/plan-table/delete-plan-dialog/delete-plan-dialog.component.html
@@ -1,5 +1,9 @@
 <h1>Delete {{ data.length }} plan{{ data.length > 1 ? 's' : '' }}</h1>
-<p>Are you sure? <b>Warning</b>: This operation cannot be reversed.</p>
+<p>
+  Are you sure?
+  <b>Warning</b>
+  : This operation cannot be reversed.
+</p>
 <div class="button-row">
   <button mat-raised-button (click)="cancel()">CANCEL</button>
   <button mat-raised-button (click)="confirm()" color="error" cdkFocusInitial>

--- a/src/interface/src/app/home/plan-table/delete-plan-dialog/delete-plan-dialog.component.html
+++ b/src/interface/src/app/home/plan-table/delete-plan-dialog/delete-plan-dialog.component.html
@@ -2,5 +2,7 @@
 <p>Are you sure? <b>Warning</b>: This operation cannot be reversed.</p>
 <div class="button-row">
   <button mat-raised-button (click)="cancel()">CANCEL</button>
-  <button mat-raised-button (click)="confirm()" color="error" cdkFocusInitial>YES, DELETE</button>
+  <button mat-raised-button (click)="confirm()" color="error" cdkFocusInitial>
+    YES, DELETE
+  </button>
 </div>

--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -2,8 +2,8 @@
   <h1>
     {{
       datasource.data.length && (loggedIn$ | async)
-        ? "Welcome back!"
-        : "Welcome to Planscape preview!"
+        ? 'Welcome back!'
+        : 'Welcome to Planscape preview!'
     }}
   </h1>
 
@@ -20,8 +20,7 @@
             <mat-cell *matCellDef="let element">
               <mat-checkbox
                 name="${element.id}-selected"
-                [(ngModel)]="element.selected"
-              ></mat-checkbox>
+                [(ngModel)]="element.selected"></mat-checkbox>
             </mat-cell>
           </ng-container>
 
@@ -41,7 +40,7 @@
               Date Created
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              {{ element.createdTimestamp | date: "medium" }}
+              {{ element.createdTimestamp | date: 'medium' }}
             </mat-cell>
           </ng-container>
 
@@ -92,8 +91,7 @@
               <button
                 mat-icon-button
                 [matMenuTriggerFor]="menu"
-                aria-label="More options"
-              >
+                aria-label="More options">
                 <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #menu="matMenu">
@@ -112,8 +110,7 @@
         <mat-paginator
           [pageSizeOptions]="[10, 20, 30]"
           showFirstLastButtons
-          aria-label="Select page of plans"
-        >
+          aria-label="Select page of plans">
         </mat-paginator>
 
         <div class="button-row">
@@ -121,8 +118,7 @@
             mat-button
             color="primary"
             (click)="delete()"
-            [disabled]="!showDelete()"
-          >
+            [disabled]="!showDelete()">
             <mat-icon>delete</mat-icon>
             DELETE
           </button>

--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -1,11 +1,13 @@
 <div class="root-container">
   <h1>
-    {{ datasource.data.length && (loggedIn$ | async) ? 'Welcome back!' : 'Welcome to Planscape preview!' }}
+    {{
+      datasource.data.length && (loggedIn$ | async)
+        ? 'Welcome back!'
+        : 'Welcome to Planscape preview!'
+    }}
   </h1>
 
   <div class="plans-container">
-    
-    
     <div *ngIf="login_enabled; else notimplemented">
       <h2>My Plans</h2>
       <div *ngIf="datasource.data.length && (loggedIn$ | async); else noplans">
@@ -16,7 +18,9 @@
               <mat-checkbox (change)="toggleAll($event.checked)"></mat-checkbox>
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              <mat-checkbox name="${element.id}-selected" [(ngModel)]="element.selected"></mat-checkbox>
+              <mat-checkbox
+                name="${element.id}-selected"
+                [(ngModel)]="element.selected"></mat-checkbox>
             </mat-cell>
           </ng-container>
 
@@ -26,7 +30,7 @@
               Name
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              <a href="/plan/{{element.id}}">{{element.name}}</a>
+              <a href="/plan/{{ element.id }}">{{ element.name }}</a>
             </mat-cell>
           </ng-container>
 
@@ -36,7 +40,7 @@
               Date Created
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              {{element.createdTimestamp | date:'medium' }}
+              {{ element.createdTimestamp | date: 'medium' }}
             </mat-cell>
           </ng-container>
 
@@ -46,7 +50,7 @@
               Region
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              {{element.region}}
+              {{ element.region }}
             </mat-cell>
           </ng-container>
 
@@ -56,7 +60,7 @@
               Saved Scenarios
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              {{element.savedScenarios}}
+              {{ element.savedScenarios }}
             </mat-cell>
           </ng-container>
 
@@ -66,7 +70,7 @@
               Configurations
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              {{element.configurations}}
+              {{ element.configurations }}
             </mat-cell>
           </ng-container>
 
@@ -76,16 +80,18 @@
               Status
             </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              {{element.status}}
+              {{ element.status }}
             </mat-cell>
           </ng-container>
 
           <!-- Options Column -->
           <ng-container matColumnDef="options">
-            <mat-header-cell *matHeaderCellDef>
-            </mat-header-cell>
+            <mat-header-cell *matHeaderCellDef> </mat-header-cell>
             <mat-cell *matCellDef="let element">
-              <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="More options">
+              <button
+                mat-icon-button
+                [matMenuTriggerFor]="menu"
+                aria-label="More options">
                 <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #menu="matMenu">
@@ -98,16 +104,21 @@
           </ng-container>
 
           <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-          <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+          <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
         </mat-table>
 
-        <mat-paginator [pageSizeOptions]="[10, 20, 30]"
-                      showFirstLastButtons
-                      aria-label="Select page of plans">
+        <mat-paginator
+          [pageSizeOptions]="[10, 20, 30]"
+          showFirstLastButtons
+          aria-label="Select page of plans">
         </mat-paginator>
 
         <div class="button-row">
-          <button mat-button color="primary" (click)="delete()" [disabled]="!showDelete()">
+          <button
+            mat-button
+            color="primary"
+            (click)="delete()"
+            [disabled]="!showDelete()">
             <mat-icon>delete</mat-icon>
             DELETE
           </button>
@@ -119,40 +130,103 @@
       </div>
     </div>
     <ng-template #notimplemented class="plans-not-implemented">
-
       <div class="plans-not-implemented">
-      <b font-size="20px"> What is Planscape?<br></b>
-      <p>Planscape is a new wildfire resilience planning support tool designed to bring the best available state & federal data and science together. Planscape guides regional planners in prioritizing landscape treatments to mitigate fire risk, maximize ecological benefits, and help California&#39;s landscapes adapt to climate change.<br></p>
-      <b> What is the Planscape preview? <br> </b>
-      <p>This version of Planscape is intended to give you a preview into the tool with limited data and capabilities for the Sierra Nevada, Southern California, and Central Coast regions. This preview version: </p>
-      <ul>
-        <li>Considers everyone as guest users and does not require you to login</li>
-        <li>Includes data from the <a href="https://wildfiretaskforce.org/regional-resource-kits-page/" target="_blank" rel="noopener noreferrer">Regional Resource Kits</a> for the Sierra Nevada, Southern California, and Central Coast regions</li>
-        <li>Provides the ability to explore and view maps but not create or save plans yet</li>
-      </ul>  
-      <b>What can I do with it?<br></b>
-        
-      <p>You can view and explore this landscape resilience planning data on a set of maps.You can also visualize this data for the three regions alongside other provided data sets such as county and watershed boundaries.<br></p>
-        
-      <b>How do I learn more?<br></b>
-        
-      <p>Click on the <a routerLink="/help" target="_blank" rel="noopener noreferrer"> Help</a> icon on the top right corner of the tool to read
-        the <a href="https://github.com/OurPlanscape/Planscape/wiki/Planscape-User-Guide" target="_blank" rel="noopener noreferrer">user guide</a>
-        or check out the
-        <a href="https://github.com/OurPlanscape/Planscape/wiki/Release-Notes" target="_blank" rel="noopener noreferrer">Planscape Release Notes</a> or
-        <a href="https://www.planscape.org/faqs" target="_blank" rel="noopener noreferrer">FAQ</a>.
-        You can also visit <a href="https://www.planscape.org/" target= "_blank" rel="noopener noreferrer">Planscape.org</a> for
-        more information about the tool, to sign up for regular updates as we release new versions, and to receive our newsletter.</p>
+        <b font-size="20px"> What is Planscape?<br /></b>
+        <p>
+          Planscape is a new wildfire resilience planning support tool designed
+          to bring the best available state & federal data and science together.
+          Planscape guides regional planners in prioritizing landscape
+          treatments to mitigate fire risk, maximize ecological benefits, and
+          help California&#39;s landscapes adapt to climate change.<br />
+        </p>
+        <b> What is the Planscape preview? <br /> </b>
+        <p>
+          This version of Planscape is intended to give you a preview into the
+          tool with limited data and capabilities for the Sierra Nevada,
+          Southern California, and Central Coast regions. This preview version:
+        </p>
+        <ul>
+          <li>
+            Considers everyone as guest users and does not require you to login
+          </li>
+          <li>
+            Includes data from the
+            <a
+              href="https://wildfiretaskforce.org/regional-resource-kits-page/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Regional Resource Kits</a
+            >
+            for the Sierra Nevada, Southern California, and Central Coast
+            regions
+          </li>
+          <li>
+            Provides the ability to explore and view maps but not create or save
+            plans yet
+          </li>
+        </ul>
+        <b>What can I do with it?<br /></b>
 
-      <b>Conditions of Use<br></b>
-      <p>Please read our <a href="https://www.planscape.org/conditions-of-use/" target="_blank">Conditions of Use</a> for information regarding usage of this tool.</p>
-    </div>
+        <p>
+          You can view and explore this landscape resilience planning data on a
+          set of maps.You can also visualize this data for the three regions
+          alongside other provided data sets such as county and watershed
+          boundaries.<br />
+        </p>
+
+        <b>How do I learn more?<br /></b>
+
+        <p>
+          Click on the
+          <a routerLink="/help" target="_blank" rel="noopener noreferrer">
+            Help</a
+          >
+          icon on the top right corner of the tool to read the
+          <a
+            href="https://github.com/OurPlanscape/Planscape/wiki/Planscape-User-Guide"
+            target="_blank"
+            rel="noopener noreferrer"
+            >user guide</a
+          >
+          or check out the
+          <a
+            href="https://github.com/OurPlanscape/Planscape/wiki/Release-Notes"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Planscape Release Notes</a
+          >
+          or
+          <a
+            href="https://www.planscape.org/faqs"
+            target="_blank"
+            rel="noopener noreferrer"
+            >FAQ</a
+          >. You can also visit
+          <a
+            href="https://www.planscape.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Planscape.org</a
+          >
+          for more information about the tool, to sign up for regular updates as
+          we release new versions, and to receive our newsletter.
+        </p>
+
+        <b>Conditions of Use<br /></b>
+        <p>
+          Please read our
+          <a href="https://www.planscape.org/conditions-of-use/" target="_blank"
+            >Conditions of Use</a
+          >
+          for information regarding usage of this tool.
+        </p>
+      </div>
     </ng-template>
     <ng-template #noplans class="no-saved-plans">
-      <p *ngIf="(loggedIn$ | async); else signedout">There are no saved plans.</p>
+      <p *ngIf="loggedIn$ | async; else signedout">There are no saved plans.</p>
       <ng-template #signedout>
         <p><a href="/signup">Create an account</a> to start making plans.</p>
-    </ng-template>
+      </ng-template>
     </ng-template>
   </div>
 </div>

--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -86,7 +86,7 @@
 
           <!-- Options Column -->
           <ng-container matColumnDef="options">
-            <mat-header-cell *matHeaderCellDef> </mat-header-cell>
+            <mat-header-cell *matHeaderCellDef></mat-header-cell>
             <mat-cell *matCellDef="let element">
               <button
                 mat-icon-button
@@ -110,8 +110,7 @@
         <mat-paginator
           [pageSizeOptions]="[10, 20, 30]"
           showFirstLastButtons
-          aria-label="Select page of plans">
-        </mat-paginator>
+          aria-label="Select page of plans"></mat-paginator>
 
         <div class="button-row">
           <button
@@ -131,83 +130,103 @@
     </div>
     <ng-template #notimplemented class="plans-not-implemented">
       <div class="plans-not-implemented">
-        <b font-size="20px"> What is Planscape?<br /></b>
+        <b font-size="20px">
+          What is Planscape?
+          <br />
+        </b>
         <p>
           Planscape is a new wildfire resilience planning support tool designed
           to bring the best available state & federal data and science together
           to enable better land management. Planscape is for you, the regional
           wildland planners, to help prioritize landscape treatments. With
           Planscape, you can mitigate fire risk, maximize ecological benefits,
-          and help California&#39;s landscapes adapt to climate change.<br />
+          and help California&#39;s landscapes adapt to climate change.
+          <br />
         </p>
         <p>
           Planscape preview includes all data from the
           <a
-            href="https://wildfiretaskforce.org/regional-resource-kits-and-profiles-are-now-available/"
-            >Regional Resource Kit</a
-          >
+            href="https://wildfiretaskforce.org/regional-resource-kits-and-profiles-are-now-available/">
+            Regional Resource Kit
+          </a>
           layers for the Sierra Nevada, Southern California, and Central Coast
-          regions.<br />
+          regions.
+          <br />
         </p>
 
-        <b>What can I do with Planscape?<br /></b>
+        <b>
+          What can I do with Planscape?
+          <br />
+        </b>
         <p>
           You can view and explore the landscape resilience planning data on a
           set of maps. You can also visualize this data for the three regions
           alongside other provided data sets such as county and watershed
-          boundaries.<br />
+          boundaries.
+          <br />
         </p>
 
         <p>
           Future Planscape releases will give you the ability to create plans,
           to identify treatment areas from the plans, and to collaborate with
-          other stakeholders.<br />
+          other stakeholders.
+          <br />
         </p>
 
-        <b>How do I learn more?<br /></b>
+        <b>
+          How do I learn more?
+          <br />
+        </b>
         <p>
           Click on the
           <a routerLink="/help" target="_blank" rel="noopener noreferrer">
-            Help</a
-          >
+            Help
+          </a>
           icon on the top right corner of the tool to read the
           <a
             href="https://github.com/OurPlanscape/Planscape/wiki/Planscape-User-Guide"
             target="_blank"
-            rel="noopener noreferrer"
-            >user guide</a
-          >
+            rel="noopener noreferrer">
+            user guide
+          </a>
           or check out the
           <a
             href="https://github.com/OurPlanscape/Planscape/wiki/Release-Notes"
             target="_blank"
-            rel="noopener noreferrer"
-            >Planscape Release Notes</a
-          >
+            rel="noopener noreferrer">
+            Planscape Release Notes
+          </a>
           or
           <a
             href="https://www.planscape.org/faqs"
             target="_blank"
-            rel="noopener noreferrer"
-            >FAQ</a
-          >. You can also visit
+            rel="noopener noreferrer">
+            FAQ
+          </a>
+          . You can also visit
           <a
             href="https://www.planscape.org/"
             target="_blank"
-            rel="noopener noreferrer"
-            >Planscape.org</a
-          >
+            rel="noopener noreferrer">
+            Planscape.org
+          </a>
           for more information about the tool. If you would like to receive our
           newsletter for regular updates, you can
-          <a href="https://www.planscape.org/contact">sign up here</a>.
+          <a href="https://www.planscape.org/contact">sign up here</a>
+          .
         </p>
 
-        <b>Conditions of Use<br /></b>
+        <b>
+          Conditions of Use
+          <br />
+        </b>
         <p>
           Please read our
-          <a href="https://www.planscape.org/conditions-of-use/" target="_blank"
-            >Conditions of Use</a
-          >
+          <a
+            href="https://www.planscape.org/conditions-of-use/"
+            target="_blank">
+            Conditions of Use
+          </a>
           for information regarding usage of this tool.
         </p>
       </div>
@@ -215,7 +234,10 @@
     <ng-template #noplans class="no-saved-plans">
       <p *ngIf="loggedIn$ | async; else signedout">There are no saved plans.</p>
       <ng-template #signedout>
-        <p><a href="/signup">Create an account</a> to start making plans.</p>
+        <p>
+          <a href="/signup">Create an account</a>
+          to start making plans.
+        </p>
       </ng-template>
     </ng-template>
   </div>

--- a/src/interface/src/app/home/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/home/plan-table/plan-table.component.ts
@@ -9,7 +9,7 @@ import { AuthService } from 'src/app/services';
 import { PlanService } from '../../services/plan.service';
 import { PlanPreview } from '../../types/plan.types';
 import { DeletePlanDialogComponent } from './delete-plan-dialog/delete-plan-dialog.component';
-import features from '../../features/features.json'
+import features from '../../features/features.json';
 
 interface PlanRow extends PlanPreview {
   selected: boolean;
@@ -68,8 +68,8 @@ export class PlanTableComponent implements OnInit {
           })
           .sort((plan) => plan.createdTimestamp ?? 0)
           .reverse();
-          this.datasource.paginator = this.paginator;
-          this.datasource.sort = this.sort;
+        this.datasource.paginator = this.paginator;
+        this.datasource.sort = this.sort;
       });
   }
 

--- a/src/interface/src/app/home/region-selection/region-selection.component.html
+++ b/src/interface/src/app/home/region-selection/region-selection.component.html
@@ -1,11 +1,11 @@
 <div class="center-block">
   <!-- Content text -->
   <section class="content-section">
-    <span *ngIf="!hasPlans || !(loggedIn$ | async)"
-      >Welcome to Planscape preview!
+    <span *ngIf="!hasPlans || !(loggedIn$ | async)">
+      Welcome to Planscape preview!
     </span>
-    <span *ngIf="multiple_regions_enabled; else singleRegionEnabled"
-      >Choose one of the regions to explore
+    <span *ngIf="multiple_regions_enabled; else singleRegionEnabled">
+      Choose one of the regions to explore
     </span>
     <ng-template #singleRegionEnabled>
       Click Sierra Nevada to explore

--- a/src/interface/src/app/home/region-selection/region-selection.component.html
+++ b/src/interface/src/app/home/region-selection/region-selection.component.html
@@ -1,10 +1,14 @@
 <div class="center-block">
   <!-- Content text -->
   <section class="content-section">
-    <span *ngIf="!hasPlans || !(loggedIn$ | async)">Welcome to Planscape preview! </span>
-    <span *ngIf="multiple_regions_enabled; else singleRegionEnabled">Choose one of the regions to explore </span>
+    <span *ngIf="!hasPlans || !(loggedIn$ | async)"
+      >Welcome to Planscape preview!
+    </span>
+    <span *ngIf="multiple_regions_enabled; else singleRegionEnabled"
+      >Choose one of the regions to explore
+    </span>
     <ng-template #singleRegionEnabled>
-      Click Sierra Nevada to explore 
+      Click Sierra Nevada to explore
     </ng-template>
   </section>
 

--- a/src/interface/src/app/home/region-selection/region-selection.component.spec.ts
+++ b/src/interface/src/app/home/region-selection/region-selection.component.spec.ts
@@ -50,13 +50,16 @@ describe('RegionSelectionComponent', () => {
   });
 
   it('should disable unavailable regions', async () => {
-    const regionButtons: MatButtonHarness[] = await loader.getAllHarnesses(
-      MatButtonHarness
-    );
+    const regionButtons: MatButtonHarness[] =
+      await loader.getAllHarnesses(MatButtonHarness);
 
     for (let regionButton of regionButtons) {
       // Add regions here as they become available to avoid false failures
-      if ((await regionButton.getText()).match(/(SIERRA NEVADA)|(SOUTHERN CALIFORNIA)|(CENTRAL COAST)/)) {
+      if (
+        (await regionButton.getText()).match(
+          /(SIERRA NEVADA)|(SOUTHERN CALIFORNIA)|(CENTRAL COAST)/
+        )
+      ) {
         expect(await regionButton.isDisabled()).toBeFalse();
       } else {
         expect(await regionButton.isDisabled()).toBeTrue();

--- a/src/interface/src/app/home/region-selection/region-selection.component.ts
+++ b/src/interface/src/app/home/region-selection/region-selection.component.ts
@@ -2,10 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { take } from 'rxjs';
 
-import { AuthService, PlanService, SessionService, MapService } from '../../services';
+import {
+  AuthService,
+  PlanService,
+  SessionService,
+  MapService,
+} from '../../services';
 import { RegionOption, regionOptions } from '../../types';
-import features from '../../features/features.json'
-
+import features from '../../features/features.json';
 
 /**
  * The main region selection view component.
@@ -28,7 +32,7 @@ export class RegionSelectionComponent implements OnInit {
     private planService: PlanService,
     private sessionService: SessionService,
     private mapService: MapService,
-    private router: Router,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -46,6 +50,6 @@ export class RegionSelectionComponent implements OnInit {
     }
     this.sessionService.setRegion(regionOption.type);
     this.mapService.setConfigs();
-    this.router.navigateByUrl('/map');  
+    this.router.navigateByUrl('/map');
   }
 }

--- a/src/interface/src/app/login/login.component.html
+++ b/src/interface/src/app/login/login.component.html
@@ -33,8 +33,8 @@
       </button>
 
       <p class="signup-text">
-        <a href="signup/">Create an account</a> to save your work & collaborate
-        with others
+        <a href="signup/">Create an account</a>
+        to save your work & collaborate with others
       </p>
     </div>
 
@@ -60,9 +60,10 @@
         by the California Wildfire & Forest Resilience Task Force. You can find
         more detailed information about these
         <a
-          href="https://wildfiretaskforce.org/regional-resource-kits-page/#kits"
-          >here</a
-        >.
+          href="https://wildfiretaskforce.org/regional-resource-kits-page/#kits">
+          here
+        </a>
+        .
       </p>
     </div>
   </div>

--- a/src/interface/src/app/login/login.component.html
+++ b/src/interface/src/app/login/login.component.html
@@ -1,5 +1,4 @@
 <div class="signin-root">
-
   <div class="signin-card-container">
     <div class="signin-card">
       <h1 class="signin-title">Sign in to Planscape</h1>
@@ -7,29 +6,24 @@
       <form [formGroup]="form" (ngSubmit)="login()">
         <mat-form-field appearance="fill">
           <mat-label>Email</mat-label>
-          <input
-            type="text"
-            required
-            formControlName="email"
-            matInput>
+          <input type="text" required formControlName="email" matInput />
         </mat-form-field>
 
         <mat-form-field appearance="fill">
           <mat-label>Password</mat-label>
-          <input
-            type="password"
-            required
-            formControlName="password"
-            matInput>
+          <input type="password" required formControlName="password" matInput />
         </mat-form-field>
 
         <p>{{ error?.message }}</p>
-            <p *ngIf="error">{{ error?.error | json }}</p>
+        <p *ngIf="error">{{ error?.error | json }}</p>
 
-        <button mat-flat-button color="primary" type="submit" [disabled]="!form.valid">
+        <button
+          mat-flat-button
+          color="primary"
+          type="submit"
+          [disabled]="!form.valid">
           Sign in
         </button>
-
       </form>
 
       <mat-divider></mat-divider>
@@ -39,34 +33,37 @@
       </button>
 
       <p class="signup-text">
-        <a href="signup/">Create an account</a> to save your work & collaborate with others
+        <a href="signup/">Create an account</a> to save your work & collaborate
+        with others
       </p>
     </div>
 
     <div class="disclaimer-text">
-      <p>{{text1}}</p>
+      <p>{{ text1 }}</p>
     </div>
   </div>
 
   <div class="info-text-container">
     <h1>A new wildfire resilience planning tool</h1>
 
-    <h3>{{text2}}</h3>
+    <h3>{{ text2 }}</h3>
 
     <ul>
       <li *ngFor="let bullet of bulletPoints">
-        <h3>{{bullet}}</h3>
+        <h3>{{ bullet }}</h3>
       </li>
     </ul>
 
     <div class="data-info-box">
       <p>
-        The data used is based on California's Regional Resource Kits, developed by the California
-        Wildfire & Forest Resilience Task Force.
-        You can find more detailed information about these
-        <a href="https://wildfiretaskforce.org/regional-resource-kits-page/#kits">here</a>.
+        The data used is based on California's Regional Resource Kits, developed
+        by the California Wildfire & Forest Resilience Task Force. You can find
+        more detailed information about these
+        <a
+          href="https://wildfiretaskforce.org/regional-resource-kits-page/#kits"
+          >here</a
+        >.
       </p>
     </div>
   </div>
-
 </div>

--- a/src/interface/src/app/login/login.component.spec.ts
+++ b/src/interface/src/app/login/login.component.spec.ts
@@ -48,7 +48,10 @@ describe('LoginComponent', () => {
 
       component.login();
 
-      expect(fakeAuthService.login).toHaveBeenCalledOnceWith('test@test.com', 'password');
+      expect(fakeAuthService.login).toHaveBeenCalledOnceWith(
+        'test@test.com',
+        'password'
+      );
     });
   });
 

--- a/src/interface/src/app/login/login.component.ts
+++ b/src/interface/src/app/login/login.component.ts
@@ -7,10 +7,9 @@ import { AuthService } from '../services';
 @Component({
   selector: 'app-login',
   templateUrl: './login.component.html',
-  styleUrls: ['./login.component.scss']
+  styleUrls: ['./login.component.scss'],
 })
 export class LoginComponent {
-
   error: any;
 
   form: FormGroup;
@@ -32,17 +31,20 @@ export class LoginComponent {
     landscapes`,
     `Designed to utilize the latest Regional Resource Kits as the primary data source`,
     `Built to utilize the best state and federal science and models`,
-    `Intends to be scalable across US Landscapes`
+    `Intends to be scalable across US Landscapes`,
   ];
 
   constructor(
     private authService: AuthService,
     private formBuilder: FormBuilder,
-    private router: Router,
+    private router: Router
   ) {
     this.form = this.formBuilder.group({
-      email: this.formBuilder.control('', [Validators.required, Validators.email]),
-      password: this.formBuilder.control('', Validators.required)
+      email: this.formBuilder.control('', [
+        Validators.required,
+        Validators.email,
+      ]),
+      password: this.formBuilder.control('', Validators.required),
     });
   }
 
@@ -53,8 +55,8 @@ export class LoginComponent {
     const password: string = this.form.get('password')?.value;
 
     this.authService.login(email, password).subscribe(
-      _ => this.router.navigate(['map']),
-      error => this.error = error
+      (_) => this.router.navigate(['map']),
+      (error) => (this.error = error)
     );
   }
 
@@ -65,5 +67,4 @@ export class LoginComponent {
   continueAsGuest() {
     this.router.navigate(['home']);
   }
-
 }

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
@@ -1,30 +1,37 @@
 <div class="layer-info-card">
-  <h2>{{dataLayerConfig?.display_name}}</h2>
+  <h2>{{ dataLayerConfig?.display_name }}</h2>
 
-  <p *ngIf="dataUnits()">
-    DATA UNITS: {{dataUnits()}}
-  </p>
+  <p *ngIf="dataUnits()">DATA UNITS: {{ dataUnits() }}</p>
 
-  <p *ngIf="hasMinMax()">
-    VALUE RANGE: {{computeMinMax()}}
-  </p>
+  <p *ngIf="hasMinMax()">VALUE RANGE: {{ computeMinMax() }}</p>
 
   <p>
     <span *ngIf="hasSource()">
-      SOURCE: <a [href]="dataLayerConfig?.source_link" target="_blank">{{dataLayerConfig?.source}}</a>
+      SOURCE:
+      <a [href]="dataLayerConfig?.source_link" target="_blank">{{
+        dataLayerConfig?.source
+      }}</a>
     </span>
   </p>
 
   <div *ngIf="hasDownloadLink()">
     <div *ngIf="hasDataProvider()">
-      <p>
-        PROVIDER: {{dataLayerConfig?.data_provider}}
-      </p>
+      <p>PROVIDER: {{ dataLayerConfig?.data_provider }}</p>
     </div>
     <p>
-      DATA: <a [href]="dataLayerConfig?.data_download_link" target="_blank">Download</a>
+      DATA:
+      <a [href]="dataLayerConfig?.data_download_link" target="_blank"
+        >Download</a
+      >
     </p>
   </div>
 
-  <a mat-raised-button color="primary" *ngIf="hasReferenceLink()" [href]="dataLayerConfig?.reference_link" target="_blank">Learn more</a>
+  <a
+    mat-raised-button
+    color="primary"
+    *ngIf="hasReferenceLink()"
+    [href]="dataLayerConfig?.reference_link"
+    target="_blank"
+    >Learn more</a
+  >
 </div>

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.html
@@ -8,9 +8,9 @@
   <p>
     <span *ngIf="hasSource()">
       SOURCE:
-      <a [href]="dataLayerConfig?.source_link" target="_blank">{{
-        dataLayerConfig?.source
-      }}</a>
+      <a [href]="dataLayerConfig?.source_link" target="_blank">
+        {{ dataLayerConfig?.source }}
+      </a>
     </span>
   </p>
 
@@ -20,9 +20,9 @@
     </div>
     <p>
       DATA:
-      <a [href]="dataLayerConfig?.data_download_link" target="_blank"
-        >Download</a
-      >
+      <a [href]="dataLayerConfig?.data_download_link" target="_blank">
+        Download
+      </a>
     </p>
   </div>
 
@@ -31,7 +31,7 @@
     color="primary"
     *ngIf="hasReferenceLink()"
     [href]="dataLayerConfig?.reference_link"
-    target="_blank"
-    >Learn more</a
-  >
+    target="_blank">
+    Learn more
+  </a>
 </div>

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.spec.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.spec.ts
@@ -8,9 +8,8 @@ describe('LayerInfoCardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ LayerInfoCardComponent ]
-    })
-    .compileComponents();
+      declarations: [LayerInfoCardComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(LayerInfoCardComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
+++ b/src/interface/src/app/map/layer-info-card/layer-info-card.component.ts
@@ -16,7 +16,7 @@ export class LayerInfoCardComponent {
   hasDownloadLink(): boolean {
     return !!this.dataLayerConfig?.data_download_link;
   }
-  
+
   hasMinMax(): boolean {
     return (
       this.dataLayerConfig?.min_value != undefined &&

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -29,9 +29,9 @@
               *ngIf="!node.condition.disableSelect"
               class="white"
               (change)="onSelect(node)">
-              <span class="condition-label">{{
-                node.condition.display_name
-              }}</span>
+              <span class="condition-label">
+                {{ node.condition.display_name }}
+              </span>
             </mat-radio-button>
             <span *ngIf="node.condition.disableSelect">
               {{ node.condition.display_name }}

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -1,12 +1,17 @@
 <mat-expansion-panel expanded="false">
   <mat-expansion-panel-header class="layer-panel-header">
-    {{header}}
+    {{ header }}
   </mat-expansion-panel-header>
 
-  <mat-radio-group name="{{ map.id + '-conditions-select' }}" aria-label="Select an option"
+  <mat-radio-group
+    name="{{ map.id + '-conditions-select' }}"
+    aria-label="Select an option"
     color="primary"
-    [(ngModel)]="map.config.dataLayerConfig" (change)="changeConditionLayer.emit(map)">
-    <mat-tree [dataSource]="conditionDataSource" [treeControl]="treeControl"
+    [(ngModel)]="map.config.dataLayerConfig"
+    (change)="changeConditionLayer.emit(map)">
+    <mat-tree
+      [dataSource]="conditionDataSource"
+      [treeControl]="treeControl"
       class="condition-tree">
       <!-- This is the tree node template for leaf nodes -->
       <!-- There is inline padding applied to this node using styles.
@@ -15,58 +20,70 @@
         *matTreeNodeDef="let node"
         [class.selected]="map.config.dataLayerConfig === node.condition">
         <div class="mat-tree-node">
-          <div class="selected-dot" [class.hidden]="!node.styleDescendantSelected"></div>
+          <div
+            class="selected-dot"
+            [class.hidden]="!node.styleDescendantSelected"></div>
           <div [class.disabled]="node.styleDisabled">
             <mat-radio-button
               [value]="node.condition"
               *ngIf="!node.condition.disableSelect"
               class="white"
               (change)="onSelect(node)">
-              <span class="condition-label">{{node.condition.display_name}}</span>
+              <span class="condition-label">{{
+                node.condition.display_name
+              }}</span>
             </mat-radio-button>
             <span *ngIf="node.condition.disableSelect">
-              {{node.condition.display_name}}
+              {{ node.condition.display_name }}
             </span>
           </div>
-          <button mat-icon-button
+          <button
+            mat-icon-button
             *ngIf="!node.condition.disableInfoCard"
             class="info-button"
-            [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+            [matMenuTriggerFor]="popoverMenu"
+            (menuOpened)="node.infoMenuOpen = true"
             (menuClosed)="node.infoMenuOpen = false">
             <mat-icon color="primary">info_outline</mat-icon>
           </button>
           <mat-menu #popoverMenu="matMenu">
-            <app-layer-info-card [dataLayerConfig]="node.condition"></app-layer-info-card>
+            <app-layer-info-card
+              [dataLayerConfig]="node.condition"></app-layer-info-card>
           </mat-menu>
         </div>
       </mat-tree-node>
       <!-- This is the tree node template for expandable nodes -->
       <mat-tree-node
-        *matTreeNodeDef="let node;when: hasChild"
+        *matTreeNodeDef="let node; when: hasChild"
         [class.selected]="map.config.dataLayerConfig === node.condition">
         <div class="mat-tree-node expandable-condition-node">
-          <div class="selected-dot" [class.hidden]="!node.styleDescendantSelected"></div>
+          <div
+            class="selected-dot"
+            [class.hidden]="!node.styleDescendantSelected"></div>
           <div [class.disabled]="node.styleDisabled">
             <mat-radio-button
               [value]="node.condition"
               *ngIf="!node.condition.disableSelect"
               class="white"
               (change)="onSelect(node)">
-              {{node.condition.display_name}}
+              {{ node.condition.display_name }}
             </mat-radio-button>
             <span *ngIf="node.condition.disableSelect">
-              {{node.condition.display_name}}
+              {{ node.condition.display_name }}
             </span>
           </div>
           <!-- TODO: remove disableInfoCard if it is no longer needed -->
-          <button mat-icon-button
+          <button
+            mat-icon-button
             *ngIf="!node.condition.disableInfoCard"
             class="info-button"
-            [matMenuTriggerFor]="popoverMenu" (menuOpened)="node.infoMenuOpen = true"
+            [matMenuTriggerFor]="popoverMenu"
+            (menuOpened)="node.infoMenuOpen = true"
             (menuClosed)="node.infoMenuOpen = false">
             <mat-icon color="primary">info_outline</mat-icon>
             <mat-menu #popoverMenu="matMenu">
-              <app-layer-info-card [dataLayerConfig]="node.condition"></app-layer-info-card>
+              <app-layer-info-card
+                [dataLayerConfig]="node.condition"></app-layer-info-card>
             </mat-menu>
           </button>
           <button
@@ -74,7 +91,7 @@
             matTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.condition.display_name">
             <mat-icon class="mat-icon-rtl-mirror">
-              {{treeControl.isExpanded(node) ? 'expand_less' : 'expand_more'}}
+              {{ treeControl.isExpanded(node) ? 'expand_less' : 'expand_more' }}
             </mat-icon>
           </button>
         </div>

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.spec.ts
@@ -70,11 +70,11 @@ describe('ConditionTreeComponent', () => {
     it('styles ancestors of a selected node and unstyles all other nodes', () => {
       const childNode = component.treeControl.dataNodes[1];
       const parentNode = component.treeControl.dataNodes[0];
-  
+
       component.onSelect(childNode);
-  
+
       expect(parentNode.styleDescendantSelected).toBeTrue();
-  
+
       component.treeControl.dataNodes
         .filter((node) => {
           return node !== childNode && node !== parentNode;
@@ -85,6 +85,4 @@ describe('ConditionTreeComponent', () => {
         });
     });
   });
-
-
 });

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -11,8 +11,7 @@
       <app-opacity-slider
         (changeOpacity)="changeOpacity.emit($event)"
         [opacity]="selectedMapOpacity"
-        label="Data Transparency: ">
-      </app-opacity-slider>
+        label="Data Transparency: "></app-opacity-slider>
     </div>
   </div>
 
@@ -129,8 +128,7 @@
               </mat-radio-button>
               <mat-spinner
                 [diameter]="24"
-                *ngIf="loadingIndicators[boundary.boundary_name]">
-              </mat-spinner>
+                *ngIf="loadingIndicators[boundary.boundary_name]"></mat-spinner>
             </div>
           </mat-radio-group>
         </mat-expansion-panel>
@@ -152,8 +150,7 @@
             </mat-checkbox>
             <mat-spinner
               [diameter]="24"
-              *ngIf="loadingIndicators['existing_projects']">
-            </mat-spinner>
+              *ngIf="loadingIndicators['existing_projects']"></mat-spinner>
           </div>
         </mat-expansion-panel>
 
@@ -167,8 +164,7 @@
             [dataType]="dataTypeEnum.RAW"
             (changeConditionLayer)="
               changeConditionLayer.emit($event); unstyleConditionTree(1)
-            ">
-          </app-condition-tree>
+            "></app-condition-tree>
         </div>
 
         <!-- Normalized current condition controls -->
@@ -181,8 +177,7 @@
             [dataType]="dataTypeEnum.TRANSLATED"
             (changeConditionLayer)="
               changeConditionLayer.emit($event); unstyleConditionTree(0)
-            ">
-          </app-condition-tree>
+            "></app-condition-tree>
         </div>
 
         <!-- Future condition controls -->
@@ -195,8 +190,7 @@
             [dataType]="dataTypeEnum.FUTURE"
             (changeConditionLayer)="
               changeConditionLayer.emit($event); unstyleConditionTree(0)
-            ">
-          </app-condition-tree>
+            "></app-condition-tree>
         </div>
 
         <!-- No Data Region controls -->
@@ -245,8 +239,8 @@
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title> Disturbances </mat-panel-title>
-              <mat-panel-description> Coming soon! </mat-panel-description>
+              <mat-panel-title>Disturbances</mat-panel-title>
+              <mat-panel-description>Coming soon!</mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </ng-container>
@@ -255,8 +249,8 @@
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title> HVRAs </mat-panel-title>
-              <mat-panel-description> Coming soon! </mat-panel-description>
+              <mat-panel-title>HVRAs</mat-panel-title>
+              <mat-panel-description>Coming soon!</mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </ng-container>
@@ -265,8 +259,8 @@
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title> Land types </mat-panel-title>
-              <mat-panel-description> Coming soon! </mat-panel-description>
+              <mat-panel-title>Land types</mat-panel-title>
+              <mat-panel-description>Coming soon!</mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </ng-container>
@@ -275,8 +269,8 @@
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title> Operability </mat-panel-title>
-              <mat-panel-description> Coming soon! </mat-panel-description>
+              <mat-panel-title>Operability</mat-panel-title>
+              <mat-panel-description>Coming soon!</mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </ng-container>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -3,8 +3,10 @@
   <div *ngIf="mapHasDataLayer" class="title-container">
     <div class="transparency-box">
       <!-- Opacity controls for the currently shown data layer -->
-      <app-opacity-slider (change)="changeOpacity.emit($event)" [opacity]="selectedMapOpacity"
-			  label="Data Transparency: ">
+      <app-opacity-slider
+        (changeOpacity)="changeOpacity.emit($event)"
+        [opacity]="selectedMapOpacity"
+        label="Data Transparency: ">
       </app-opacity-slider>
     </div>
   </div>
@@ -13,37 +15,49 @@
 
   <!-- Controls for specifying how many maps should be shown -->
   <div class="map-count-button-row">
-    <button mat-button class="map-count-button" (click)="changeMapCount.emit(1)"
+    <button
+      mat-button
+      class="map-count-button"
+      (click)="changeMapCount.emit(1)"
       aria-label="Show 1 map"
-      [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 1}">
+      [ngClass]="{ selected: mapViewOptions?.numVisibleMaps === 1 }">
       <div class="map-count-button-grid-cell"></div>
     </button>
-    <button mat-button class="map-count-button" (click)="changeMapCount.emit(2)"
+    <button
+      mat-button
+      class="map-count-button"
+      (click)="changeMapCount.emit(2)"
       aria-label="Show 2 maps"
-      [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 2}">
+      [ngClass]="{ selected: mapViewOptions?.numVisibleMaps === 2 }">
       <div class="map-count-button-grid-row">
         <div class="map-count-button-grid-cell"></div>
         <div class="map-count-button-grid-cell"></div>
       </div>
     </button>
-    <button mat-button class="map-count-button" (click)="changeMapCount.emit(4)"
+    <button
+      mat-button
+      class="map-count-button"
+      (click)="changeMapCount.emit(4)"
       aria-label="Show 4 maps"
-      [ngClass]="{'selected': mapViewOptions?.numVisibleMaps === 4}">
-    <div class="map-count-button-grid-row">
-      <div class="map-count-button-grid-cell"></div>
-      <div class="map-count-button-grid-cell"></div>
-    </div>
-    <div class="map-count-button-grid-row">
-      <div class="map-count-button-grid-cell"></div>
-      <div class="map-count-button-grid-cell"></div>
-    </div>
+      [ngClass]="{ selected: mapViewOptions?.numVisibleMaps === 4 }">
+      <div class="map-count-button-grid-row">
+        <div class="map-count-button-grid-cell"></div>
+        <div class="map-count-button-grid-cell"></div>
+      </div>
+      <div class="map-count-button-grid-row">
+        <div class="map-count-button-grid-cell"></div>
+        <div class="map-count-button-grid-cell"></div>
+      </div>
     </button>
   </div>
 
   <!-- Layer controls for each map, displayed in tabs -->
-  <mat-tab-group mat-align-tabs="center" mat-stretch-tabs="true"
+  <mat-tab-group
+    mat-align-tabs="center"
+    mat-stretch-tabs="true"
     [selectedIndex]="mapViewOptions?.selectedMapIndex"
-    class="layer-controls-tab-group" (selectedIndexChange)="selectMap.emit($event)">
+    class="layer-controls-tab-group"
+    (selectedIndexChange)="selectMap.emit($event)">
     <mat-tab *ngFor="let map of maps; index as i" label="MAP {{ map.name }}">
       <!-- Clear All button -->
       <div class="clear-all-button-wrapper">
@@ -57,19 +71,24 @@
       </div>
 
       <mat-accordion multi displayMode="flat">
-
         <!-- Basemap layer controls -->
         <mat-expansion-panel expanded="true">
           <mat-expansion-panel-header class="layer-panel-header">
             Basemaps
           </mat-expansion-panel-header>
-          <mat-radio-group name="{{ map.id + '-base-layer-select' }}" aria-label="Select an option"
-            class="layer-radio-group" [(ngModel)]="map.config.baseLayerType"
+          <mat-radio-group
+            name="{{ map.id + '-base-layer-select' }}"
+            aria-label="Select an option"
+            class="layer-radio-group"
+            [(ngModel)]="map.config.baseLayerType"
             color="primary"
             (change)="changeBaseLayer.emit(map)">
-            <div class="layer-control-container" *ngFor="let baseLayerType of baseLayerTypes">
-              <mat-radio-button [value]="baseLayerType"
-                checked="{{ baseLayerType == map.config.baseLayerType }}">
+            <div
+              class="layer-control-container"
+              *ngFor="let baseLayerType of baseLayerTypes">
+              <mat-radio-button
+                [value]="baseLayerType"
+                checked="{{ baseLayerType === map.config.baseLayerType }}">
                 {{ BaseLayerType[baseLayerType] }}
               </mat-radio-button>
             </div>
@@ -81,19 +100,31 @@
           <mat-expansion-panel-header class="layer-panel-header">
             Boundaries
           </mat-expansion-panel-header>
-          <mat-radio-group name="{{ map.id + '-boundaries-select' }}" aria-label="Select an option"
-            class="layer-radio-group" color="primary"
-            [(ngModel)]="map.config.boundaryLayerConfig" (change)="changeBoundaryLayer.emit(map)">
+          <mat-radio-group
+            name="{{ map.id + '-boundaries-select' }}"
+            aria-label="Select an option"
+            class="layer-radio-group"
+            color="primary"
+            [(ngModel)]="map.config.boundaryLayerConfig"
+            (change)="changeBoundaryLayer.emit(map)">
             <div class="layer-control-container">
               <mat-radio-button [value]="noneBoundaryConfig">
                 None
               </mat-radio-button>
             </div>
-            <div *ngFor="let boundary of boundaryConfig" class="layer-control-container">
+            <div
+              *ngFor="let boundary of boundaryConfig"
+              class="layer-control-container">
               <mat-radio-button [value]="boundary">
-                {{ boundary.display_name ? boundary.display_name : boundary.boundary_name }}
+                {{
+                  boundary.display_name
+                    ? boundary.display_name
+                    : boundary.boundary_name
+                }}
               </mat-radio-button>
-              <mat-spinner [diameter]="24" *ngIf="loadingIndicators[boundary.boundary_name]">
+              <mat-spinner
+                [diameter]="24"
+                *ngIf="loadingIndicators[boundary.boundary_name]">
               </mat-spinner>
             </div>
           </mat-radio-group>
@@ -105,13 +136,18 @@
             Recent treatment areas
           </mat-expansion-panel-header>
           <div class="layer-control-container">
-            <mat-checkbox name="{{ map.id + '-existing-projects-toggle' }}"
-              aria-label="Select or deselect" color="primary"
-              class="layer-checkbox" [(ngModel)]="map.config.showExistingProjectsLayer"
+            <mat-checkbox
+              name="{{ map.id + '-existing-projects-toggle' }}"
+              aria-label="Select or deselect"
+              color="primary"
+              class="layer-checkbox"
+              [(ngModel)]="map.config.showExistingProjectsLayer"
               (change)="toggleExistingProjectsLayer.emit(map)">
               Existing projects
             </mat-checkbox>
-            <mat-spinner [diameter]="24" *ngIf="loadingIndicators['existing_projects']">
+            <mat-spinner
+              [diameter]="24"
+              *ngIf="loadingIndicators['existing_projects']">
             </mat-spinner>
           </div>
         </mat-expansion-panel>
@@ -119,36 +155,42 @@
         <!-- Current condition controls -->
         <div *ngIf="rawDataEnabled">
           <app-condition-tree
-          #conditionTreeRaw
-          [conditionsConfig$]="conditionsConfig$"
-          [header]="'Regional Resource Kit Data'"
-          [map]="map"
-          [dataType]="dataTypeEnum.RAW"
-          (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(1)">
-        </app-condition-tree>
-       </div>
+            #conditionTreeRaw
+            [conditionsConfig$]="conditionsConfig$"
+            [header]="'Regional Resource Kit Data'"
+            [map]="map"
+            [dataType]="dataTypeEnum.RAW"
+            (changeConditionLayer)="
+              changeConditionLayer.emit($event); unstyleConditionTree(1)
+            ">
+          </app-condition-tree>
+        </div>
 
         <!-- Normalized current condition controls -->
-         <div *ngIf="translated_control_panel_enabled && translatedDataEnabled">
-         <app-condition-tree
-           #conditionTreeNormalized
-           [conditionsConfig$]="conditionsConfig$"
-           [header]="'Current Condition'"
-           [map]="map"
-           [dataType]="dataTypeEnum.TRANSLATED"
-           (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
-         </app-condition-tree>
-         </div>
+        <div *ngIf="translated_control_panel_enabled && translatedDataEnabled">
+          <app-condition-tree
+            #conditionTreeNormalized
+            [conditionsConfig$]="conditionsConfig$"
+            [header]="'Current Condition'"
+            [map]="map"
+            [dataType]="dataTypeEnum.TRANSLATED"
+            (changeConditionLayer)="
+              changeConditionLayer.emit($event); unstyleConditionTree(0)
+            ">
+          </app-condition-tree>
+        </div>
 
         <!-- Future condition controls -->
-         <div *ngIf="future_control_panel_enabled && futureDataEnabled">
+        <div *ngIf="future_control_panel_enabled && futureDataEnabled">
           <app-condition-tree
             #conditionTreeNormalized
             [conditionsConfig$]="conditionsConfig$"
             [header]="'Future Climate Stability'"
             [map]="map"
             [dataType]="dataTypeEnum.FUTURE"
-            (changeConditionLayer)="changeConditionLayer.emit($event); unstyleConditionTree(0)">
+            (changeConditionLayer)="
+              changeConditionLayer.emit($event); unstyleConditionTree(0)
+            ">
           </app-condition-tree>
         </div>
 
@@ -198,12 +240,8 @@
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Disturbances
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
+              <mat-panel-title> Disturbances </mat-panel-title>
+              <mat-panel-description> Coming soon! </mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </ng-container>
@@ -212,44 +250,31 @@
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                HVRAs
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
+              <mat-panel-title> HVRAs </mat-panel-title>
+              <mat-panel-description> Coming soon! </mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
-      </ng-container>
+        </ng-container>
 
         <!-- Land types controls -->
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Land types
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
+              <mat-panel-title> Land types </mat-panel-title>
+              <mat-panel-description> Coming soon! </mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
-      </ng-container>
+        </ng-container>
 
         <!-- Operability controls -->
         <ng-container *featureFlag="'unlaunched_layers'">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
-              <mat-panel-title>
-                Operability
-              </mat-panel-title>
-              <mat-panel-description>
-                Coming soon!
-              </mat-panel-description>
+              <mat-panel-title> Operability </mat-panel-title>
+              <mat-panel-description> Coming soon! </mat-panel-description>
             </mat-expansion-panel-header>
           </mat-expansion-panel>
-      </ng-container>
-
+        </ng-container>
       </mat-accordion>
     </mat-tab>
   </mat-tab-group>

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.spec.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.spec.ts
@@ -43,7 +43,7 @@ describe('MapControlPanelComponent', () => {
         boundary_name: 'huc12',
         display_name: 'HUC-12',
         vector_name: 'sierra-nevada:vector_huc12',
-        shape_name: 'Name",'
+        shape_name: 'Name",',
       },
     ];
     component.conditionsConfig$ = of({});
@@ -186,7 +186,7 @@ describe('MapControlPanelComponent', () => {
         boundary_name: 'huc12',
         display_name: 'HUC-12',
         vector_name: 'sierra-nevada:vector_huc12',
-        shape_name: 'Name",'
+        shape_name: 'Name",',
       };
       spyOn(component.changeBoundaryLayer, 'emit');
       spyOn(component.toggleExistingProjectsLayer, 'emit');

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.ts
@@ -16,14 +16,16 @@ import {
 } from 'src/app/types';
 import * as L from 'leaflet';
 
-import { NONE_DATA_LAYER_CONFIG, ConditionTreeType } from './../../types/data.types';
+import {
+  NONE_DATA_LAYER_CONFIG,
+  ConditionTreeType,
+} from './../../types/data.types';
 import { Map, MapViewOptions } from './../../types/map.types';
 import {
   ConditionsNode,
   ConditionTreeComponent,
 } from './condition-tree/condition-tree.component';
 import features from '../../features/features.json';
-
 
 /** Map Legend Display Strings */
 
@@ -63,7 +65,6 @@ export class MapControlPanelComponent implements OnInit {
   readonly noneBoundaryConfig = NONE_BOUNDARY_CONFIG;
   readonly noneDataLayerConfig = NONE_DATA_LAYER_CONFIG;
 
-
   private readonly destroy$ = new Subject<void>();
   // Region-specific data flags
   rawDataEnabled: boolean | null = null;
@@ -73,7 +74,7 @@ export class MapControlPanelComponent implements OnInit {
   // General data flags
   future_control_panel_enabled = features.show_future_control_panel;
   translated_control_panel_enabled = features.show_translated_control_panel;
-  
+
   public dataTypeEnum = ConditionTreeType;
 
   conditionDataRaw$ = new BehaviorSubject<ConditionsNode[]>([]);
@@ -92,7 +93,6 @@ export class MapControlPanelComponent implements OnInit {
       });
   }
 
-
   enableClearAllButton(map: Map): boolean {
     return (
       map.config.boundaryLayerConfig !== NONE_BOUNDARY_CONFIG ||
@@ -107,7 +107,7 @@ export class MapControlPanelComponent implements OnInit {
     map.config.showExistingProjectsLayer = false;
     this.toggleExistingProjectsLayer.emit(map);
     map.config.dataLayerConfig = NONE_DATA_LAYER_CONFIG;
-    if(map.legend){
+    if (map.legend) {
       L.DomUtil.remove(map.legend);
     }
     this.changeConditionLayer.emit(map);

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -24,7 +24,7 @@ import {
   Map,
   MapViewOptions,
   Region,
-  regionMapCenters
+  regionMapCenters,
 } from '../types';
 
 // Set to true so that layers are not editable by default
@@ -52,9 +52,9 @@ export class MapManager {
     private startLoadingLayerCallback: (layerName: string) => void,
     private doneLoadingLayerCallback: (layerName: string) => void,
     private http: HttpClient
-    ) {
-      this.selectedRegion$ = this.session.region$;
-    }
+  ) {
+    this.selectedRegion$ = this.session.region$;
+  }
 
   getGeomanDrawOptions(): L.PM.ToolbarOptions {
     return {
@@ -79,9 +79,7 @@ export class MapManager {
       features: Feature<Geometry, any>[],
       onInitialized: () => void
     ) => any,
-    getBoundaryLayerVectorCallback: (
-      vectorName: string
-    ) => Observable<L.Layer>
+    getBoundaryLayerVectorCallback: (vectorName: string) => Observable<L.Layer>
   ) {
     if (map.instance != undefined) map.instance.remove();
 
@@ -159,7 +157,8 @@ export class MapManager {
       'https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}',
       {
         maxZoom: 13,
-        attribution: 'Tiles &copy; Esri &mdash; Source: USGS, Esri, TANA, DeLorme, and NPS',
+        attribution:
+          'Tiles &copy; Esri &mdash; Source: USGS, Esri, TANA, DeLorme, and NPS',
         zIndex: 0,
       }
     );
@@ -183,7 +182,8 @@ export class MapManager {
     return L.tileLayer(
       'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
       {
-        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+        attribution:
+          'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
         zIndex: 0,
       }
     );
@@ -587,7 +587,7 @@ export class MapManager {
         fillColor: '#000000',
         fillOpacity: 0.4,
       }),
-    })
+    });
     map.regionLayerRef.addTo(map.instance!);
   }
 
@@ -621,9 +621,7 @@ export class MapManager {
   /** Toggles which boundary layer is shown. */
   toggleBoundaryLayer(
     map: Map,
-    getBoundaryLayerVectorCallback: (
-      vectorName: string
-    ) => Observable<L.Layer>
+    getBoundaryLayerVectorCallback: (vectorName: string) => Observable<L.Layer>
   ) {
     if (map.instance === undefined) return;
 
@@ -632,7 +630,7 @@ export class MapManager {
     const boundaryLayerName = map.config.boundaryLayerConfig.boundary_name;
     const boundaryVectorName = map.config.boundaryLayerConfig.vector_name;
     const boundaryShapeName = map.config.boundaryLayerConfig.shape_name;
-    
+
     if (boundaryLayerName !== '') {
       this.startLoadingLayerCallback(boundaryLayerName);
       getBoundaryLayerVectorCallback(boundaryVectorName)
@@ -640,14 +638,21 @@ export class MapManager {
         .subscribe((vector) => {
           this.doneLoadingLayerCallback(boundaryLayerName);
           this.boundaryVectorCache.set(boundaryLayerName, vector);
-          map.boundaryLayerRef = this.boundaryLayer(vector, boundaryShapeName, map.instance!);
+          map.boundaryLayerRef = this.boundaryLayer(
+            vector,
+            boundaryShapeName,
+            map.instance!
+          );
           map.boundaryLayerRef.addTo(map.instance!);
-          }
-        )
+        });
     }
   }
 
-  private boundaryLayer(boundary: L.Layer, shapeName: string, map: L.Map):  L.Layer {
+  private boundaryLayer(
+    boundary: L.Layer,
+    shapeName: string,
+    map: L.Map
+  ): L.Layer {
     const normalStyle: L.PathOptions = {
       weight: 1,
       color: '#0000ff',
@@ -660,19 +665,27 @@ export class MapManager {
       fillOpacity: 0.5,
       fill: true,
     };
-      return boundary.on('mouseover', function(e) {
+    return boundary
+      .on('mouseover', function (e) {
         var featureName = e.propagatedFrom.properties[shapeName];
-        if (featureName==''){
-          featureName= 'UNKNOWN';
+        if (featureName == '') {
+          featureName = 'UNKNOWN';
         }
         const pops = L.tooltip()
           .setContent(`<div>Name: ${featureName}</div>`)
           .setLatLng(e.latlng)
           .openOn(map);
         e.propagatedFrom.bindTooltip(pops);
-        (boundary as unknown as typeof L.vectorGrid).setFeatureStyle(e.propagatedFrom.properties.OBJECTID, hoverStyle);
-      }).on('mouseout', function(e){
-        (boundary as unknown as typeof L.vectorGrid).setFeatureStyle(e.propagatedFrom.properties.OBJECTID, normalStyle);        
+        (boundary as unknown as typeof L.vectorGrid).setFeatureStyle(
+          e.propagatedFrom.properties.OBJECTID,
+          hoverStyle
+        );
+      })
+      .on('mouseout', function (e) {
+        (boundary as unknown as typeof L.vectorGrid).setFeatureStyle(
+          e.propagatedFrom.properties.OBJECTID,
+          normalStyle
+        );
       });
   }
 
@@ -690,8 +703,8 @@ export class MapManager {
   addLegend(colormap: any, dataUnit: string | undefined, map: Map) {
     var entries = colormap['entries'];
     const legend = new (L.Control.extend({
-      options: { position: 'topleft' }
-    }));
+      options: { position: 'topleft' },
+    }))();
     const mapRef = map;
     legend.onAdd = function (map) {
       // Remove any pre-existing legend on map
@@ -701,7 +714,7 @@ export class MapManager {
 
       const div = L.DomUtil.create('div', 'legend');
       // htmlContent of HTMLDivElement must be directly added here to add to leaflet map
-      // Creating a string and then assigning to div.innerHTML to allow for class encapsulation 
+      // Creating a string and then assigning to div.innerHTML to allow for class encapsulation
       // (otherwise div tags are automatically closed before they should be)
       var htmlContent = '';
       htmlContent += '<div class=parentlegend>';
@@ -712,31 +725,41 @@ export class MapManager {
         // For legends with categorical labels make header 'Legend'
         htmlContent += '<div><b>Legend</b></div>';
       }
-        // Reversing order to present legend values from high to low (default is low to high)
-        for (let i = entries.length-1; i >= 0; i--) {
-          var entry = entries[i]
-          // Add a margin-bottom to only the last entry in the legend
-          var lastChild = "";
-          if (i ==0) {
-            lastChild = 'style="margin-bottom: 6px;"';
+      // Reversing order to present legend values from high to low (default is low to high)
+      for (let i = entries.length - 1; i >= 0; i--) {
+        var entry = entries[i];
+        // Add a margin-bottom to only the last entry in the legend
+        var lastChild = '';
+        if (i == 0) {
+          lastChild = 'style="margin-bottom: 6px;"';
+        }
+        if (entry['label']) {
+          // Filter out 'nodata' entries
+          if (entry['color'] != '#000000') {
+            htmlContent +=
+              '<div class="legendline" ' +
+              lastChild +
+              '><i style="background:' +
+              entry['color'] +
+              '"> &emsp; &hairsp;</i> &nbsp;<label>' +
+              entry['label'] +
+              '<br/></label></div>';
+          } else if (lastChild != '') {
+            htmlContent += '<div class="legendline"' + lastChild + '></div>';
           }
-          if (entry['label']) {
-            // Filter out 'nodata' entries
-            if (entry['color'] != '#000000') {
-              htmlContent += '<div class="legendline" '+ lastChild+ '><i style="background:'+ entry['color'] + '"> &emsp; &hairsp;</i> &nbsp;<label>'
-              + entry['label'] + '<br/></label></div>';
-            } 
-            else if (lastChild != "") {
-              htmlContent += '<div class="legendline"' + lastChild + '></div>';
-            }
-          } else {
-            htmlContent += '<div class="legendline" '+ lastChild+ '><i style="background:'+ entry['color'] + '"> &emsp; &hairsp;</i> &nbsp; <br/></div>';
-          }
+        } else {
+          htmlContent +=
+            '<div class="legendline" ' +
+            lastChild +
+            '><i style="background:' +
+            entry['color'] +
+            '"> &emsp; &hairsp;</i> &nbsp; <br/></div>';
+        }
       }
       htmlContent += '</div>';
       div.innerHTML = htmlContent;
-      // Needed to allow for scrolling on the legend 
-      L.DomEvent.on(div, 'mousewheel', L.DomEvent.stopPropagation)
+      // Needed to allow for scrolling on the legend
+      L.DomEvent.on(div, 'mousewheel', L.DomEvent.stopPropagation);
       // Set reference to legend for later deletion
       mapRef.legend = div;
       return div;
@@ -763,12 +786,12 @@ export class MapManager {
       region = 'sierra-nevada';
     }
     map.dataLayerRef = L.tileLayer.wms(
-      BackendConstants.TILES_END_POINT + region + "/wms?" ,
+      BackendConstants.TILES_END_POINT + region + '/wms?',
       {
         layers: region + layer,
         minZoom: 7,
         maxZoom: 13,
-        format:'image/png',
+        format: 'image/png',
         transparent: true,
         opacity:
           map.config.dataLayerConfig.opacity !== undefined
@@ -778,21 +801,20 @@ export class MapManager {
     );
 
     map.dataLayerRef.addTo(map.instance);
-    
+
     // Map legend request
     var dataUnit = map.config.dataLayerConfig.data_units;
     const legendUrl = BackendConstants.TILES_END_POINT + 'wms';
     let queryParams = new HttpParams();
-    queryParams = queryParams.append("request", "GetLegendGraphic");
-    queryParams = queryParams.append("layer", layer);
-    queryParams = queryParams.append("format", "application/json");
-    var legendJson = this.http.get<string>(legendUrl,{params:queryParams});
-    legendJson
-      .pipe(take(1))
-      .subscribe((value:any) => {
-        var colorMap = value['Legend'][0]['rules'][0]['symbolizers'][0]['Raster']['colormap'];
-        this.addLegend(colorMap, dataUnit, map);
-      });
+    queryParams = queryParams.append('request', 'GetLegendGraphic');
+    queryParams = queryParams.append('layer', layer);
+    queryParams = queryParams.append('format', 'application/json');
+    var legendJson = this.http.get<string>(legendUrl, { params: queryParams });
+    legendJson.pipe(take(1)).subscribe((value: any) => {
+      var colorMap =
+        value['Legend'][0]['rules'][0]['symbolizers'][0]['Raster']['colormap'];
+      this.addLegend(colorMap, dataUnit, map);
+    });
   }
 
   /** Change the opacity of a map's data layer. */
@@ -800,4 +822,3 @@ export class MapManager {
     map.dataLayerRef?.setOpacity(map.config.dataLayerConfig.opacity!);
   }
 }
-

--- a/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
+++ b/src/interface/src/app/map/map-nameplate/map-nameplate.component.html
@@ -1,5 +1,9 @@
-<div class="map-nameplate" [style.max-width]="widthInPx" [class.selected]="selected"
-  [matTooltip]="map?.config | stringifyMapConfig" [matTooltipClass]="'map-nameplate-tooltip'">
+<div
+  class="map-nameplate"
+  [style.max-width]="widthInPx"
+  [class.selected]="selected"
+  [matTooltip]="map?.config | stringifyMapConfig"
+  [matTooltipClass]="'map-nameplate-tooltip'">
   <div class="map-name">{{ map?.name }}</div>
   <div class="map-config-string">{{ map?.config | stringifyMapConfig }}</div>
 </div>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -15,8 +15,9 @@
     (changeMapCount)="changeMapCount($event)"
     (changeOpacity)="changeOpacity($event)"
     (selectMap)="selectMap($event)"
-    (toggleExistingProjectsLayer)="toggleExistingProjectsLayer($event)">
-  </app-map-control-panel>
+    (toggleExistingProjectsLayer)="
+      toggleExistingProjectsLayer($event)
+    "></app-map-control-panel>
 
   <!-- Display containers for leaflet maps (up to 4) -->
   <div class="maps-container">
@@ -37,7 +38,8 @@
             deselected: selectedAreaCreationAction === AreaCreationAction.UPLOAD
           }"
           (click)="onAreaCreationActionChange(AreaCreationAction.DRAW)">
-          <mat-icon>draw</mat-icon> DRAW AREA
+          <mat-icon>draw</mat-icon>
+          DRAW AREA
         </button>
       </div>
 
@@ -56,7 +58,8 @@
               deselected: selectedAreaCreationAction === AreaCreationAction.DRAW
             }"
             (click)="onAreaCreationActionChange(AreaCreationAction.UPLOAD)">
-            <mat-icon>upload_file</mat-icon> UPLOAD AREA
+            <mat-icon>upload_file</mat-icon>
+            UPLOAD AREA
           </button>
           <file-uploader
             *ngIf="showUploader"
@@ -107,8 +110,7 @@
         <app-map-nameplate
           [map]="maps[0]"
           [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 0"
-          [width$]="mapNameplateWidths[0]">
-        </app-map-nameplate>
+          [width$]="mapNameplateWidths[0]"></app-map-nameplate>
         <div id="map1" class="map"></div>
       </div>
       <div
@@ -121,8 +123,7 @@
         <app-map-nameplate
           [map]="maps[1]"
           [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 1"
-          [width$]="mapNameplateWidths[1]">
-        </app-map-nameplate>
+          [width$]="mapNameplateWidths[1]"></app-map-nameplate>
         <div id="map2" class="map"></div>
       </div>
     </div>
@@ -137,8 +138,7 @@
         <app-map-nameplate
           [map]="maps[2]"
           [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 2"
-          [width$]="mapNameplateWidths[2]">
-        </app-map-nameplate>
+          [width$]="mapNameplateWidths[2]"></app-map-nameplate>
         <div id="map3" class="map"></div>
       </div>
       <div
@@ -151,8 +151,7 @@
         <app-map-nameplate
           [map]="maps[3]"
           [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 3"
-          [width$]="mapNameplateWidths[3]">
-        </app-map-nameplate>
+          [width$]="mapNameplateWidths[3]"></app-map-nameplate>
         <div id="map4" class="map"></div>
       </div>
     </div>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,5 +1,4 @@
 <div class="root-container">
-
   <!-- Map control panel -->
   <app-map-control-panel
     [boundaryConfig]="boundaryConfig$ | async"
@@ -23,45 +22,58 @@
   <div class="maps-container">
     <!-- Actions bar above the maps -->
     <div class="map-actions-bar">
-      <div class="actions-bar-text">
-        START PLANNING:
-      </div>
+      <div class="actions-bar-text">START PLANNING:</div>
 
       <!-- Draw a planning area -->
-      <div matTooltip="This feature is not available at this time." [matTooltipDisabled]="login_enabled">
-      <button mat-button
-      [disabled]="!login_enabled"
-        class="draw-area-button"
-        [ngClass]="{selected: selectedAreaCreationAction === AreaCreationAction.DRAW,
-          deselected: selectedAreaCreationAction === AreaCreationAction.UPLOAD}"
-        (click)="onAreaCreationActionChange(AreaCreationAction.DRAW)">
-        <mat-icon>draw</mat-icon> DRAW AREA
-      </button>
-    </div>
+      <div
+        matTooltip="This feature is not available at this time."
+        [matTooltipDisabled]="login_enabled">
+        <button
+          mat-button
+          [disabled]="!login_enabled"
+          class="draw-area-button"
+          [ngClass]="{
+            selected: selectedAreaCreationAction === AreaCreationAction.DRAW,
+            deselected: selectedAreaCreationAction === AreaCreationAction.UPLOAD
+          }"
+          (click)="onAreaCreationActionChange(AreaCreationAction.DRAW)">
+          <mat-icon>draw</mat-icon> DRAW AREA
+        </button>
+      </div>
 
       <!-- Upload a planning area -->
       <div class="upload-wrapper">
-        <div matTooltip="This feature is not available at this time." [matTooltipDisabled]="login_enabled">
-          <button mat-button
-          [disabled]="!login_enabled"
+        <div
+          matTooltip="This feature is not available at this time."
+          [matTooltipDisabled]="login_enabled">
+          <button
+            mat-button
+            [disabled]="!login_enabled"
             class="upload-area-button"
-            [ngClass]="{selected: selectedAreaCreationAction === AreaCreationAction.UPLOAD,
-              deselected: selectedAreaCreationAction === AreaCreationAction.DRAW}"
+            [ngClass]="{
+              selected:
+                selectedAreaCreationAction === AreaCreationAction.UPLOAD,
+              deselected: selectedAreaCreationAction === AreaCreationAction.DRAW
+            }"
             (click)="onAreaCreationActionChange(AreaCreationAction.UPLOAD)">
             <mat-icon>upload_file</mat-icon> UPLOAD AREA
           </button>
-          <file-uploader *ngIf="showUploader"
+          <file-uploader
+            *ngIf="showUploader"
             class="file-uploader"
             requiredFileType="application/zip"
-            (fileEvent)="loadArea($event)"
-            ></file-uploader>
-         </div>
+            (fileEvent)="loadArea($event)"></file-uploader>
+        </div>
       </div>
 
       <!-- Cancel button -->
-      <button *ngIf="selectedAreaCreationAction === AreaCreationAction.DRAW ||
-        selectedAreaCreationAction === AreaCreationAction.UPLOAD"
-        mat-button type="button"
+      <button
+        *ngIf="
+          selectedAreaCreationAction === AreaCreationAction.DRAW ||
+          selectedAreaCreationAction === AreaCreationAction.UPLOAD
+        "
+        mat-button
+        type="button"
         [disabled]="!login_enabled"
         class="cancel-button"
         (click)="cancelAreaCreationAction()">
@@ -69,9 +81,13 @@
       </button>
 
       <!-- Done (confirm area) button -->
-      <button *ngIf="selectedAreaCreationAction === AreaCreationAction.DRAW ||
-        selectedAreaCreationAction === AreaCreationAction.UPLOAD"
-        mat-button type="button"
+      <button
+        *ngIf="
+          selectedAreaCreationAction === AreaCreationAction.DRAW ||
+          selectedAreaCreationAction === AreaCreationAction.UPLOAD
+        "
+        mat-button
+        type="button"
         class="done-button"
         [disabled]="!(showConfirmAreaButton$ | async) || !login_enabled"
         (click)="openCreatePlanDialog()">
@@ -80,35 +96,63 @@
     </div>
 
     <!-- Maps (1, 2, or 4) -->
-    <div class="map-row" [ngStyle]="{'height': mapRowHeight(0)}">
-      <div class="map-box" [ngClass]="{'selected': (mapViewOptions$ | async)?.selectedMapIndex === 0}"
-        [hidden]="!isMapVisible(0)" data-testid="map1">
-        <app-map-nameplate [map]="maps[0]" [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 0"
+    <div class="map-row" [ngStyle]="{ height: mapRowHeight(0) }">
+      <div
+        class="map-box"
+        [ngClass]="{
+          selected: (mapViewOptions$ | async)?.selectedMapIndex === 0
+        }"
+        [hidden]="!isMapVisible(0)"
+        data-testid="map1">
+        <app-map-nameplate
+          [map]="maps[0]"
+          [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 0"
           [width$]="mapNameplateWidths[0]">
         </app-map-nameplate>
         <div id="map1" class="map"></div>
       </div>
-      <div class="map-box" [ngClass]="{'selected': (mapViewOptions$ | async)?.selectedMapIndex === 1}"
-        [hidden]="!isMapVisible(1)" data-testid="map2">
-        <app-map-nameplate [map]="maps[1]" [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 1"
-        [width$]="mapNameplateWidths[1]">
-      </app-map-nameplate>
+      <div
+        class="map-box"
+        [ngClass]="{
+          selected: (mapViewOptions$ | async)?.selectedMapIndex === 1
+        }"
+        [hidden]="!isMapVisible(1)"
+        data-testid="map2">
+        <app-map-nameplate
+          [map]="maps[1]"
+          [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 1"
+          [width$]="mapNameplateWidths[1]">
+        </app-map-nameplate>
         <div id="map2" class="map"></div>
       </div>
     </div>
-    <div class="map-row" [ngStyle]="{'height': mapRowHeight(1)}">
-      <div class="map-box" [ngClass]="{'selected': (mapViewOptions$ | async)?.selectedMapIndex === 2}"
-        [hidden]="!isMapVisible(2)" data-testid="map3">
-        <app-map-nameplate [map]="maps[2]" [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 2"
-        [width$]="mapNameplateWidths[2]">
-      </app-map-nameplate>
+    <div class="map-row" [ngStyle]="{ height: mapRowHeight(1) }">
+      <div
+        class="map-box"
+        [ngClass]="{
+          selected: (mapViewOptions$ | async)?.selectedMapIndex === 2
+        }"
+        [hidden]="!isMapVisible(2)"
+        data-testid="map3">
+        <app-map-nameplate
+          [map]="maps[2]"
+          [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 2"
+          [width$]="mapNameplateWidths[2]">
+        </app-map-nameplate>
         <div id="map3" class="map"></div>
       </div>
-      <div class="map-box" [ngClass]="{'selected': (mapViewOptions$ | async)?.selectedMapIndex === 3}"
-        [hidden]="!isMapVisible(3)" data-testid="map4">
-        <app-map-nameplate [map]="maps[3]" [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 3"
-        [width$]="mapNameplateWidths[3]">
-      </app-map-nameplate>
+      <div
+        class="map-box"
+        [ngClass]="{
+          selected: (mapViewOptions$ | async)?.selectedMapIndex === 3
+        }"
+        [hidden]="!isMapVisible(3)"
+        data-testid="map4">
+        <app-map-nameplate
+          [map]="maps[3]"
+          [selected]="(mapViewOptions$ | async)?.selectedMapIndex === 3"
+          [width$]="mapNameplateWidths[3]">
+        </app-map-nameplate>
         <div id="map4" class="map"></div>
       </div>
     </div>

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -10,7 +10,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { featureCollection, point } from '@turf/helpers';
 import * as L from 'leaflet';
-import "leaflet.vectorgrid";
+import 'leaflet.vectorgrid';
 import { BehaviorSubject, of } from 'rxjs';
 import * as shp from 'shpjs';
 
@@ -52,8 +52,9 @@ describe('MapComponent', () => {
 
   beforeEach(() => {
     const fakeLayer: L.Layer = L.vectorGrid.protobuf(
-      "https://dev-geo.planscape.org/geoserver/gwc/service/tms/1.0.0/sierra-nevada:vector_huc12@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf",
-      { } );
+      'https://dev-geo.planscape.org/geoserver/gwc/service/tms/1.0.0/sierra-nevada:vector_huc12@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf',
+      {}
+    );
     const fakeGeoJson: GeoJSON.GeoJSON = {
       type: 'FeatureCollection',
       features: [
@@ -101,9 +102,9 @@ describe('MapComponent', () => {
       {
         boundaryConfig$: new BehaviorSubject<BoundaryConfig[] | null>([
           {
-            boundary_name: 'HUC-12', 
-            vector_name: "sierra-nevada:vector_huc12", 
-            shape_name: "Name",
+            boundary_name: 'HUC-12',
+            vector_name: 'sierra-nevada:vector_huc12',
+            shape_name: 'Name',
           },
         ]),
         conditionsConfig$: new BehaviorSubject<ConditionsConfig | null>({
@@ -112,7 +113,7 @@ describe('MapComponent', () => {
               display: true,
               elements: [
                 {
-		              display: true,
+                  display: true,
                   metrics: [
                     {
                       metric_name: 'test_metric_1',
@@ -145,7 +146,9 @@ describe('MapComponent', () => {
       ['setMapConfigs', 'setMapViewOptions'],
       {
         mapViewOptions$: new BehaviorSubject<MapViewOptions | null>(null),
-        mapConfigs$: new BehaviorSubject<Record<Region, MapConfig[]> | null>(defaultMapConfigsDictionary()),
+        mapConfigs$: new BehaviorSubject<Record<Region, MapConfig[]> | null>(
+          defaultMapConfigsDictionary()
+        ),
         region$: new BehaviorSubject<Region | null>(Region.SIERRA_NEVADA),
         sessionInterval$: sessionInterval,
       }
@@ -164,7 +167,12 @@ describe('MapComponent', () => {
     );
     const routerStub = () => ({ navigate: (array: string[]) => ({}) });
     TestBed.configureTestingModule({
-      imports: [FormsModule, MaterialModule, BrowserAnimationsModule, HttpClientTestingModule],
+      imports: [
+        FormsModule,
+        MaterialModule,
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [
         MapComponent,
@@ -203,8 +211,7 @@ describe('MapComponent', () => {
       const mapServiceStub: MapService =
         fixture.debugElement.injector.get(MapService);
 
-
-      // Region highlighting temporarily disabled. 
+      // Region highlighting temporarily disabled.
       // expect(mapServiceStub.getRegionBoundary).toHaveBeenCalledWith(
       //   Region.SIERRA_NEVADA
       // );
@@ -389,10 +396,11 @@ describe('MapComponent', () => {
           expect(map.boundaryLayerRef).toBeUndefined();
 
           // Act: select the HUC-12 boundary
-          map.config.boundaryLayerConfig = { 
-            boundary_name: 'HUC-12', 
-            vector_name: "sierra-nevada:vector_huc12", 
-            shape_name: "Name", };
+          map.config.boundaryLayerConfig = {
+            boundary_name: 'HUC-12',
+            vector_name: 'sierra-nevada:vector_huc12',
+            shape_name: 'Name',
+          };
           component.toggleBoundaryLayer(map);
 
           // Assert: expect that the map contains the HUC-12 layer
@@ -704,17 +712,19 @@ describe('MapComponent', () => {
         fixture.debugElement.injector.get(SessionService);
       const mapConfig = defaultMapConfig();
       mapConfig.boundaryLayerConfig = {
-        boundary_name: 'HUC-12', 
-        vector_name: "sierra-nevada:vector_huc12", 
-        shape_name: "Name",
-
+        boundary_name: 'HUC-12',
+        vector_name: 'sierra-nevada:vector_huc12',
+        shape_name: 'Name',
       };
-      const savedMapConfigs: Record<Region, MapConfig[]> = defaultMapConfigsDictionary();
+      const savedMapConfigs: Record<Region, MapConfig[]> =
+        defaultMapConfigsDictionary();
 
       sessionServiceStub.mapConfigs$.next(savedMapConfigs);
       component.ngOnInit();
 
-      expect(component.maps.map((map) => map.config)).toEqual(savedMapConfigs['Sierra Nevada']);
+      expect(component.maps.map((map) => map.config)).toEqual(
+        savedMapConfigs['Sierra Nevada']
+      );
     });
 
     it('restores map view options from session', () => {

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -7,8 +7,8 @@ import {
   EnvironmentInjector,
   OnDestroy,
   OnInit,
-  ChangeDetectorRef, 
-  DoCheck
+  ChangeDetectorRef,
+  DoCheck,
 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
@@ -22,7 +22,7 @@ import {
   Subject,
   take,
   takeUntil,
-  of
+  of,
 } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import * as shp from 'shpjs';
@@ -49,20 +49,19 @@ import {
   NONE_BOUNDARY_CONFIG,
   NONE_COLORMAP,
   Region,
-  regionMapCenters
+  regionMapCenters,
 } from '../types';
 import { MapManager } from './map-manager';
 import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dialog.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
 import { SignInDialogComponent } from './sign-in-dialog/sign-in-dialog.component';
-import features from '../features/features.json'
+import features from '../features/features.json';
 
 export enum AreaCreationAction {
   NONE = 0,
   DRAW = 1,
   UPLOAD = 2,
 }
-
 
 @Component({
   selector: 'app-map',
@@ -82,7 +81,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
 
   boundaryConfig$: Observable<BoundaryConfig[] | null>;
   conditionsConfig$: Observable<ConditionsConfig | null>;
-  regionRecord$: string= "";
+  regionRecord$: string = '';
   selectedRegion$: Observable<Region | null>;
   planState$: Observable<PlanState>;
   selectedMap$: Observable<Map | undefined>;
@@ -137,7 +136,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     private planService: PlanService,
     private router: Router,
     private http: HttpClient,
-    private cdr: ChangeDetectorRef,
+    private cdr: ChangeDetectorRef
   ) {
     this.boundaryConfig$ = this.mapService.boundaryConfig$.pipe(
       takeUntil(this.destroy$)
@@ -149,13 +148,13 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
       takeUntil(this.destroy$)
     );
     this.sessionService.mapViewOptions$
-    .pipe(take(1))
-    .subscribe((mapViewOptions: MapViewOptions | null) => {
-      if (mapViewOptions) {
-        this.mapViewOptions$.next(mapViewOptions);
-      }
-    });
-  
+      .pipe(take(1))
+      .subscribe((mapViewOptions: MapViewOptions | null) => {
+        if (mapViewOptions) {
+          this.mapViewOptions$.next(mapViewOptions);
+        }
+      });
+
     this.planState$ = this.planService.planState$.pipe(
       takeUntil(this.destroy$)
     );
@@ -199,9 +198,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   }
 
   ngOnInit(): void {
-    this.selectedRegion$
-    .pipe(take(1))
-    .subscribe((region) => {
+    this.selectedRegion$.pipe(take(1)).subscribe((region) => {
       this.regionRecord$ = region!;
     });
     this.restoreSession();
@@ -217,36 +214,33 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   }
 
   ngDoCheck(): void {
-    this.selectedRegion$
-    .pipe(take(1))
-    .subscribe((region) => {
+    this.selectedRegion$.pipe(take(1)).subscribe((region) => {
       if (this.regionRecord$ != region) {
         this.regionRecord$ = region!;
         this.sessionService.mapConfigs$
-        .pipe(take(1))
-        .subscribe((mapConfigs:  Record<Region, MapConfig[]> | null) => {
-          if (mapConfigs && region) {
-            var regionMaps = mapConfigs[region];
-            if (regionMaps) {
-              regionMaps.forEach((mapConfig, index) => {
-                this.maps[index].config = mapConfig;
-                this.boundaryConfig$
-                .pipe(filter((config) => !!config))
-                .subscribe((config) => {
-                // Ensure the radio button corresponding to the saved selection is selected.
-                  const boundaryConfig = config?.find(
-                  (boundary) =>
-                    boundary.boundary_name ===
-                    mapConfig.boundaryLayerConfig.boundary_name
-                  );
-                  this.maps[index].config.boundaryLayerConfig = boundaryConfig
-                  ? boundaryConfig
-                  : NONE_BOUNDARY_CONFIG;
+          .pipe(take(1))
+          .subscribe((mapConfigs: Record<Region, MapConfig[]> | null) => {
+            if (mapConfigs && region) {
+              var regionMaps = mapConfigs[region];
+              if (regionMaps) {
+                regionMaps.forEach((mapConfig, index) => {
+                  this.maps[index].config = mapConfig;
+                  this.boundaryConfig$
+                    .pipe(filter((config) => !!config))
+                    .subscribe((config) => {
+                      // Ensure the radio button corresponding to the saved selection is selected.
+                      const boundaryConfig = config?.find(
+                        (boundary) =>
+                          boundary.boundary_name ===
+                          mapConfig.boundaryLayerConfig.boundary_name
+                      );
+                      this.maps[index].config.boundaryLayerConfig =
+                        boundaryConfig ? boundaryConfig : NONE_BOUNDARY_CONFIG;
+                    });
                 });
-              });
+              }
             }
-          }
-        });
+          });
         this.maps.forEach((map: Map) => {
           this.initMap(map, map.id);
         });
@@ -280,19 +274,19 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
       });
     this.sessionService.mapConfigs$
       .pipe(take(1))
-      .subscribe((mapConfigs:  Record<Region, MapConfig[]> | null) => {
+      .subscribe((mapConfigs: Record<Region, MapConfig[]> | null) => {
         this.selectedRegion$
-        .pipe(take(1))
-        .subscribe((region: Region | null) => {
-        if (mapConfigs && region) {
-          var regionMaps = mapConfigs[region]
-          if(regionMaps){
-          regionMaps.forEach((mapConfig, index) => {
-            this.maps[index].config = mapConfig;
+          .pipe(take(1))
+          .subscribe((region: Region | null) => {
+            if (mapConfigs && region) {
+              var regionMaps = mapConfigs[region];
+              if (regionMaps) {
+                regionMaps.forEach((mapConfig, index) => {
+                  this.maps[index].config = mapConfig;
+                });
+              }
+            }
           });
-        }
-        }
-        });
         this.boundaryConfig$
           .pipe(filter((config) => !!config))
           .subscribe((config) => {
@@ -309,7 +303,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
             });
           });
       });
-      this.cdr.detectChanges();
+    this.cdr.detectChanges();
   }
 
   /** Initializes the map with controls and the layer options specified in its config. */
@@ -400,9 +394,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     return component.location.nativeElement;
   }
 
-  private getBoundaryLayerVector(
-    vectorName: string
-  ): Observable<L.Layer> {
+  private getBoundaryLayerVector(vectorName: string): Observable<L.Layer> {
     return this.mapService.getBoundaryShapes(vectorName);
   }
 
@@ -415,12 +407,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
       return;
     }
 
-    const openedDialog = this.dialog.open(
-      PlanCreateDialogComponent,
-      {
-        maxWidth: '560px'
-      }
-    );
+    const openedDialog = this.dialog.open(PlanCreateDialogComponent, {
+      maxWidth: '560px',
+    });
 
     openedDialog.afterClosed().subscribe((result) => {
       if (result) {
@@ -430,12 +419,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   }
 
   private openSignInDialog() {
-    this.dialog.open(
-      SignInDialogComponent,
-      {
-        maxWidth: '560px'
-      }
-    );
+    this.dialog.open(SignInDialogComponent, {
+      maxWidth: '560px',
+    });
   }
 
   private createPlan(name: string, shape: GeoJSON.GeoJSON) {
@@ -561,8 +547,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     });
   }
 
-  /** Gets the selected region geojson and renders it on the map. 
-   * Currently unused. 
+  /** Gets the selected region geojson and renders it on the map.
+   * Currently unused.
    * */
   private displayRegionBoundary(map: Map, selectedRegion: Region | null) {
     if (!selectedRegion) return;
@@ -616,7 +602,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
       map.legend = undefined;
       return;
     }
-
   }
 
   /** Change the opacity of the currently shown data layer on all maps (if any). */
@@ -625,25 +610,22 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     this.maps.forEach((map: Map) => {
       map.config.dataLayerConfig.opacity = opacity;
       this.mapManager.changeOpacity(map);
-    })
+    });
   }
 
   /** Return the selected map's data layer opacity. */
   getOpacityForSelectedMap(): Observable<number | undefined> {
     var dataLayerConfigOpacityDefined = true;
-    this.selectedMap$
-    .pipe(take(1))
-    .subscribe((selectedMap: any) => {
-      if(selectedMap?.config.dataLayerConfig.opacity == null){
+    this.selectedMap$.pipe(take(1)).subscribe((selectedMap: any) => {
+      if (selectedMap?.config.dataLayerConfig.opacity == null) {
         dataLayerConfigOpacityDefined = false;
       }
-    })
-    if(dataLayerConfigOpacityDefined){
-    return this.selectedMap$.pipe(
-      map((selectedMap) => selectedMap?.config.dataLayerConfig.opacity)
-    );
-    }
-    else{
+    });
+    if (dataLayerConfigOpacityDefined) {
+      return this.selectedMap$.pipe(
+        map((selectedMap) => selectedMap?.config.dataLayerConfig.opacity)
+      );
+    } else {
       return of(this.mapManager.defaultOpacity);
     }
   }

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
@@ -4,23 +4,14 @@
     <mat-icon>info</mat-icon>
     <span>Boundaries cannot be modified after the plan is saved.</span>
   </div>
-    <mat-form-field>
-      <mat-label>Name</mat-label>
-      <input matInput [formControl]="planNameControl">
-    </mat-form-field>
+  <mat-form-field>
+    <mat-label>Name</mat-label>
+    <input matInput [formControl]="planNameControl" />
+  </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button
-    mat-button
-    color="primary"
-    (click)="cancel()">
-    CANCEL
-  </button>
-  <button
-    mat-button
-    type="submit"
-    color="primary"
-    (click)="submit()">
+  <button mat-button color="primary" (click)="cancel()">CANCEL</button>
+  <button mat-button type="submit" color="primary" (click)="submit()">
     SAVE
   </button>
 </mat-dialog-actions>

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
@@ -10,15 +10,10 @@ describe('PlanCreateDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PlanCreateDialogComponent ],
-      providers: [
-        { provide: MatDialogRef, useValue: {} },
-      ],
-      schemas: [
-        NO_ERRORS_SCHEMA,
-      ],
-    })
-    .compileComponents();
+      declarations: [PlanCreateDialogComponent],
+      providers: [{ provide: MatDialogRef, useValue: {} }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PlanCreateDialogComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-plan-create-dialog',
   templateUrl: './plan-create-dialog.component.html',
-  styleUrls: ['./plan-create-dialog.component.scss']
+  styleUrls: ['./plan-create-dialog.component.scss'],
 })
 export class PlanCreateDialogComponent {
   planNameControl = new FormControl('', Validators.required);

--- a/src/interface/src/app/map/project-card/project-card.component.html
+++ b/src/interface/src/app/map/project-card/project-card.component.html
@@ -16,9 +16,8 @@
       <p>Treatments here:</p>
       <ul>
         <li *ngFor="let treatment of project.treatments">
-          <b>{{ treatment.TREATMENT_NAME }}</b> ({{
-            treatment.ACTIVITY_STATUS
-          }}): {{ treatment.TREATMENT_OBJECTIVE }}
+          <b>{{ treatment.TREATMENT_NAME }}</b>
+          ({{ treatment.ACTIVITY_STATUS }}): {{ treatment.TREATMENT_OBJECTIVE }}
         </li>
       </ul>
     </mat-card-content>

--- a/src/interface/src/app/map/project-card/project-card.component.html
+++ b/src/interface/src/app/map/project-card/project-card.component.html
@@ -3,7 +3,9 @@
     <mat-card-title-group>
       <mat-card-title>{{ project.PROJECT_NAME }}</mat-card-title>
       <mat-card-subtitle>
-        Project ({{ project.PROJECT_STATUS }}) &#8226; {{ project.PROJECT_START_DATE | date }} - {{ project.PROJECT_END_DATE | date }}
+        Project ({{ project.PROJECT_STATUS }}) &#8226;
+        {{ project.PROJECT_START_DATE | date }} -
+        {{ project.PROJECT_END_DATE | date }}
       </mat-card-subtitle>
     </mat-card-title-group>
     <mat-card-content>
@@ -14,7 +16,9 @@
       <p>Treatments here:</p>
       <ul>
         <li *ngFor="let treatment of project.treatments">
-          <b>{{ treatment.TREATMENT_NAME }}</b> ({{ treatment.ACTIVITY_STATUS }}): {{ treatment.TREATMENT_OBJECTIVE }}
+          <b>{{ treatment.TREATMENT_NAME }}</b> ({{
+            treatment.ACTIVITY_STATUS
+          }}): {{ treatment.TREATMENT_OBJECTIVE }}
         </li>
       </ul>
     </mat-card-content>

--- a/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.html
+++ b/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.html
@@ -1,9 +1,7 @@
 <h1 mat-dialog-title>Sign in or create an account to continue</h1>
 
 <div mat-dialog-content>
-  <p>
-    You must be signed in to save plans and collaborate with others.
-  </p>
+  <p>You must be signed in to save plans and collaborate with others.</p>
 </div>
 
 <div mat-dialog-actions align="end">

--- a/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.spec.ts
+++ b/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.spec.ts
@@ -9,12 +9,9 @@ describe('SignInCardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SignInDialogComponent ],
-      providers: [
-        { provide: MatDialogRef, useValue: {} },
-      ],
-    })
-    .compileComponents();
+      declarations: [SignInDialogComponent],
+      providers: [{ provide: MatDialogRef, useValue: {} }],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SignInDialogComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.ts
+++ b/src/interface/src/app/map/sign-in-dialog/sign-in-dialog.component.ts
@@ -4,8 +4,8 @@ import { MatDialogRef } from '@angular/material/dialog';
 @Component({
   selector: 'app-sign-in-dialog',
   templateUrl: './sign-in-dialog.component.html',
-  styleUrls: ['./sign-in-dialog.component.scss']
+  styleUrls: ['./sign-in-dialog.component.scss'],
 })
 export class SignInDialogComponent {
-  constructor(public dialogRef: MatDialogRef<SignInDialogComponent>) { }
+  constructor(public dialogRef: MatDialogRef<SignInDialogComponent>) {}
 }

--- a/src/interface/src/app/navigation/navigation.component.html
+++ b/src/interface/src/app/navigation/navigation.component.html
@@ -45,9 +45,9 @@
             routerLink="/login"
             class="save-nav-link"
             [ngClass]="{ selected: isSelected('/login') }">
-            <mat-icon class="material-symbols-outlined"
-              >account_circle</mat-icon
-            >
+            <mat-icon class="material-symbols-outlined">
+              account_circle
+            </mat-icon>
             <div class="nav-text">Sign In / Create Account</div>
           </a>
         </ng-template>

--- a/src/interface/src/app/navigation/navigation.component.html
+++ b/src/interface/src/app/navigation/navigation.component.html
@@ -1,36 +1,36 @@
 <mat-sidenav-container class="sidenav-container">
-  <mat-sidenav #drawer class="sidenav"
+  <mat-sidenav
+    #drawer
+    class="sidenav"
     [attr.role]="'navigation'"
     [mode]="'side'"
     [opened]="!sidebarOpen"
     [disableClose]>
     <mat-nav-list class="nav-list">
       <ng-container *ngFor="let link of sidenavLinks">
-
-        <a routerLink="{{link.href}}"
+        <a
+          routerLink="{{ link.href }}"
           class="nav-link"
-          [ngClass]="{'selected': isSelected(link.href)}">
-            <mat-icon class="material-symbols-outlined">
-              {{link.icon}}
-            </mat-icon>
-            <div class="nav-text">
-              {{link.text}}
-            </div>
-          </a>
-
+          [ngClass]="{ selected: isSelected(link.href) }">
+          <mat-icon class="material-symbols-outlined">
+            {{ link.icon }}
+          </mat-icon>
+          <div class="nav-text">
+            {{ link.text }}
+          </div>
+        </a>
       </ng-container>
-      <a 
-      routerLink="/feedback"
-      class="nav-link"
-      target="_blank" 
-      rel="noopener noreferrer">
+      <a
+        routerLink="/feedback"
+        class="nav-link"
+        target="_blank"
+        rel="noopener noreferrer">
         <mat-icon class="material-symbols-outlined">
-          {{"feedback"}}
+          {{ 'feedback' }}
         </mat-icon>
         <div class="nav-text">
-          {{"feedback"}}
+          {{ 'feedback' }}
         </div>
-        
       </a>
       <ng-container *featureFlag="'login'">
         <a
@@ -38,18 +38,17 @@
           class="save-nav-link"
           (click)="logout()">
           <mat-icon>logout</mat-icon>
-          <div class="nav-text">
-            Logout
-          </div>
+          <div class="nav-text">Logout</div>
         </a>
         <ng-template #showLogin>
-          <a routerLink="/login"
+          <a
+            routerLink="/login"
             class="save-nav-link"
-            [ngClass]="{'selected': isSelected('/login')}">
-            <mat-icon class="material-symbols-outlined">account_circle</mat-icon>
-            <div class="nav-text">
-              Sign In / Create Account
-            </div>
+            [ngClass]="{ selected: isSelected('/login') }">
+            <mat-icon class="material-symbols-outlined"
+              >account_circle</mat-icon
+            >
+            <div class="nav-text">Sign In / Create Account</div>
           </a>
         </ng-template>
       </ng-container>

--- a/src/interface/src/app/navigation/navigation.component.ts
+++ b/src/interface/src/app/navigation/navigation.component.ts
@@ -12,31 +12,31 @@ export interface SidenavLink {
 @Component({
   selector: 'app-navigation',
   templateUrl: './navigation.component.html',
-  styleUrls: ['./navigation.component.scss']
+  styleUrls: ['./navigation.component.scss'],
 })
 export class NavigationComponent implements OnInit, OnDestroy {
   @Input() sidebarOpen = false;
 
   sidenavLinks: SidenavLink[] = [
     {
-      text: "Home",
-      href: "/home",
-      icon: "home",
+      text: 'Home',
+      href: '/home',
+      icon: 'home',
     },
     {
-      text: "Explore",
-      href: "/map",
-      icon: "explore",
+      text: 'Explore',
+      href: '/map',
+      icon: 'explore',
     },
-  ]
+  ];
   isLoggedIn$: Observable<boolean> = this.authService.isLoggedIn$;
 
   private isLoggedInSubscription!: Subscription;
 
   constructor(
     private authService: AuthService,
-    private router: Router,
-    ) {}
+    private router: Router
+  ) {}
 
   ngOnInit() {
     this.isLoggedInSubscription = this.authService.isLoggedIn$.subscribe();

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -21,7 +21,7 @@
                 matInput
                 type="number" />
               <span matPrefix>$&nbsp;</span>
-              <span matSuffix> /acre</span>
+              <span matSuffix>/acre</span>
             </mat-form-field>
           </div>
           <div>
@@ -59,7 +59,7 @@
                 formControlName="maxSlope"
                 matInput
                 type="number" />
-              <span matSuffix> %</span>
+              <span matSuffix>%</span>
             </mat-form-field>
           </div>
           <div>
@@ -67,13 +67,13 @@
               class="input-field"
               appearance="outline"
               floatLabel="always">
-              <mat-label>Distance from roads </mat-label>
+              <mat-label>Distance from roads</mat-label>
               <input
                 class="right-align"
                 formControlName="maxRoadDistance"
                 matInput
                 type="number" />
-              <span matSuffix> yds</span>
+              <span matSuffix>yds</span>
             </mat-form-field>
           </div>
         </div>
@@ -86,9 +86,9 @@
             <mat-button-toggle
               *ngFor="let item of standSizeOptions"
               [value]="item"
-              checked
-              >{{ item }}</mat-button-toggle
-            >
+              checked>
+              {{ item }}
+            </mat-button-toggle>
           </mat-button-toggle-group>
         </div>
       </div>
@@ -104,9 +104,9 @@
               [color]="'primary'"
               *ngFor="let item of excludedAreasOptions"
               [formControlName]="item"
-              [value]="item"
-              >{{ item }}</mat-checkbox
-            >
+              [value]="item">
+              {{ item }}
+            </mat-checkbox>
           </div>
         </section>
       </div>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -10,17 +10,31 @@
         </div>
         <div class="flex-row">
           <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Treatment cost</mat-label>
-              <input class="right-align" formControlName="estimatedCost" matInput type="number">
+              <input
+                class="right-align"
+                formControlName="estimatedCost"
+                matInput
+                type="number" />
               <span matPrefix>$&nbsp;</span>
               <span matSuffix> /acre</span>
             </mat-form-field>
           </div>
           <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Max total cost</mat-label>
-              <input class="right-align" formControlName="maxCost" matInput type="number">
+              <input
+                class="right-align"
+                formControlName="maxCost"
+                matInput
+                type="number" />
               <span matPrefix>$&nbsp;</span>
             </mat-form-field>
           </div>
@@ -35,25 +49,46 @@
         </div>
         <div class="flex-row">
           <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Max slope</mat-label>
-              <input class="right-align" formControlName="maxSlope" matInput type="number">
+              <input
+                class="right-align"
+                formControlName="maxSlope"
+                matInput
+                type="number" />
               <span matSuffix> %</span>
             </mat-form-field>
           </div>
           <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Distance from roads </mat-label>
-              <input class="right-align" formControlName="maxRoadDistance" matInput type="number">
+              <input
+                class="right-align"
+                formControlName="maxRoadDistance"
+                matInput
+                type="number" />
               <span matSuffix> yds</span>
             </mat-form-field>
           </div>
         </div>
         <div class="button-wrapper">
           <div class="small-label">Stand Size</div>
-          <mat-button-toggle-group formControlName="standSize" name="standSize" aria-label="Stand Size">
-            <mat-button-toggle *ngFor="let item of standSizeOptions;" [value]="item"
-              checked>{{item}}</mat-button-toggle>
+          <mat-button-toggle-group
+            formControlName="standSize"
+            name="standSize"
+            aria-label="Stand Size">
+            <mat-button-toggle
+              *ngFor="let item of standSizeOptions"
+              [value]="item"
+              checked
+              >{{ item }}</mat-button-toggle
+            >
           </mat-button-toggle-group>
         </div>
       </div>
@@ -65,8 +100,13 @@
         </div>
         <section class="area-selection">
           <div class="checkbox-column">
-            <mat-checkbox [color]="'primary'" *ngFor="let item of excludedAreasOptions;" [formControlName]="item"
-              [value]="item">{{item}}</mat-checkbox>
+            <mat-checkbox
+              [color]="'primary'"
+              *ngFor="let item of excludedAreasOptions"
+              [formControlName]="item"
+              [value]="item"
+              >{{ item }}</mat-checkbox
+            >
           </div>
         </section>
       </div>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
@@ -37,8 +37,12 @@ describe('ConstraintsPanelComponent', () => {
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
 
-    var excludedAreasOptions = ["Private Land", "National Forests and Parks",
-      "Wilderness Area", "Tribal Lands"];
+    var excludedAreasOptions = [
+      'Private Land',
+      'National Forests and Parks',
+      'Wilderness Area',
+      'Tribal Lands',
+    ];
     var excludedAreasChosen: { [key: string]: (boolean | Validators)[] } = {};
     excludedAreasOptions.forEach((area: string) => {
       excludedAreasChosen[area] = [false, Validators.required];
@@ -106,7 +110,4 @@ describe('ConstraintsPanelComponent', () => {
 
   //   expect(component.formNextEvent.emit).toHaveBeenCalledTimes(0);
   // });
-
-
-
 });

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -9,5 +9,5 @@ import { FormGroup, Validators } from '@angular/forms';
 export class ConstraintsPanelComponent {
   @Input() constraintsForm: FormGroup | undefined;
   @Input() excludedAreasOptions: Array<string> | undefined;
-  standSizeOptions: Array<String> = ["Small", "Medium", "Large"];
+  standSizeOptions: Array<String> = ['Small', 'Medium', 'Large'];
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -1,40 +1,51 @@
-<div class="create-scenarios-panel mat-elevation-z2" [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
-  <div class="create-scenarios-panel-content" [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
-
+<div
+  class="create-scenarios-panel mat-elevation-z2"
+  [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
+  <div
+    class="create-scenarios-panel-content"
+    [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
     <mat-tab-group>
       <mat-tab label="Configuration">
         <div class="create-scenarios-inner-wrapper">
-          <app-set-priorities [plan$]="plan$" [formGroup]="formGroups[0]" [treatmentGoals$]="treatmentGoals | async"
+          <app-set-priorities
+            [plan$]="plan$"
+            [formGroup]="formGroups[0]"
+            [treatmentGoals$]="treatmentGoals | async"
             (changeConditionEvent)="changeCondition($event)">
           </app-set-priorities>
-          <app-identify-project-areas *ngIf="project_area_upload_enabled" [formGroup]="formGroups[2]">
+          <app-identify-project-areas
+            *ngIf="project_area_upload_enabled"
+            [formGroup]="formGroups[2]">
           </app-identify-project-areas>
-          <app-constraints-panel [constraintsForm]="formGroups[1]" [excludedAreasOptions]="excludedAreasOptions"> </app-constraints-panel>
+          <app-constraints-panel
+            [constraintsForm]="formGroups[1]"
+            [excludedAreasOptions]="excludedAreasOptions">
+          </app-constraints-panel>
           <div class="flex-row gap-12">
             <button
               mat-raised-button
               color="primary"
-              [disabled]="!formGroups[0].valid || !formGroups[1].valid || !formGroups[2].valid || generatingScenario"
+              [disabled]="
+                !formGroups[0].valid ||
+                !formGroups[1].valid ||
+                !formGroups[2].valid ||
+                generatingScenario
+              "
               (click)="createScenario()">
               {{ generatingScenario ? 'GENERATING SCENARIO...' : 'GENERATE' }}
             </button>
-            <div *ngIf="project_area_upload_enabled" >
-              Estimated time ?????? 
-            </div>
+            <div *ngIf="project_area_upload_enabled">Estimated time ??????</div>
           </div>
         </div>
       </mat-tab>
-      <mat-tab label="Outcome">
-        Scenario Results
-      </mat-tab>
+      <mat-tab label="Outcome"> Scenario Results </mat-tab>
     </mat-tab-group>
 
-
-
-
     <!-- Expand/collapse button -->
-    <div class="create-scenarios-panel-expand-button" [class.collapsed]="!panelExpanded"
-      [@expandCollapseButton]="panelExpanded ? 'colorA': 'colorB'">
+    <div
+      class="create-scenarios-panel-expand-button"
+      [class.collapsed]="!panelExpanded"
+      [@expandCollapseButton]="panelExpanded ? 'colorA' : 'colorB'">
       <button mat-icon-button (click)="togglePanelExpand()">
         <mat-icon>chevron_left</mat-icon>
       </button>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -11,16 +11,17 @@
             [plan$]="plan$"
             [formGroup]="formGroups[0]"
             [treatmentGoals$]="treatmentGoals | async"
-            (changeConditionEvent)="changeCondition($event)">
-          </app-set-priorities>
+            (changeConditionEvent)="
+              changeCondition($event)
+            "></app-set-priorities>
           <app-identify-project-areas
             *ngIf="project_area_upload_enabled"
-            [formGroup]="formGroups[2]">
-          </app-identify-project-areas>
+            [formGroup]="formGroups[2]"></app-identify-project-areas>
           <app-constraints-panel
             [constraintsForm]="formGroups[1]"
-            [excludedAreasOptions]="excludedAreasOptions">
-          </app-constraints-panel>
+            [excludedAreasOptions]="
+              excludedAreasOptions
+            "></app-constraints-panel>
           <div class="flex-row gap-12">
             <button
               mat-raised-button
@@ -38,7 +39,7 @@
           </div>
         </div>
       </mat-tab>
-      <mat-tab label="Outcome"> Scenario Results </mat-tab>
+      <mat-tab label="Outcome">Scenario Results</mat-tab>
     </mat-tab-group>
 
     <!-- Expand/collapse button -->

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -6,14 +6,18 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 import { PlanService, PlanState } from 'src/app/services';
-import { Region, TreatmentGoalConfig, TreatmentQuestionConfig } from 'src/app/types';
+import {
+  Region,
+  TreatmentGoalConfig,
+  TreatmentQuestionConfig,
+} from 'src/app/types';
 
 import { PlanModule } from '../plan.module';
 import { CreateScenariosComponent } from './create-scenarios.component';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 
-// TODO Update commented tests once all new configs are in 
+// TODO Update commented tests once all new configs are in
 
 describe('CreateScenariosComponent', () => {
   let component: CreateScenariosComponent;
@@ -22,10 +26,10 @@ describe('CreateScenariosComponent', () => {
   let fakeGeoJson: GeoJSON.GeoJSON;
   let loader: HarnessLoader;
   let defaultSelectedQuestion: TreatmentQuestionConfig = {
-    question_text: "",
+    question_text: '',
     priorities: [''],
-    weights: [0]
-  }
+    weights: [0],
+  };
 
   beforeEach(async () => {
     fakeGeoJson = {
@@ -63,21 +67,20 @@ describe('CreateScenariosComponent', () => {
           mapShapes: null,
           panelExpanded: true,
         }),
-        treatmentGoalsConfig$: new BehaviorSubject<TreatmentGoalConfig[] | null>([
+        treatmentGoalsConfig$: new BehaviorSubject<
+          TreatmentGoalConfig[] | null
+        >([
           {
-            category_name: "test_category",
-            questions: [{
-              question_text: "test_question",
-              priorities: [
-                "test_priority"
-              ],
-              weights: [
-                1
-              ]
-            }
-            ]
-          }
-        ])
+            category_name: 'test_category',
+            questions: [
+              {
+                question_text: 'test_question',
+                priorities: ['test_priority'],
+                weights: [1],
+              },
+            ],
+          },
+        ]),
       }
     );
 
@@ -101,18 +104,21 @@ describe('CreateScenariosComponent', () => {
     expect(fakePlanService.getProject).toHaveBeenCalledOnceWith(1);
 
     component.formGroups[1].valueChanges.subscribe((_) => {
-      expect(
-        component.formGroups[1].get('budgetForm.maxCost')?.value
-      ).toEqual(100);
+      expect(component.formGroups[1].get('budgetForm.maxCost')?.value).toEqual(
+        100
+      );
     });
   });
 
-
   it('should emit create scenario event', async () => {
     spyOn(component, 'createScenario');
-    component.formGroups[0].get('selectedQuestion')?.setValue(defaultSelectedQuestion);
+    component.formGroups[0]
+      .get('selectedQuestion')
+      ?.setValue(defaultSelectedQuestion);
     component.formGroups[1].get('physicalConstraintForm.maxSlope')?.setValue(1);
-    component.formGroups[1].get('physicalConstraintForm.maxRoadDistance')?.setValue(1);
+    component.formGroups[1]
+      .get('physicalConstraintForm.maxRoadDistance')
+      ?.setValue(1);
     fixture.detectChanges();
 
     const buttonHarness: MatButtonHarness = await loader.getHarness(
@@ -123,7 +129,6 @@ describe('CreateScenariosComponent', () => {
     await buttonHarness.click();
 
     expect(component.createScenario).toHaveBeenCalled();
-
   });
 
   it('should disable Generate button if form is invalid', async () => {
@@ -131,7 +136,9 @@ describe('CreateScenariosComponent', () => {
       MatButtonHarness.with({ text: /GENERATE/ })
     );
     component.formGroups[0].markAsDirty();
-    component.formGroups[1].get('physicalConstraintForm.maxRoadDistance')?.setValue(-1);
+    component.formGroups[1]
+      .get('physicalConstraintForm.maxRoadDistance')
+      ?.setValue(-1);
     fixture.detectChanges();
 
     // Click on "GENERATE SCENARIO" button
@@ -144,9 +151,13 @@ describe('CreateScenariosComponent', () => {
     const buttonHarness: MatButtonHarness = await loader.getHarness(
       MatButtonHarness.with({ text: /GENERATE/ })
     );
-    component.formGroups[0].get('selectedQuestion')?.setValue(defaultSelectedQuestion);
+    component.formGroups[0]
+      .get('selectedQuestion')
+      ?.setValue(defaultSelectedQuestion);
     component.formGroups[1].get('physicalConstraintForm.maxSlope')?.setValue(1);
-    component.formGroups[1].get('physicalConstraintForm.maxRoadDistance')?.setValue(1);
+    component.formGroups[1]
+      .get('physicalConstraintForm.maxRoadDistance')
+      ?.setValue(1);
     component.generatingScenario = false;
     fixture.detectChanges();
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,5 +1,11 @@
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
-import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -17,7 +23,7 @@ import {
   concatMap,
   of,
   throwError,
-  Observable
+  Observable,
 } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
 
@@ -27,8 +33,14 @@ import {
   expandCollapsePanelTrigger,
   opacityTransitionTrigger,
 } from 'src/app/shared/animations';
-import { Plan, ProjectArea, ProjectConfig, TreatmentGoalConfig, TreatmentQuestionConfig } from 'src/app/types';
-import features from '../../features/features.json'
+import {
+  Plan,
+  ProjectArea,
+  ProjectConfig,
+  TreatmentGoalConfig,
+  TreatmentQuestionConfig,
+} from 'src/app/types';
+import features from '../../features/features.json';
 
 interface StepState {
   complete?: boolean;
@@ -67,12 +79,16 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
   panelExpanded: boolean = true;
   treatmentGoals: Observable<TreatmentGoalConfig[] | null>;
   defaultSelectedQuestion: TreatmentQuestionConfig = {
-    question_text: "",
+    question_text: '',
     priorities: [''],
-    weights: [0]
-  }
-  excludedAreasOptions: Array<string> = ["Private Land", "National Forests and Parks",
-    "Wilderness Area", "Tribal Lands"];
+    weights: [0],
+  };
+  excludedAreasOptions: Array<string> = [
+    'Private Land',
+    'National Forests and Parks',
+    'Wilderness Area',
+    'Tribal Lands',
+  ];
 
   private readonly destroy$ = new Subject<void>();
   project_area_upload_enabled = features.upload_project_area;
@@ -108,13 +124,17 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
           }),
           physicalConstraintForm: this.fb.group({
             // Maximum slope allowed for planning area
-            maxSlope: ['', 
-              [Validators.min(0), Validators.max(100), Validators.required]],
+            maxSlope: [
+              '',
+              [Validators.min(0), Validators.max(100), Validators.required],
+            ],
             // Minimum distance from road allowed for planning area
-            // TODO update variable name to minDistanceFromRoad 
-            maxRoadDistance: ['', Validators.compose(
-              [Validators.min(0), Validators.required])],
-            // Stand Size selection 
+            // TODO update variable name to minDistanceFromRoad
+            maxRoadDistance: [
+              '',
+              Validators.compose([Validators.min(0), Validators.required]),
+            ],
+            // Stand Size selection
             // TODO validate to make sure standSize is only 'Small', 'Medium', or 'Large'
             standSize: ['Large', Validators.required],
           }),
@@ -175,8 +195,10 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     // TODO Add maxArea input and make required, this extra validator may be deprecated
     // const estimatedCost = constraintsForm.get('budgetForm.estimatedCost');
     // const maxArea = constraintsForm.get('treatmentForm.maxArea');
-     const maxSlope = constraintsForm.get('physicalConstraintForm.maxSlope');
-     const maxDistance = constraintsForm.get('physicalConstraintForm.maxRoadDistance');
+    const maxSlope = constraintsForm.get('physicalConstraintForm.maxSlope');
+    const maxDistance = constraintsForm.get(
+      'physicalConstraintForm.maxRoadDistance'
+    );
     const valid = !!maxSlope?.value || !!maxDistance?.value;
     return valid ? null : { budgetOrAreaRequired: true };
   }
@@ -206,18 +228,20 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
         excludeSlope?.setValue(config.max_slope);
       }
       // Check if scenario config priorities and weights match those of a question.
-      // If so, assume this was the selected treatment question. 
+      // If so, assume this was the selected treatment question.
       this.treatmentGoals.subscribe((goals) => {
         goals!.forEach((goal) => {
           goal.questions.forEach((question) => {
-            if ((question['priorities']?.toString() == config.priorities?.toString()) &&
-              question['weights']?.toString() == config.weights?.toString()) {
+            if (
+              question['priorities']?.toString() ==
+                config.priorities?.toString() &&
+              question['weights']?.toString() == config.weights?.toString()
+            ) {
               selectedQuestion?.setValue(question);
             }
-          })
-        })
+          });
+        });
       });
-
     });
   }
 
@@ -225,7 +249,9 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     const estimatedCost = this.formGroups[1].get('budgetForm.estimatedCost');
     const maxCost = this.formGroups[1].get('budgetForm.maxCost');
     const maxArea = this.formGroups[1].get('treatmentForm.maxArea');
-    const maxRoadDistance = this.formGroups[1].get('physicalConstraintForm.maxRoadDistance');
+    const maxRoadDistance = this.formGroups[1].get(
+      'physicalConstraintForm.maxRoadDistance'
+    );
     const maxSlope = this.formGroups[1].get('physicalConstraintForm.maxSlope');
     const selectedQuestion = this.formGroups[0].get('selectedQuestion');
 
@@ -240,8 +266,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       projectConfig.max_treatment_area_ratio = parseFloat(maxArea.value);
     if (maxRoadDistance?.valid)
       projectConfig.max_road_distance = parseFloat(maxRoadDistance.value);
-    if (maxSlope?.valid)
-      projectConfig.max_slope = parseFloat(maxSlope.value);
+    if (maxSlope?.valid) projectConfig.max_slope = parseFloat(maxSlope.value);
     if (selectedQuestion?.valid) {
       projectConfig.priorities = selectedQuestion.value['priorities'];
       projectConfig.weights = selectedQuestion!.value['weights'];
@@ -278,27 +303,27 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     //       );
     //     }),
 
-        // TODO Implement more specific error catching (currently raises shapefile error message for any thrown error)
-        // catchError(() => {
-        //   this.matSnackBar.open(
-        //     '[Error] Project area shapefile should only include polygons or multipolygons',
-        //     'Dismiss',
-        //     {
-        //       duration: 10000,
-        //       panelClass: ['snackbar-error'],
-        //       verticalPosition: 'top',
-        //     }
-        //   );
-        //   return throwError(
-        //     () => new Error('Problem creating uploaded project areas')
-        //   );
-        // })
-      // )
-      // .subscribe(() => {
-      //   // Navigate to scenario confirmation page
-      //   const planId = this.plan$.getValue()?.id;
-      //   this.router.navigate(['scenario-confirmation', planId]);
-      // });
+    // TODO Implement more specific error catching (currently raises shapefile error message for any thrown error)
+    // catchError(() => {
+    //   this.matSnackBar.open(
+    //     '[Error] Project area shapefile should only include polygons or multipolygons',
+    //     'Dismiss',
+    //     {
+    //       duration: 10000,
+    //       panelClass: ['snackbar-error'],
+    //       verticalPosition: 'top',
+    //     }
+    //   );
+    //   return throwError(
+    //     () => new Error('Problem creating uploaded project areas')
+    //   );
+    // })
+    // )
+    // .subscribe(() => {
+    //   // Navigate to scenario confirmation page
+    //   const planId = this.plan$.getValue()?.id;
+    //   this.router.navigate(['scenario-confirmation', planId]);
+    // });
   }
 
   createUploadedProjectAreas() {

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
@@ -1,33 +1,42 @@
 <div>
   <form [formGroup]="formGroup!" class="form">
     <div class="form-content">
-    
-    
-    <mat-radio-group formControlName="generateAreas" (change)="validateFormRequirements()" class="flex-column">
-      <div class="top-label">
-        <label class="form-label">PROJECT AREAS</label>
+      <mat-radio-group
+        formControlName="generateAreas"
+        (change)="validateFormRequirements()"
+        class="flex-column">
+        <div class="top-label">
+          <label class="form-label">PROJECT AREAS</label>
+        </div>
+        <mat-radio-button [color]="'primary'" [value]="true">
+          Define them for me
+        </mat-radio-button>
+        <mat-radio-button [color]="'primary'" [value]="false">
+          Upload exising areas
+          <button
+            mat-stroked-button
+            color="primary"
+            (click)="showUploader = true">
+            <mat-icon color="primary">upload</mat-icon>
+            UPLOAD SHAPE FILES
+          </button>
+        </mat-radio-button>
+      </mat-radio-group>
+
+      <!-- File uploader -->
+      <file-uploader
+        *ngIf="showUploader"
+        class="file-uploader"
+        requiredFileType="application/zip"
+        (fileEvent)="loadFile($event)"></file-uploader>
+
+      <mat-error *ngIf="showErrorText"
+        >[Error] Not a valid shapefile!</mat-error
+      >
+      <div class="success-text" *ngIf="showSuccessText">
+        <mat-icon class="success-icon">check_circle</mat-icon>
+        {{ filename }} uploaded
       </div>
-      <mat-radio-button [color]="'primary'" [value]="true">
-        Define them for me
-      </mat-radio-button>
-      <mat-radio-button [color]="'primary'" [value]="false">
-        Upload exising areas
-        <button mat-stroked-button color="primary" (click)="showUploader = true">
-          <mat-icon color="primary">upload</mat-icon>
-          UPLOAD SHAPE FILES
-        </button>
-      </mat-radio-button>
-    </mat-radio-group>
-
-    <!-- File uploader -->
-    <file-uploader *ngIf="showUploader" class="file-uploader" requiredFileType="application/zip"
-      (fileEvent)="loadFile($event)"></file-uploader>
-
-    <mat-error *ngIf="showErrorText">[Error] Not a valid shapefile!</mat-error>
-    <div class="success-text" *ngIf="showSuccessText">
-      <mat-icon class="success-icon">check_circle</mat-icon>
-      {{ filename }} uploaded
     </div>
-  </div>
   </form>
 </div>

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.html
@@ -30,9 +30,9 @@
         requiredFileType="application/zip"
         (fileEvent)="loadFile($event)"></file-uploader>
 
-      <mat-error *ngIf="showErrorText"
-        >[Error] Not a valid shapefile!</mat-error
-      >
+      <mat-error *ngIf="showErrorText">
+        [Error] Not a valid shapefile!
+      </mat-error>
       <div class="success-text" *ngIf="showSuccessText">
         <mat-icon class="success-icon">check_circle</mat-icon>
         {{ filename }} uploaded

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.spec.ts
@@ -53,9 +53,8 @@ describe('IdentifyProjectAreasComponent', () => {
   });
 
   it('should not require file upload when the "generate areas" button is selected', async () => {
-    const radioButtonGroup: MatRadioGroupHarness = await loader.getHarness(
-      MatRadioGroupHarness
-    );
+    const radioButtonGroup: MatRadioGroupHarness =
+      await loader.getHarness(MatRadioGroupHarness);
 
     // Select 'generate areas' button
     await (await radioButtonGroup.getRadioButtons())[0].check();
@@ -64,9 +63,8 @@ describe('IdentifyProjectAreasComponent', () => {
   });
 
   it('should require file upload when the "upload files" button is selected', async () => {
-    const radioButtonGroup: MatRadioGroupHarness = await loader.getHarness(
-      MatRadioGroupHarness
-    );
+    const radioButtonGroup: MatRadioGroupHarness =
+      await loader.getHarness(MatRadioGroupHarness);
 
     // Select 'upload file' button
     await (await radioButtonGroup.getRadioButtons())[1].check();

--- a/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/identify-project-areas/identify-project-areas.component.ts
@@ -6,9 +6,9 @@ import * as shp from 'shpjs';
 @Component({
   selector: 'app-identify-project-areas',
   templateUrl: './identify-project-areas.component.html',
-  styleUrls: ['./identify-project-areas.component.scss']
+  styleUrls: ['./identify-project-areas.component.scss'],
 })
-export class IdentifyProjectAreasComponent implements OnInit {
+export class IdentifyProjectAreasComponent {
   @Input() formGroup: FormGroup | undefined;
   @Output() formNextEvent = new EventEmitter<void>();
   @Output() formBackEvent = new EventEmitter<void>();
@@ -17,11 +17,6 @@ export class IdentifyProjectAreasComponent implements OnInit {
   showErrorText: boolean = false;
   showSuccessText: boolean = false;
   showUploader: boolean = false;
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
 
   /** Updates validators for the form based on radio button selection.
    *  If the "generate areas" radio button is selected, uploading an area isn't required.
@@ -69,5 +64,4 @@ export class IdentifyProjectAreasComponent implements OnInit {
       }
     }
   }
-
 }

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -1,18 +1,25 @@
 <div class="panel-container">
   <form [formGroup]="formGroup!">
     <div class="config-group">
-
-      <mat-radio-group name="treatmentGoalSelect" aria-label="Select an option" class="layer-radio-group" color="primary"
+      <mat-radio-group
+        name="treatmentGoalSelect"
+        aria-label="Select an option"
+        class="layer-radio-group"
+        color="primary"
         formControlName="selectedQuestion">
         <div class="goal-category">TREATMENT GOALS</div>
-        <div *ngFor="let treatmentGoal of treatmentGoals$" class="goal-control-container">
+        <div
+          *ngFor="let treatmentGoal of treatmentGoals$"
+          class="goal-control-container">
           <mat-expansion-panel expanded="true" [togglePosition]="'before'">
             <mat-expansion-panel-header class="goal-panel-header">
-              {{treatmentGoal['category_name']}}
+              {{ treatmentGoal['category_name'] }}
             </mat-expansion-panel-header>
-            <div *ngFor="let treatmentQuestion of treatmentGoal['questions']" class="layer-control-container">
+            <div
+              *ngFor="let treatmentQuestion of treatmentGoal['questions']"
+              class="layer-control-container">
               <mat-radio-button [value]="treatmentQuestion">
-                {{ treatmentQuestion.question_text}}
+                {{ treatmentQuestion.question_text }}
               </mat-radio-button>
             </div>
           </mat-expansion-panel>

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -12,7 +12,12 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject, of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
 import { SharedModule } from 'src/app/shared/shared.module';
-import { Plan, Region, TreatmentQuestionConfig, TreatmentGoalConfig } from 'src/app/types';
+import {
+  Plan,
+  Region,
+  TreatmentQuestionConfig,
+  TreatmentGoalConfig,
+} from 'src/app/types';
 
 import { MapService } from './../../../services/map.service';
 import { PlanService } from './../../../services/plan.service';
@@ -23,7 +28,7 @@ import {
   SetPrioritiesComponent,
 } from './set-priorities.component';
 
-// TODO Update commented tests once all new configs are in 
+// TODO Update commented tests once all new configs are in
 
 describe('SetPrioritiesComponent', () => {
   let component: SetPrioritiesComponent;
@@ -36,13 +41,13 @@ describe('SetPrioritiesComponent', () => {
   const defaultSelectedQuestion: TreatmentQuestionConfig = {
     question_text: '',
     priorities: [''],
-    weights: [0]
-  }
+    weights: [0],
+  };
   const testQuestion: TreatmentQuestionConfig = {
     question_text: 'test_question',
     priorities: ['test_priority'],
-    weights: [1]
-  }
+    weights: [1],
+  };
 
   const fakeColormapConfig: ColormapConfig = {
     name: 'fakecolormap',
@@ -106,17 +111,14 @@ describe('SetPrioritiesComponent', () => {
         }),
       },
       {
-        treatmentGoalsConfig$: new BehaviorSubject<TreatmentGoalConfig[] | null>(
-          [
-            {
-              category_name: 'test_category',
-              questions: [
-                testQuestion,
-              ]
-            }
-          ]
-        )
-
+        treatmentGoalsConfig$: new BehaviorSubject<
+          TreatmentGoalConfig[] | null
+        >([
+          {
+            category_name: 'test_category',
+            questions: [testQuestion],
+          },
+        ]),
       }
     );
     await TestBed.configureTestingModule({
@@ -152,11 +154,9 @@ describe('SetPrioritiesComponent', () => {
     component.treatmentGoals$ = [
       {
         category_name: 'test_category',
-        questions: [
-          testQuestion,
-        ]
-      }
-    ]
+        questions: [testQuestion],
+      },
+    ];
 
     fixture.detectChanges();
   });
@@ -232,11 +232,16 @@ describe('SetPrioritiesComponent', () => {
 
   it('selecting a priority should update the form value', async () => {
     const radioButtonGroup = await loader.getHarness(
-      MatRadioGroupHarness.with({ name: 'treatmentGoalSelect' }));
+      MatRadioGroupHarness.with({ name: 'treatmentGoalSelect' })
+    );
 
     // Act: select the test treatment question
-    await radioButtonGroup.checkRadioButton({ label: testQuestion['question_text'] });
+    await radioButtonGroup.checkRadioButton({
+      label: testQuestion['question_text'],
+    });
 
-    expect(component.formGroup?.get('selectedQuestion')?.value).toEqual(testQuestion);
+    expect(component.formGroup?.get('selectedQuestion')?.value).toEqual(
+      testQuestion
+    );
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -9,7 +9,11 @@ import { Plan } from 'src/app/types';
 import { MapService } from './../../../services/map.service';
 import { PlanService } from './../../../services/plan.service';
 import { ConditionsConfig } from './../../../types/data.types';
-import { PlanConditionScores, TreatmentQuestionConfig, TreatmentGoalConfig } from './../../../types/plan.types';
+import {
+  PlanConditionScores,
+  TreatmentQuestionConfig,
+  TreatmentGoalConfig,
+} from './../../../types/plan.types';
 
 export interface ScoreColumn {
   label: string;
@@ -104,17 +108,17 @@ export class SetPrioritiesComponent implements OnInit {
             element.metrics
               ?.filter((metric) => !!metric.filepath)
               .forEach((metric) => {
-              let metricRow: PriorityRow = {
-                conditionName: metric.metric_name!,
-                displayName: metric.display_name,
-                filepath: metric.filepath!.concat('_normalized'),
-                children: [],
-                level: 2,
-                hidden: true,
-              };
-              data.push(metricRow);
-              elementRow.children.push(metricRow);
-            });
+                let metricRow: PriorityRow = {
+                  conditionName: metric.metric_name!,
+                  displayName: metric.display_name,
+                  filepath: metric.filepath!.concat('_normalized'),
+                  children: [],
+                  level: 2,
+                  hidden: true,
+                };
+                data.push(metricRow);
+                elementRow.children.push(metricRow);
+              });
           });
       });
     return data;

--- a/src/interface/src/app/plan/plan-map/plan-map.component.html
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.html
@@ -1,8 +1,8 @@
-<div id="{{mapId ? mapId : 'map'}}" class="plan-map"></div>
+<div id="{{ mapId ? mapId : 'map' }}" class="plan-map"></div>
 <button
   mat-raised-button
   class="expand-panel-button"
   *ngIf="showTogglePanelButton() | async"
   (click)="togglePanel()">
-  {{panelExpanded ? 'COLLAPSE PANEL' : 'EXPAND PANEL'}}
+  {{ panelExpanded ? 'COLLAPSE PANEL' : 'EXPAND PANEL' }}
 </button>

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -17,7 +17,12 @@ import {
 import { SessionService } from 'src/app/services';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { PlanService } from 'src/app/services';
-import { FrontendConstants, regionMapCenters, Plan, Region } from 'src/app/types';
+import {
+  FrontendConstants,
+  regionMapCenters,
+  Plan,
+  Region,
+} from 'src/app/types';
 
 import { BackendConstants } from './../../backend-constants';
 
@@ -48,7 +53,11 @@ export class PlanMapComponent implements OnInit, AfterViewInit, OnDestroy {
   private layer: string = '';
   private shapes: any | null = null;
 
-  constructor(private planService: PlanService, private session: SessionService, private router: Router) {
+  constructor(
+    private planService: PlanService,
+    private session: SessionService,
+    private router: Router
+  ) {
     this.selectedRegion$ = this.session.region$;
   }
 

--- a/src/interface/src/app/plan/plan-navigation-bar/plan-navigation-bar.component.spec.ts
+++ b/src/interface/src/app/plan/plan-navigation-bar/plan-navigation-bar.component.spec.ts
@@ -9,10 +9,9 @@ describe('BottomBarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ MaterialModule ],
-      declarations: [ PlanNavigationBarComponent ]
-    })
-    .compileComponents();
+      imports: [MaterialModule],
+      declarations: [PlanNavigationBarComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PlanNavigationBarComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
@@ -5,17 +5,22 @@
     <h1>{{ (plan$ | async)?.name }}</h1>
     <div class="plan-scenario-panel-content">
       <p class="plan-scenario-panel-text">
-        Your planning area, priorities, and constraints are used to generate scenarios.
-        Using the Scenario Explorer, you can adjust the relative importance of priorities.
-        Saved scenarios are added to the Comparison table. Scenarios consist of Project Areas,
-        Treatment plans, Potential Outcomes, and Estimated costs.
+        Your planning area, priorities, and constraints are used to generate
+        scenarios. Using the Scenario Explorer, you can adjust the relative
+        importance of priorities. Saved scenarios are added to the Comparison
+        table. Scenarios consist of Project Areas, Treatment plans, Potential
+        Outcomes, and Estimated costs.
       </p>
       <button mat-raised-button color="primary" (click)="openConfig()">
         <mat-icon class="material-symbols-outlined">add_box</mat-icon>
         NEW CONFIGURATION
       </button>
     </div>
-    <app-scenario-configurations [plan]="plan$ | async" (openConfigEvent)="openConfig($event)"></app-scenario-configurations>
-    <app-saved-scenarios [plan]="plan$ | async" (createScenarioEvent)="openConfig()"></app-saved-scenarios>
+    <app-scenario-configurations
+      [plan]="plan$ | async"
+      (openConfigEvent)="openConfig($event)"></app-scenario-configurations>
+    <app-saved-scenarios
+      [plan]="plan$ | async"
+      (createScenarioEvent)="openConfig()"></app-saved-scenarios>
   </div>
 </div>

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -7,13 +7,13 @@
     <mat-card-content>
       <p>{{ text1 }}</p>
 
-      <mat-table [dataSource]="scenarios" >
+      <mat-table [dataSource]="scenarios">
         <!-- ID Column -->
         <ng-container matColumnDef="id">
           <mat-header-cell *matHeaderCellDef> Scenario </mat-header-cell>
           <mat-cell *matCellDef="let element">
             <div class="hover-indicator"></div>
-            {{element.id}}
+            {{ element.id }}
             <mat-checkbox
               class="scenario-checkbox"
               [(ngModel)]="element.selected"
@@ -25,15 +25,21 @@
         <ng-container matColumnDef="starred">
           <mat-header-cell *matHeaderCellDef> Starred by you </mat-header-cell>
           <mat-cell *matCellDef="let element">
-            <button mat-icon-button (click)="$event.stopPropagation(); toggleFavorited(element)">
-              <mat-icon [class.material-symbols-outlined]="!element.favorited">star</mat-icon>
+            <button
+              mat-icon-button
+              (click)="$event.stopPropagation(); toggleFavorited(element)">
+              <mat-icon [class.material-symbols-outlined]="!element.favorited"
+                >star</mat-icon
+              >
             </button>
           </mat-cell>
         </ng-container>
 
         <!-- Project Areas Column -->
         <ng-container matColumnDef="projectAreas">
-          <mat-header-cell *matHeaderCellDef> Number of Project Areas </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>
+            Number of Project Areas
+          </mat-header-cell>
           <mat-cell *matCellDef="let element"></mat-cell>
         </ng-container>
 
@@ -45,7 +51,9 @@
 
         <!-- Estimated Cost Column -->
         <ng-container matColumnDef="estimatedCost">
-          <mat-header-cell *matHeaderCellDef> Estimated cost range </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>
+            Estimated cost range
+          </mat-header-cell>
           <mat-cell *matCellDef="let element"></mat-cell>
         </ng-container>
 
@@ -58,29 +66,38 @@
         <!-- Owner Column -->
         <ng-container matColumnDef="owner">
           <mat-header-cell *matHeaderCellDef> Owner </mat-header-cell>
-          <mat-cell *matCellDef="let element"> {{element.owner}} </mat-cell>
+          <mat-cell *matCellDef="let element"> {{ element.owner }} </mat-cell>
         </ng-container>
 
         <!-- Timestamp Column -->
         <ng-container matColumnDef="createdTimestamp">
           <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
-          <mat-cell *matCellDef="let element"> {{element.createdTimestamp | date:'medium' }} </mat-cell>
+          <mat-cell *matCellDef="let element">
+            {{ element.createdTimestamp | date: 'medium' }}
+          </mat-cell>
         </ng-container>
 
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
         <mat-row
           class="scenario-row"
-          *matRowDef="let row; columns: displayedColumns;"
+          *matRowDef="let row; columns: displayedColumns"
           (click)="viewScenario(row.id)"></mat-row>
       </mat-table>
     </mat-card-content>
 
     <mat-card-actions align="end">
-      <button mat-button [disabled]="!showDeleteButton()" (click)="deleteSelectedScenarios()">
+      <button
+        mat-button
+        [disabled]="!showDeleteButton()"
+        (click)="deleteSelectedScenarios()">
         <mat-icon>delete</mat-icon>
         DELETE
       </button>
-      <button mat-raised-button [disabled]="!showViewButton()" color="primary" (click)="viewScenario()">
+      <button
+        mat-raised-button
+        [disabled]="!showViewButton()"
+        color="primary"
+        (click)="viewScenario()">
         VIEW
       </button>
     </mat-card-actions>

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -10,7 +10,7 @@
       <mat-table [dataSource]="scenarios">
         <!-- ID Column -->
         <ng-container matColumnDef="id">
-          <mat-header-cell *matHeaderCellDef> Scenario </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>Scenario</mat-header-cell>
           <mat-cell *matCellDef="let element">
             <div class="hover-indicator"></div>
             {{ element.id }}
@@ -23,14 +23,14 @@
 
         <!-- Starred Column -->
         <ng-container matColumnDef="starred">
-          <mat-header-cell *matHeaderCellDef> Starred by you </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>Starred by you</mat-header-cell>
           <mat-cell *matCellDef="let element">
             <button
               mat-icon-button
               (click)="$event.stopPropagation(); toggleFavorited(element)">
-              <mat-icon [class.material-symbols-outlined]="!element.favorited"
-                >star</mat-icon
-              >
+              <mat-icon [class.material-symbols-outlined]="!element.favorited">
+                star
+              </mat-icon>
             </button>
           </mat-cell>
         </ng-container>
@@ -45,7 +45,7 @@
 
         <!-- Acres Treated Column -->
         <ng-container matColumnDef="acresTreated">
-          <mat-header-cell *matHeaderCellDef> Acres treated </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>Acres treated</mat-header-cell>
           <mat-cell *matCellDef="let element"></mat-cell>
         </ng-container>
 
@@ -59,19 +59,19 @@
 
         <!-- Status Column -->
         <ng-container matColumnDef="status">
-          <mat-header-cell *matHeaderCellDef> Status </mat-header-cell>
-          <mat-cell *matCellDef="let element"> In Progress </mat-cell>
+          <mat-header-cell *matHeaderCellDef>Status</mat-header-cell>
+          <mat-cell *matCellDef="let element">In Progress</mat-cell>
         </ng-container>
 
         <!-- Owner Column -->
         <ng-container matColumnDef="owner">
-          <mat-header-cell *matHeaderCellDef> Owner </mat-header-cell>
-          <mat-cell *matCellDef="let element"> {{ element.owner }} </mat-cell>
+          <mat-header-cell *matHeaderCellDef>Owner</mat-header-cell>
+          <mat-cell *matCellDef="let element">{{ element.owner }}</mat-cell>
         </ng-container>
 
         <!-- Timestamp Column -->
         <ng-container matColumnDef="createdTimestamp">
-          <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>Date Created</mat-header-cell>
           <mat-cell *matCellDef="let element">
             {{ element.createdTimestamp | date: 'medium' }}
           </mat-cell>

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -47,7 +47,12 @@ describe('SavedScenariosComponent', () => {
     );
 
     await TestBed.configureTestingModule({
-      imports: [FormsModule, HttpClientTestingModule, MaterialModule, NoopAnimationsModule],
+      imports: [
+        FormsModule,
+        HttpClientTestingModule,
+        MaterialModule,
+        NoopAnimationsModule,
+      ],
       declarations: [SavedScenariosComponent],
       providers: [
         { provide: ActivatedRoute, useValue: fakeRoute },

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -98,7 +98,10 @@ export class SavedScenariosComponent implements OnInit {
     if (scenario.favorited) {
       this.planService.favoriteScenario(scenario.id).pipe(take(1)).subscribe();
     } else {
-      this.planService.unfavoriteScenario(scenario.id).pipe(take(1)).subscribe();
+      this.planService
+        .unfavoriteScenario(scenario.id)
+        .pipe(take(1))
+        .subscribe();
     }
   }
 }

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
@@ -1,13 +1,15 @@
 <div class="configurations-wrapper">
   <mat-card [style.margin-top]="'24px'">
     <mat-card-header>
-      <mat-card-title>My Configurations ({{ configurations.length }})</mat-card-title>
+      <mat-card-title
+        >My Configurations ({{ configurations.length }})</mat-card-title
+      >
     </mat-card-header>
 
     <mat-card-content>
       <p>{{ text1 }}</p>
 
-      <mat-table [dataSource]="configurations" >
+      <mat-table [dataSource]="configurations">
         <!-- Select Column -->
         <ng-container matColumnDef="select">
           <mat-header-cell *matHeaderCellDef>
@@ -15,29 +17,38 @@
           </mat-header-cell>
           <mat-cell *matCellDef="let element">
             <div class="hover-indicator"></div>
-            <mat-checkbox [(ngModel)]="element.selected" (click)="$event.stopPropagation()"></mat-checkbox>
+            <mat-checkbox
+              [(ngModel)]="element.selected"
+              (click)="$event.stopPropagation()"></mat-checkbox>
           </mat-cell>
         </ng-container>
 
         <!-- Timestamp Column -->
         <ng-container matColumnDef="createdTimestamp">
           <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
-          <mat-cell *matCellDef="let element"> {{element.createdTimestamp | date:'medium' }} </mat-cell>
+          <mat-cell *matCellDef="let element">
+            {{ element.createdTimestamp | date: 'medium' }}
+          </mat-cell>
         </ng-container>
 
         <!-- Score Type Column -->
         <ng-container matColumnDef="scoreType">
-          <mat-header-cell *matHeaderCellDef> Calculating Score </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>
+            Calculating Score
+          </mat-header-cell>
           <mat-cell *matCellDef="let element"> Condition Score </mat-cell>
         </ng-container>
 
         <!-- Priorities Column -->
         <ng-container matColumnDef="priorities">
-          <mat-header-cell *matHeaderCellDef> Selected Priorities </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>
+            Selected Priorities
+          </mat-header-cell>
           <mat-cell *matCellDef="let element">
             <div>
-              <div *ngFor="let priority of displayPriorities(element.priorities)">
-                {{priority}}
+              <div
+                *ngFor="let priority of displayPriorities(element.priorities)">
+                {{ priority }}
               </div>
             </div>
           </mat-cell>
@@ -45,20 +56,22 @@
 
         <!-- Constraints Column -->
         <ng-container matColumnDef="constraints">
-          <mat-header-cell *matHeaderCellDef> Selected Constraints </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>
+            Selected Constraints
+          </mat-header-cell>
           <mat-cell *matCellDef="let element">
             <div>
               <div *ngIf="element.max_budget">
-                Max budget: ${{element.max_budget}}
+                Max budget: ${{ element.max_budget }}
               </div>
               <div *ngIf="element.max_treatment_area_ratio">
-                Max treatment area: {{element.max_treatment_area_ratio}}%
+                Max treatment area: {{ element.max_treatment_area_ratio }}%
               </div>
               <div *ngIf="element.max_slope">
-                Exclude slope > {{element.max_slope}} degrees
+                Exclude slope > {{ element.max_slope }} degrees
               </div>
               <div *ngIf="element.max_road_distance">
-                Exclude areas off road by {{element.max_road_distance}} ft.
+                Exclude areas off road by {{ element.max_road_distance }} ft.
               </div>
             </div>
           </mat-cell>
@@ -66,7 +79,7 @@
 
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
         <mat-row
-          *matRowDef="let row; columns: displayedColumns;"
+          *matRowDef="let row; columns: displayedColumns"
           class="config-row"
           (click)="openConfig(row)"></mat-row>
       </mat-table>
@@ -76,18 +89,28 @@
     </mat-card-content>
 
     <mat-card-actions align="end">
-      <button mat-button [disabled]="!showDeleteButton()" (click)="deleteSelectedConfigs()">
+      <button
+        mat-button
+        [disabled]="!showDeleteButton()"
+        (click)="deleteSelectedConfigs()">
         <mat-icon>delete</mat-icon>
         DELETE
       </button>
-      <button mat-raised-button [disabled]="!showContinueButton()" color="primary" (click)="openConfig()">
+      <button
+        mat-raised-button
+        [disabled]="!showContinueButton()"
+        color="primary"
+        (click)="openConfig()">
         CONTINUE PLANNING
       </button>
     </mat-card-actions>
   </mat-card>
 
   <div *ngIf="configurations.length === 0" class="no-configs-overlay">
-    <p>Configurations use priorities & constraints to identify and rank project areas for treatment.</p>
+    <p>
+      Configurations use priorities & constraints to identify and rank project
+      areas for treatment.
+    </p>
     <button mat-raised-button color="primary" (click)="openConfig()">
       <mat-icon class="material-symbols-outlined">add_box</mat-icon>
       NEW CONFIGURATION

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.html
@@ -1,9 +1,9 @@
 <div class="configurations-wrapper">
   <mat-card [style.margin-top]="'24px'">
     <mat-card-header>
-      <mat-card-title
-        >My Configurations ({{ configurations.length }})</mat-card-title
-      >
+      <mat-card-title>
+        My Configurations ({{ configurations.length }})
+      </mat-card-title>
     </mat-card-header>
 
     <mat-card-content>
@@ -25,7 +25,7 @@
 
         <!-- Timestamp Column -->
         <ng-container matColumnDef="createdTimestamp">
-          <mat-header-cell *matHeaderCellDef> Date Created </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef>Date Created</mat-header-cell>
           <mat-cell *matCellDef="let element">
             {{ element.createdTimestamp | date: 'medium' }}
           </mat-cell>
@@ -33,10 +33,8 @@
 
         <!-- Score Type Column -->
         <ng-container matColumnDef="scoreType">
-          <mat-header-cell *matHeaderCellDef>
-            Calculating Score
-          </mat-header-cell>
-          <mat-cell *matCellDef="let element"> Condition Score </mat-cell>
+          <mat-header-cell *matHeaderCellDef>Calculating Score</mat-header-cell>
+          <mat-cell *matCellDef="let element">Condition Score</mat-cell>
         </ng-container>
 
         <!-- Priorities Column -->

--- a/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.html
+++ b/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.html
@@ -21,7 +21,7 @@
     <div class="summary-info">
       <div>Region: {{ summaryInput?.region }}</div>
       <div>Creator: {{ summaryInput?.owner }}</div>
-      <div>Created: {{ summaryInput?.createdTime | date:'MM/dd/yyyy' }}</div>
+      <div>Created: {{ summaryInput?.createdTime | date: 'MM/dd/yyyy' }}</div>
       <div>Last activity: Unavailable</div>
     </div>
   </div>

--- a/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.html
+++ b/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.html
@@ -9,7 +9,7 @@
         <span class="grid-subtitle">acres</span>
       </div>
       <div class="grid-item">
-        <span class="grid-title"> {{ summaryInput?.configs }} </span>
+        <span class="grid-title">{{ summaryInput?.configs }}</span>
         <span class="grid-subtitle">configs</span>
       </div>
       <div class="grid-item">

--- a/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.spec.ts
@@ -8,9 +8,8 @@ describe('SummaryPanelComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SummaryPanelComponent ]
-    })
-    .compileComponents();
+      declarations: [SummaryPanelComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SummaryPanelComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.ts
+++ b/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.ts
@@ -33,14 +33,14 @@ export const conditionScoreColorMap: Record<ConditionName, string> = {
   [ConditionName.NEUTRAL]: '#b1354c',
   [ConditionName.LEANING_POOR]: '#F4511e',
   [ConditionName.POOR]: '#fdd853',
-}
+};
 
 const SQUARE_METERS_PER_ACRE = 0.0002471054;
 
 @Component({
   selector: 'summary-panel',
   templateUrl: './summary-panel.component.html',
-  styleUrls: ['./summary-panel.component.scss']
+  styleUrls: ['./summary-panel.component.scss'],
 })
 export class SummaryPanelComponent implements OnChanges {
   @Input() plan: Plan | null = null;
@@ -52,21 +52,23 @@ export class SummaryPanelComponent implements OnChanges {
   conditionScoreColorMap = conditionScoreColorMap;
 
   ngOnChanges(): void {
-      if (!!this.plan) {
-        this.summaryInput = {
-          id: this.plan.id,
-          type: 'Plan',
-          name: this.plan.name,
-          owner: this.owner?.firstName ? this.owner?.firstName + ' ' + this.owner?.lastName : (this.owner?.username ?? 'Guest'),
-          region: this.plan.region,
-          area: this.plan.planningArea!,
-          createdTime: this.plan.createdTimestamp,
-          scenarios: this.plan.savedScenarios,
-          configs: this.plan.configs,
-          acres: this.calculateAcres(this.plan.planningArea!),
-          status: 'In progress',
-        }
-      }
+    if (!!this.plan) {
+      this.summaryInput = {
+        id: this.plan.id,
+        type: 'Plan',
+        name: this.plan.name,
+        owner: this.owner?.firstName
+          ? this.owner?.firstName + ' ' + this.owner?.lastName
+          : this.owner?.username ?? 'Guest',
+        region: this.plan.region,
+        area: this.plan.planningArea!,
+        createdTime: this.plan.createdTimestamp,
+        scenarios: this.plan.savedScenarios,
+        configs: this.plan.configs,
+        acres: this.calculateAcres(this.plan.planningArea!),
+        status: 'In progress',
+      };
+    }
   }
 
   calculateAcres(planningArea: GeoJSON.GeoJSON) {

--- a/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.html
+++ b/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.html
@@ -1,4 +1,7 @@
 <div class="root-container">
   <h1>Plan not found</h1>
-  <p>Sorry! Either the plan you're trying to access doesn't exist, or you don't have permission to see it.</p>
+  <p>
+    Sorry! Either the plan you're trying to access doesn't exist, or you don't
+    have permission to see it.
+  </p>
 </div>

--- a/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.spec.ts
+++ b/src/interface/src/app/plan/plan-unavailable/plan-unavailable.component.spec.ts
@@ -8,9 +8,8 @@ describe('PlanUnavailableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PlanUnavailableComponent ]
-    })
-    .compileComponents();
+      declarations: [PlanUnavailableComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PlanUnavailableComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -2,18 +2,25 @@
   <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
   <ng-container *ngIf="!planNotFound && plan">
     <div class="plan-summary-panel" *ngIf="showOverview$ | async">
-      <summary-panel [plan]="currentPlan$ | async" [owner]="planOwner$ | async"></summary-panel>
+      <summary-panel
+        [plan]="currentPlan$ | async"
+        [owner]="planOwner$ | async"></summary-panel>
     </div>
     <mat-divider [vertical]="true" *ngIf="showOverview$ | async"></mat-divider>
     <div class="plan-content">
-      <app-plan-navigation-bar (backToOverviewEvent)="backToOverview()" *ngIf="!(showOverview$ | async)"></app-plan-navigation-bar>
+      <app-plan-navigation-bar
+        (backToOverviewEvent)="backToOverview()"
+        *ngIf="!(showOverview$ | async)"></app-plan-navigation-bar>
       <div class="plan-content-inner">
         <app-plan-overview
           [plan$]="currentPlan$"
           *ngIf="showOverview$ | async"></app-plan-overview>
         <ng-container *ngIf="!(showOverview$ | async)">
           <div class="plan-map-container">
-            <app-plan-map [plan]="currentPlan$" [mapId]="'planning-map'" [mapPadding]="[700, 0]"></app-plan-map>
+            <app-plan-map
+              [plan]="currentPlan$"
+              [mapId]="'planning-map'"
+              [mapPadding]="[700, 0]"></app-plan-map>
           </div>
           <div class="plan-content-panel">
             <router-outlet #outlet="outlet"></router-outlet>

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -26,7 +26,7 @@ import { AuthService, PlanService } from '../services';
 export class PlanComponent implements OnInit, OnDestroy {
   plan: Plan | undefined;
   currentPlan$ = new BehaviorSubject<Plan | null>(null);
-  planOwner$ = new Observable<User | null>;
+  planOwner$ = new Observable<User | null>();
   planNotFound: boolean = false;
   showOverview$ = new BehaviorSubject<boolean>(false);
 

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatButtonToggleModule} from '@angular/material/button-toggle';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from 'src/app/material/material.module';
 import { RouterModule } from '@angular/router';

--- a/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.html
+++ b/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.html
@@ -3,7 +3,9 @@
 
   <h1>Planscape is generating your scenario.</h1>
 
-  <h1>Check "My Scenarios" on the Area Overview page to see it after it's done.</h1>
+  <h1>
+    Check "My Scenarios" on the Area Overview page to see it after it's done.
+  </h1>
 
   <h3>You can continue creating new configurations or explore the map.</h3>
 

--- a/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.ts
+++ b/src/interface/src/app/plan/scenario-confirmation/scenario-confirmation.component.ts
@@ -7,7 +7,10 @@ import { ActivatedRoute, Router } from '@angular/router';
   styleUrls: ['./scenario-confirmation.component.scss'],
 })
 export class ScenarioConfirmationComponent {
-  constructor(private route: ActivatedRoute, private router: Router) {}
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
 
   navigateToAreaOverview(): void {
     const planId = this.route.snapshot.paramMap.get('id');

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.html
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.html
@@ -1,28 +1,33 @@
 <mat-table [dataSource]="datasource" class="priority-table">
   <ng-container matColumnDef="displayName">
-    <mat-header-cell *matHeaderCellDef>
-      Priorities
-    </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef> Priorities </mat-header-cell>
     <mat-cell *matCellDef="let element" class="level-{{ element.level }}">
       <span class="indent-level-{{ element.level }}"></span>
-      <button mat-icon-button *ngIf="element.children.length" class="expand-button"
+      <button
+        mat-icon-button
+        *ngIf="element.children.length"
+        class="expand-button"
         (click)="toggleExpand(element)">
-        <mat-icon>{{ element.expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+        <mat-icon>{{
+          element.expanded ? 'expand_less' : 'expand_more'
+        }}</mat-icon>
       </button>
       {{ element.displayName ? element.displayName : element.conditionName }}
     </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="score">
-    <mat-header-cell *matHeaderCellDef>
-      Condition score
-    </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef> Condition score </mat-header-cell>
     <mat-cell *matCellDef="let element">
-      <mat-spinner [diameter]="24" *ngIf="!conditionScores.has(element.conditionName)"></mat-spinner>
+      <mat-spinner
+        [diameter]="24"
+        *ngIf="!conditionScores.has(element.conditionName)"></mat-spinner>
       <ng-container *ngIf="conditionScores.has(element.conditionName)">
         <div>
           <div>{{ getScoreLabel(element.conditionName) }}</div>
-          <div class="score">{{  getScore(element.conditionName) | number: '1.1-1' }}</div>
+          <div class="score">
+            {{ getScore(element.conditionName) | number: '1.1-1' }}
+          </div>
         </div>
       </ng-container>
     </mat-cell>
@@ -32,7 +37,9 @@
     <mat-header-cell *matHeaderCellDef></mat-header-cell>
     <mat-cell *matCellDef="let element">
       <button mat-icon-button>
-        <mat-icon class="material-symbols-outlined" (click)="toggleVisibility(element)"
+        <mat-icon
+          class="material-symbols-outlined"
+          (click)="toggleVisibility(element)"
           [class.grey-icon]="!element.visible">
           {{ element.visible ? 'image' : 'hide_image' }}
         </mat-icon>
@@ -41,5 +48,7 @@
   </ng-container>
 
   <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-  <mat-row *matRowDef="let row; columns: displayedColumns;" [class.hide-row]="row.hidden"></mat-row>
+  <mat-row
+    *matRowDef="let row; columns: displayedColumns"
+    [class.hide-row]="row.hidden"></mat-row>
 </mat-table>

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.html
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.html
@@ -1,6 +1,6 @@
 <mat-table [dataSource]="datasource" class="priority-table">
   <ng-container matColumnDef="displayName">
-    <mat-header-cell *matHeaderCellDef> Priorities </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef>Priorities</mat-header-cell>
     <mat-cell *matCellDef="let element" class="level-{{ element.level }}">
       <span class="indent-level-{{ element.level }}"></span>
       <button
@@ -8,16 +8,16 @@
         *ngIf="element.children.length"
         class="expand-button"
         (click)="toggleExpand(element)">
-        <mat-icon>{{
-          element.expanded ? 'expand_less' : 'expand_more'
-        }}</mat-icon>
+        <mat-icon>
+          {{ element.expanded ? 'expand_less' : 'expand_more' }}
+        </mat-icon>
       </button>
       {{ element.displayName ? element.displayName : element.conditionName }}
     </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="score">
-    <mat-header-cell *matHeaderCellDef> Condition score </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef>Condition score</mat-header-cell>
     <mat-cell *matCellDef="let element">
       <mat-spinner
         [diameter]="24"

--- a/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/map-layers/map-layers.component.spec.ts
@@ -32,7 +32,7 @@ describe('MapLayersComponent', () => {
               display: true,
               elements: [
                 {
-		  display: true,
+                  display: true,
                   element_name: 'test_element_1',
                   filepath: 'test_element_1',
                   metrics: [
@@ -50,7 +50,7 @@ describe('MapLayersComponent', () => {
     );
 
     fakePlanService = jasmine.createSpyObj('PlanService', {
-      getConditionScoresForPlanningArea: of({conditions: []}),
+      getConditionScoresForPlanningArea: of({ conditions: [] }),
     });
 
     await TestBed.configureTestingModule({
@@ -60,7 +60,7 @@ describe('MapLayersComponent', () => {
         MaterialModule,
         SharedModule,
       ],
-      declarations: [ MapLayersComponent ],
+      declarations: [MapLayersComponent],
       providers: [
         {
           provide: MapService,
@@ -68,8 +68,7 @@ describe('MapLayersComponent', () => {
         },
         { provide: PlanService, useValue: fakePlanService },
       ],
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(MapLayersComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
@@ -17,12 +17,13 @@
         <ul>
           <li>
             Show estimated cost range based on estimated treatment costs per
-            acre (Est. max: <b>${{ scenario?.config?.max_budget }}</b
-            >)
+            acre (Est. max:
+            <b>${{ scenario?.config?.max_budget }}</b>
+            )
           </li>
           <li>
-            <b>{{ scenario?.config?.max_treatment_area_ratio }}%</b> max
-            treatment percentage of total planning area
+            <b>{{ scenario?.config?.max_treatment_area_ratio }}%</b>
+            max treatment percentage of total planning area
           </li>
           <li>
             Exclude areas off a road by
@@ -79,16 +80,16 @@
             <h3>Est. cost range</h3>
           </div>
           <div class="flex-row space-between reduced-height-row">
-            <span
-              >{{ scenario?.projectAreas?.length || '0' }} project areas</span
-            >
+            <span>
+              {{ scenario?.projectAreas?.length || '0' }} project areas
+            </span>
             <span>{{ totalAcresTreated }} ac</span>
-            <span
-              >{{
+            <span>
+              {{
                 (totalAcresTreated / totalPlanningAreaAcres) * 100
                   | number: '1.0-5'
-              }}%</span
-            >
+              }}%
+            </span>
             <span>{{ totalCostRange }}</span>
           </div>
         </div>
@@ -133,8 +134,7 @@
           class="notes-text"
           formControlName="notes"
           cols="64"
-          rows="10">
-        </textarea>
+          rows="10"></textarea>
         <button class="notes-button" type="submit">SEND</button>
       </div>
     </form>

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.html
@@ -1,8 +1,8 @@
 <!-- Plan Info -->
 <div class="plan-info">
   <span>Creator: {{ displayName }}</span>
-  <br>
-  <span>Created: {{ scenario?.createdTimestamp | date:'MM/dd/yyyy'}}</span>
+  <br />
+  <span>Created: {{ scenario?.createdTimestamp | date: 'MM/dd/yyyy' }}</span>
 </div>
 
 <div class="outcome-content">
@@ -15,11 +15,23 @@
       <div class="constraints">
         <h3>Constraints</h3>
         <ul>
-          <li>Show estimated cost range based on estimated treatment costs per acre
-            (Est. max: <b>${{ scenario?.config?.max_budget }}</b>)</li>
-          <li><b>{{ scenario?.config?.max_treatment_area_ratio }}%</b> max treatment percentage of total planning area</li>
-          <li>Exclude areas off a road by <b>{{ scenario?.config?.max_road_distance}} ft.</b></li>
-          <li>Include areas that are over {{ scenario?.config?.max_slope }} degrees</li>
+          <li>
+            Show estimated cost range based on estimated treatment costs per
+            acre (Est. max: <b>${{ scenario?.config?.max_budget }}</b
+            >)
+          </li>
+          <li>
+            <b>{{ scenario?.config?.max_treatment_area_ratio }}%</b> max
+            treatment percentage of total planning area
+          </li>
+          <li>
+            Exclude areas off a road by
+            <b>{{ scenario?.config?.max_road_distance }} ft.</b>
+          </li>
+          <li>
+            Include areas that are over
+            {{ scenario?.config?.max_slope }} degrees
+          </li>
         </ul>
       </div>
 
@@ -32,13 +44,18 @@
           </div>
           <ng-container *ngFor="let priority of scenario?.priorities || []">
             <div class="flex-row space-between">
-              <h2>{{ priority.name | titlecase  }}</h2>
+              <h2>{{ priority.name | titlecase }}</h2>
               <div class="flex-row">
-                <mat-slider [disabled]=true [min]="0" [max]="5" [thumbLabel]="true" [value]="priority.weight"
+                <mat-slider
+                  [disabled]="true"
+                  [min]="0"
+                  [max]="5"
+                  [thumbLabel]="true"
+                  [value]="priority.weight"
                   color="primary">
-                  <input matSliderThumb>
+                  <input matSliderThumb />
                 </mat-slider>
-                <div class="slider-label">{{priority.weight}}</div>
+                <div class="slider-label">{{ priority.weight }}</div>
               </div>
             </div>
             <mat-divider></mat-divider>
@@ -62,9 +79,16 @@
             <h3>Est. cost range</h3>
           </div>
           <div class="flex-row space-between reduced-height-row">
-            <span>{{ scenario?.projectAreas?.length || '0' }} project areas</span>
+            <span
+              >{{ scenario?.projectAreas?.length || '0' }} project areas</span
+            >
             <span>{{ totalAcresTreated }} ac</span>
-            <span>{{ (totalAcresTreated / totalPlanningAreaAcres) * 100 | number: '1.0-5' }}%</span>
+            <span
+              >{{
+                (totalAcresTreated / totalPlanningAreaAcres) * 100
+                  | number: '1.0-5'
+              }}%</span
+            >
             <span>{{ totalCostRange }}</span>
           </div>
         </div>
@@ -73,7 +97,9 @@
         <div>
           <div *ngFor="let projectArea of scenario?.projectAreas; index as i">
             <div class="project-area-card">
-              <div class="flex-row"><h1>Area {{ i+1 }}</h1></div>
+              <div class="flex-row">
+                <h1>Area {{ i + 1 }}</h1>
+              </div>
               <div class="area-info-wrapper">
                 <div class="flex-row space-between darker-h1">
                   <span>{{ projectArea.actualAcresTreated }}</span>
@@ -94,7 +120,7 @@
             </div>
           </div>
         </div>
-    </div>
+      </div>
     </mat-expansion-panel>
   </mat-accordion>
 
@@ -114,4 +140,3 @@
     </form>
   </div>
 </div>
-

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
@@ -48,7 +48,9 @@ export class OutcomeComponent implements OnInit, OnChanges {
     this.authService.loggedInUser$.pipe(take(1)).subscribe((user) => {
       if (user) {
         this.currentUser$.next(user);
-        this.displayName = user.firstName ? user.firstName : (user.username ?? '');
+        this.displayName = user.firstName
+          ? user.firstName
+          : user.username ?? '';
       } else {
         this.displayName = 'Guest';
       }

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.html
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.html
@@ -1,25 +1,38 @@
-<div class="scenario-details-panel mat-elevation-z2"
+<div
+  class="scenario-details-panel mat-elevation-z2"
   [@expandCollapsePanel]="panelExpanded ? 'expanded' : 'collapsed'">
-  <div class="scenario-details-panel-content"
+  <div
+    class="scenario-details-panel-content"
     [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
-    <span class="scenario-details-header">Scenario {{ (scenario$ | async)?.id }} Details</span>
+    <span class="scenario-details-header"
+      >Scenario {{ (scenario$ | async)?.id }} Details</span
+    >
     <mat-divider></mat-divider>
 
     <div>
       <mat-tab-group>
-        <mat-tab class="scenario-tab" label="OUTCOME"><app-outcome [scenario]="scenario$ | async" [plan]="plan$ | async"></app-outcome></mat-tab>
+        <mat-tab class="scenario-tab" label="OUTCOME"
+          ><app-outcome
+            [scenario]="scenario$ | async"
+            [plan]="plan$ | async"></app-outcome
+        ></mat-tab>
         <mat-tab class="scenario-tab" label="MAP LAYERS">
-          <app-map-layers [plan]="plan$ | async" (changeConditionEvent)="changeCondition($event)"></app-map-layers>
+          <app-map-layers
+            [plan]="plan$ | async"
+            (changeConditionEvent)="changeCondition($event)"></app-map-layers>
         </mat-tab>
         <mat-tab class="scenario-tab" label="INFO"> Info </mat-tab>
       </mat-tab-group>
     </div>
 
     <!-- Expand/collapse button -->
-    <div class="scenario-details-panel-expand-button" [class.collapsed]="!panelExpanded"
-      [@expandCollapseButton]="panelExpanded ? 'colorA': 'colorB'">
-    <button mat-icon-button (click)="togglePanelExpand()">
-      <mat-icon>chevron_left</mat-icon>
-    </button>
+    <div
+      class="scenario-details-panel-expand-button"
+      [class.collapsed]="!panelExpanded"
+      [@expandCollapseButton]="panelExpanded ? 'colorA' : 'colorB'">
+      <button mat-icon-button (click)="togglePanelExpand()">
+        <mat-icon>chevron_left</mat-icon>
+      </button>
+    </div>
   </div>
 </div>

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.html
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.html
@@ -4,24 +4,24 @@
   <div
     class="scenario-details-panel-content"
     [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
-    <span class="scenario-details-header"
-      >Scenario {{ (scenario$ | async)?.id }} Details</span
-    >
+    <span class="scenario-details-header">
+      Scenario {{ (scenario$ | async)?.id }} Details
+    </span>
     <mat-divider></mat-divider>
 
     <div>
       <mat-tab-group>
-        <mat-tab class="scenario-tab" label="OUTCOME"
-          ><app-outcome
+        <mat-tab class="scenario-tab" label="OUTCOME">
+          <app-outcome
             [scenario]="scenario$ | async"
-            [plan]="plan$ | async"></app-outcome
-        ></mat-tab>
+            [plan]="plan$ | async"></app-outcome>
+        </mat-tab>
         <mat-tab class="scenario-tab" label="MAP LAYERS">
           <app-map-layers
             [plan]="plan$ | async"
             (changeConditionEvent)="changeCondition($event)"></app-map-layers>
         </mat-tab>
-        <mat-tab class="scenario-tab" label="INFO"> Info </mat-tab>
+        <mat-tab class="scenario-tab" label="INFO">Info</mat-tab>
       </mat-tab-group>
     </div>
 

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.spec.ts
@@ -36,16 +36,18 @@ describe('ScenarioDetailsComponent', () => {
         id: 1,
         max_budget: 200,
       },
-      projectAreas: [{
-        id: '1',
-        projectId: '1',
-        projectArea: new L.Polygon([
-          new L.LatLng(38.715517043571914, -120.42857302225725),
-          new L.LatLng(38.47079787227401, -120.5164425608172),
-          new L.LatLng(38.52668443555346, -120.11828371421737),
-        ]).toGeoJSON(),
-        estimatedAreaTreated: 5000,
-      }],
+      projectAreas: [
+        {
+          id: '1',
+          projectId: '1',
+          projectArea: new L.Polygon([
+            new L.LatLng(38.715517043571914, -120.42857302225725),
+            new L.LatLng(38.47079787227401, -120.5164425608172),
+            new L.LatLng(38.52668443555346, -120.11828371421737),
+          ]).toGeoJSON(),
+          estimatedAreaTreated: 5000,
+        },
+      ],
     };
     fakeService = jasmine.createSpyObj('PlanService', {
       getScenario: of(fakeScenario),
@@ -88,5 +90,5 @@ describe('ScenarioDetailsComponent', () => {
 
   it('should draw project areas on the map', () => {
     expect(fakeService.updateStateWithShapes).toHaveBeenCalled();
-  })
+  });
 });

--- a/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
+++ b/src/interface/src/app/plan/scenario-details/scenario-details.component.ts
@@ -57,16 +57,18 @@ export class ScenarioDetailsComponent implements OnInit {
     this.scenario$ = this.getScenario();
     this.plan$ = this.getPlan();
 
-    this.scenario$.pipe(
-      map((scenario) => {
-        return scenario?.projectAreas;
-      }),
-      take(1)
-    ).subscribe((projectAreas) => {
-      if (projectAreas) {
-        this.drawProjectAreas(projectAreas);
-      }
-    });
+    this.scenario$
+      .pipe(
+        map((scenario) => {
+          return scenario?.projectAreas;
+        }),
+        take(1)
+      )
+      .subscribe((projectAreas) => {
+        if (projectAreas) {
+          this.drawProjectAreas(projectAreas);
+        }
+      });
   }
 
   private getScenario() {
@@ -114,9 +116,9 @@ export class ScenarioDetailsComponent implements OnInit {
   }
 
   private drawProjectAreas(projectAreas: ProjectArea[]): void {
-    const areas: any[] = []
+    const areas: any[] = [];
     projectAreas.forEach((projectArea) => {
-      areas.push(projectArea.projectArea)
+      areas.push(projectArea.projectArea);
     });
     this.planService.updateStateWithShapes(areas);
   }

--- a/src/interface/src/app/redirect.guard.ts
+++ b/src/interface/src/app/redirect.guard.ts
@@ -1,19 +1,22 @@
 import { Injectable } from '@angular/core';
-import {CanActivate, ActivatedRouteSnapshot, Router, RouterStateSnapshot} from '@angular/router';
-
-
+import {
+  CanActivate,
+  ActivatedRouteSnapshot,
+  Router,
+  RouterStateSnapshot,
+} from '@angular/router';
 
 @Injectable({
-    providedIn: 'root'
+  providedIn: 'root',
 })
 export class RedirectGuard implements CanActivate {
-
   constructor(private router: Router) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-
-      window.location.href = route.data['externalUrl'];
-      return true;
-
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): boolean {
+    window.location.href = route.data['externalUrl'];
+    return true;
   }
 }

--- a/src/interface/src/app/region-dropdown/region-dropdown.component.html
+++ b/src/interface/src/app/region-dropdown/region-dropdown.component.html
@@ -1,11 +1,22 @@
 <!-- Region Dropdown -->
-<div [ngClass]="{ 'region-dropdown-wrapper': !newNavigation , 'region-wrapper': newNavigation}">
-  <select (change)="setRegion($event)" [ngClass]="{ 'region-dropdown': !newNavigation, 'region': newNavigation }">
-    <option [selected]="!(selectedRegion$ | async)" disabled>Select a region</option>
-    <option *ngFor="let region of regionOptions"
-            [value]="region.type"
-            [disabled]="!region.available"
-            [selected]="(selectedRegion$ | async) === region.type"
-            routerLink= "/map">{{ region.name }} </option>
+<div
+  [ngClass]="{
+    'region-dropdown-wrapper': !newNavigation,
+    'region-wrapper': newNavigation
+  }">
+  <select
+    (change)="setRegion($event)"
+    [ngClass]="{ 'region-dropdown': !newNavigation, region: newNavigation }">
+    <option [selected]="!(selectedRegion$ | async)" disabled>
+      Select a region
+    </option>
+    <option
+      *ngFor="let region of regionOptions"
+      [value]="region.type"
+      [disabled]="!region.available"
+      [selected]="(selectedRegion$ | async) === region.type"
+      routerLink="/map">
+      {{ region.name }}
+    </option>
   </select>
 </div>

--- a/src/interface/src/app/region-dropdown/region-dropdown.component.spec.ts
+++ b/src/interface/src/app/region-dropdown/region-dropdown.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RegionDropdownComponent } from './region-dropdown.component';
-import {By} from "@angular/platform-browser";
-import {AuthService, SessionService} from "../services";
-import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {MaterialModule} from "../material/material.module";
-import {BehaviorSubject} from "rxjs";
-import {Region, User} from "../types";
+import { By } from '@angular/platform-browser';
+import { AuthService, SessionService } from '../services';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MaterialModule } from '../material/material.module';
+import { BehaviorSubject } from 'rxjs';
+import { Region, User } from '../types';
 
 describe('RegionDropdownComponent', () => {
   let component: RegionDropdownComponent;
@@ -24,13 +24,12 @@ describe('RegionDropdownComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, MaterialModule],
-      declarations: [ RegionDropdownComponent ],
+      declarations: [RegionDropdownComponent],
       providers: [
         { provide: AuthService, useValue: mockAuthService },
         { provide: SessionService, useValue: mockSessionService },
       ],
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(RegionDropdownComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/region-dropdown/region-dropdown.component.ts
+++ b/src/interface/src/app/region-dropdown/region-dropdown.component.ts
@@ -1,16 +1,15 @@
 import { Component } from '@angular/core';
-import {Region, RegionOption, regionOptions} from "../types";
-import { MapService, SessionService } from "../services";
-import {Router} from "@angular/router";
-import {FeatureService} from "../features/feature.service";
+import { Region, RegionOption, regionOptions } from '../types';
+import { MapService, SessionService } from '../services';
+import { Router } from '@angular/router';
+import { FeatureService } from '../features/feature.service';
 
 @Component({
   selector: 'app-region-dropdown',
   templateUrl: './region-dropdown.component.html',
-  styleUrls: ['./region-dropdown.component.scss']
+  styleUrls: ['./region-dropdown.component.scss'],
 })
 export class RegionDropdownComponent {
-
   readonly regionOptions: RegionOption[] = regionOptions;
   readonly selectedRegion$ = this.sessionService.region$;
 
@@ -21,8 +20,7 @@ export class RegionDropdownComponent {
     private sessionService: SessionService,
     private mapService: MapService,
     private featureService: FeatureService
-  ) { }
-
+  ) {}
 
   /** Sets the region from the dropdown and goes to the map. */
   setRegion(event: Event) {

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -150,7 +150,7 @@ export class AuthService {
   getUser(userId: string): Observable<User> {
     const url = BackendConstants.END_POINT.concat(
       '/users/get_user_by_id/?id=',
-      userId,
+      userId
     );
     return this.http
       .get(url, {
@@ -229,7 +229,10 @@ export class AuthService {
  */
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private authService: AuthService, private router: Router) {}
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
 
   canActivate(): Observable<boolean> {
     return this.authService.refreshLoggedInUser().pipe(

--- a/src/interface/src/app/services/map.service.spec.ts
+++ b/src/interface/src/app/services/map.service.spec.ts
@@ -14,9 +14,9 @@ import {
   Region,
 } from '../types';
 import * as L from 'leaflet';
-import "leaflet.vectorgrid";
+import 'leaflet.vectorgrid';
 
-// TODO Make more robust for new boundary vector tile 
+// TODO Make more robust for new boundary vector tile
 describe('MapService', () => {
   let httpTestingController: HttpTestingController;
   let service: MapService;
@@ -39,22 +39,28 @@ describe('MapService', () => {
       type: 'FeatureCollection',
       features: [],
     };
-    fakeVector = of(L.vectorGrid.protobuf(
-      "https://dev-geo.planscape.org/geoserver/gwc/service/tms/1.0.0/sierra-nevada:vector_huc12@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf",
-      {vectorTileLayerStyles: {
-        vector_huc12: { // To set style value for every layer name (which is the value after '<region>:' in vectorName)
-          weight: 1,
-          fillOpacity: 0,
-          color: '#0000ff',
-          fill: true,
+    fakeVector = of(
+      L.vectorGrid.protobuf(
+        'https://dev-geo.planscape.org/geoserver/gwc/service/tms/1.0.0/sierra-nevada:vector_huc12@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf',
+        {
+          vectorTileLayerStyles: {
+            vector_huc12: {
+              // To set style value for every layer name (which is the value after '<region>:' in vectorName)
+              weight: 1,
+              fillOpacity: 0,
+              color: '#0000ff',
+              fill: true,
+            },
+          },
+          interactive: true,
+          zIndex: 1000, // To ensure boundary is loaded in on top of any other layers
+          getFeatureId: function (f: any) {
+            return f.properties.OBJECTID; // Every boundary feature must have a unique value OBJECTID in order to for hover info to properly work
+          },
+          maxZoom: 13,
         }
-      },
-        interactive: true,
-        zIndex: 1000, // To ensure boundary is loaded in on top of any other layers
-        getFeatureId: function(f:any) {
-          return f.properties.OBJECTID; // Every boundary feature must have a unique value OBJECTID in order to for hover info to properly work
-        },
-        maxZoom: 13, }));
+      )
+    );
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [MapService],
@@ -65,7 +71,8 @@ describe('MapService', () => {
     // Must flush the requests in the constructor for httpTestingController.verify()
     // to pass in other tests.
     const req1 = httpTestingController.expectOne(
-      BackendConstants.END_POINT + '/boundary/config/?region_name=sierra_cascade_inyo'
+      BackendConstants.END_POINT +
+        '/boundary/config/?region_name=sierra_cascade_inyo'
     );
     req1.flush(conditionsConfig);
     const req2 = httpTestingController.expectOne(
@@ -94,10 +101,10 @@ describe('MapService', () => {
       //   })
       //   });
       service
-        .getBoundaryShapes("sierra-nevada:vector_huc12")
-        .subscribe((res) => { 
+        .getBoundaryShapes('sierra-nevada:vector_huc12')
+        .subscribe((res) => {
           expect(res).toBeTruthy();
-        })
+        });
 
       // const req = httpTestingController.expectOne(
       //   'assets/geojson/sierra_cascade_inyo/huc12.geojson'

--- a/src/interface/src/app/services/map.service.ts
+++ b/src/interface/src/app/services/map.service.ts
@@ -1,8 +1,17 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import * as L from 'leaflet';
-import "leaflet.vectorgrid";
-import { BehaviorSubject, Subject, EMPTY, map, Observable, take, takeUntil, of } from 'rxjs';
+import 'leaflet.vectorgrid';
+import {
+  BehaviorSubject,
+  Subject,
+  EMPTY,
+  map,
+  Observable,
+  take,
+  takeUntil,
+  of,
+} from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
 import { SessionService } from '../services';
@@ -13,7 +22,7 @@ import {
   Region,
 } from '../types';
 
-import features from '../features/features.json'
+import features from '../features/features.json';
 
 /** A map of Region to static assets for that region. */
 const regionToGeojsonMap: Record<Region, Record<string, string>> = {
@@ -21,14 +30,14 @@ const regionToGeojsonMap: Record<Region, Record<string, string>> = {
     boundary: 'assets/geojson/sierra_nevada_region.geojson',
   },
   [Region.CENTRAL_COAST]: {
-    boundary: 'assets/geojson/central_california_region.geojson'
+    boundary: 'assets/geojson/central_california_region.geojson',
   },
   [Region.NORTHERN_CALIFORNIA]: {
-    boundary: 'assets/geojson/northern_california_region.geojson'
+    boundary: 'assets/geojson/northern_california_region.geojson',
   },
   [Region.SOUTHERN_CALIFORNIA]: {
-    boundary: 'assets/geojson/southern_california_region.geojson'
-  }
+    boundary: 'assets/geojson/southern_california_region.geojson',
+  },
 };
 
 @Injectable({
@@ -39,15 +48,22 @@ export class MapService {
   readonly conditionsConfig$ = new BehaviorSubject<ConditionsConfig | null>(
     null
   );
-  readonly conditionNameToDisplayNameMap$ = new BehaviorSubject<Map<string, string>>(new Map<string, string>());
+  readonly conditionNameToDisplayNameMap$ = new BehaviorSubject<
+    Map<string, string>
+  >(new Map<string, string>());
 
   readonly selectedRegion$ = this.sessionService.region$;
 
-
-  constructor(private http: HttpClient, private sessionService: SessionService) {
-
+  constructor(
+    private http: HttpClient,
+    private sessionService: SessionService
+  ) {
     this.http
-      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/?region_name='+ `${this.regionToString(this.selectedRegion$.getValue())}`)
+      .get<BoundaryConfig[]>(
+        BackendConstants.END_POINT +
+          '/boundary/config/?region_name=' +
+          `${this.regionToString(this.selectedRegion$.getValue())}`
+      )
       .pipe(take(1))
       .subscribe((config: BoundaryConfig[]) => {
         this.boundaryConfig$.next(config);
@@ -55,7 +71,8 @@ export class MapService {
     this.http
       .get<ConditionsConfig>(
         BackendConstants.END_POINT +
-          '/conditions/config/?region_name=' + `${this.regionToString(this.selectedRegion$.getValue())}`
+          '/conditions/config/?region_name=' +
+          `${this.regionToString(this.selectedRegion$.getValue())}`
       )
       .pipe(take(1))
       .subscribe((config: ConditionsConfig) => {
@@ -86,10 +103,13 @@ export class MapService {
     );
   }
 
-
-  setConfigs(){
+  setConfigs() {
     this.http
-      .get<BoundaryConfig[]>(BackendConstants.END_POINT + '/boundary/config/?region_name='+ `${this.regionToString(this.selectedRegion$.getValue())}`)
+      .get<BoundaryConfig[]>(
+        BackendConstants.END_POINT +
+          '/boundary/config/?region_name=' +
+          `${this.regionToString(this.selectedRegion$.getValue())}`
+      )
       .pipe(take(1))
       .subscribe((config: BoundaryConfig[]) => {
         this.boundaryConfig$.next(config);
@@ -97,16 +117,16 @@ export class MapService {
     this.http
       .get<ConditionsConfig>(
         BackendConstants.END_POINT +
-          '/conditions/config/?region_name=' + `${this.regionToString(this.selectedRegion$.getValue())}`
+          '/conditions/config/?region_name=' +
+          `${this.regionToString(this.selectedRegion$.getValue())}`
       )
       .pipe(take(1))
       .subscribe((config: ConditionsConfig) => {
         this.conditionsConfig$.next(config);
         this.populateConditionNameMap(config);
       });
-
   }
-    /* Note: these are the names used by the configurations and backend
+  /* Note: these are the names used by the configurations and backend
    * Defaults to Sierra Nevada. */
   regionToString(region: Region | null): string {
     switch (region) {
@@ -124,39 +144,47 @@ export class MapService {
 
   /** Get shapes for a boundary from assets, if possible.  Fall back to the
    *  REST server, clipping the shapes to the region if the region is non-null. */
-  getBoundaryShapes(
-    vectorName: string,
-    ):Observable<L.Layer> {
-      
-   var vector: Observable<L.Layer> = of(L.vectorGrid.protobuf(
-    BackendConstants.TILES_END_POINT + "gwc/service/tms/1.0.0/" + `${vectorName}` + "@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf",
-      { vectorTileLayerStyles: {
-        [`${vectorName.split(":")[1]}`]: { // To set style value for every layer name (which is the value after '<region>:' in vectorName)
-          weight: 1,
-          fillOpacity: 0,
-          color: '#0000ff',
-          fill: true,
+  getBoundaryShapes(vectorName: string): Observable<L.Layer> {
+    var vector: Observable<L.Layer> = of(
+      L.vectorGrid.protobuf(
+        BackendConstants.TILES_END_POINT +
+          'gwc/service/tms/1.0.0/' +
+          `${vectorName}` +
+          '@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf',
+        {
+          vectorTileLayerStyles: {
+            [`${vectorName.split(':')[1]}`]: {
+              // To set style value for every layer name (which is the value after '<region>:' in vectorName)
+              weight: 1,
+              fillOpacity: 0,
+              color: '#0000ff',
+              fill: true,
+            },
+          },
+          interactive: true,
+          zIndex: 1000, // To ensure boundary is loaded in on top of any other layers
+          getFeatureId: function (f: any) {
+            return f.properties.OBJECTID; // Every boundary feature must have a unique value OBJECTID in order to for hover info to properly work
+          },
+          maxZoom: 13,
         }
-      },
-        interactive: true,
-        zIndex: 1000, // To ensure boundary is loaded in on top of any other layers
-        getFeatureId: function(f:any) {
-          return f.properties.OBJECTID; // Every boundary feature must have a unique value OBJECTID in order to for hover info to properly work
-        },
-        maxZoom: 13,
-        }            
-      ))
+      )
+    );
 
     return vector;
-    }
+  }
   // Queries the CalMAPPER ArcGIS Web Feature Service for known land management projects without filtering.
   getExistingProjects(): Observable<GeoJSON.GeoJSON> {
-    return this.http.get<string>(BackendConstants.END_POINT +
-      (features.use_its ? '/projects/its' : '/projects/calmapper')).pipe(
-      map((response: string) => {
-        return JSON.parse(response);
-      })
-    );
+    return this.http
+      .get<string>(
+        BackendConstants.END_POINT +
+          (features.use_its ? '/projects/its' : '/projects/calmapper')
+      )
+      .pipe(
+        map((response: string) => {
+          return JSON.parse(response);
+        })
+      );
   }
 
   /** Get colormap values from the REST server. */
@@ -170,15 +198,15 @@ export class MapService {
 
   private populateConditionNameMap(config: ConditionsConfig) {
     let nameMap = this.conditionNameToDisplayNameMap$.value;
-    config.pillars?.forEach(pillar => {
+    config.pillars?.forEach((pillar) => {
       if (!!pillar.pillar_name && !!pillar.display_name) {
         nameMap.set(pillar.pillar_name, pillar.display_name);
       }
-      pillar.elements?.forEach(element => {
+      pillar.elements?.forEach((element) => {
         if (!!element.element_name && !!element.display_name) {
           nameMap.set(element.element_name, element.display_name);
         }
-        element.metrics?.forEach(metric => {
+        element.metrics?.forEach((metric) => {
           if (!!metric.metric_name && !!metric.display_name) {
             nameMap.set(metric.metric_name, metric.display_name);
           }

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -5,14 +5,19 @@ import {
 import { TestBed } from '@angular/core/testing';
 
 import { BackendConstants } from '../backend-constants';
-import { BasePlan, Plan, Region, BoundaryConfig, ConditionsConfig } from '../types';
+import {
+  BasePlan,
+  Plan,
+  Region,
+  BoundaryConfig,
+  ConditionsConfig,
+} from '../types';
 import {
   PlanConditionScores,
   PlanPreview,
   ProjectConfig,
   Scenario,
   TreatmentGoalConfig,
-
 } from './../types/plan.types';
 import { BackendPlan, PlanService } from './plan.service';
 import { MapService } from './map.service';
@@ -55,11 +60,13 @@ describe('PlanService', () => {
     // Must flush the requests in the constructor for httpTestingController.verify()
     // to pass in other tests.
     const req1 = httpTestingController.expectOne(
-      BackendConstants.END_POINT + '/plan/treatment_goals_config/?region_name=sierra_cascade_inyo'
+      BackendConstants.END_POINT +
+        '/plan/treatment_goals_config/?region_name=sierra_cascade_inyo'
     );
     req1.flush(treatmentGoalConfigs);
     const req2 = httpTestingController.expectOne(
-      BackendConstants.END_POINT + '/boundary/config/?region_name=sierra_cascade_inyo'
+      BackendConstants.END_POINT +
+        '/boundary/config/?region_name=sierra_cascade_inyo'
     );
     req2.flush(boundaryConfigs);
     const req3 = httpTestingController.expectOne(
@@ -253,7 +260,9 @@ describe('PlanService', () => {
       });
 
       const req = httpTestingController.expectOne(
-        BackendConstants.END_POINT.concat('/plan/create_project_areas_for_project/')
+        BackendConstants.END_POINT.concat(
+          '/plan/create_project_areas_for_project/'
+        )
       );
       expect(req.request.body).toEqual({
         project_id: 1,

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -70,12 +70,22 @@ export class PlanService {
     mapShapes: null,
     panelExpanded: true,
   });
-  readonly treatmentGoalsConfig$ = new BehaviorSubject<TreatmentGoalConfig[] | null>(null);
+  readonly treatmentGoalsConfig$ = new BehaviorSubject<
+    TreatmentGoalConfig[] | null
+  >(null);
   readonly selectedRegion$ = this.sessionService.region$;
 
-  constructor(private http: HttpClient, private sessionService: SessionService, private mapService: MapService) {
+  constructor(
+    private http: HttpClient,
+    private sessionService: SessionService,
+    private mapService: MapService
+  ) {
     this.http
-      .get<TreatmentGoalConfig[]>(BackendConstants.END_POINT + '/plan/treatment_goals_config/?region_name=' + `${this.mapService.regionToString(this.selectedRegion$.getValue())}`)
+      .get<TreatmentGoalConfig[]>(
+        BackendConstants.END_POINT +
+          '/plan/treatment_goals_config/?region_name=' +
+          `${this.mapService.regionToString(this.selectedRegion$.getValue())}`
+      )
       .pipe(take(1))
       .subscribe((config: TreatmentGoalConfig[]) => {
         this.treatmentGoalsConfig$.next(config);
@@ -337,12 +347,16 @@ export class PlanService {
   updateScenarioNotes(scenario: Scenario): Observable<number> {
     const url = BackendConstants.END_POINT.concat('/plan/update_scenario/');
     return this.http
-      .patch<number>(url, {
-        id: scenario.id,
-        notes: scenario.notes,
-      }, {
-        withCredentials: true,
-      })
+      .patch<number>(
+        url,
+        {
+          id: scenario.id,
+          notes: scenario.notes,
+        },
+        {
+          withCredentials: true,
+        }
+      )
       .pipe(take(1));
   }
 

--- a/src/interface/src/app/services/popup.service.spec.ts
+++ b/src/interface/src/app/services/popup.service.spec.ts
@@ -17,8 +17,7 @@ describe('PopupService', () => {
   describe('makeDetailsPopup', () => {
     it('returns html', () => {
       const data = 'Test data';
-      const expectedHtml = `` +
-      `<div>Name: Test data</div>`
+      const expectedHtml = `` + `<div>Name: Test data</div>`;
 
       expect(service.makeDetailsPopup(data)).toEqual(expectedHtml);
     });

--- a/src/interface/src/app/services/popup.service.ts
+++ b/src/interface/src/app/services/popup.service.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@angular/core';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class PopupService {
-
-  constructor() { }
+  constructor() {}
 
   makeDetailsPopup(data: any): string {
-    return `` +
-      `<div>Name: ${ data }</div>`
+    return `` + `<div>Name: ${data}</div>`;
   }
 }

--- a/src/interface/src/app/services/redirect.guard.ts
+++ b/src/interface/src/app/services/redirect.guard.ts
@@ -1,19 +1,22 @@
 import { Injectable } from '@angular/core';
-import {CanActivate, ActivatedRouteSnapshot, Router, RouterStateSnapshot} from '@angular/router';
-
-
+import {
+  CanActivate,
+  ActivatedRouteSnapshot,
+  Router,
+  RouterStateSnapshot,
+} from '@angular/router';
 
 @Injectable({
-    providedIn: 'root'
+  providedIn: 'root',
 })
 export class RedirectGuard implements CanActivate {
-
   constructor(private router: Router) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-
-      window.location.href = route.data['externalUrl'];
-      return true;
-
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): boolean {
+    window.location.href = route.data['externalUrl'];
+    return true;
   }
 }

--- a/src/interface/src/app/services/session.service.spec.ts
+++ b/src/interface/src/app/services/session.service.spec.ts
@@ -56,14 +56,14 @@ describe('SessionService', () => {
     });
 
     it('should default to sierra nevada when the saved value is invalid', () => {
-      mockLocalStorage.setItem('region', 'invalid')
+      mockLocalStorage.setItem('region', 'invalid');
       service = TestBed.inject(SessionService);
 
       expect(service.region$.value).toBe(Region.SIERRA_NEVADA);
     });
 
     it('should get the saved region', () => {
-      mockLocalStorage.setItem('region', Region.CENTRAL_COAST)
+      mockLocalStorage.setItem('region', Region.CENTRAL_COAST);
       service = TestBed.inject(SessionService);
 
       expect(service.region$.value).toBe(Region.CENTRAL_COAST);
@@ -88,7 +88,9 @@ describe('SessionService', () => {
         'mapConfigs',
         JSON.stringify(testMapConfigs)
       );
-      expect(service.mapConfigs$.value!['Sierra Nevada']).toBe(testMapConfigs['Sierra Nevada']);
+      expect(service.mapConfigs$.value!['Sierra Nevada']).toBe(
+        testMapConfigs['Sierra Nevada']
+      );
     });
 
     it('should save map view options', () => {

--- a/src/interface/src/app/services/session.service.ts
+++ b/src/interface/src/app/services/session.service.ts
@@ -26,7 +26,10 @@ export class SessionService {
     SESSION_SAVE_INTERVAL
   );
 
-  readonly mapConfigs$ = new BehaviorSubject<Record<Region, MapConfig[]> | null>(defaultMapConfigsDictionary());
+  readonly mapConfigs$ = new BehaviorSubject<Record<
+    Region,
+    MapConfig[]
+  > | null>(defaultMapConfigsDictionary());
   readonly mapViewOptions$ = new BehaviorSubject<MapViewOptions | null>(null);
   readonly region$ = new BehaviorSubject<Region | null>(null);
 
@@ -53,13 +56,13 @@ export class SessionService {
   /** Emits the map configs and saves them in local storage. */
   setMapConfigs(value: MapConfig[]) {
     var regionIndex: Region | null = this.region$.getValue();
-    if(!regionIndex){
+    if (!regionIndex) {
       regionIndex = Region.SIERRA_NEVADA;
     }
-    var mapConf: Record<Region, MapConfig[]> | null= this.mapConfigs$.getValue();
-    if(mapConf && regionIndex){
+    var mapConf: Record<Region, MapConfig[]> | null =
+      this.mapConfigs$.getValue();
+    if (mapConf && regionIndex) {
       mapConf![regionIndex] = value;
-      
     }
     this.mapConfigs$.next(mapConf);
     localStorage.setItem('mapConfigs', JSON.stringify(mapConf));
@@ -89,16 +92,16 @@ export class SessionService {
    *  are present. */
   private validateSavedMapConfigs(data: string): boolean {
     const configs: any[] = JSON.parse(data);
-    for( var regionConfig of Object.values(configs)){
-      for (var mapConfig of Object.values(regionConfig)){
-        if(!this.instanceOfMapConfig(mapConfig)){
+    for (var regionConfig of Object.values(configs)) {
+      for (var mapConfig of Object.values(regionConfig)) {
+        if (!this.instanceOfMapConfig(mapConfig)) {
           console.log('not valid config ' + JSON.stringify(mapConfig));
           return false;
         }
       }
     }
-    for(var region of Object.keys(configs)){
-      if(!Object.values(Region).includes(region as unknown as Region)){
+    for (var region of Object.keys(configs)) {
+      if (!Object.values(Region).includes(region as unknown as Region)) {
         console.log('Config key not valid Region ' + region);
         return false;
       }

--- a/src/interface/src/app/shared/file-uploader/file-uploader.component.html
+++ b/src/interface/src/app/shared/file-uploader/file-uploader.component.html
@@ -1,14 +1,16 @@
 <div class="file-uploader-wrapper mat-elevation-z4">
   <div class="title">Upload area shape file</div>
-  <input type="file"
+  <input
+    type="file"
     class="file-input"
     [accept]="requiredFileType"
-    (change)="onFileUploaded($event)" #fileUpload>
+    (change)="onFileUploaded($event)"
+    #fileUpload />
   <div class="upload-outline">
     <mat-icon *ngIf="!file">upload</mat-icon>
-    {{fileName || "Select a file"}}
-    <button mat-flat-button class="upload-button"
-      (click)="fileUpload.click()"> UPLOAD
+    {{ fileName || 'Select a file' }}
+    <button mat-flat-button class="upload-button" (click)="fileUpload.click()">
+      UPLOAD
     </button>
   </div>
   <span class="caption">only .zip of shapefile allowed</span>

--- a/src/interface/src/app/shared/file-uploader/file-uploader.component.ts
+++ b/src/interface/src/app/shared/file-uploader/file-uploader.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 @Component({
   selector: 'file-uploader',
   templateUrl: './file-uploader.component.html',
-  styleUrls: ['./file-uploader.component.scss']
+  styleUrls: ['./file-uploader.component.scss'],
 })
 export class FileUploaderComponent {
   /** File uploaded event. */
@@ -13,7 +13,7 @@ export class FileUploaderComponent {
   file: File | null = null;
 
   @Input()
-    requiredFileType: string = 'application/zip';
+  requiredFileType: string = 'application/zip';
 
   onFileUploaded(event: Event) {
     const target = event.target as HTMLInputElement;
@@ -28,7 +28,7 @@ export class FileUploaderComponent {
   /**
    * Emits a file upload event to the parent component.
    */
-   private emitEvent(file: File) {
-    this.fileEvent.emit({type: 'area_upload', value: file});
+  private emitEvent(file: File) {
+    this.fileEvent.emit({ type: 'area_upload', value: file });
   }
 }

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.html
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.html
@@ -1,6 +1,6 @@
 <div class="root-container">
   <div class="opacity-slider-wrapper">
-    {{label}}
+    {{ label }}
     <mat-slider
       class="opacity-slider"
       color="primary"
@@ -9,7 +9,7 @@
       [thumbLabel]="true"
       [value]="opacityPercentage"
       (input)="onChange($event.value)">
-      <input matSliderThumb>
+      <input matSliderThumb />
     </mat-slider>
   </div>
 </div>

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.spec.ts
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.spec.ts
@@ -30,10 +30,10 @@ describe('OpacitySliderComponent', () => {
   });
 
   it('should emit event when opacity value changes', () => {
-    spyOn(component.change, 'emit');
+    spyOn(component.changeOpacity, 'emit');
 
     component.onChange(35);
 
-    expect(component.change.emit).toHaveBeenCalledOnceWith(0.35);
+    expect(component.changeOpacity.emit).toHaveBeenCalledOnceWith(0.35);
   });
 });

--- a/src/interface/src/app/shared/opacity-slider/opacity-slider.component.ts
+++ b/src/interface/src/app/shared/opacity-slider/opacity-slider.component.ts
@@ -1,23 +1,25 @@
 import { FrontendConstants } from 'src/app/types';
-import { Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
-import { map, Observable, of } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  OnChanges,
+} from '@angular/core';
 
 @Component({
   selector: 'app-opacity-slider',
   templateUrl: './opacity-slider.component.html',
   styleUrls: ['./opacity-slider.component.scss'],
 })
-export class OpacitySliderComponent implements OnInit, OnChanges {
-  @Input() opacity: number | null | undefined = FrontendConstants.MAP_DATA_LAYER_OPACITY;
-  @Input() label: string | null = "";
-  @Output() change = new EventEmitter<number>();
+export class OpacitySliderComponent implements OnChanges {
+  @Input() opacity: number | null | undefined =
+    FrontendConstants.MAP_DATA_LAYER_OPACITY;
+  @Input() label: string | null = '';
+  @Output() changeOpacity = new EventEmitter<number>();
 
   opacityPercentage: number = FrontendConstants.MAP_DATA_LAYER_OPACITY * 100;
-
-  constructor() {}
-
-  ngOnInit(): void {}
 
   ngOnChanges(): void {
     if (this.opacity !== undefined && this.opacity !== null) {
@@ -26,6 +28,6 @@ export class OpacitySliderComponent implements OnInit, OnChanges {
   }
 
   onChange(value: number | null): void {
-    if (value != null) this.change.emit(value / 100);
+    if (value != null) this.changeOpacity.emit(value / 100);
   }
 }

--- a/src/interface/src/app/shared/shared.module.ts
+++ b/src/interface/src/app/shared/shared.module.ts
@@ -7,10 +7,7 @@ import { FileUploaderComponent } from './file-uploader/file-uploader.component';
 import { OpacitySliderComponent } from './opacity-slider/opacity-slider.component';
 
 @NgModule({
-  declarations: [
-    FileUploaderComponent,
-    OpacitySliderComponent,
-  ],
+  declarations: [FileUploaderComponent, OpacitySliderComponent],
   exports: [FileUploaderComponent, OpacitySliderComponent],
   imports: [CommonModule, FormsModule, MaterialModule, ReactiveFormsModule],
 })

--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -17,7 +17,7 @@
         <li><h3>View plans and/or scenarios that are publicly visible*</h3></li>
       </ul>
 
-      <p><i> *Accessible only via direct links </i></p>
+      <p><i>*Accessible only via direct links</i></p>
     </div>
   </div>
 

--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -1,38 +1,23 @@
 <div class="signup-root">
-
   <div class="info-card-container">
     <div class="info-card">
       <h3><b>With a Planscape account, you can:</b></h3>
 
       <ul>
-        <li><h3>
-          Save planning areas
-        </h3></li>
-        <li><h3>
-          Create plans, configurations, and scenarios
-        </h3></li>
-        <li><h3>
-          Download shapefiles & metadata
-        </h3></li>
-        <li><h3>
-          Share work with collaborators
-        </h3></li>
+        <li><h3>Save planning areas</h3></li>
+        <li><h3>Create plans, configurations, and scenarios</h3></li>
+        <li><h3>Download shapefiles & metadata</h3></li>
+        <li><h3>Share work with collaborators</h3></li>
       </ul>
 
       <h3><b>As a guest user, you can:</b></h3>
 
       <ul>
-        <li><h3>
-          Explore regional data on the map
-        </h3></li>
-        <li><h3>
-          View plans and/or scenarios that are publicly visible*
-        </h3></li>
+        <li><h3>Explore regional data on the map</h3></li>
+        <li><h3>View plans and/or scenarios that are publicly visible*</h3></li>
       </ul>
 
-      <p><i>
-        *Accessible only via direct links
-      </i></p>
+      <p><i> *Accessible only via direct links </i></p>
     </div>
   </div>
 
@@ -40,28 +25,20 @@
     <div class="signup-form">
       <h1 class="signup-title">Create your account</h1>
 
-      <form [formGroup]="form" (ngSubmit)="step === 0 ? step = 1 : signup()">
+      <form [formGroup]="form" (ngSubmit)="step === 0 ? (step = 1) : signup()">
         <ng-container *ngIf="step === 0; else finalStep">
-
           <mat-form-field appearance="fill">
             <mat-label>First name</mat-label>
-            <input
-              type="text"
-              required
-              formControlName="firstName"
-              matInput>
+            <input type="text" required formControlName="firstName" matInput />
           </mat-form-field>
 
           <mat-form-field appearance="fill">
             <mat-label>Last name</mat-label>
-            <input
-              type="text"
-              required
-              formControlName="lastName"
-              matInput>
+            <input type="text" required formControlName="lastName" matInput />
           </mat-form-field>
 
-          <button mat-flat-button
+          <button
+            mat-flat-button
             type="submit"
             color="primary"
             (click)="step = 1"
@@ -69,18 +46,15 @@
             Continue
           </button>
 
-          <button mat-button color="primary" type="button" (click)="login()">Log in</button>
+          <button mat-button color="primary" type="button" (click)="login()">
+            Log in
+          </button>
         </ng-container>
 
         <ng-template #finalStep>
-
           <mat-form-field appearance="fill">
             <mat-label>Email</mat-label>
-            <input
-              type="text"
-              required
-              formControlName="email"
-              matInput>
+            <input type="text" required formControlName="email" matInput />
           </mat-form-field>
 
           <mat-form-field appearance="fill">
@@ -89,10 +63,10 @@
               type="password"
               required
               formControlName="password1"
-              matInput>
-              <mat-error *ngIf="form.get('password1')?.hasError('minlength')">
-                Password must contain at least 8 characters.
-              </mat-error>
+              matInput />
+            <mat-error *ngIf="form.get('password1')?.hasError('minlength')">
+              Password must contain at least 8 characters.
+            </mat-error>
           </mat-form-field>
 
           <mat-form-field appearance="fill">
@@ -101,24 +75,27 @@
               type="password"
               required
               formControlName="password2"
-              matInput>
-              <mat-error *ngIf="form.hasError('passwordsNotEqual')">
-                Passwords must match.
-              </mat-error>
+              matInput />
+            <mat-error *ngIf="form.hasError('passwordsNotEqual')">
+              Passwords must match.
+            </mat-error>
           </mat-form-field>
 
           <p>{{ error?.message }}</p>
           <p *ngIf="error">{{ error?.error | json }}</p>
 
-          <button mat-flat-button
+          <button
+            mat-flat-button
             type="submit"
             color="primary"
             (click)="signup()"
             [disabled]="!form.valid || submitted">
-            {{submitted ? 'Please wait...' : 'Create account'}}
+            {{ submitted ? 'Please wait...' : 'Create account' }}
           </button>
 
-          <button mat-button color="primary" type="button" (click)="step = 0">Back</button>
+          <button mat-button color="primary" type="button" (click)="step = 0">
+            Back
+          </button>
         </ng-template>
       </form>
     </div>
@@ -128,5 +105,4 @@
       <div class="section-dot" [class.selected]="step === 1"></div>
     </div>
   </div>
-
 </div>

--- a/src/interface/src/app/signup/signup.component.spec.ts
+++ b/src/interface/src/app/signup/signup.component.spec.ts
@@ -80,7 +80,7 @@ describe('SignupComponent', () => {
         'password',
         'password',
         'Foo',
-        'Bar',
+        'Bar'
       );
     });
   });

--- a/src/interface/src/app/stringify-map-config.pipe.spec.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.spec.ts
@@ -26,10 +26,9 @@ describe('StringifyMapConfigPipe', () => {
           display_name: 'HUC-12',
           boundary_name: '',
           vector_name: 'sierra-nevada:vector_huc12',
-          shape_name: 'Name",'
+          shape_name: 'Name",',
         },
-        dataLayerConfig: {
-        },
+        dataLayerConfig: {},
         showExistingProjectsLayer: false,
       };
 
@@ -45,10 +44,9 @@ describe('StringifyMapConfigPipe', () => {
           display_name: 'HUC-12',
           boundary_name: 'huc12',
           vector_name: 'sierra-nevada:vector_huc12',
-          shape_name: 'Name",'
+          shape_name: 'Name",',
         },
-        dataLayerConfig: {
-        },
+        dataLayerConfig: {},
         showExistingProjectsLayer: false,
       };
       let mapConfigStr = 'HUC-12';
@@ -65,10 +63,9 @@ describe('StringifyMapConfigPipe', () => {
           display_name: 'HUC-12',
           boundary_name: '',
           vector_name: 'sierra-nevada:vector_huc12',
-          shape_name: 'Name",'
+          shape_name: 'Name",',
         },
-        dataLayerConfig: {
-        },
+        dataLayerConfig: {},
         showExistingProjectsLayer: true,
       };
       let mapConfigStr = 'Existing Projects';
@@ -85,7 +82,7 @@ describe('StringifyMapConfigPipe', () => {
           display_name: 'HUC-12',
           boundary_name: '',
           vector_name: 'sierra-nevada:vector_huc12',
-          shape_name: 'Name",'
+          shape_name: 'Name",',
         },
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',
@@ -93,8 +90,7 @@ describe('StringifyMapConfigPipe', () => {
         },
         showExistingProjectsLayer: false,
       };
-      let mapConfigStr =
-        'Habitat Connectivity';
+      let mapConfigStr = 'Habitat Connectivity';
 
       let transformedStr = pipe.transform(mapConfig);
 
@@ -108,7 +104,7 @@ describe('StringifyMapConfigPipe', () => {
           display_name: 'HUC-12',
           boundary_name: 'huc12',
           vector_name: 'sierra-nevada:vector_huc12',
-          shape_name: 'Name",'
+          shape_name: 'Name",',
         },
         dataLayerConfig: {
           display_name: 'Habitat Connectivity',

--- a/src/interface/src/app/stringify-map-config.pipe.ts
+++ b/src/interface/src/app/stringify-map-config.pipe.ts
@@ -19,9 +19,11 @@ export class StringifyMapConfigPipe implements PipeTransform {
     let str: string = '';
     let labels: string[] = [];
 
-    if (!!mapConfig.dataLayerConfig.display_name &&
+    if (
+      !!mapConfig.dataLayerConfig.display_name &&
       mapConfig.dataLayerConfig.display_name.length > 0 &&
-      mapConfig.dataLayerConfig.display_name != "None") {
+      mapConfig.dataLayerConfig.display_name != 'None'
+    ) {
       let dataLabel = mapConfig.dataLayerConfig.display_name;
       if (mapConfig.dataLayerConfig.normalized) {
         dataLabel = dataLabel.concat(' (Normalized)');

--- a/src/interface/src/app/top-bar/top-bar.component.html
+++ b/src/interface/src/app/top-bar/top-bar.component.html
@@ -5,8 +5,7 @@
     data-testid="menu-button"
     class="menu-button"
     aria-label="menu icon button"
-    (click)="sendToggle($event)"
-  >
+    (click)="sendToggle($event)">
     <mat-icon>menu</mat-icon>
   </button>
 
@@ -17,13 +16,11 @@
   <img
     class="region-dropdown-icon"
     src="assets/svg/region-dropdown-icon.svg"
-    *featureFlag="'new_navigation'; hide: true"
-  />
+    *featureFlag="'new_navigation'; hide: true" />
 
   <!-- Region Dropdown -->
   <app-region-dropdown
-    *featureFlag="'new_navigation'; hide: true"
-  ></app-region-dropdown>
+    *featureFlag="'new_navigation'; hide: true"></app-region-dropdown>
 
   <!-- Space between left and right elements -->
   <span class="spacer"></span>
@@ -35,8 +32,7 @@
     data-id="feedback"
     target="_blank"
     rel="noopener noreferrer"
-    *featureFlag="'new_navigation'"
-  >
+    *featureFlag="'new_navigation'">
     Feedback
   </a>
 
@@ -48,10 +44,9 @@
     aria-label="help button"
     rel="noopener noreferrer"
     data-id="help"
-    *featureFlag="'new_navigation'; hide: true"
-  >
+    *featureFlag="'new_navigation'; hide: true">
     <mat-icon class="material-symbols-outlined">
-      {{ "help_outline" }}
+      {{ 'help_outline' }}
     </mat-icon>
   </a>
   <span class="username">{{ displayName }}</span>
@@ -62,8 +57,7 @@
     class="top-bar-account-button"
     aria-label="account icon button"
     #accountButton
-    (click)="openAccountDialog()"
-  >
+    (click)="openAccountDialog()">
     <mat-icon>account_circle</mat-icon>
   </button>
 </mat-toolbar>

--- a/src/interface/src/app/top-bar/top-bar.component.html
+++ b/src/interface/src/app/top-bar/top-bar.component.html
@@ -6,12 +6,11 @@
     class="menu-button"
     aria-label="menu icon button"
     (click)="sendToggle($event)">
-     <mat-icon>menu</mat-icon>
+    <mat-icon>menu</mat-icon>
   </button>
 
   <!-- Title -->
   <a class="site-link" routerLink="/home">Planscape preview</a>
-
 
   <!-- Dropdown Icon -->
   <img class="region-dropdown-icon" src="assets/svg/region-dropdown-icon.svg" />
@@ -19,12 +18,17 @@
   <!-- Region Dropdown -->
   <div class="region-dropdown-wrapper">
     <select class="region-dropdown" (change)="setRegion($event)">
-      <option [selected]="!(selectedRegion$ | async)" disabled>Select a region</option>
-      <option *ngFor="let region of regionOptions"
+      <option [selected]="!(selectedRegion$ | async)" disabled>
+        Select a region
+      </option>
+      <option
+        *ngFor="let region of regionOptions"
         [value]="region.type"
         [disabled]="!region.available"
         [selected]="(selectedRegion$ | async) === region.type"
-        routerLink= "/map">{{ region.name }} </option>    
+        routerLink="/map">
+        {{ region.name }}
+      </option>
     </select>
   </div>
 
@@ -35,15 +39,15 @@
   <a
     mat-icon-button
     routerLink="/help"
-    target="_blank" 
+    target="_blank"
     aria-label="help button"
     rel="noopener noreferrer">
     <mat-icon class="material-symbols-outlined">
-      {{"help_outline"}}
+      {{ 'help_outline' }}
     </mat-icon>
   </a>
   <span class="username">{{ displayName }}</span>
-  
+
   <button
     mat-icon-button
     data-testid="account-button"

--- a/src/interface/src/app/top-bar/top-bar.component.spec.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.spec.ts
@@ -9,9 +9,9 @@ import { AuthService, SessionService } from '../services';
 import { Region, User } from '../types';
 import { AccountDialogComponent } from './../account-dialog/account-dialog.component';
 import { TopBarComponent } from './top-bar.component';
-import {FeatureService} from "../features/feature.service";
-import {FeaturesModule} from "../features/features.module";
-import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
+import { FeatureService } from '../features/feature.service';
+import { FeaturesModule } from '../features/features.module';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('TopBarComponent', () => {
   let component: TopBarComponent;
@@ -37,20 +37,20 @@ describe('TopBarComponent', () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, MaterialModule, FeaturesModule],
       declarations: [TopBarComponent],
-      schemas:[CUSTOM_ELEMENTS_SCHEMA],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
         { provide: AuthService, useValue: mockAuthService },
         { provide: MatDialog, useValue: fakeMatDialog },
         { provide: SessionService, useValue: mockSessionService },
-        { provide: FeatureService, useValue: { isFeatureEnabled: () => false}}
+        {
+          provide: FeatureService,
+          useValue: { isFeatureEnabled: () => false },
+        },
       ],
     }).compileComponents();
 
-
-
     fixture = TestBed.createComponent(TopBarComponent);
     component = fixture.componentInstance;
-
   });
 
   it('should create', () => {
@@ -58,8 +58,8 @@ describe('TopBarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('actions', ()=>{
-    beforeEach(()=>{
+  describe('actions', () => {
+    beforeEach(() => {
       fixture.detectChanges();
     });
 
@@ -89,15 +89,14 @@ describe('TopBarComponent', () => {
       accountButton.triggerEventHandler('click', clickEvent);
 
       // Assert: expect that the dialog opens
-      expect(fakeMatDialog.open).toHaveBeenCalledOnceWith(AccountDialogComponent);
+      expect(fakeMatDialog.open).toHaveBeenCalledOnceWith(
+        AccountDialogComponent
+      );
     });
-  })
-
-
+  });
 
   describe('username', () => {
-
-    beforeEach(()=>{
+    beforeEach(() => {
       fixture.detectChanges();
     });
 
@@ -122,42 +121,44 @@ describe('TopBarComponent', () => {
   });
 
   describe('feedback button', () => {
-
-    it('should show the feedback button when on new_navigation flag is on', ()=>{
+    it('should show the feedback button when on new_navigation flag is on', () => {
       const featureService = TestBed.inject(FeatureService);
       spyOn(featureService, 'isFeatureEnabled').and.returnValue(true);
       fixture.detectChanges();
-      const feedbackBtn = fixture.debugElement.query( By.css('[data-id="feedback"]'));
+      const feedbackBtn = fixture.debugElement.query(
+        By.css('[data-id="feedback"]')
+      );
       expect(feedbackBtn).toBeTruthy();
-
     });
-    it('should not show the button when new_navigation flag is off ', ()=>{
+    it('should not show the button when new_navigation flag is off ', () => {
       const featureService = TestBed.inject(FeatureService);
       spyOn(featureService, 'isFeatureEnabled').and.returnValue(false);
       fixture.detectChanges();
-      const feedbackBtn = fixture.debugElement.query( By.css('[data-id="feedback"]'));
+      const feedbackBtn = fixture.debugElement.query(
+        By.css('[data-id="feedback"]')
+      );
       expect(feedbackBtn).toBeFalsy();
     });
-
   });
 
   describe('help button', () => {
-
-    it('should not show the help button when on new_navigation flag is on', ()=>{
+    it('should not show the help button when on new_navigation flag is on', () => {
       const featureService = TestBed.inject(FeatureService);
       spyOn(featureService, 'isFeatureEnabled').and.returnValue(true);
       fixture.detectChanges();
-      const feedbackBtn = fixture.debugElement.query( By.css('[data-id="help"]'));
+      const feedbackBtn = fixture.debugElement.query(
+        By.css('[data-id="help"]')
+      );
       expect(feedbackBtn).toBeFalsy();
-
     });
-    it('should show the help button when new_navigation flag is off ', ()=>{
+    it('should show the help button when new_navigation flag is off ', () => {
       const featureService = TestBed.inject(FeatureService);
       spyOn(featureService, 'isFeatureEnabled').and.returnValue(false);
       fixture.detectChanges();
-      const feedbackBtn = fixture.debugElement.query( By.css('[data-id="help"]'));
+      const feedbackBtn = fixture.debugElement.query(
+        By.css('[data-id="help"]')
+      );
       expect(feedbackBtn).toBeTruthy();
     });
-
   });
 });

--- a/src/interface/src/app/top-bar/top-bar.component.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.ts
@@ -14,7 +14,7 @@ import { Region, RegionOption, regionOptions } from '../types';
 import { AccountDialogComponent } from './../account-dialog/account-dialog.component';
 
 @Component({
-  selector: 'top-bar',
+  selector: 'app-top-bar',
   templateUrl: './top-bar.component.html',
   styleUrls: ['./top-bar.component.scss'],
 })
@@ -35,7 +35,7 @@ export class TopBarComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private router: Router,
     private sessionService: SessionService,
-    private mapService: MapService,
+    private mapService: MapService
   ) {}
 
   ngOnInit(): void {
@@ -44,7 +44,11 @@ export class TopBarComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((user) => {
         if (user) {
-          this.displayName = user.firstName ? user.firstName : (user.username ? user.username : '');
+          this.displayName = user.firstName
+            ? user.firstName
+            : user.username
+            ? user.username
+            : '';
         } else {
           this.displayName = 'Guest';
         }
@@ -70,9 +74,9 @@ export class TopBarComponent implements OnInit, OnDestroy {
   setRegion(event: Event) {
     // The built-in type for event is generic, so it needs to be cast
     const region = (event.target as HTMLSelectElement).value as Region;
-    this.sessionService.setRegion(region);  
+    this.sessionService.setRegion(region);
     this.mapService.setConfigs();
-    if(this.router.url == '/home'){
+    if (this.router.url == '/home') {
       this.router.navigateByUrl('/map');
     }
   }

--- a/src/interface/src/app/top-bar/top-bar.component.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.ts
@@ -30,7 +30,7 @@ export class TopBarComponent implements OnInit, OnDestroy {
   constructor(
     private authService: AuthService,
     private dialog: MatDialog,
-    private router: Router,
+    private router: Router
   ) {}
 
   ngOnInit(): void {

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -65,7 +65,7 @@ export interface PillarConfig extends DataLayerConfig {
 export enum ConditionTreeType {
   RAW = 'Raw',
   TRANSLATED = 'Translated',
-  FUTURE = "Future",
+  FUTURE = 'Future',
 }
 
 export const NONE_BOUNDARY_CONFIG: BoundaryConfig = {

--- a/src/interface/src/app/types/map.types.ts
+++ b/src/interface/src/app/types/map.types.ts
@@ -56,12 +56,32 @@ export function defaultMapViewOptions(): MapViewOptions {
   };
 }
 
-export function defaultMapConfigsDictionary(): Record<Region, MapConfig[]> { 
+export function defaultMapConfigsDictionary(): Record<Region, MapConfig[]> {
   return {
-    [Region.SIERRA_NEVADA] : [defaultMapConfig(), defaultMapConfig(), defaultMapConfig(), defaultMapConfig()],
-    [Region.SOUTHERN_CALIFORNIA] : [defaultMapConfig(), defaultMapConfig(), defaultMapConfig(), defaultMapConfig()],
-    [Region.NORTHERN_CALIFORNIA] : [defaultMapConfig(), defaultMapConfig(), defaultMapConfig(), defaultMapConfig()],
-    [Region.CENTRAL_COAST] : [defaultMapConfig(), defaultMapConfig(), defaultMapConfig(), defaultMapConfig()],
+    [Region.SIERRA_NEVADA]: [
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+    ],
+    [Region.SOUTHERN_CALIFORNIA]: [
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+    ],
+    [Region.NORTHERN_CALIFORNIA]: [
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+    ],
+    [Region.CENTRAL_COAST]: [
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+      defaultMapConfig(),
+    ],
   };
 }
 
@@ -86,5 +106,5 @@ export function regionMapCenters(region: Region): L.LatLngTuple {
     default:
       // Defaults to Sierra Nevada center
       return [38.646, -120.548];
-  };
+  }
 }

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -23,7 +23,7 @@ export interface BasePlan {
 export interface PlanPreview {
   id: string;
   name: string;
-  createdTimestamp?: number;  // in milliseconds since epoch
+  createdTimestamp?: number; // in milliseconds since epoch
   region?: Region;
   savedScenarios?: number;
   configurations?: number;
@@ -70,7 +70,7 @@ export interface ProjectConfig {
   max_slope?: number;
   priorities?: string[];
   weights?: number[];
-  createdTimestamp? : number;
+  createdTimestamp?: number;
 }
 
 export interface ProjectArea {

--- a/src/interface/src/app/types/region.types.ts
+++ b/src/interface/src/app/types/region.types.ts
@@ -1,10 +1,10 @@
-import features from '../features/features.json'
+import features from '../features/features.json';
 
 export enum Region {
   SIERRA_NEVADA = 'Sierra Nevada',
   SOUTHERN_CALIFORNIA = 'Southern California',
-  CENTRAL_COAST = "Central Coast",
-  NORTHERN_CALIFORNIA = "Northern California",
+  CENTRAL_COAST = 'Central Coast',
+  NORTHERN_CALIFORNIA = 'Northern California',
 }
 
 export interface RegionOption {
@@ -18,18 +18,18 @@ const regions: Region[] = [
   Region.SOUTHERN_CALIFORNIA,
   Region.CENTRAL_COAST,
   Region.NORTHERN_CALIFORNIA,
-]
+];
 
 const availableRegions = new Set([
   Region.SIERRA_NEVADA,
   features.show_socal ? Region.SOUTHERN_CALIFORNIA : null,
-  features.show_centralcoast ? Region.CENTRAL_COAST : null
-])
+  features.show_centralcoast ? Region.CENTRAL_COAST : null,
+]);
 
 export const regionOptions = regions.map((region) => {
   return {
     type: region,
     name: region,
     available: availableRegions.has(region),
-  }
+  };
 });

--- a/src/interface/src/environments/environment.ts
+++ b/src/interface/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   backend_endpoint: 'http://localhost:8000/planscape-backend',
-  google_analytics_id: '',  // Replace with actual ID.
+  google_analytics_id: '', // Replace with actual ID.
   tile_endpoint: '', // Replace with actual URL
   download_endpoint: '', // Replace with actual URL
 };

--- a/src/interface/src/index.html
+++ b/src/interface/src/index.html
@@ -1,16 +1,20 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Interface</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css?family=Public+Sans:300,400,500,600,700|Roboto:300,400,500,600,700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-</head>
-<body class="mat-typography">
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Interface</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Public+Sans:300,400,500,600,700|Roboto:300,400,500,600,700&display=swap"
+      rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet" />
+  </head>
+  <body class="mat-typography">
+    <app-root></app-root>
+  </body>
 </html>

--- a/src/interface/src/main.ts
+++ b/src/interface/src/main.ts
@@ -8,5 +8,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/src/interface/src/polyfills.ts
+++ b/src/interface/src/polyfills.ts
@@ -45,12 +45,11 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js';  // Included with Angular CLI.
-
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
 
- (window as any).global = window;
- global.Buffer = global.Buffer || require('buffer').Buffer;
+(window as any).global = window;
+global.Buffer = global.Buffer || require('buffer').Buffer;

--- a/src/interface/src/test.ts
+++ b/src/interface/src/test.ts
@@ -4,11 +4,15 @@ import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
+  platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
 declare const require: {
-  context(path: string, deep?: boolean, filter?: RegExp): {
+  context(
+    path: string,
+    deep?: boolean,
+    filter?: RegExp
+  ): {
     <T>(id: string): T;
     keys(): string[];
   };
@@ -17,7 +21,7 @@ declare const require: {
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
+  platformBrowserDynamicTesting()
 );
 
 // Then we find all the tests.

--- a/src/interface/src/typings/leaflet.vectorgrid.d.ts
+++ b/src/interface/src/typings/leaflet.vectorgrid.d.ts
@@ -1,25 +1,25 @@
-import * as L from "leaflet";
+import * as L from 'leaflet';
 
-declare module "leaflet" {
+declare module 'leaflet' {
   namespace vectorGrid {
-      export function slicer(data: any, options?: any): L.Layer;
-      export function protobuf(data: string, VectorTileOptions?: any): L.Layer;
-      export function  setFeatureStyle(id: Number, layerStyle: L.PathOptions): any;
-      export function resetFeatureStyle(id: Number): any;
+    export function slicer(data: any, options?: any): L.Layer;
+    export function protobuf(data: string, VectorTileOptions?: any): L.Layer;
+    export function setFeatureStyle(id: Number, layerStyle: L.PathOptions): any;
+    export function resetFeatureStyle(id: Number): any;
   }
 }
 
 export interface VectorTileOptions {
-      rendererFactory?: L.RendererOptions;
-      interactive?: boolean;
-      getFeatureId? (f: any): string|boolean;
-      attribution?: string;
-      vectorTileLayerStyles?: VTLStyleOptions;
-      subdomains?: string;
-      key?: string;
-      maxNativeZoom?: number;
-      token?: string;
-   }
-  export interface VTLStyleOptions {
-      [index: string]: any;
-  }
+  rendererFactory?: L.RendererOptions;
+  interactive?: boolean;
+  getFeatureId?(f: any): string | boolean;
+  attribution?: string;
+  vectorTileLayerStyles?: VTLStyleOptions;
+  subdomains?: string;
+  key?: string;
+  maxNativeZoom?: number;
+  token?: string;
+}
+export interface VTLStyleOptions {
+  [index: string]: any;
+}


### PR DESCRIPTION
PLAN-342

Added lint and prettier for format and glory.
We do have some things to fix, but instead of jumping the gun on some "fixes" that might have consequences, I've marked some of the rules as warnings instead of errors.

Ideally we should set up our editors to lint on save. That way we'll get the same format across the board and we'll get computers to do format for us.
Here is a guide on how to do it on VScode or Webstorm:
https://itnext.io/configure-prettier-and-eslint-with-angular-e7b4ce979cd8

You can also do it manually by running 
```
npm run lint
```
To see if you have some issues or
```
npm run lint:fix
```
To fix lint and format automatically


This pr has A LOT OF CHANGES given that its applying the linting rules. The rules can be tweaked if we want some changes. The only two non-default options I've added are [trailing commas](https://prettier.io/docs/en/options.html#trailing-commas), [braket line](https://prettier.io/docs/en/options.html#trailing-commas)  and [single quotes](https://prettier.io/docs/en/options.html#quotes)

See `.pretttierrc` for format configuration and `.eslintrc.json` for es lint rules

