### PR TITLE
remove new_navigation feature flag and update tests

### DIFF
--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -83,9 +83,6 @@ This flag will enable the Project Area control panel in the Scenario Configurati
 This flag will enable use of ITS data for past resilience projects rather than
 Calmapper.
 
-### new_navigation
-This flag controls the changes regarding the new navigation. The new navigation introduces another top toolbar and removes the left sidebar and menu.
-
 ### Other flags
 There are two other flags, testFalseFeature and testTrueFeature created just for
 automated testing.  Their values should be kept to "false" and "true" for

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,6 +1,5 @@
 {
   "login": true,
-  "new_navigation": true,
   "show_centralcoast": true,
   "show_future_control_panel": false,
   "show_socal": true,

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -1,6 +1,6 @@
 <div class="controls-container">
   <h1><b>Map Control Panel</b></h1>
-  <div *featureFlag="'new_navigation'" class="region-wrapper">
+  <div *featureFlag="'login'" class="region-wrapper">
     <div>Region</div>
     <app-region-dropdown></app-region-dropdown>
   </div>

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,8 +1,8 @@
 <app-nav-bar
   (goBack)="backHome()"
   [breadcrumbs]="['New Plan']"
-  *featureFlag="'new_navigation'"></app-nav-bar>
-<div class="root-container" [ngClass]="{ 'with-navbar': hasNewNavigation }">
+  *featureFlag="'login'"></app-nav-bar>
+<div class="root-container" [ngClass]="{ 'with-navbar': login_enabled }">
   <!-- Map control panel -->
   <app-map-control-panel
     [boundaryConfig]="boundaryConfig$ | async"

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -123,8 +123,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   private readonly destroy$ = new Subject<void>();
   login_enabled = this.featureService.isFeatureEnabled('login');
 
-  hasNewNavigation = this.featureService.isFeatureEnabled('new_navigation');
-
   constructor(
     public applicationRef: ApplicationRef,
     private authService: AuthService,

--- a/src/interface/src/app/navigation/navigation.component.html
+++ b/src/interface/src/app/navigation/navigation.component.html
@@ -1,6 +1,6 @@
 <mat-sidenav-container
   class="sidenav-container"
-  *featureFlag="'new_navigation'; hide: true">
+  *featureFlag="'login'; hide: true">
   <mat-sidenav
     #drawer
     class="sidenav"
@@ -62,4 +62,4 @@
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>
-<router-outlet *featureFlag="'new_navigation'"></router-outlet>
+<router-outlet *featureFlag="'login'"></router-outlet>

--- a/src/interface/src/app/navigation/navigation.component.spec.ts
+++ b/src/interface/src/app/navigation/navigation.component.spec.ts
@@ -9,6 +9,7 @@ import { AuthService } from '../services';
 import { NavigationComponent } from './navigation.component';
 import { FeatureService } from '../features/feature.service';
 import { By } from '@angular/platform-browser';
+import { FEATURES_JSON } from '../features/features-config';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
@@ -34,41 +35,46 @@ describe('NavigationComponent', () => {
         RouterTestingModule,
       ],
       declarations: [NavigationComponent],
-      providers: [{ provide: AuthService, useValue: fakeAuthService }],
+      providers: [
+        { provide: AuthService, useValue: fakeAuthService },
+        { provide: FEATURES_JSON, useValue: { login: false } },
+      ],
     });
-    fixture = TestBed.createComponent(NavigationComponent);
-    component = fixture.componentInstance;
   });
 
-  it('can load instance', () => {
+  function setUpComponent() {
+    fixture = TestBed.createComponent(NavigationComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  it('can load instance', () => {
+    setUpComponent();
     expect(component).toBeTruthy();
   });
 
   it(`sidebarOpen has default value`, () => {
-    fixture.detectChanges();
+    setUpComponent();
     expect(component.sidebarOpen).toEqual(false);
   });
 
-  it('should show sidebar if not on new_navigation fflag', () => {
-    const service = TestBed.inject(FeatureService);
-    spyOn(service, 'isFeatureEnabled').and.returnValue(false);
-    fixture.detectChanges();
-
+  it('should show sidebar if not on login fflag', () => {
+    setUpComponent();
     const sidebar = fixture.debugElement.query(By.css('.sidenav'));
     expect(sidebar).toBeTruthy();
   });
 
   it('should not show sidebar if on navigation fflag', () => {
-    const service = TestBed.inject(FeatureService);
-    spyOn(service, 'isFeatureEnabled').and.returnValue(true);
-    fixture.detectChanges();
+    TestBed.overrideProvider(FEATURES_JSON, {
+      useValue: { login: true },
+    });
+    setUpComponent();
     const sidebar = fixture.debugElement.query(By.css('.sidenav'));
     expect(sidebar).toBeFalsy();
   });
 
   it(`isLoggedIn$ has default value`, () => {
-    fixture.detectChanges();
+    setUpComponent();
     const authServiceStub: AuthService =
       fixture.debugElement.injector.get(AuthService);
     expect(component.isLoggedIn$).toEqual(authServiceStub.isLoggedIn$);
@@ -76,7 +82,7 @@ describe('NavigationComponent', () => {
 
   describe('logout', () => {
     it('makes expected calls', () => {
-      fixture.detectChanges();
+      setUpComponent();
       const authServiceStub: AuthService =
         fixture.debugElement.injector.get(AuthService);
       component.logout();

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -1,8 +1,8 @@
 <app-nav-bar
   (goBack)="goBack()"
   [breadcrumbs]="(breadcrumbs$ | async) || []"
-  *featureFlag="'new_navigation'"></app-nav-bar>
-<div class="root-container" [ngClass]="{ 'with-navbar': hasNewNavigation }">
+  *featureFlag="'login'"></app-nav-bar>
+<div class="root-container" [ngClass]="{ 'with-navbar': loginEnabled }">
   <app-plan-unavailable *ngIf="planNotFound"></app-plan-unavailable>
   <ng-container *ngIf="currentPlan$ | async">
     <div class="plan-summary-panel" *ngIf="showOverview$ | async">
@@ -12,7 +12,7 @@
     </div>
     <mat-divider [vertical]="true" *ngIf="showOverview$ | async"></mat-divider>
     <div class="plan-content">
-      <ng-container *featureFlag="'new_navigation'; hide: true">
+      <ng-container *featureFlag="'login'; hide: true">
         <app-plan-navigation-bar
           (backToOverviewEvent)="backToOverview()"
           *ngIf="!(showOverview$ | async)"></app-plan-navigation-bar>

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -59,7 +59,7 @@ export class PlanComponent implements OnInit, OnDestroy {
     })
   );
 
-  hasNewNavigation = this.featureService.isFeatureEnabled('new_navigation');
+  loginEnabled = this.featureService.isFeatureEnabled('login');
 
   private readonly destroy$ = new Subject<void>();
 

--- a/src/interface/src/app/region-dropdown/region-dropdown.component.html
+++ b/src/interface/src/app/region-dropdown/region-dropdown.component.html
@@ -1,12 +1,12 @@
 <!-- Region Dropdown -->
 <div
   [ngClass]="{
-    'region-dropdown-wrapper': !newNavigation,
-    'region-wrapper': newNavigation
+    'region-dropdown-wrapper': !loginEnabled,
+    'region-wrapper': loginEnabled
   }">
   <select
     (change)="setRegion($event)"
-    [ngClass]="{ 'region-dropdown': !newNavigation, region: newNavigation }">
+    [ngClass]="{ 'region-dropdown': !loginEnabled, region: loginEnabled }">
     <option [selected]="!(selectedRegion$ | async)" disabled>
       Select a region
     </option>

--- a/src/interface/src/app/region-dropdown/region-dropdown.component.ts
+++ b/src/interface/src/app/region-dropdown/region-dropdown.component.ts
@@ -13,7 +13,7 @@ export class RegionDropdownComponent {
   readonly regionOptions: RegionOption[] = regionOptions;
   readonly selectedRegion$ = this.sessionService.region$;
 
-  newNavigation = this.featureService.isFeatureEnabled('new_navigation');
+  loginEnabled = this.featureService.isFeatureEnabled('login');
 
   constructor(
     private router: Router,

--- a/src/interface/src/app/top-bar/top-bar.component.html
+++ b/src/interface/src/app/top-bar/top-bar.component.html
@@ -1,7 +1,7 @@
 <mat-toolbar [color]="color" class="mat-elevation-z4">
   <!-- Hamburger Menu -->
   <button
-    *featureFlag="'new_navigation'; hide: true"
+    *featureFlag="'login'; hide: true"
     mat-icon-button
     data-testid="menu-button"
     class="menu-button"
@@ -14,7 +14,7 @@
   <a
     class="site-link"
     routerLink="/home"
-    *featureFlag="'new_navigation'; hide: true"
+    *featureFlag="'login'; hide: true"
     data-id="title">
     Planscape preview
   </a>
@@ -23,7 +23,7 @@
   <a
     class="site-link logo-center"
     routerLink="/home"
-    *featureFlag="'new_navigation'"
+    *featureFlag="'login'"
     data-id="logo">
     <img src="assets/svg/logo.svg" alt="planscape logo" />
     Planscape
@@ -33,11 +33,10 @@
   <img
     class="region-dropdown-icon"
     src="assets/svg/region-dropdown-icon.svg"
-    *featureFlag="'new_navigation'; hide: true" />
+    *featureFlag="'login'; hide: true" />
 
   <!-- Region Dropdown -->
-  <app-region-dropdown
-    *featureFlag="'new_navigation'; hide: true"></app-region-dropdown>
+  <app-region-dropdown *featureFlag="'login'; hide: true"></app-region-dropdown>
 
   <!-- Space between left and right elements -->
   <span class="spacer"></span>
@@ -49,7 +48,7 @@
     data-id="feedback"
     target="_blank"
     rel="noopener noreferrer"
-    *featureFlag="'new_navigation'">
+    *featureFlag="'login'">
     Feedback
   </a>
 
@@ -61,15 +60,12 @@
     aria-label="help button"
     rel="noopener noreferrer"
     data-id="help"
-    *featureFlag="'new_navigation'; hide: true">
+    *featureFlag="'login'; hide: true">
     <mat-icon class="material-symbols-outlined">help_outline</mat-icon>
   </a>
   <span class="username">{{ displayName }}</span>
 
-  <button
-    mat-icon-button
-    [matMenuTriggerFor]="dotMenu"
-    *featureFlag="'new_navigation'">
+  <button mat-icon-button [matMenuTriggerFor]="dotMenu" *featureFlag="'login'">
     <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
   </button>
   <mat-menu #dotMenu="matMenu">

--- a/src/interface/src/app/top-bar/top-bar.component.spec.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.spec.ts
@@ -53,7 +53,7 @@ describe('TopBarComponent', () => {
         { provide: SessionService, useValue: mockSessionService },
         {
           provide: FEATURES_JSON,
-          useValue: { new_navigation: false },
+          useValue: { login: false },
         },
       ],
     }).compileComponents();
@@ -133,9 +133,9 @@ describe('TopBarComponent', () => {
   });
 
   describe('feedback button', () => {
-    it('should show the feedback button when on new_navigation flag is on', () => {
+    it('should show the feedback button when on login flag is on', () => {
       TestBed.overrideProvider(FEATURES_JSON, {
-        useValue: { new_navigation: true },
+        useValue: { login: true },
       });
       setUpComponent();
       const feedbackBtn = fixture.debugElement.query(
@@ -143,7 +143,7 @@ describe('TopBarComponent', () => {
       );
       expect(feedbackBtn).toBeTruthy();
     });
-    it('should not show the button when new_navigation flag is off ', () => {
+    it('should not show the button when login flag is off ', () => {
       setUpComponent();
       const feedbackBtn = fixture.debugElement.query(
         By.css('[data-id="feedback"]')
@@ -153,9 +153,9 @@ describe('TopBarComponent', () => {
   });
 
   describe('help button', () => {
-    it('should not show the help button when on new_navigation flag is on', () => {
+    it('should not show the help button when on login flag is on', () => {
       TestBed.overrideProvider(FEATURES_JSON, {
-        useValue: { new_navigation: true },
+        useValue: { login: true },
       });
       setUpComponent();
       const feedbackBtn = fixture.debugElement.query(
@@ -163,7 +163,7 @@ describe('TopBarComponent', () => {
       );
       expect(feedbackBtn).toBeFalsy();
     });
-    it('should show the help button when new_navigation flag is off ', () => {
+    it('should show the help button when login flag is off ', () => {
       setUpComponent();
       const feedbackBtn = fixture.debugElement.query(
         By.css('[data-id="help"]')
@@ -173,9 +173,9 @@ describe('TopBarComponent', () => {
   });
 
   describe('new logo', () => {
-    it('should show the new logo when new_navigation flag is on', () => {
+    it('should show the new logo when login flag is on', () => {
       TestBed.overrideProvider(FEATURES_JSON, {
-        useValue: { new_navigation: true },
+        useValue: { login: true },
       });
       setUpComponent();
       const logo = fixture.debugElement.query(By.css('[data-id="logo"]'));
@@ -183,7 +183,7 @@ describe('TopBarComponent', () => {
       expect(logo).toBeTruthy();
       expect(title).toBeFalsy();
     });
-    it('should show the preview logo when new_navigation flag is off ', () => {
+    it('should show the preview logo when login flag is off ', () => {
       setUpComponent();
       const logo = fixture.debugElement.query(By.css('[data-id="logo"]'));
       const title = fixture.debugElement.query(By.css('[data-id="title"]'));


### PR DESCRIPTION
I've added a feature flag for the new navigation and flows, however this changes are really dependent on having `login` enabled, so we don't really need two flags.
This pr removes the `new_navigation` flag  and uses `login` instead, and updates some tests.

With `login` false
<img width="1496" alt="Screen Shot 2023-09-12 at 14 10 14" src="https://github.com/PatManley/Planscape/assets/358892/92393e09-e0cd-4af5-9b12-f2854c0728b4">


With `login` true, guest

<img width="1496" alt="Screen Shot 2023-09-12 at 14 10 55" src="https://github.com/OurPlanscape/Planscape/assets/358892/54fb054c-dad0-4df7-a128-e5cb64aab240">

With `login` true, signed in
<img width="1496" alt="Screen Shot 2023-09-12 at 14 11 04" src="https://github.com/OurPlanscape/Planscape/assets/358892/18ff7e35-1cb3-4113-b9da-52d6896b9961">

