### PR TITLE
Change Planning Area to Scenario Config page Flow + Add Scenario Name Field to Scenario Config Page

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -76,7 +76,7 @@ const routes: Routes = [
             component: ScenarioDetailsComponent,
           },
           {
-            path: 'config/:id',
+            path: 'config',
             title: 'Scenario Configuration',
             component: CreateScenariosComponent,
           },

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -4,43 +4,58 @@
   <div
     class="create-scenarios-panel-content"
     [@expandCollapsePanelContent]="panelExpanded ? 'opaque' : 'transparent'">
-    <mat-tab-group>
-      <mat-tab label="Configuration">
-        <div class="create-scenarios-inner-wrapper">
-          <app-set-priorities
-            [plan$]="plan$"
-            [formGroup]="formGroups[0]"
-            [treatmentGoals$]="treatmentGoals | async"
-            (changeConditionEvent)="
-              changeCondition($event)
-            "></app-set-priorities>
-          <app-identify-project-areas
-            *ngIf="project_area_upload_enabled"
-            [formGroup]="formGroups[2]"></app-identify-project-areas>
-          <app-constraints-panel
-            [constraintsForm]="formGroups[1]"
-            [excludedAreasOptions]="
-              excludedAreasOptions
-            "></app-constraints-panel>
-          <div class="flex-row gap-12">
-            <button
-              mat-raised-button
-              color="primary"
-              [disabled]="
-                !formGroups[0].valid ||
-                !formGroups[1].valid ||
-                !formGroups[2].valid ||
-                generatingScenario
-              "
-              (click)="createScenario()">
-              {{ generatingScenario ? 'GENERATING SCENARIO...' : 'GENERATE' }}
-            </button>
-            <div *ngIf="project_area_upload_enabled">Estimated time ??????</div>
+    <div class="scenario-name">
+      <form [formGroup]="formGroups[0]!">
+        <mat-form-field class="scenario-name-input">
+          <input
+            formControlName="scenarioName"
+            matInput
+            placeholder="Scenario Name" />
+        </mat-form-field>
+      </form>
+    </div>
+    <div class="tab-container">
+      <mat-tab-group>
+        <mat-tab label=" Configuration">
+          <div class="create-scenarios-inner-wrapper">
+            <app-set-priorities
+              [plan$]="plan$"
+              [formGroup]="formGroups[1]"
+              [treatmentGoals$]="treatmentGoals | async"
+              (changeConditionEvent)="
+                changeCondition($event)
+              "></app-set-priorities>
+            <app-identify-project-areas
+              *ngIf="project_area_upload_enabled"
+              [formGroup]="formGroups[3]"></app-identify-project-areas>
+            <app-constraints-panel
+              [constraintsForm]="formGroups[2]"
+              [excludedAreasOptions]="
+                excludedAreasOptions
+              "></app-constraints-panel>
+            <div class="flex-row gap-12">
+              <button
+                mat-raised-button
+                color="primary"
+                [disabled]="
+                  !formGroups[0].valid ||
+                  !formGroups[1].valid ||
+                  !formGroups[2].valid ||
+                  !formGroups[3].valid ||
+                  generatingScenario
+                "
+                (click)="createScenario()">
+                {{ generatingScenario ? 'GENERATING SCENARIO...' : 'GENERATE' }}
+              </button>
+              <div *ngIf="project_area_upload_enabled">
+                Estimated time ??????
+              </div>
+            </div>
           </div>
-        </div>
-      </mat-tab>
-      <mat-tab label="Outcome">Scenario Results</mat-tab>
-    </mat-tab-group>
+        </mat-tab>
+        <mat-tab label="Outcome">Scenario Results</mat-tab>
+      </mat-tab-group>
+    </div>
 
     <!-- Expand/collapse button -->
     <div

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -3,6 +3,7 @@
   height: 100%;
   left: 0px;
   position: absolute;
+  width: 100%;
   max-width: 700px;
   z-index: 2;
 }
@@ -24,14 +25,16 @@
 .create-scenarios-panel-content {
   box-sizing: border-box;
   display: flex;
+  flex-direction: column;
+  align-items:center;
   height: 100%;
-  padding: 16px 16px 32px 32px;
+  padding: 1px 16px 32px 32px;
   width: 100%;
   z-index: 5;
   top: 0;
   left: 0;
   background-color: #E6e9f4;
-  background-image: linear-gradient(to bottom, white 64px, rgba(0, 0, 0, 0) 64px);
+  background-image: linear-gradient(to bottom, white 95px, rgba(0, 0, 0, 0) 95px);
 }
 
 /** Always show scrollbar. */
@@ -66,6 +69,13 @@
   opacity: 0.66;
 }
 
+// Needed to keep tabs steady on switch
+.tab-container {
+  display:block;
+  width: 100%;
+  height:100%;
+}
+
 ::ng-deep .mat-tab-body-content {
   overflow-x: hidden;
 }
@@ -78,4 +88,18 @@
 .gap-12 {
   gap: 12px;
   margin-top:30px;
+}
+
+.scenario-name {
+  display:block;
+  flex-direction: row;
+  height: fit-content;
+  width: 100%;
+  padding-top: 10px;
+}
+
+.scenario-name-input {
+  width: 100%;
+  height: 40px;
+
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -108,8 +108,8 @@ describe('CreateScenariosComponent', () => {
   it('should load existing config into form', () => {
     expect(fakePlanService.getProject).toHaveBeenCalledOnceWith(1);
 
-    component.formGroups[1].valueChanges.subscribe((_) => {
-      expect(component.formGroups[1].get('budgetForm.maxCost')?.value).toEqual(
+    component.formGroups[2].valueChanges.subscribe((_) => {
+      expect(component.formGroups[2].get('budgetForm.maxCost')?.value).toEqual(
         100
       );
     });
@@ -118,13 +118,16 @@ describe('CreateScenariosComponent', () => {
   it('should emit create scenario event on Generate button click', async () => {
     spyOn(component, 'createScenario');
     component.formGroups[0]
+      .get('scenarioName')
+      ?.setValue('scenarioName');
+    component.formGroups[1]
       .get('selectedQuestion')
       ?.setValue(defaultSelectedQuestion);
-    component.formGroups[1].get('physicalConstraintForm.maxSlope')?.setValue(1);
-    component.formGroups[1]
+    component.formGroups[2].get('physicalConstraintForm.maxSlope')?.setValue(1);
+    component.formGroups[2]
       .get('physicalConstraintForm.minDistanceFromRoad')
       ?.setValue(1);
-    component.formGroups[1].get('physicalConstraintForm.maxArea')?.setValue(1);
+    component.formGroups[2].get('physicalConstraintForm.maxArea')?.setValue(1);
     fixture.detectChanges();
 
     const buttonHarness: MatButtonHarness = await loader.getHarness(
@@ -141,8 +144,8 @@ describe('CreateScenariosComponent', () => {
     const buttonHarness: MatButtonHarness = await loader.getHarness(
       MatButtonHarness.with({ text: /GENERATE/ })
     );
-    component.formGroups[0].markAsDirty();
-    component.formGroups[1]
+    component.formGroups[1].markAsDirty();
+    component.formGroups[2]
       .get('physicalConstraintForm.minDistanceFromRoad')
       ?.setValue(-1);
     fixture.detectChanges();
@@ -158,36 +161,40 @@ describe('CreateScenariosComponent', () => {
       MatButtonHarness.with({ text: /GENERATE/ })
     );
     component.formGroups[0]
+      .get('scenarioName')
+      ?.setValue('scenarioName');
+    component.formGroups[1]
       .get('selectedQuestion')
       ?.setValue(defaultSelectedQuestion);
-    component.formGroups[1].get('physicalConstraintForm.maxSlope')?.setValue(1);
-    component.formGroups[1]
+    component.formGroups[2].get('physicalConstraintForm.maxSlope')?.setValue(1);
+    component.formGroups[2]
       .get('physicalConstraintForm.minDistanceFromRoad')
       ?.setValue(1);
-    component.formGroups[1].get('physicalConstraintForm.maxArea')?.setValue(1);
+    component.formGroups[2].get('physicalConstraintForm.maxArea')?.setValue(1);
     component.generatingScenario = false;
     fixture.detectChanges();
 
     expect(await buttonHarness.isDisabled()).toBeFalse();
   });
 
-  it('update plan state when "identify project areas" form inputs change', () => {
-    const generateAreas = component.formGroups[2].get('generateAreas');
-    const uploadedArea = component.formGroups[2].get('uploadedArea');
+  // TODO Re-enable when support for uploading project areas in implemented
+  // it('update plan state when "identify project areas" form inputs change', () => {
+  //   const generateAreas = component.formGroups[3].get('generateAreas');
+  //   const uploadedArea = component.formGroups[3].get('uploadedArea');
 
-    // Set "generate areas automatically" to true
-    generateAreas?.setValue(true);
+  //   // Set "generate areas automatically" to true
+  //   generateAreas?.setValue(true);
 
-    expect(fakePlanService.updateStateWithShapes).toHaveBeenCalledWith(null);
+  //   expect(fakePlanService.updateStateWithShapes).toHaveBeenCalledWith(null);
 
-    // Add an uploaded area and set "generate areas automatically" to false
-    generateAreas?.setValue(false);
-    uploadedArea?.setValue('testvalue');
+  //   // Add an uploaded area and set "generate areas automatically" to false
+  //   generateAreas?.setValue(false);
+  //   uploadedArea?.setValue('testvalue');
 
-    expect(fakePlanService.updateStateWithShapes).toHaveBeenCalledWith(
-      'testvalue'
-    );
-  });
+  //   expect(fakePlanService.updateStateWithShapes).toHaveBeenCalledWith(
+  //     'testvalue'
+  //   );
+  // });
 
   describe('convertSingleGeoJsonToGeoJsonArray', () => {
     it('converts a geojson with multiple multipolygons into geojsons', () => {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -110,6 +110,11 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     // TODO Move form builders to their corresponding components rather than passing as input
     // Initialize empty form
     this.formGroups = [
+            // Name the scenario
+      //TODO make this the first group and shift the indexing of the rest
+      this.fb.group({
+        scenarioName: ['', Validators.required],
+      }),
       // Step 1: Select priorities
       this.fb.group({
         selectedQuestion: ['', Validators.required],
@@ -249,7 +254,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     });
   }
 
-  private formValueToProjectConfig(): ProjectConfig {
+  private formValueToProjectConfig(): any {
     const estimatedCost = this.formGroups[1].get('budgetForm.estimatedCost');
     const maxCost = this.formGroups[1].get('budgetForm.maxCost');
     const maxArea = this.formGroups[1].get('physicalConstraintForm.maxArea');
@@ -258,7 +263,10 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     );
     const maxSlope = this.formGroups[1].get('physicalConstraintForm.maxSlope');
     const selectedQuestion = this.formGroups[0].get('selectedQuestion');
+    const scenarioName = this.formGroups[3].get('scenarioName');
 
+    let scenarioNameConfig: string = '';
+    let planID: string = '';
     let projectConfig: ProjectConfig = {
       id: this.scenarioConfigId!,
       planId: Number(this.plan$.getValue()?.id),
@@ -277,7 +285,20 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       projectConfig.priorities = selectedQuestion.value['priorities'];
       projectConfig.weights = selectedQuestion!.value['weights'];
     }
-    return projectConfig;
+    if (scenarioName?.valid) {
+      scenarioNameConfig = scenarioName.value;
+    }
+    this.planService.planState$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((planState) => {
+        planID = planState.currentPlanId!;
+      });
+
+    return {
+      name: scenarioNameConfig,
+      planning_area: planID,
+      configuration: projectConfig,
+    };
   }
 
   private updatePriorityWeightsFormControls(): void {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -110,16 +110,15 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     // TODO Move form builders to their corresponding components rather than passing as input
     // Initialize empty form
     this.formGroups = [
-            // Name the scenario
-      //TODO make this the first group and shift the indexing of the rest
+      // Step 1: Name the scenario
       this.fb.group({
         scenarioName: ['', Validators.required],
       }),
-      // Step 1: Select priorities
+      // Step 2: Select priorities
       this.fb.group({
         selectedQuestion: ['', Validators.required],
       }),
-      // Step 2: Set constraints
+      // Step 3: Set constraints
       this.fb.group(
         {
           budgetForm: this.fb.group({
@@ -149,7 +148,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
         },
         { validators: this.constraintsFormValidator }
       ),
-      // Step 3: Identify project areas
+      // Step 4: Identify project areas
       this.fb.group({
         // TODO Use flag to set required validator
         generateAreas: [''],

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
@@ -74,8 +74,7 @@ describe('PlanOverviewComponent', () => {
 
     await createScenarioButton.click();
 
-    expect(fakePlanService.createProjectInPlan).toHaveBeenCalledOnceWith('1');
-    expect(router.navigate).toHaveBeenCalledOnceWith(['config', 1], {
+    expect(router.navigate).toHaveBeenCalledOnceWith(['config'], {
       relativeTo: route,
     });
   });

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.ts
@@ -19,11 +19,10 @@ export class PlanOverviewComponent {
   ) {}
 
   openConfig(configId?: number): void {
+    // TODO Make scenario id an optional parameter
     if (!configId) {
-      this.newConfig().subscribe((newConfigId) => {
-        this.router.navigate(['config', newConfigId], {
-          relativeTo: this.route,
-        });
+      this.router.navigate(['config'], {
+        relativeTo: this.route,
       });
     } else {
       this.router.navigate(['config', configId], { relativeTo: this.route });

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -68,10 +68,16 @@ export class PlanComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    const routeChild = this.route.snapshot.firstChild;
+    const path = routeChild?.url[0].path;
     this.planService.planState$
       .pipe(takeUntil(this.destroy$))
       .subscribe((state) => {
-        if (state.currentScenarioId || state.currentConfigId) {
+        if (
+          state.currentScenarioId ||
+          state.currentConfigId ||
+          path === 'config'
+        ) {
           this.showOverview$.next(false);
         } else {
           this.showOverview$.next(true);


### PR DESCRIPTION
- Remove Scenario ID as required parameter for config url path
   - This was previously required because a Scenario would be created upon the start of the configuration process, and the resulting ID would be passed to the url path
   - Since we are creating the Scenarios on completion of the configuration process, this is no longer possible
   - A future TODO is to make the ID an optional parameter, for looking at the configurations of completed Scenarios
 
- Add Scenario Name text field in Scenario Config
- Make scenarioName a required form value 
- Update corresponding tests 
<img width="484" alt="Screenshot 2023-08-31 at 2 17 38 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/95fd5d27-c8ce-4d23-9fd5-a61f0d91afa0">
 