### PR TITLE
Update error output for existing albeit old tests.

### DIFF
--- a/src/planscape/attributes/raster_utils_test.py
+++ b/src/planscape/attributes/raster_utils_test.py
@@ -53,8 +53,8 @@ class AttributePixelsTest(RasterRetrievalTestCase):
         geo.srid = 4269
         with self.assertRaises(Exception) as context:
             get_attribute_values_from_raster(geo, "foo")
-        self.assertIn(
-            "invalid geo: Ring Self-intersection[", str(context.exception))
+        self.assertRegex(str(context.exception),
+                         'invalid geo: .*Self-intersection[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(

--- a/src/planscape/attributes/raster_utils_test.py
+++ b/src/planscape/attributes/raster_utils_test.py
@@ -54,7 +54,7 @@ class AttributePixelsTest(RasterRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             get_attribute_values_from_raster(geo, "foo")
         self.assertIn(
-            "invalid geo: Self-intersection[", str(context.exception))
+            "invalid geo: Ring Self-intersection[", str(context.exception))
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(

--- a/src/planscape/attributes/raster_utils_test.py
+++ b/src/planscape/attributes/raster_utils_test.py
@@ -54,7 +54,7 @@ class AttributePixelsTest(RasterRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             get_attribute_values_from_raster(geo, "foo")
         self.assertRegex(str(context.exception),
-                         r'invalid geo: .*Self-intersection[')
+                         r'invalid geo: .*Self-intersection\[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(

--- a/src/planscape/attributes/raster_utils_test.py
+++ b/src/planscape/attributes/raster_utils_test.py
@@ -54,7 +54,7 @@ class AttributePixelsTest(RasterRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             get_attribute_values_from_raster(geo, "foo")
         self.assertRegex(str(context.exception),
-                         'invalid geo: .*Self-intersection[')
+                         r'invalid geo: .*Self-intersection[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(

--- a/src/planscape/conditions/raster_utils_test.py
+++ b/src/planscape/conditions/raster_utils_test.py
@@ -47,7 +47,7 @@ class ConditionStatsTest(RasterConditionRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             compute_condition_stats_from_raster(geo, "foo")
         self.assertRegex(str(context.exception),
-                         'invalid geo: .*Self-intersection[')
+                         r'invalid geo: .*Self-intersection[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(

--- a/src/planscape/conditions/raster_utils_test.py
+++ b/src/planscape/conditions/raster_utils_test.py
@@ -47,7 +47,7 @@ class ConditionStatsTest(RasterConditionRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             compute_condition_stats_from_raster(geo, "foo")
         self.assertIn(
-            "invalid geo: Self-intersection[", str(context.exception))
+            "invalid geo: Ring Self-intersection[", str(context.exception))
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(
@@ -369,7 +369,7 @@ class ConditionPixelsTest(RasterConditionRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             get_condition_values_from_raster(geo, "foo")
         self.assertIn(
-            "invalid geo: Self-intersection[", str(context.exception))
+            "invalid geo: Ring Self-intersection[", str(context.exception))
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(

--- a/src/planscape/conditions/raster_utils_test.py
+++ b/src/planscape/conditions/raster_utils_test.py
@@ -47,7 +47,7 @@ class ConditionStatsTest(RasterConditionRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             compute_condition_stats_from_raster(geo, "foo")
         self.assertRegex(str(context.exception),
-                         r'invalid geo: .*Self-intersection[')
+                         r'invalid geo: .*Self-intersection\[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(
@@ -369,7 +369,7 @@ class ConditionPixelsTest(RasterConditionRetrievalTestCase):
         with self.assertRaises(Exception) as context:
             get_condition_values_from_raster(geo, "foo")
         self.assertRegex(str(context.exception),
-                         r'invalid geo: .*Self-intersection[')
+                         r'invalid geo: .*Self-intersection\[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(

--- a/src/planscape/conditions/raster_utils_test.py
+++ b/src/planscape/conditions/raster_utils_test.py
@@ -46,8 +46,8 @@ class ConditionStatsTest(RasterConditionRetrievalTestCase):
         geo.srid = 4269
         with self.assertRaises(Exception) as context:
             compute_condition_stats_from_raster(geo, "foo")
-        self.assertIn(
-            "invalid geo: Ring Self-intersection[", str(context.exception))
+        self.assertRegex(str(context.exception),
+                         'invalid geo: .*Self-intersection[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(
@@ -368,8 +368,8 @@ class ConditionPixelsTest(RasterConditionRetrievalTestCase):
         geo.srid = 4269
         with self.assertRaises(Exception) as context:
             get_condition_values_from_raster(geo, "foo")
-        self.assertIn(
-            "invalid geo: Ring Self-intersection[", str(context.exception))
+        self.assertRegex(str(context.exception),
+                         r'invalid geo: .*Self-intersection[')
 
     def test_fails_for_wrong_srid(self):
         polygon = Polygon(


### PR DESCRIPTION
These are old tests for a raster utilty that is on its way out.  Exception output for expected errors appears to have changed mildly, but the tests are working as expected outside of the exception string.
