### PR TITLE
Remove reduntant subscribe call from account creation page

### DIFF
--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -76,7 +76,6 @@
             mat-flat-button
             type="submit"
             color="primary"
-            (click)="signup()"
             [disabled]="!form.valid || submitted">
             {{ submitted ? 'Please wait...' : 'Create account' }}
           </button>


### PR DESCRIPTION
The `signup()` method was accidentally being called twice, once from the form submit tag and once from the button tag, causing a "user account already exists" error to be thrown on the server on the second invocation every time a new account was being created.