### PR TITLE
Fix Angular test failure due to missing module import in test file

### DIFF
--- a/src/interface/src/app/signup/signup.component.spec.ts
+++ b/src/interface/src/app/signup/signup.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
 
@@ -20,7 +21,7 @@ describe('SignupComponent', () => {
       {}
     );
     TestBed.configureTestingModule({
-      imports: [FormsModule, MaterialModule, ReactiveFormsModule],
+      imports: [FormsModule, MaterialModule, NoopAnimationsModule, ReactiveFormsModule],
       declarations: [SignupComponent],
       providers: [
         { provide: Router, useFactory: routerStub },


### PR DESCRIPTION
Added NoopAnimationsModule to resolve test error message with MatDialog.