### PR TITLE
Breadcrumbs for scenarios

### DIFF
--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -4,7 +4,7 @@
   *featureFlag="'new_navigation'"></app-nav-bar>
 <div class="root-container" [ngClass]="{ 'with-navbar': hasNewNavigation }">
   <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
-  <ng-container *ngIf="!planNotFound && plan">
+  <ng-container *ngIf="currentPlan$ | async">
     <div class="plan-summary-panel" *ngIf="showOverview$ | async">
       <summary-panel
         [plan]="currentPlan$ | async"

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -97,11 +97,6 @@ describe('PlanComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('fetches plan from service using ID', () => {
-    expect(component.planNotFound).toBeFalse();
-    expect(component.plan).toEqual(fakePlan);
-  });
-
   it('calls service to update plan state based on route', () => {
     const planService = fixture.debugElement.injector.get(PlanService);
 

--- a/src/interface/src/app/top-bar/top-bar.component.scss
+++ b/src/interface/src/app/top-bar/top-bar.component.scss
@@ -63,6 +63,7 @@
   background-color: white;
   color: #494949;
   font-weight: bold;
+  text-transform: uppercase;
 }
 
 .menu-link {


### PR DESCRIPTION
PLAN-328

Adds scenario name on breadcrumbs and cleans up a bit plan component.


Plan Page
<img width="1496" alt="Screen Shot 2023-09-08 at 09 34 29" src="https://github.com/OurPlanscape/Planscape/assets/358892/7f502c8a-6447-4a77-83a1-829586b90582">


New Scenario / Configuration
<img width="1492" alt="Screen Shot 2023-09-08 at 09 34 35" src="https://github.com/OurPlanscape/Planscape/assets/358892/d9d322f1-660e-4709-bf04-736eb4db0603">



Plan Scenario / Configuration
<img width="1494" alt="Screen Shot 2023-09-08 at 09 35 14" src="https://github.com/OurPlanscape/Planscape/assets/358892/5c41a820-4b4c-4a06-9da0-291f878792a4">



Plan not found
<img width="1496" alt="Screen Shot 2023-09-08 at 09 34 20" src="https://github.com/OurPlanscape/Planscape/assets/358892/96ef589f-773a-424f-8a05-226cd9297b70">




