### PR TITLE
expand tree panels when clicking on row

### DIFF
--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -8,27 +8,32 @@
     aria-label="Select an option"
     color="primary"
     [(ngModel)]="map.config.dataLayerConfig"
-    (change)="changeConditionLayer.emit(map)">
+    (change)="changeConditionLayer.emit(map)"
+  >
     <mat-tree
       [dataSource]="conditionDataSource"
       [treeControl]="treeControl"
-      class="condition-tree">
+      class="condition-tree"
+    >
       <!-- This is the tree node template for leaf nodes -->
       <!-- There is inline padding applied to this node using styles.
         This padding value depends on the mat-icon-button width. -->
       <mat-tree-node
         *matTreeNodeDef="let node"
-        [class.selected]="map.config.dataLayerConfig === node.condition">
+        [class.selected]="map.config.dataLayerConfig === node.condition"
+      >
         <div class="mat-tree-node">
           <div
             class="selected-dot"
-            [class.hidden]="!node.styleDescendantSelected"></div>
+            [class.hidden]="!node.styleDescendantSelected"
+          ></div>
           <div [class.disabled]="node.styleDisabled">
             <mat-radio-button
               [value]="node.condition"
               *ngIf="!node.condition.disableSelect"
               class="white"
-              (change)="onSelect(node)">
+              (change)="onSelect(node)"
+            >
               <span class="condition-label">
                 {{ node.condition.display_name }}
               </span>
@@ -43,29 +48,37 @@
             class="info-button"
             [matMenuTriggerFor]="popoverMenu"
             (menuOpened)="node.infoMenuOpen = true"
-            (menuClosed)="node.infoMenuOpen = false">
+            (menuClosed)="node.infoMenuOpen = false"
+          >
             <mat-icon color="primary">info_outline</mat-icon>
           </button>
           <mat-menu #popoverMenu="matMenu">
             <app-layer-info-card
-              [dataLayerConfig]="node.condition"></app-layer-info-card>
+              [dataLayerConfig]="node.condition"
+            ></app-layer-info-card>
           </mat-menu>
         </div>
       </mat-tree-node>
       <!-- This is the tree node template for expandable nodes -->
       <mat-tree-node
         *matTreeNodeDef="let node; when: hasChild"
-        [class.selected]="map.config.dataLayerConfig === node.condition">
-        <div class="mat-tree-node expandable-condition-node">
+        [class.selected]="map.config.dataLayerConfig === node.condition"
+      >
+        <div
+          class="mat-tree-node expandable-condition-node"
+          (click)="treeControl.toggle(node)"
+        >
           <div
             class="selected-dot"
-            [class.hidden]="!node.styleDescendantSelected"></div>
+            [class.hidden]="!node.styleDescendantSelected"
+          ></div>
           <div [class.disabled]="node.styleDisabled">
             <mat-radio-button
               [value]="node.condition"
               *ngIf="!node.condition.disableSelect"
               class="white"
-              (change)="onSelect(node)">
+              (change)="onSelect(node)"
+            >
               {{ node.condition.display_name }}
             </mat-radio-button>
             <span *ngIf="node.condition.disableSelect">
@@ -79,19 +92,22 @@
             class="info-button"
             [matMenuTriggerFor]="popoverMenu"
             (menuOpened)="node.infoMenuOpen = true"
-            (menuClosed)="node.infoMenuOpen = false">
+            (menuClosed)="node.infoMenuOpen = false"
+          >
             <mat-icon color="primary">info_outline</mat-icon>
             <mat-menu #popoverMenu="matMenu">
               <app-layer-info-card
-                [dataLayerConfig]="node.condition"></app-layer-info-card>
+                [dataLayerConfig]="node.condition"
+              ></app-layer-info-card>
             </mat-menu>
           </button>
           <button
             mat-icon-button
             matTreeNodeToggle
-            [attr.aria-label]="'Toggle ' + node.condition.display_name">
+            [attr.aria-label]="'Toggle ' + node.condition.display_name"
+          >
             <mat-icon class="mat-icon-rtl-mirror">
-              {{ treeControl.isExpanded(node) ? 'expand_less' : 'expand_more' }}
+              {{ treeControl.isExpanded(node) ? "expand_less" : "expand_more" }}
             </mat-icon>
           </button>
         </div>

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.scss
@@ -88,6 +88,7 @@ mat-tree-node {
 .expandable-condition-node {
   align-items: center;
   display: flex;
+  cursor: pointer;
 }
 
 .condition-label {


### PR DESCRIPTION
PLAN-346
I noticed that the tree panels on the map control only expand when clicking on the chevron/arrow icon but not when you click on the whole row. Mentioned this to scott and he suggested we should fix it. This should fix it :) 