### PR TITLE
Add a convenience link to login alongside the link to create an account on home page

### DIFF
--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -235,7 +235,8 @@
       <p *ngIf="loggedIn$ | async; else signedout">There are no saved plans.</p>
       <ng-template #signedout>
         <p>
-          <a href="/signup">Create an account</a>
+          <a href="/signup">Create an account</a> or
+	  <a href="/login">log in</a>
           to start making plans.
         </p>
       </ng-template>


### PR DESCRIPTION
Show a link to log in when login is enabled but the user is not logged in.

This link is temporary; this page is currently hidden from the public but will allow others (e.g. hackathon people working on login) to be able to log in without going through the create account page first.

This can be removed when the page content is replaced, and after there is a long-term login option in the upper-right.

With this change (login enabled, user not logged in):
![Screenshot 2023-09-01 at 10 14 40 AM](https://github.com/OurPlanscape/Planscape/assets/125416076/6b9e62b9-6cec-43fa-9fcd-35bad470f481)


With this change (login enabled, user logged in - i.e. no change):
![Screenshot 2023-09-01 at 10 18 14 AM](https://github.com/OurPlanscape/Planscape/assets/125416076/05a5c64f-9b49-4936-949e-3fd1c3ba362e)


With this change (login disabled - i.e. no change):
![Screenshot 2023-09-01 at 10 17 09 AM](https://github.com/OurPlanscape/Planscape/assets/125416076/e730a2b6-f330-4ba8-9086-e7abb59d5195)
