### PR TITLE
Add users/is_verified endpoint

### DIFF
--- a/src/planscape/users/urls.py
+++ b/src/planscape/users/urls.py
@@ -6,4 +6,5 @@ app_name = 'users'
 urlpatterns = [
     path('delete/', views.delete_user, name='delete'),
     path('get_user_by_id/', views.get_user_by_id, name='get_user_by_id'),
+    path('is_verified/', views.is_verified_user, name='is_verified_user'),
 ]

--- a/src/planscape/users/views.py
+++ b/src/planscape/users/views.py
@@ -1,5 +1,6 @@
 import json
 
+from allauth.account.utils import has_verified_email
 from django.contrib.auth.models import User
 from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest,
                          JsonResponse)
@@ -42,5 +43,17 @@ def delete_user(request: HttpRequest) -> HttpResponse:
         logged_in_user.save()
 
         return JsonResponse({"deleted": True})
+    except Exception as e:
+        return HttpResponseBadRequest("Ill-formed request: " + str(e))
+
+
+def is_verified_user(request: HttpRequest) -> HttpResponse:
+    try:
+        logged_in_user = get_user(request)
+        if logged_in_user is None:
+            raise ValueError("Must be logged in")
+        if not has_verified_email(logged_in_user):
+            raise ValueError("Email not verified.")
+        return JsonResponse({"verified": True})
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))


### PR DESCRIPTION
Get request to `/users/is_verified`.
* If the user is not logged in, it will return 400 Bad request.
* If the user is logged in but not verified, it will return 400 Bad request. 
* If the user is logged in and verified, it will return 200 Success. 

@macieksmuga -- Would this work for the frontend? I assume it is also possible to trigger a resend email if they login and are not verified? 
Let me know if anything would help make this easier for the frontend. 