### PR TITLE
HTTP origin aware password reset link

### DIFF
--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -247,8 +247,6 @@ ACCOUNT_USERNAME_REQUIRED = False
 LOGOUT_ON_PASSWORD_CHANGE = False
 ACCOUNT_ADAPTER = "users.allauth_adapter.CustomAllauthAdapter"
 PASSWORD_RESET_TIMEOUT = 1800  # 30 minutes.
-# TODO: Need to figure out how this will be decided.
-PASSWORD_RESET_DOMAIN = "planscape.org"  # Password reset domain
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "smtp.gmail.com"

--- a/src/planscape/users/forms.py
+++ b/src/planscape/users/forms.py
@@ -16,26 +16,19 @@ class CustomAllAuthPasswordResetForm(AllAuthPasswordResetForm):
         configuration set via Django's configuration.
 
         """
-        domain = settings.PASSWORD_RESET_DOMAIN
+        referrer = request.META.get('HTTP_ORIGIN')
         token_generator = kwargs.get('token_generator', default_token_generator)
         email = self.cleaned_data['email']
         for user in self.users:
             token = token_generator.make_token(user)
             user_id = user_pk_to_url_str(user)
-            url = "{proto}://{domain}/reset/{uid}/{token}".format(
-                # Assume that the other service's http protocol is consistent
-                # with this one.
-                proto=app_settings.DEFAULT_HTTP_PROTOCOL,
-                domain=domain,
-                uid=user_id,
-                token=token,
-            )
+            url = f"{referrer}/reset/{user_id}/{token}"
             # We don't specify a username because authentication is based
             # on email.
             context = {
                 # TODO: Change the template since the default template expects
                 # a Site object.
-                "current_site": domain,
+                "current_site": referrer,
                 "user": user,
                 "password_reset_url": url,
                 "request": request,

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -99,3 +99,28 @@ class IsVerifiedUserTest(TransactionTestCase):
 
         response = self.client.get(reverse('users:is_verified_user'))
         self.assertEqual(response.status_code, 200)
+
+
+class PasswordResetTest(TransactionTestCase):
+    def setUp(self):
+        self.client.post(
+            reverse('rest_register'), {
+                                         "email": "testuser@test.com",
+                                         "password1": "ComplexPassword123",
+                                         "password2": "ComplexPassword123",
+                                         "first_name": "FirstName",
+                                         "last_name": "LastName"
+                                     })
+        self.user = User.objects.filter(email='testuser@test.com').get()
+
+    def test_reset_link(self):
+        self.client.force_login(self.user)
+        self.client.post(reverse("rest_password_reset"),
+                         {"email": "testuser@test.com"},
+                         HTTP_ORIGIN='http://localhost:4200')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject,
+                         "[Planscape] Password Reset E-mail")
+        self.assertContains(mail.outbox[0].body, "http://localhost:4200/reset")
+        

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -122,5 +122,5 @@ class PasswordResetTest(TransactionTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject,
                          "[Planscape] Password Reset E-mail")
-        self.assertContains(mail.outbox[0].body, "http://localhost:4200/reset")
+        self.assertIn("http://localhost:4200/reset", mail.outbox[0].body)
         


### PR DESCRIPTION
More work still needed on the email. It needs to saw "Team Planscape" instead of blank. Will handle as a follow up PR. 

current email example: 
```
Hello from !

You're receiving this e-mail because you or someone else has requested a password for your user account.
It can be safely ignored if you did not request a password reset. Click the link below to reset your password.

http://localhost:4200/reset/5n/bugby2-b26c2f9c2932330d7aabae24d7803ddd

Thank you for using !
```