### PR TITLE
Require traffic to django BE to originate from localhost.  Permit future expansion of allowed traffic.

### DIFF
--- a/src/interface/src/environments/environment.ts
+++ b/src/interface/src/environments/environment.ts
@@ -6,8 +6,8 @@ export const environment = {
   production: false,
   backend_endpoint: 'http://localhost:8000/planscape-backend',
   google_analytics_id: '', // Replace with actual ID.
-  tile_endpoint: '', // Replace with actual URL
-  download_endpoint: '', // Replace with actual URL
+  tile_endpoint: 'https://dev-geo.planscape.org/geoserver/', // Replace with actual URL
+  download_endpoint: 'https://dev-geo.planscape.org/', // Replace with actual URL
 };
 
 /*

--- a/src/interface/src/environments/environment.ts
+++ b/src/interface/src/environments/environment.ts
@@ -6,8 +6,8 @@ export const environment = {
   production: false,
   backend_endpoint: 'http://localhost:8000/planscape-backend',
   google_analytics_id: '', // Replace with actual ID.
-  tile_endpoint: 'https://dev-geo.planscape.org/geoserver/', // Replace with actual URL
-  download_endpoint: 'https://dev-geo.planscape.org/', // Replace with actual URL
+  tile_endpoint: '', // Replace with actual URL
+  download_endpoint: '', // Replace with actual URL
 };
 
 /*

--- a/src/planscape/existing_projects/tests.py
+++ b/src/planscape/existing_projects/tests.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.urls import reverse
 from requests.models import Response
-from django.test.client import Client as HttpClient
 
 class ITSTest(TestCase):
     def test_token_missing(self):

--- a/src/planscape/existing_projects/tests.py
+++ b/src/planscape/existing_projects/tests.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.urls import reverse
 from requests.models import Response
-
+from django.test.client import Client as HttpClient
 
 class ITSTest(TestCase):
     def test_token_missing(self):
@@ -15,5 +15,21 @@ class ITSTest(TestCase):
             response = self.client.get(
                 reverse("existing_projects:its"), {}, content_type="application/json"
             )
-
             self.assertEqual(response.status_code, 200)
+            self.assertRegex(str(response.content), r'key')
+            self.assertNotRegex(str(response.content), r'Coming soon')
+
+    def test_wrong_ip(self):
+        response = Response()
+        response.code = 200
+        response._content = b'{ "key" : "a" }'
+        with patch(
+            "existing_projects.views.requests.get", return_value=response
+        ) as get:
+            response = self.client.get(
+                '/planscape-backend/projects/its/', {}, **{'content_type':"application/json", 'REMOTE_ADDR':'192.168.0.1'}
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertRegex(str(response.content), r'Coming soon')
+            self.assertNotRegex(str(response.content), r'key')
+

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     "django.contrib.gis",
     "forsys",
     "leaflet",
+    "lockdown",
     "password_policies",
     "rest_framework",
     "rest_framework_gis",
@@ -89,6 +90,7 @@ MIDDLEWARE = [
     "password_policies.middleware.PasswordExpirationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+#    'lockdown.middleware.LockdownMiddleware',
 ]
 
 ROOT_URLCONF = "planscape.urls"
@@ -132,6 +134,22 @@ DATABASES = {
         },
     }
 }
+
+
+# Locking down API calls to only itself.
+LOCKDOWN_ENABLED = True
+
+# if we ever needed to make some backend APIs (views) available to anyone.
+LOCKDOWN_VIEW_EXCEPTIONS = [
+]
+
+# should put in all IPs matching planscape/trusted hosts
+LOCKDOWN_REMOTE_ADDR_EXCEPTIONS = [
+#    '127.0.0.1',
+#    '::1',
+]
+
+
 
 
 # Password validation

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -90,7 +90,7 @@ MIDDLEWARE = [
     "password_policies.middleware.PasswordExpirationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-#    'lockdown.middleware.LockdownMiddleware',
+    'lockdown.middleware.LockdownMiddleware',
 ]
 
 ROOT_URLCONF = "planscape.urls"
@@ -145,8 +145,8 @@ LOCKDOWN_VIEW_EXCEPTIONS = [
 
 # should put in all IPs matching planscape/trusted hosts
 LOCKDOWN_REMOTE_ADDR_EXCEPTIONS = [
-#    '127.0.0.1',
-#    '::1',
+    '127.0.0.1',
+    '::1',
 ]
 
 

--- a/src/planscape/requirements.txt
+++ b/src/planscape/requirements.txt
@@ -4,6 +4,7 @@ django-allauth~=0.53.1
 django-cors-headers
 django-filter~=21.1.0
 django-leaflet
+django-lockdown
 djangorestframework~=3.13.1
 djangorestframework-gis~=0.18.0
 djangorestframework-simplejwt~=5.2.2


### PR DESCRIPTION
This introduces django-lockdown, and adds the ability to restrict traffic to the django backend only from localhost.  This can be expanded later if we start adding additional boxes that need to call the django backend.

Any of the existing APIs could have been used to test this; I decided to go with one that doesn't involve any data writing whatsoever in existing_projects.