### PR TITLE
set theme palette to match figma and move primary color to variable

### DIFF
--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -1,3 +1,5 @@
+@import "../../../shared/variables";
+
 .layer-panel-header {
   background-color: #D8D8D8 !important;
   font-size: 14px;
@@ -57,7 +59,7 @@ mat-tree-node {
   }
 
   &.selected {
-    background-color: #3367D6;
+    background-color: $primary-color;
 
     span {
       color: white;
@@ -100,7 +102,7 @@ mat-tree-node {
 }
 
 .selected-dot {
-  background-color: #3367D6;
+  background-color: $primary-color;
   border-radius: 4px;
   height: 8px;
   margin-right: 4px;

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -63,12 +63,12 @@
   transition-duration: 0.8s;
 }
 
-// Setting heights for built-in leaflet styles to be able to configure relative max-height 
+// Setting heights for built-in leaflet styles to be able to configure relative max-height
 ::ng-deep .leaflet-left  .leaflet-control {
   height:auto;
   max-height:75%;
 }
-// Setting heights for built-in leaflet styles to be able to configure relative max-height 
+// Setting heights for built-in leaflet styles to be able to configure relative max-height
 ::ng-deep .leaflet-top {
   height:100%;
 }
@@ -87,7 +87,7 @@
   overflow-x:hidden;
   line-height: 18px;
   background: white;
-  white-space: nowrap; 
+  white-space: nowrap;
   opacity: 0.7;
   display: inline-block;
   border: 2px #AAA solid;
@@ -104,7 +104,7 @@
 
 // Legend line
 ::ng-deep .legendline {
-  white-space: nowrap; 
+  white-space: nowrap;
   display: inline-block;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -122,7 +122,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   flex:1;
-  white-space: nowrap; 
+  white-space: nowrap;
   max-width: 65px;
 }
 
@@ -148,7 +148,7 @@
 }
 
 .draw-area-button, .upload-area-button {
-  background-color: #3367D6;
+  background-color: $primary-color;
   box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.12), 0px 2px 2px rgba(0, 0, 0, 0.2), 0px 1px 1px rgba(0, 0, 0, 0.14);
   color: #ffffff;
   font-size: 13px;
@@ -167,7 +167,7 @@
 
 .selected {
   background-color: #ffffff;
-  color: #3367D6;
+  color: $primary-color;
 }
 
 .deselected {
@@ -187,7 +187,7 @@
 }
 
 .done-button {
-  background-color: #3367D6;
+  background-color: $primary-color;
   box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.12), 0px 2px 2px rgba(0, 0, 0, 0.2), 0px 1px 1px rgba(0, 0, 0, 0.14);
   color: #ffffff;
   font-size: 13px;

--- a/src/interface/src/app/region-dropdown/region-dropdown.component.scss
+++ b/src/interface/src/app/region-dropdown/region-dropdown.component.scss
@@ -74,7 +74,7 @@ select.region-dropdown {
     height: 0;
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
-    border-top: 5px solid #3367D6;
+    border-top: 5px solid $primary-color;
     pointer-events: none;
   }
 }
@@ -90,7 +90,7 @@ select.region-dropdown {
   font-weight: 500;
   border: none;
   text-transform: uppercase;
-  color: #3367D6;
+  color: $primary-color;
   padding: 10px;
   padding-right: 36px;
   border-right: 1px solid #eeeeee;

--- a/src/interface/src/app/shared/_variables.scss
+++ b/src/interface/src/app/shared/_variables.scss
@@ -1,2 +1,4 @@
 $toolbar-height: 48px;
 $info-bar-height: 50px;
+$primary-color: #3367D6;
+$error-color: #b00020;

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -10,78 +10,46 @@
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
 @include mat.core();
+@import "app/shared/variables";
 
-// CUSTOM
-// $primary-palette: (
-//     50 : #e9e9e9,
-//     100 : #c8c8c8,
-//     200 : #a4a4a4,
-//     300 : #808080,
-//     400 : #646464,
-//     500 : #494949,
-//     600 : #424242,
-//     700 : #393939,
-//     800 : #313131,
-//     900 : #212121,
-//     A100 : #f17d7d,
-//     A200 : #eb4f4f,
-//     A400 : #ff0808,
-//     A700 : #ee0000,
-//     contrast: (
-//         50 : #000000,
-//         100 : #000000,
-//         200 : #000000,
-//         300 : #000000,
-//         400 : #ffffff,
-//         500 : #ffffff,
-//         600 : #ffffff,
-//         700 : #ffffff,
-//         800 : #ffffff,
-//         900 : #ffffff,
-//         A100 : #000000,
-//         A200 : #ffffff,
-//         A400 : #ffffff,
-//         A700 : #ffffff,
-//     )
-// );
-
-// $secondary-palette: (
-//     50 : #e7edfa,
-//     100 : #c2d1f3,
-//     200 : #99b3eb,
-//     300 : #7095e2,
-//     400 : #527edc,
-//     500 : #3367d6,
-//     600 : #2e5fd1,
-//     700 : #2754cc,
-//     800 : #204ac6,
-//     900 : #1439bc,
-//     A100 : #edf0ff,
-//     A200 : #bac7ff,
-//     A400 : #879dff,
-//     A700 : #6e88ff,
-//     contrast: (
-//         50 : #000000,
-//         100 : #000000,
-//         200 : #000000,
-//         300 : #000000,
-//         400 : #ffffff,
-//         500 : #ffffff,
-//         600 : #ffffff,
-//         700 : #ffffff,
-//         800 : #ffffff,
-//         900 : #ffffff,
-//         A100 : #000000,
-//         A200 : #000000,
-//         A400 : #000000,
-//         A700 : #000000,
-//     )
-// );
+// Planscape palette, based on the $primary-color, generated with http://mcg.mbitson.com/
+$planscape: (
+  50 : #e7edfa,
+  100 : #c2d1f3,
+  200 : #99b3eb,
+  300 : #7095e2,
+  400 : #527edc,
+  500 : $primary-color,
+  600 : #2e5fd1,
+  700 : #2754cc,
+  800 : #204ac6,
+  900 : #1439bc,
+  A100 : #edf0ff,
+  A200 : #bac7ff,
+  A400 : #879dff,
+  A700 : #6e88ff,
+  contrast: (
+          50 : #000000,
+          100 : #000000,
+          200 : #000000,
+          300 : #000000,
+          400 : #ffffff,
+          500 : #ffffff,
+          600 : #ffffff,
+          700 : #ffffff,
+          800 : #ffffff,
+          900 : #ffffff,
+          A100 : #000000,
+          A200 : #000000,
+          A400 : #000000,
+          A700 : #000000,
+  )
+);
 
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue. Available color palettes: https://material.io/design/color/
-$planscape-frontend-primary: mat.define-palette(mat.$indigo-palette);
+$planscape-frontend-primary: mat.define-palette($planscape);
 $planscape-frontend-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);
 
 // The warn palette is optional (defaults to red).
@@ -117,7 +85,7 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 }
 
 .snackbar-error {
-  background: #b00020;
+  background: $error-color;
   button {
     color: #ffffff;
   }
@@ -136,7 +104,7 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 // Geoman drawing vertex styling
 .marker-icon,
  .marker-icon:focus {
-    border: 3px solid #3367D6;
+    border: 3px solid $primary-color;
     margin: -5px 0 0 -5px !important;
     width: 5px !important;
     height: 5px !important;


### PR DESCRIPTION
I've noticed that we are using the default `indigo` palette, however our primary color is not part of that palette.

- Generated a palette using http://mcg.mbitson.com/ based on our primary color (#3367D6)
- Moved instances of `#3367D6` to a sass variable to avoid repetition. There are _a lot_ of other hardcoded color values (specially a ton of shades of white/gray). Ideally we'll define a set of colors and gradually standarize all this shades into a consistent set.