### PR TITLE
Session and loading

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
@@ -24,7 +24,7 @@ describe('AccountDialogComponent', () => {
         updateUser: of(),
       },
       {
-        loggedInUser$: new BehaviorSubject<User | null>({
+        loggedInUser$: new BehaviorSubject<User | null | undefined>({
           firstName: 'Foo',
           lastName: 'Bar',
           email: 'test@test.com',

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -27,7 +27,7 @@ export class AccountDialogComponent implements OnInit {
   editingAccount: boolean = false;
   editAccountForm: FormGroup;
   error: any;
-  user$!: Observable<User | null>;
+  user$!: Observable<User | null | undefined>;
 
   constructor(
     private authService: AuthService,

--- a/src/interface/src/app/home/home.component.ts
+++ b/src/interface/src/app/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostBinding } from '@angular/core';
 import { AuthService } from '../services';
 import { FeatureService } from '../features/feature.service';
+import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-home',
@@ -8,7 +9,7 @@ import { FeatureService } from '../features/feature.service';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent {
-  loggedIn$ = this.authService.loggedInStatus$;
+  loggedIn$ = this.authService.loggedInStatus$.pipe(tap((v) => console.log(v)));
 
   login_enabled = this.featuresService.isFeatureEnabled('login');
 

--- a/src/interface/src/app/home/home.component.ts
+++ b/src/interface/src/app/home/home.component.ts
@@ -1,7 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { AuthService } from '../services';
 import { FeatureService } from '../features/feature.service';
-import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-home',
@@ -9,7 +8,7 @@ import { tap } from 'rxjs';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent {
-  loggedIn$ = this.authService.loggedInStatus$.pipe(tap((v) => console.log(v)));
+  loggedIn$ = this.authService.loggedInStatus$;
 
   login_enabled = this.featuresService.isFeatureEnabled('login');
 

--- a/src/interface/src/app/home/plan-table/plan-table.component.html
+++ b/src/interface/src/app/home/plan-table/plan-table.component.html
@@ -1,89 +1,97 @@
-<div *ngIf="datasource.data.length; else noplans">
-  <mat-table [dataSource]="datasource" matSort>
-    <!-- Name Column -->
-    <ng-container matColumnDef="name">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
-      <mat-cell *matCellDef="let element">
-        {{ element.name }}
-      </mat-cell>
-    </ng-container>
-
-    <!-- Timestamp Column -->
-    <!-- TODO replace with last modified-->
-    <ng-container matColumnDef="lastUpdated">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>
-        Date Last Modified
-      </mat-header-cell>
-      <mat-cell *matCellDef="let element">
-        {{ element.lastUpdated | date: 'medium' }}
-      </mat-cell>
-    </ng-container>
-
-    <!-- Acres Column -->
-    <ng-container matColumnDef="totalAcres">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>
-        Total Acres
-      </mat-header-cell>
-      <mat-cell *matCellDef="let element">
-        {{ element.totalAcres | number }}
-      </mat-cell>
-    </ng-container>
-
-    <!-- Saved Scenarios Column -->
-    <ng-container matColumnDef="scenarios">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>
-        # of Scenarios
-      </mat-header-cell>
-      <mat-cell *matCellDef="let element">
-        {{ element.scenarios }}
-      </mat-cell>
-    </ng-container>
-
-    <!-- Region Column -->
-    <ng-container matColumnDef="region">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>
-        Region
-      </mat-header-cell>
-      <mat-cell *matCellDef="let element">
-        {{ element.region }}
-      </mat-cell>
-    </ng-container>
-
-    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row
-      class="table-row"
-      [ngClass]="{ selected: selectedPlan && selectedPlan.id === row.id }"
-      *matRowDef="let row; columns: displayedColumns"
-      (click)="selectPlan(row)"
-      (dblclick)="goToScenario()"></mat-row>
-  </mat-table>
-
-  <div class="button-row">
-    <button
-      mat-button
-      (click)="deletePlan()"
-      [disabled]="!selectedPlan"
-      class="action-button">
-      delete
-    </button>
-    <!--    Todo add view map-->
-    <!--    <button-->
-    <!--      mat-raised-button-->
-    <!--      (click)="viewMap()"-->
-    <!--      [disabled]="!selectedPlan"-->
-    <!--      class="action-button primary">-->
-    <!--      view map-->
-    <!--    </button>-->
-    <button
-      mat-raised-button
-      (click)="goToScenario()"
-      [disabled]="!selectedPlan"
-      class="action-button primary">
-      scenarios
-    </button>
-  </div>
+<div *ngIf="loading; else dataLoaded">
+  <mat-spinner diameter="40" class="spinner"></mat-spinner>
 </div>
 
-<ng-template #noplans class="no-saved-plans">
-  <p>There are no saved plans.</p>
+<ng-template #dataLoaded>
+  <div *ngIf="datasource.data.length; else noplans">
+    <mat-table [dataSource]="datasource" matSort>
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>
+          Name
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
+          {{ element.name }}
+        </mat-cell>
+      </ng-container>
+
+      <!-- Timestamp Column -->
+      <!-- TODO replace with last modified-->
+      <ng-container matColumnDef="lastUpdated">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>
+          Date Last Modified
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
+          {{ element.lastUpdated | date: 'medium' }}
+        </mat-cell>
+      </ng-container>
+
+      <!-- Acres Column -->
+      <ng-container matColumnDef="totalAcres">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>
+          Total Acres
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
+          {{ element.totalAcres | number }}
+        </mat-cell>
+      </ng-container>
+
+      <!-- Saved Scenarios Column -->
+      <ng-container matColumnDef="scenarios">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>
+          # of Scenarios
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
+          {{ element.scenarios }}
+        </mat-cell>
+      </ng-container>
+
+      <!-- Region Column -->
+      <ng-container matColumnDef="region">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>
+          Region
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
+          {{ element.region }}
+        </mat-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row
+        class="table-row"
+        [ngClass]="{ selected: selectedPlan && selectedPlan.id === row.id }"
+        *matRowDef="let row; columns: displayedColumns"
+        (click)="selectPlan(row)"
+        (dblclick)="goToScenario()"></mat-row>
+    </mat-table>
+
+    <div class="button-row">
+      <button
+        mat-button
+        (click)="deletePlan()"
+        [disabled]="!selectedPlan"
+        class="action-button">
+        delete
+      </button>
+      <!--    Todo add view map-->
+      <!--    <button-->
+      <!--      mat-raised-button-->
+      <!--      (click)="viewMap()"-->
+      <!--      [disabled]="!selectedPlan"-->
+      <!--      class="action-button primary">-->
+      <!--      view map-->
+      <!--    </button>-->
+      <button
+        mat-raised-button
+        (click)="goToScenario()"
+        [disabled]="!selectedPlan"
+        class="action-button primary">
+        scenarios
+      </button>
+    </div>
+  </div>
+
+  <ng-template #noplans class="no-saved-plans">
+    <p>There are no saved plans.</p>
+  </ng-template>
 </ng-template>

--- a/src/interface/src/app/home/plan-table/plan-table.component.scss
+++ b/src/interface/src/app/home/plan-table/plan-table.component.scss
@@ -95,3 +95,8 @@ mat-header-row , mat-row{
 .mat-header-cell:not(.mat-column-name ) {
   border-right: 1px solid rgba(0, 0, 0, 0.12);
 }
+
+.spinner {
+  margin: auto;
+  padding-top: 20px;
+}

--- a/src/interface/src/app/home/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/home/plan-table/plan-table.component.ts
@@ -25,6 +25,7 @@ export class PlanTableComponent implements OnInit {
 
   datasource = new MatTableDataSource<PlanRow>();
   selectedPlan: PlanRow | null = null;
+  loading = true;
 
   displayedColumns: string[] = [
     'name',
@@ -53,6 +54,7 @@ export class PlanTableComponent implements OnInit {
       .listPlansByUser(null)
       .pipe(take(1))
       .subscribe((plans) => {
+        this.loading = false;
         this.datasource.data = plans.map((plan) => {
           return {
             ...plan,

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -49,7 +49,7 @@ describe('MapComponent', () => {
   let fixture: ComponentFixture<MapComponent>;
   let loader: HarnessLoader;
   let sessionInterval = new BehaviorSubject<number>(0);
-  let userSignedIn$ = new BehaviorSubject<boolean>(false);
+  let userSignedIn$ = new BehaviorSubject<boolean | null>(false);
 
   beforeEach(() => {
     const fakeLayer: L.Layer = L.vectorGrid.protobuf(

--- a/src/interface/src/app/navigation/navigation.component.ts
+++ b/src/interface/src/app/navigation/navigation.component.ts
@@ -29,7 +29,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
       icon: 'explore',
     },
   ];
-  isLoggedIn$: Observable<boolean> = this.authService.isLoggedIn$;
+  isLoggedIn$: Observable<boolean | null> = this.authService.isLoggedIn$;
 
   private isLoggedInSubscription!: Subscription;
 

--- a/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
+++ b/src/interface/src/app/plan/scenario-details/outcome/outcome.component.ts
@@ -59,7 +59,7 @@ export class OutcomeComponent implements OnInit, OnChanges {
     if (this.plan) {
       this.totalPlanningAreaAcres = calculateAcres(this.plan.planningArea!);
     }
-    this.authService.loggedInUser$.pipe(take(1)).subscribe(this.currentUser$);
+    //this.authService.loggedInUser$.pipe(take(1)).subscribe(this.currentUser$);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/interface/src/app/region-dropdown/region-dropdown.component.spec.ts
+++ b/src/interface/src/app/region-dropdown/region-dropdown.component.spec.ts
@@ -17,7 +17,7 @@ describe('RegionDropdownComponent', () => {
 
   beforeEach(async () => {
     mockAuthService = {
-      loggedInUser$: new BehaviorSubject<User | null>(null),
+      loggedInUser$: new BehaviorSubject<User | null | undefined>(null),
     };
     mockSessionService = {
       region$: new BehaviorSubject<Region | null>(null),

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -90,7 +90,7 @@ describe('AuthService', () => {
       service.login('email', 'password').subscribe(
         (_) => {},
         (_) => {
-          expect(service.loggedInStatus$.value).toBeFalse();
+          expect(service.loggedInStatus$.value).toBeNull();
           done();
         }
       );
@@ -128,11 +128,11 @@ describe('AuthService', () => {
     it('if unsuccessful, does not make request to backend /user endpoint', (done) => {
       service.login('email', 'password').subscribe(
         (_) => {
-          expect(service.loggedInStatus$.value).toBeFalse();
+          expect(service.loggedInStatus$.value).toBeNull();
           done();
         },
         (_) => {
-          expect(service.loggedInStatus$.value).toBeFalse();
+          expect(service.loggedInStatus$.value).toBeNull();
           done();
         }
       );
@@ -154,7 +154,7 @@ describe('AuthService', () => {
       service
         .signup('email', 'password1', 'password2', 'Foo', 'Bar')
         .subscribe((_) => {
-          expect(service.loggedInStatus$.value).toBeFalse();
+          expect(service.loggedInStatus$.value).toBeNull();
           done();
         });
 
@@ -168,7 +168,7 @@ describe('AuthService', () => {
       service.signup('email', 'password1', 'password2', 'Foo', 'Bar').subscribe(
         (_) => {},
         (_) => {
-          expect(service.loggedInStatus$.value).toBeFalse();
+          expect(service.loggedInStatus$.value).toBeNull();
           done();
         }
       );
@@ -417,7 +417,10 @@ describe('AuthService', () => {
         BackendConstants.END_POINT + '/users/delete/'
       );
       expect(req.request.method).toEqual('POST');
-      expect(req.request.body).toEqual({ email: 'test@test.com', password: 'password' });
+      expect(req.request.body).toEqual({
+        email: 'test@test.com',
+        password: 'password',
+      });
       req.flush({ deleted: true });
       httpTestingController.verify();
     });

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -1,17 +1,25 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { ActivatedRouteSnapshot, CanActivate, Resolve, Router, RouterStateSnapshot } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Resolve,
+  Router,
+  RouterStateSnapshot,
+} from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import {
   BehaviorSubject,
   catchError,
   concatMap,
   map,
+  NEVER,
   Observable,
   of,
   take,
   tap,
+  throwError,
 } from 'rxjs';
 
 import { BackendConstants } from '../backend-constants';
@@ -25,9 +33,9 @@ interface LogoutResponse {
   providedIn: 'root',
 })
 export class AuthService {
-  loggedInStatus$ = new BehaviorSubject(false);
-  isLoggedIn$: Observable<boolean> = this.loggedInStatus$;
-  loggedInUser$ = new BehaviorSubject<User | null>(null);
+  loggedInStatus$ = new BehaviorSubject<boolean | null>(null);
+  isLoggedIn$: Observable<boolean | null> = this.loggedInStatus$;
+  loggedInUser$ = new BehaviorSubject<User | null | undefined>(undefined);
 
   private readonly API_ROOT = BackendConstants.END_POINT + '/dj-rest-auth/';
 
@@ -63,23 +71,19 @@ export class AuthService {
     firstName: string,
     lastName: string
   ) {
-    return this.http
-      .post(this.API_ROOT.concat('registration/'), {
-        password1,
-        password2,
-        email,
-        first_name: firstName,
-        last_name: lastName,
-      });
+    return this.http.post(this.API_ROOT.concat('registration/'), {
+      password1,
+      password2,
+      email,
+      first_name: firstName,
+      last_name: lastName,
+    });
   }
 
-  resendValidationEmail(
-    email: string,
-  ) {
-    return this.http
-      .post(this.API_ROOT.concat('registration/resend-email/'), {
-        email,
-      });
+  resendValidationEmail(email: string) {
+    return this.http.post(this.API_ROOT.concat('registration/resend-email/'), {
+      email,
+    });
   }
 
   logout() {
@@ -97,10 +101,12 @@ export class AuthService {
   }
 
   validateAccount(token: string) {
-    return this.http
-      .post(this.API_ROOT.concat('registration/account-confirm-email/'), {
+    return this.http.post(
+      this.API_ROOT.concat('registration/account-confirm-email/'),
+      {
         key: token,
-      });
+      }
+    );
   }
 
   private refreshToken() {
@@ -113,6 +119,11 @@ export class AuthService {
       .pipe(
         tap((response: any) => {
           this.loggedInStatus$.next(!!response.access);
+        }),
+        catchError((err) => {
+          this.loggedInStatus$.next(false);
+          this.loggedInUser$.next(null);
+          return throwError(err);
         })
       );
   }
@@ -292,13 +303,13 @@ export class AuthGuard implements CanActivate {
 export class ValidationResolver implements Resolve<boolean> {
   constructor(
     private authService: AuthService,
-    private router: Router,
+    private router: Router
   ) {}
 
   resolve(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-    ): Observable<boolean> {
+  ): Observable<boolean> {
     const token = route.paramMap.get('id');
     if (!token) {
       this.router.navigate(['home']);

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -14,7 +14,6 @@ import {
   catchError,
   concatMap,
   map,
-  NEVER,
   Observable,
   of,
   take,

--- a/src/interface/src/app/top-bar/top-bar.component.html
+++ b/src/interface/src/app/top-bar/top-bar.component.html
@@ -42,73 +42,76 @@
   <!-- Space between left and right elements -->
   <span class="spacer"></span>
 
-  <!--  Feedback-->
-  <a
-    routerLink="/feedback"
-    class="nav-link"
-    data-id="feedback"
-    target="_blank"
-    rel="noopener noreferrer"
-    *featureFlag="'new_navigation'">
-    Feedback
-  </a>
+  <!-- Show this section once we know if the user is logged in or not to avoid -->
+  <!-- flashing guest / default icon and content shifting -->
+  <ng-container *ngIf="(displayName$ | async) !== undefined">
+    <!--  Feedback-->
+    <a
+      routerLink="/feedback"
+      class="nav-link"
+      data-id="feedback"
+      target="_blank"
+      rel="noopener noreferrer"
+      *featureFlag="'new_navigation'">
+      Feedback
+    </a>
 
-  <!-- Account Name & Button -->
-  <a
-    mat-icon-button
-    routerLink="/help"
-    target="_blank"
-    aria-label="help button"
-    rel="noopener noreferrer"
-    data-id="help"
-    *featureFlag="'new_navigation'; hide: true">
-    <mat-icon class="material-symbols-outlined">help_outline</mat-icon>
-  </a>
-  <span class="username">{{ displayName }}</span>
+    <!-- Account Name & Button -->
+    <a
+      mat-icon-button
+      routerLink="/help"
+      target="_blank"
+      aria-label="help button"
+      rel="noopener noreferrer"
+      data-id="help"
+      *featureFlag="'new_navigation'; hide: true">
+      <mat-icon class="material-symbols-outlined">help_outline</mat-icon>
+    </a>
+    <span class="username">{{ displayName$ | async }}</span>
 
-  <button
-    mat-icon-button
-    [matMenuTriggerFor]="dotMenu"
-    *featureFlag="'new_navigation'">
-    <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
-  </button>
-  <mat-menu #dotMenu="matMenu">
     <button
-      mat-menu-item
-      *ngIf="loggedIn$ | async"
-      (click)="logout()"
-      data-id="logout"
-      class="menu-link">
-      Log out
+      mat-icon-button
+      [matMenuTriggerFor]="dotMenu"
+      *featureFlag="'new_navigation'">
+      <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
     </button>
-    <a
-      mat-menu-item
-      *ngIf="(loggedIn$ | async) === false"
-      routerLink="/login"
-      class="menu-link">
-      Log in
-    </a>
-    <a
-      mat-menu-item
-      *ngIf="(loggedIn$ | async) === false"
-      routerLink="/signup"
-      class="menu-link">
-      Create account
-    </a>
-  </mat-menu>
+    <mat-menu #dotMenu="matMenu">
+      <button
+        mat-menu-item
+        *ngIf="loggedIn$ | async"
+        (click)="logout()"
+        data-id="logout"
+        class="menu-link">
+        Log out
+      </button>
+      <a
+        mat-menu-item
+        *ngIf="(loggedIn$ | async) === false"
+        routerLink="/login"
+        class="menu-link">
+        Log in
+      </a>
+      <a
+        mat-menu-item
+        *ngIf="(loggedIn$ | async) === false"
+        routerLink="/signup"
+        class="menu-link">
+        Create account
+      </a>
+    </mat-menu>
 
-  <button
-    mat-icon-button
-    data-testid="account-button"
-    class="top-bar-account-button"
-    aria-label="account icon button"
-    #accountButton
-    (click)="openAccountDialog()">
-    <!-- If user is not logged in or we dont have a display name, show default avatar icon -->
-    <mat-icon *ngIf="!loggedIn || !displayName">account_circle</mat-icon>
-    <!-- If we have a display name, show the first letter as avatar -->
-    <div class="avatar mat-icon" *ngIf="loggedIn && displayName">
-      {{ displayName.substring(0, 1) }}
-    </div>
-  </button>
+    <button
+      mat-icon-button
+      data-testid="account-button"
+      class="top-bar-account-button"
+      aria-label="account icon button"
+      (click)="openAccountDialog()">
+      <!-- If not logged in show default avatar icon -->
+      <mat-icon *ngIf="(loggedIn$ | async) === false">account_circle</mat-icon>
+      <!-- If logged in, show the first letter as avatar -->
+      <div *ngIf="loggedIn$ | async" class="avatar mat-icon">
+        {{ initial$ | async }}
+      </div>
+    </button>
+  </ng-container>
 </mat-toolbar>

--- a/src/interface/src/app/top-bar/top-bar.component.spec.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, of } from 'rxjs';
 
 import { MaterialModule } from '../material/material.module';
 import { AuthService, SessionService } from '../services';
@@ -31,7 +31,7 @@ describe('TopBarComponent', () => {
     );
 
     mockAuthService = {
-      loggedInUser$: new BehaviorSubject<User | null>(null),
+      loggedInUser$: new BehaviorSubject<User | null | undefined>(null),
       logout: () => of({ detail: '' }),
     };
     mockSessionService = {
@@ -112,8 +112,11 @@ describe('TopBarComponent', () => {
       setUpComponent();
     });
 
-    it('should be "Guest" when no user is logged in', () => {
-      expect(component.displayName).toEqual('Guest');
+    it('should be "Guest" when no user is logged in', async () => {
+      // expect(component.displayName).toEqual('Guest');
+      const displayName = await firstValueFrom(component.displayName$);
+      console.log('the display!');
+      console.log(displayName);
     });
 
     it('should be the first name of the logged in user', () => {
@@ -122,13 +125,13 @@ describe('TopBarComponent', () => {
         username: 'User',
       });
 
-      expect(component.displayName).toEqual('Foo');
+      //   expect(component.displayName).toEqual('Foo');
     });
 
     it('should be the username of the logged in user if they have no first name', () => {
       mockAuthService.loggedInUser$?.next({ username: 'User' });
 
-      expect(component.displayName).toEqual('User');
+      // expect(component.displayName).toEqual('User');
     });
   });
 

--- a/src/interface/src/app/top-bar/top-bar.component.spec.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.spec.ts
@@ -32,6 +32,7 @@ describe('TopBarComponent', () => {
 
     mockAuthService = {
       loggedInUser$: new BehaviorSubject<User | null | undefined>(null),
+      isLoggedIn$: new BehaviorSubject(false),
       logout: () => of({ detail: '' }),
     };
     mockSessionService = {
@@ -113,25 +114,23 @@ describe('TopBarComponent', () => {
     });
 
     it('should be "Guest" when no user is logged in', async () => {
-      // expect(component.displayName).toEqual('Guest');
       const displayName = await firstValueFrom(component.displayName$);
-      console.log('the display!');
-      console.log(displayName);
+      expect(displayName).toEqual('Guest');
     });
 
-    it('should be the first name of the logged in user', () => {
+    it('should be the first name of the logged in user', async () => {
       mockAuthService.loggedInUser$?.next({
         firstName: 'Foo',
         username: 'User',
       });
-
-      //   expect(component.displayName).toEqual('Foo');
+      const displayName = await firstValueFrom(component.displayName$);
+      expect(displayName).toEqual('Foo');
     });
 
-    it('should be the username of the logged in user if they have no first name', () => {
+    it('should be the username of the logged in user if they have no first name', async () => {
       mockAuthService.loggedInUser$?.next({ username: 'User' });
-
-      // expect(component.displayName).toEqual('User');
+      const displayName = await firstValueFrom(component.displayName$);
+      expect(displayName).toEqual('User');
     });
   });
 

--- a/src/interface/src/app/top-bar/top-bar.component.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.ts
@@ -1,13 +1,7 @@
-import {
-  Component,
-  EventEmitter,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subject, take, takeUntil } from 'rxjs';
+import { map, switchMap } from 'rxjs';
 
 import { AuthService } from '../services';
 import { AccountDialogComponent } from '../account-dialog/account-dialog.component';
@@ -18,52 +12,42 @@ import { FeatureService } from '../features/feature.service';
   templateUrl: './top-bar.component.html',
   styleUrls: ['./top-bar.component.scss'],
 })
-export class TopBarComponent implements OnInit, OnDestroy {
+export class TopBarComponent implements OnInit {
   @Output()
   toggleEvent = new EventEmitter<Event>();
 
-  // display name is first name and then username
-  displayName: string = '';
-  loggedIn = false;
-
   readonly color = 'primary';
 
-  private readonly destroy$ = new Subject<void>();
-
   loggedIn$ = this.authService.isLoggedIn$;
+
+  displayName$ = this.loggedIn$.pipe(
+    switchMap((loggedIn) => this.authService.loggedInUser$),
+    map((user) => {
+      if (user === undefined) {
+        return;
+      }
+
+      if (user) {
+        return user.firstName || user.username;
+      } else {
+        return 'Guest';
+      }
+    })
+  );
+
+  initial$ = this.displayName$.pipe(
+    map((displayName) => displayName?.substring(0, 1))
+  );
 
   constructor(
     private authService: AuthService,
     private dialog: MatDialog,
-    private router: Router,
-    private featureService: FeatureService,
-    private route: ActivatedRoute
+    private router: Router
   ) {}
 
   ngOnInit(): void {
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-    this.authService.loggedInUser$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((user) => {
-        if (user) {
-          this.displayName = user.firstName
-            ? user.firstName
-            : user.username
-            ? user.username
-            : '';
-          this.loggedIn = true;
-        } else {
-          this.displayName = 'Guest';
-          this.loggedIn = false;
-        }
-      });
   }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
   /** Opens the account management dialog. */
   openAccountDialog() {
     this.dialog.open(AccountDialogComponent);


### PR DESCRIPTION
In `AuthService` we where defaulting to false/ null the BehaviorSubjects for loggedInStatus$ and loggedInUser$.
This has the drawback that we cannot identify when we are _loading_ the user state, as the streams have an initial value which is the same as not having a user. 
This causes a flash of content while we get this info.

To solve this Im introducing null and undefined values to each stream. That way we can have the three scenarios we need:
- We don't now yet if user is logged in or not
- We know user is not logged in
- We know user is logged in.

Additionally Im adding some loading states on the plan table.
Im also hiding some contents on the navbar until we figure out user login state, to avoid a flash or shift of content.


This is how it looks like (with network throttling) :



https://github.com/OurPlanscape/Planscape/assets/358892/a93c9a46-2f04-48db-ad42-eededf2c35bf




I've updated tests and looks good on my end on login/logout but let me know if there is other scenarios I should test!
