### PR TITLE
fix container size for new home

### DIFF
--- a/src/interface/src/app/app.component.html
+++ b/src/interface/src/app/app.component.html
@@ -1,5 +1,3 @@
 <!-- Toolbar -->
 <app-top-bar (toggleEvent)="toggleSidebar($event)"></app-top-bar>
-<app-navigation
-  [sidebarOpen]="sidebarOpen"
-  [ngClass]="{ 'with-navbar': hasNewNavigation }"></app-navigation>
+<app-navigation [sidebarOpen]="sidebarOpen"></app-navigation>

--- a/src/interface/src/app/app.component.scss
+++ b/src/interface/src/app/app.component.scss
@@ -11,7 +11,3 @@
 app-navigation {
   height: calc(100% - $toolbar-height);
 }
-
-.with-navbar {
-  height: calc(100% - $toolbar-height - $navbar-height);
-}

--- a/src/interface/src/app/app.component.ts
+++ b/src/interface/src/app/app.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { take } from 'rxjs';
-
 import { AuthService } from './services';
-import { FeatureService } from './features/feature.service';
 
 @Component({
   selector: 'app-root',
@@ -12,11 +10,7 @@ import { FeatureService } from './features/feature.service';
 export class AppComponent implements OnInit {
   sidebarOpen = false;
 
-  hasNewNavigation = this.featureService.isFeatureEnabled('new_navigation');
-  constructor(
-    private authService: AuthService,
-    private featureService: FeatureService
-  ) {}
+  constructor(private authService: AuthService) {}
 
   toggleSidebar(event: Event) {
     this.sidebarOpen = !this.sidebarOpen;

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -2,7 +2,7 @@
   (goBack)="backHome()"
   [breadcrumbs]="['New Plan']"
   *featureFlag="'new_navigation'"></app-nav-bar>
-<div class="root-container">
+<div class="root-container" [ngClass]="{ 'with-navbar': hasNewNavigation }">
   <!-- Map control panel -->
   <app-map-control-panel
     [boundaryConfig]="boundaryConfig$ | async"

--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -7,6 +7,11 @@
   width: 100%;
 }
 
+.root-container.with-navbar {
+  height: calc(100%  - $navbar-height);
+}
+
+
 .maps-container {
   display: flex;
   flex-direction: column;
@@ -63,12 +68,12 @@
   transition-duration: 0.8s;
 }
 
-// Setting heights for built-in leaflet styles to be able to configure relative max-height 
+// Setting heights for built-in leaflet styles to be able to configure relative max-height
 ::ng-deep .leaflet-left  .leaflet-control {
   height:auto;
   max-height:75%;
 }
-// Setting heights for built-in leaflet styles to be able to configure relative max-height 
+// Setting heights for built-in leaflet styles to be able to configure relative max-height
 ::ng-deep .leaflet-top {
   height:100%;
 }
@@ -87,7 +92,7 @@
   overflow-x:hidden;
   line-height: 18px;
   background: white;
-  white-space: nowrap; 
+  white-space: nowrap;
   opacity: 0.7;
   display: inline-block;
   border: 2px #AAA solid;
@@ -104,7 +109,7 @@
 
 // Legend line
 ::ng-deep .legendline {
-  white-space: nowrap; 
+  white-space: nowrap;
   display: inline-block;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -122,7 +127,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   flex:1;
-  white-space: nowrap; 
+  white-space: nowrap;
   max-width: 65px;
 }
 

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -41,6 +41,7 @@ import { MapComponent } from './map.component';
 import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dialog.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
 import { SignInDialogComponent } from './sign-in-dialog/sign-in-dialog.component';
+import { FeaturesModule } from '../features/features.module';
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -172,6 +173,7 @@ describe('MapComponent', () => {
         MaterialModule,
         BrowserAnimationsModule,
         HttpClientTestingModule,
+        FeaturesModule,
       ],
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -11,7 +11,7 @@ import {
   DoCheck,
 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Feature, Geometry } from 'geojson';
@@ -37,7 +37,6 @@ import {
 } from '../services';
 import {
   BoundaryConfig,
-  colormapConfigToLegend,
   ConditionsConfig,
   DEFAULT_COLORMAP,
   defaultMapConfig,
@@ -55,7 +54,7 @@ import { MapManager } from './map-manager';
 import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dialog.component';
 import { ProjectCardComponent } from './project-card/project-card.component';
 import { SignInDialogComponent } from './sign-in-dialog/sign-in-dialog.component';
-import features from '../features/features.json';
+import { FeatureService } from '../features/feature.service';
 
 export enum AreaCreationAction {
   NONE = 0,
@@ -122,7 +121,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   showConfirmAreaButton$ = new BehaviorSubject(false);
 
   private readonly destroy$ = new Subject<void>();
-  login_enabled = features.login;
+  login_enabled = this.featureService.isFeatureEnabled('login');
+
+  hasNewNavigation = this.featureService.isFeatureEnabled('new_navigation');
 
   constructor(
     public applicationRef: ApplicationRef,
@@ -136,7 +137,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     private planService: PlanService,
     private router: Router,
     private http: HttpClient,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private featureService: FeatureService
   ) {
     this.boundaryConfig$ = this.mapService.boundaryConfig$.pipe(
       takeUntil(this.destroy$)

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -2,8 +2,7 @@
   (goBack)="goBack()"
   [breadcrumbs]="(breadcrumbs$ | async) || []"
   *featureFlag="'new_navigation'"></app-nav-bar>
-
-<div class="root-container">
+<div class="root-container" [ngClass]="{ 'with-navbar': hasNewNavigation }">
   <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
   <ng-container *ngIf="!planNotFound && plan">
     <div class="plan-summary-panel" *ngIf="showOverview$ | async">

--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -1,8 +1,14 @@
+@import "../shared/_variables.scss";
+
 .root-container {
   display: flex;
   flex-direction: row;
   height: 100%;
   width: 100%;
+}
+
+.root-container.with-navbar {
+  height: calc(100%  - $navbar-height);
 }
 
 .plan-summary-panel {

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -19,6 +19,7 @@ import {
 
 import { Plan, User } from '../types';
 import { AuthService, PlanService } from '../services';
+import { FeatureService } from '../features/feature.service';
 
 @Component({
   selector: 'app-plan',
@@ -36,11 +37,13 @@ export class PlanComponent implements OnInit, OnDestroy {
       const crumbs = plan ? [plan.name] : [];
       const path = this.getPathFromSnapshot();
       if (path === 'config') {
-        crumbs.push('New Configuration');
+        crumbs.push('New Scenario');
       }
       return crumbs;
     })
   );
+
+  hasNewNavigation = this.featureService.isFeatureEnabled('new_navigation');
 
   openConfigId?: number;
 
@@ -50,7 +53,8 @@ export class PlanComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private planService: PlanService,
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private featureService: FeatureService
   ) {
     // TODO: Move everything in the constructor to ngOnInit
     const planId = this.route.snapshot.paramMap.get('id');


### PR DESCRIPTION
Just noticed a bug on the css for the new home, the screen size when we do not show the nav bar was not taking 100% of the browser window.

I've added the condition of shrinking the available height on the main app component, but it should have been on the child components where we show the nav bar.

Before
<img width="1496" alt="Screen Shot 2023-09-07 at 09 55 18" src="https://github.com/OurPlanscape/Planscape/assets/358892/70bd6a27-0352-4e1c-8d9d-36bfdc25005b">

After
<img width="1496" alt="Screen Shot 2023-09-07 at 09 54 00" src="https://github.com/OurPlanscape/Planscape/assets/358892/2f0a54da-a3db-4a82-9a3e-1923e2bee5bf">


Ideally once we cleanup the feature flag and remove the artifacts from the sidebars we can revisit this and use flex to distribute the available window size without doing math.
