### PR TITLE
Improve account deletion flow

### DIFF
--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
@@ -10,7 +10,6 @@
   </p>
 
   <div class="button-row">
-    <button mat-raised-button (click)="cancel()">CANCEL</button>
 
     <button
       mat-raised-button
@@ -19,6 +18,9 @@
       [disabled]="disableDeleteButton">
       DELETE
     </button>
+
+    <button mat-raised-button (click)="cancel()">CANCEL</button>
+
   </div>
 
   <p *ngIf="error">{{ error }}</p>

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
@@ -5,6 +5,8 @@
     <b>Are you sure you want to delete your account?</b>
     <br />
     This will permanently erase your account and delete any plans that you own, including any shared plans.
+    <br />
+    <a href="/home">View my plans</a>
   </p>
 
   <div class="button-row">

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.html
@@ -9,19 +9,30 @@
     <a href="/home">View my plans</a>
   </p>
 
-  <div class="button-row">
+      <form [formGroup]="deleteAccountForm">
+        <mat-form-field>
+          <mat-label>Password</mat-label>
+          <input
+            type="password"
+            required
+            formControlName="currentPassword"
+            matInput />
+        </mat-form-field>
 
-    <button
-      mat-raised-button
-      color="warn"
-      (click)="deleteAccount()"
-      [disabled]="disableDeleteButton">
-      DELETE
-    </button>
+        <div class="button-row">
 
-    <button mat-raised-button (click)="cancel()">CANCEL</button>
+          <button
+            mat-raised-button
+            color="warn"
+            (click)="deleteAccount()"
+            [disabled]="disableDeleteButton">
+            DELETE
+          </button>
 
-  </div>
+          <button mat-raised-button (click)="cancel()">CANCEL</button>
+
+        </div>
+      </form>
 
   <p *ngIf="error">{{ error }}</p>
 </div>

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.spec.ts
@@ -1,12 +1,14 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import {
   MAT_DIALOG_DATA,
   MatDialog,
   MatDialogRef,
 } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
 import { AuthService } from 'src/app/services';
@@ -47,7 +49,7 @@ describe('DeleteAccountDialogComponent', () => {
       {}
     );
     await TestBed.configureTestingModule({
-      imports: [MaterialModule],
+      imports: [FormsModule, MaterialModule, ReactiveFormsModule, NoopAnimationsModule],
       declarations: [DeleteAccountDialogComponent],
       providers: [
         {
@@ -95,12 +97,15 @@ describe('DeleteAccountDialogComponent', () => {
     const deleteButton: MatButtonHarness = await loader.getHarness(
       MatButtonHarness.with({ text: /DELETE/ })
     );
+    component.deleteAccountForm.setValue({
+      currentPassword: 'password',
+    });
 
     await deleteButton.click();
 
     expect(fakeAuthService.deleteUser).toHaveBeenCalledOnceWith({
       email: 'test@test.com',
-    });
+    }, 'password');
     expect(dialogRef.close).toHaveBeenCalledOnceWith({ deletedAccount: true });
   });
 });

--- a/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/delete-account-dialog/delete-account-dialog.component.ts
@@ -1,4 +1,5 @@
 import { Component, Inject } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { AuthService } from 'src/app/services';
 import { User } from 'src/app/types';
@@ -9,14 +10,22 @@ import { User } from 'src/app/types';
   styleUrls: ['./delete-account-dialog.component.scss'],
 })
 export class DeleteAccountDialogComponent {
+  deleteAccountForm: FormGroup;
   disableDeleteButton: boolean = false;
   error: any;
 
   constructor(
     private authService: AuthService,
     @Inject(MAT_DIALOG_DATA) private data: { user: User },
+    private fb: FormBuilder,
     private dialogRef: MatDialogRef<DeleteAccountDialogComponent>
-  ) {}
+  ) {
+    this.deleteAccountForm = this.fb.group(
+      {
+        currentPassword: this.fb.control('', [Validators.required]),
+      },
+    );
+  }
 
   cancel(): void {
     this.dialogRef.close();
@@ -24,7 +33,7 @@ export class DeleteAccountDialogComponent {
 
   deleteAccount(): void {
     this.disableDeleteButton = true;
-    this.authService.deleteUser(this.data.user).subscribe(
+    this.authService.deleteUser(this.data.user, this.deleteAccountForm.get("currentPassword")?.value).subscribe(
       (_) => {
         this.dialogRef.close({
           deletedAccount: true,

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -413,7 +413,7 @@ describe('AuthService', () => {
         email: 'test@test.com',
       };
 
-      service.deleteUser(user).subscribe((res) => {
+      service.deleteUser(user, 'password').subscribe((res) => {
         expect(res).toBeTrue();
         done();
       });
@@ -422,7 +422,7 @@ describe('AuthService', () => {
         BackendConstants.END_POINT + '/users/delete/'
       );
       expect(req.request.method).toEqual('POST');
-      expect(req.request.body).toEqual({ email: 'test@test.com' });
+      expect(req.request.body).toEqual({ email: 'test@test.com', password: 'password' });
       req.flush({ deleted: true });
       httpTestingController.verify();
     });
@@ -436,7 +436,7 @@ describe('AuthService', () => {
       email: 'test@test.com',
     };
 
-    service.deleteUser(user).subscribe((res) => {
+    service.deleteUser(user, 'password').subscribe((res) => {
       expect(service.loggedInStatus$.value).toBeFalse();
       expect(service.loggedInUser$.value).toBeNull();
       done();

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -203,11 +203,12 @@ export class AuthService {
    * "Deletes" user from backend. The behavior of this command is to disable the user account,
    *  not fully delete it, so data can be restored later if necessary.
    */
-  deleteUser(user: User): Observable<boolean> {
+  deleteUser(user: User, password: string): Observable<boolean> {
     return this.http
       .post(
         BackendConstants.END_POINT.concat('/users/delete/'),
         {
+          password: password,
           email: user.email,
         },
         {

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -22,6 +22,13 @@ class DeleteUserTest(TransactionTestCase):
             reverse('users:delete'), {},
             content_type='application/json')
         self.assertEqual(response.status_code, 400)
+
+    def test_missing_password(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse('users:delete'), {'email': 'testuser@test.com'},
+            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
     
     def test_different_user(self):
         self.client.force_login(self.user)
@@ -33,7 +40,7 @@ class DeleteUserTest(TransactionTestCase):
     def test_same_user(self):
         self.client.force_login(self.user)
         response = self.client.post(
-            reverse('users:delete'), {'email': 'testuser@test.com'},
+            reverse('users:delete'), {'email': 'testuser@test.com', 'password': '12345'},
             content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertFalse(User.objects.get(pk=self.user.pk).is_active)

--- a/src/planscape/users/views.py
+++ b/src/planscape/users/views.py
@@ -29,8 +29,11 @@ def delete_user(request: HttpRequest) -> HttpResponse:
             raise ValueError("Must be logged in")
         body = json.loads(request.body)
         user_email_to_delete = body.get('email', None)
+        password = body.get('password', None)
         if user_email_to_delete is None or not isinstance(user_email_to_delete, str):
             raise ValueError("User email must be provided as a string")
+        if not logged_in_user.check_password(password):
+            raise ValueError("Invalid password")
         if user_email_to_delete != logged_in_user.email:
             raise ValueError("Cannot delete another user account")
 


### PR DESCRIPTION
See: https://sig-gis.atlassian.net/browse/PLAM-7
- Add URL to list of plans in delete account dialog so that user can visit them before making the final blow
- Swap position of delete/cancel buttons in delete account dialog for consistency
- Require user to type their password to delete account