### PR TITLE
Move Treatment Goals endpoint to planning app + Add short/long question text to config 

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -31,7 +31,7 @@ describe('CreateScenariosComponent', () => {
   let fakeGeoJson: GeoJSON.GeoJSON;
   let loader: HarnessLoader;
   let defaultSelectedQuestion: TreatmentQuestionConfig = {
-    question_text: '',
+    short_question_text: '',
     priorities: [''],
     weights: [0],
   };
@@ -79,7 +79,7 @@ describe('CreateScenariosComponent', () => {
             category_name: 'test_category',
             questions: [
               {
-                question_text: 'test_question',
+                short_question_text: 'test_question',
                 priorities: ['test_priority'],
                 weights: [1],
               },

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -81,7 +81,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
   panelExpanded: boolean = true;
   treatmentGoals: Observable<TreatmentGoalConfig[] | null>;
   defaultSelectedQuestion: TreatmentQuestionConfig = {
-    question_text: '',
+    short_question_text: '',
     priorities: [''],
     weights: [0],
   };

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -19,7 +19,7 @@
               *ngFor="let treatmentQuestion of treatmentGoal['questions']"
               class="layer-control-container">
               <mat-radio-button [value]="treatmentQuestion">
-                {{ treatmentQuestion.question_text }}
+                {{ treatmentQuestion.short_question_text }}
               </mat-radio-button>
             </div>
           </mat-expansion-panel>

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.spec.ts
@@ -37,12 +37,12 @@ describe('SetPrioritiesComponent', () => {
   let fakePlanService: PlanService;
 
   const defaultSelectedQuestion: TreatmentQuestionConfig = {
-    question_text: '',
+    short_question_text: '',
     priorities: [''],
     weights: [0],
   };
   const testQuestion: TreatmentQuestionConfig = {
-    question_text: 'test_question',
+    short_question_text: 'test_question',
     priorities: ['test_priority'],
     weights: [1],
   };
@@ -199,7 +199,7 @@ describe('SetPrioritiesComponent', () => {
 
     // Act: select the test treatment question
     await radioButtonGroup.checkRadioButton({
-      label: testQuestion['question_text'],
+      label: testQuestion['short_question_text'],
     });
 
     expect(component.formGroup?.get('selectedQuestion')?.value).toEqual(

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -66,7 +66,7 @@ describe('PlanService', () => {
     // to pass in other tests.
     const req1 = httpTestingController.expectOne(
       BackendConstants.END_POINT +
-        '/plan/treatment_goals_config/?region_name=sierra-nevada'
+        '/planning/treatment_goals_config/?region_name=sierra-nevada'
     );
     req1.flush(treatmentGoalConfigs);
     const req2 = httpTestingController.expectOne(

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -83,7 +83,7 @@ export class PlanService {
     this.http
       .get<TreatmentGoalConfig[]>(
         BackendConstants.END_POINT +
-          '/plan/treatment_goals_config/?region_name=' +
+          '/planning/treatment_goals_config/?region_name=' +
           `${this.mapService.regionToString(this.selectedRegion$.getValue())}`
       )
       .pipe(take(1))

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -56,7 +56,8 @@ export interface TreatmentGoalConfig {
 }
 
 export interface TreatmentQuestionConfig {
-  question_text?: string;
+  long_question_text?: string;
+  short_question_text?: string;
   priorities?: string[];
   weights?: number[];
 }

--- a/src/planscape/config/treatment_goals.json
+++ b/src/planscape/config/treatment_goals.json
@@ -7,7 +7,8 @@
          "category_name": "Fire Dynamics",
           "questions": [
             {
-             "question_text": "Which areas within my planning area have the highest probability of high severity fire?",
+              "long_question_text": "What areas have the highest probability of high severity fire?",
+              "short_question_text": "[High-severity Fire Areas]",
              "priorities": [
                 "probability_of_fire_severity_high"
              ],

--- a/src/planscape/config/treatment_goals_config.py
+++ b/src/planscape/config/treatment_goals_config.py
@@ -52,10 +52,10 @@ class TreatmentGoalsConfig:
         
         def check_treatment_question(treatment_question) -> bool:
             return (isinstance(treatment_question, dict) and
-                    treatment_question.keys() <= set(['question_text', 'priorities', 'weights']) and
-                    isinstance(treatment_question['question_text'], str) and
+                    treatment_question.keys() <= set(['short_question_text', 'long_question_text','priorities', 'weights']) and
+                    isinstance(treatment_question['short_question_text'], str) and
+                    isinstance(treatment_question['long_question_text'], str) and
                     isinstance(treatment_question['priorities'], list) and
                     isinstance(treatment_question['weights'], list))
-
 
         return 'regions' in self._config and check_regions(self._config['regions'])

--- a/src/planscape/planning/urls.py
+++ b/src/planscape/planning/urls.py
@@ -4,7 +4,7 @@ from planning.views import (create_planning_area, delete_planning_area,
                             get_planning_area_by_id, list_planning_areas,
                             update_planning_area,
                             create_scenario, delete_scenario, get_scenario_by_id,
-                            list_scenarios_for_planning_area, update_scenario,
+                            list_scenarios_for_planning_area, treatment_goals_config, update_scenario,
                             update_scenario_result)
 
 app_name = 'planning'
@@ -15,6 +15,8 @@ urlpatterns = [
     # Auto-generated API documentation
     path('admin/doc/', include('django.contrib.admindocs.urls')),
 
+    # Treatment Goals
+     path('treatment_goals_config/', treatment_goals_config, name='treatment_goals_config'),
     # Plans / Planning Areas
     path('create_planning_area/', create_planning_area, name='create_planning_area'),
     path('delete_planning_area/', delete_planning_area, name='delete_planning_area'),


### PR DESCRIPTION
- Move treatment_goal_config endpoint from plan app to planning app (plan app deprecated)
- Add short and long question text to treatment goal config (only one goal for now) 