### PR TITLE
Add validation for password reset confirmation

### DIFF
--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -225,7 +225,6 @@ REST_AUTH = {
     "JWT_AUTH_HTTPONLY": False,
     "REGISTER_SERIALIZER": "users.serializers.NameRegistrationSerializer",
     "OLD_PASSWORD_FIELD_ENABLED": True,
-
     "PASSWORD_RESET_SERIALIZER": "users.serializers.CustomPasswordResetSerializer",
     "PASSWORD_RESET_CONFIRM_SERIALIZER": "users.serializers.PasswordResetConfirmSerializer",
 }
@@ -259,6 +258,10 @@ EMAIL_USE_TLS = True
 EMAIL_PORT = 587
 EMAIL_HOST_USER = "noreply@planscape.org"
 EMAIL_HOST_PASSWORD = config("EMAIL_BACKEND_APP_PASSWORD", default="UNSET")
+<<<<<<< HEAD
+=======
+PASSWORD_RESET_TIMEOUT = 1800   # 30 minutes.
+>>>>>>> 166929a0 (Rebasing to resolve conflicts.)
 
 
 # PostGIS constants. All raster data should be ingested with a common

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -113,6 +113,9 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "planscape.wsgi.application"
 
+# TODO: This is for debugging email messages, and it needs to be removed.
+EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend'
+
 PLANSCAPE_DATABASE_HOST = config("PLANSCAPE_DATABASE_HOST", default="localhost")
 PLANSCAPE_DATABASE_PASSWORD = config("PLANSCAPE_DATABASE_PASSWORD", default="pass")
 PLANSCAPE_DATABASE_USER = config("PLANSCAPE_DATABASE_USER", default="planscape")
@@ -222,8 +225,9 @@ REST_AUTH = {
     "JWT_AUTH_HTTPONLY": False,
     "REGISTER_SERIALIZER": "users.serializers.NameRegistrationSerializer",
     "OLD_PASSWORD_FIELD_ENABLED": True,
+
     "PASSWORD_RESET_SERIALIZER": "users.serializers.CustomPasswordResetSerializer",
-    "PASSWORD_RESET_CONFIRM_SERIALIZER": "dj_rest_auth.serializers.PasswordResetConfirmSerializer",
+    "PASSWORD_RESET_CONFIRM_SERIALIZER": "users.serializers.PasswordResetConfirmSerializer",
 }
 
 AUTHENTICATION_BACKENDS = [

--- a/src/planscape/planscape/urls.py
+++ b/src/planscape/planscape/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from dj_rest_auth.registration.views import VerifyEmailView
+from dj_rest_auth.views import PasswordResetConfirmView
 
 urlpatterns = [
     path('planscape-backend/admin/', admin.site.urls),
@@ -33,4 +34,8 @@ urlpatterns = [
     path(
         'planscape-backend/dj-rest-auth/registration/account-confirm-email/',
         VerifyEmailView.as_view()),
+    # TODO: We don't actually need this since we'll be using
+    # a different endpoint.
+    path('planscape-backend/dj-rest-auth/password/reset/confirm/<uidb64>/<token>/',
+         PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
 ]


### PR DESCRIPTION
The existing behavior of dj-rest-auth provided serializer PasswordResetConfirmSerializer validate the token and set the password in one go, this change extends the serializer and make that a two steps process.