### PR TITLE
adding more wiring for upcoming charts on metrics per project areas

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.scss
@@ -181,16 +181,19 @@
   border: #cccfd8 solid 2px;
 }
 
-::ng-deep .mat-button-toggle-appearance-standard .mat-button-toggle-label-content {
-  line-height: 20px;
-  top: 5px;
-  width: 60px;
+:host {
+  ::ng-deep .mat-button-toggle-appearance-standard .mat-button-toggle-label-content {
+    line-height: 20px;
+    top: 5px;
+    width: 60px;
+  }
+  ::ng-deep .mat-select-value, ::ng-deep .mat-option-text {
+    text-align: center;
+  }
 }
+
 
 .mat-grid-tile-content {
   width: fit-content;
 }
 
-::ng-deep .mat-select-value, ::ng-deep .mat-option-text {
-  text-align: center;
-}

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -102,7 +102,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
   project_area_upload_enabled = features.upload_project_area;
 
   // TODO This should come from somewhere
-  scenarioState: ScenarioState = 'pending';
+  scenarioState: ScenarioState = 'completed';
 
   constructor(
     private fb: FormBuilder,
@@ -190,7 +190,6 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
       this.loadConfig();
     }
 
-
     // When an area is uploaded, issue an event to draw it on the map.
     // If the "generate areas" option is selected, remove any drawn areas.
     this.projectAreaGroup.valueChanges.subscribe((_) => {
@@ -276,7 +275,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
           goal.questions.forEach((question) => {
             if (
               question['priorities']?.toString() ==
-              config.priorities?.toString() &&
+                config.priorities?.toString() &&
               question['weights']?.toString() == config.weights?.toString()
             ) {
               selectedQuestion?.setValue(question);

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -5,7 +5,7 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from 'src/app/material/material.module';
 import { RouterModule } from '@angular/router';
-import { HttpClientModule, HttpClientXsrfModule } from '@angular/common/http';
+import { HttpClientXsrfModule } from '@angular/common/http';
 
 import { SharedModule } from './../shared/shared.module';
 import { ConstraintsPanelComponent } from './create-scenarios/constraints-panel/constraints-panel.component';
@@ -31,6 +31,7 @@ import { ScenarioPendingComponent } from './scenario-pending/scenario-pending.co
 import { ScenarioResultsComponent } from './scenario-results/scenario-results.component';
 import { ProjectAreasComponent } from './project-areas/project-areas.component';
 import { ProjectAreasMetricsComponent } from './project-areas-metrics/project-areas-metrics.component';
+import { ReportChartComponent } from './report-chart/report-chart.component';
 
 /** Components used in the plan flow. */
 @NgModule({
@@ -56,6 +57,7 @@ import { ProjectAreasMetricsComponent } from './project-areas-metrics/project-ar
     ScenarioResultsComponent,
     ProjectAreasComponent,
     ProjectAreasMetricsComponent,
+    ReportChartComponent,
   ],
   providers: [WINDOW_PROVIDERS],
   imports: [

--- a/src/interface/src/app/plan/project-areas-metrics/chart-data.ts
+++ b/src/interface/src/app/plan/project-areas-metrics/chart-data.ts
@@ -1,0 +1,4 @@
+export interface ChartData {
+  label: string;
+  values: number[];
+}

--- a/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.html
+++ b/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.html
@@ -3,8 +3,20 @@
   <mat-icon class="material-symbols-outlined" color="primary">info</mat-icon>
 </div>
 <div class="chart-holder">
-  <div class="chart-temp-container">Chart!</div>
-  <div class="chart-temp-container">Chart!</div>
-  <div class="chart-temp-container">Chart!</div>
-  <div class="chart-temp-container">Chart!</div>
+  <div *ngFor="let chart of selectedCharts; index as i">
+    <mat-form-field>
+      <mat-select
+        [value]="chart"
+        (selectionChange)="selectDataPoint($event, i)">
+        <mat-option
+          *ngFor="let dataSet of filterData(data, selectedCharts, chart)"
+          [value]="dataSet">
+          {{ dataSet.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <app-report-chart
+      [label]="chart.label"
+      [values]="chart.values"></app-report-chart>
+  </div>
 </div>

--- a/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.scss
+++ b/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.scss
@@ -31,11 +31,6 @@
   gap: 10px;
 }
 
-// temp class for display purposes, remove once we have charts.
-.chart-temp-container {
-  background-color: #f0f0f0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 150px;
+mat-form-field {
+  width: 100%;
 }

--- a/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.ts
+++ b/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.ts
@@ -1,8 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { MatSelectChange } from '@angular/material/select';
+import { ChartData } from './chart-data';
 
 @Component({
   selector: 'app-project-areas-metrics',
   templateUrl: './project-areas-metrics.component.html',
   styleUrls: ['./project-areas-metrics.component.scss'],
 })
-export class ProjectAreasMetricsComponent {}
+export class ProjectAreasMetricsComponent {
+  @Input() data: ChartData[] = [];
+  @Input() selectedCharts: ChartData[] = [];
+
+  selectDataPoint(e: MatSelectChange, i: number) {
+    this.selectedCharts[i] = e.value;
+  }
+
+  filterData(
+    data: ChartData[],
+    dataToFilter: ChartData[],
+    currentChart: ChartData
+  ): ChartData[] {
+    return data.filter((d) => d === currentChart || !dataToFilter.includes(d));
+  }
+}

--- a/src/interface/src/app/plan/report-chart/report-chart.component.html
+++ b/src/interface/src/app/plan/report-chart/report-chart.component.html
@@ -1,0 +1,2 @@
+<div>Label:{{ label }}</div>
+<div>Values: {{ values | json }}</div>

--- a/src/interface/src/app/plan/report-chart/report-chart.component.spec.ts
+++ b/src/interface/src/app/plan/report-chart/report-chart.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReportChartComponent } from './report-chart.component';
+
+describe('ReportChartComponent', () => {
+  let component: ReportChartComponent;
+  let fixture: ComponentFixture<ReportChartComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ReportChartComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ReportChartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/report-chart/report-chart.component.ts
+++ b/src/interface/src/app/plan/report-chart/report-chart.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-report-chart',
+  templateUrl: './report-chart.component.html',
+  styleUrls: ['./report-chart.component.scss'],
+})
+export class ReportChartComponent {
+  @Input() label = '';
+  @Input() values: number[] = [];
+}

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.html
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.html
@@ -1,5 +1,7 @@
 <app-project-areas [areas]="areas" [total]="total"></app-project-areas>
-<app-project-areas-metrics></app-project-areas-metrics>
+<app-project-areas-metrics
+  [data]="data"
+  [selectedCharts]="selectedCharts"></app-project-areas-metrics>
 
 <div class="actions">
   <button mat-raised-button>Download CSV data</button>

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
@@ -3,6 +3,7 @@ import {
   ProjectAreaReport,
   ProjectTotalReport,
 } from '../project-areas/project-areas.component';
+import { generateDummyData, generateDummyReport } from './temp-helper';
 
 @Component({
   selector: 'app-scenario-results',
@@ -11,27 +12,14 @@ import {
 })
 export class ScenarioResultsComponent {
   // TODO this data is a placeholder.
-  areas: ProjectAreaReport[] = [
-    { id: 1, acres: 123, percentTotal: 12, estimatedCost: '$12k', score: 12 },
-    { id: 2, acres: 444, percentTotal: 2.2, estimatedCost: '$32k', score: 2 },
-    {
-      id: 3,
-      acres: 983,
-      percentTotal: 32.2,
-      estimatedCost: '$432k',
-      score: 32,
-    },
-    {
-      id: 4,
-      acres: 12,
-      percentTotal: 12.2,
-      estimatedCost: '$2k',
-      score: 0.2,
-    },
-  ];
+  areas: ProjectAreaReport[] = generateDummyReport();
   total: ProjectTotalReport = {
     acres: 983,
     percentTotal: 32.2,
     estimatedCost: '$432k',
   };
+
+  data = generateDummyData();
+  // start with the first 4 as selected
+  selectedCharts = this.data.slice(0, 4);
 }

--- a/src/interface/src/app/plan/scenario-results/temp-helper.ts
+++ b/src/interface/src/app/plan/scenario-results/temp-helper.ts
@@ -1,0 +1,49 @@
+import { ChartData } from '../project-areas-metrics/chart-data';
+
+/**
+ * Temp file to hold dummy data. remove once done!
+ */
+export function generateDummyData(): ChartData[] {
+  const labels = [
+    'Dead and down fuels',
+    'Total Large tree carbon',
+    'Residential Structures',
+    'Potential Smoke Emissions',
+    'Particulate Matter',
+    'Community Integrity',
+    'Species Richness: Cavity Nesters/Excavators',
+    'Open Habitat Raptors Species Richness',
+    'Wood Product Industry',
+    'Ember Load Index',
+    'Wildfire Ignitions',
+  ];
+
+  return labels.map((label) => ({
+    label,
+    values: Array.from({ length: 5 }, () => Math.floor(Math.random() * 10)),
+  }));
+}
+
+/**
+ * Temp data to fill in the report
+ */
+export function generateDummyReport() {
+  return [
+    { id: 1, acres: 123, percentTotal: 12, estimatedCost: '$12k', score: 12 },
+    { id: 2, acres: 444, percentTotal: 2.2, estimatedCost: '$32k', score: 2 },
+    {
+      id: 3,
+      acres: 983,
+      percentTotal: 32.2,
+      estimatedCost: '$432k',
+      score: 32,
+    },
+    {
+      id: 4,
+      acres: 12,
+      percentTotal: 12.2,
+      estimatedCost: '$2k',
+      score: 0.2,
+    },
+  ];
+}


### PR DESCRIPTION
Adding the controls and filters necessary to display the charts on metrics per project areas. 
Still using dummy data.


<img width="698" alt="Screen Shot 2023-09-15 at 11 04 56" src="https://github.com/OurPlanscape/Planscape/assets/358892/1790f915-0f42-47e0-9bb8-eeeb3acf9711">


<img width="739" alt="Screen Shot 2023-09-15 at 11 04 09" src="https://github.com/OurPlanscape/Planscape/assets/358892/6e9a47cc-4a94-4a46-9d05-bd89d96710a1">
