### PR TITLE
update navigation and add help icon again

### DIFF
--- a/src/interface/src/app/home/preview/preview.component.html
+++ b/src/interface/src/app/home/preview/preview.component.html
@@ -18,7 +18,7 @@
           <br />
         </p>
         <p>
-          Planscape preview includes all data from the
+          Planscape includes all data from the
           <a
             href="https://wildfiretaskforce.org/regional-resource-kits-and-profiles-are-now-available/">
             Regional Resource Kit

--- a/src/interface/src/app/home/welcome/welcome.component.html
+++ b/src/interface/src/app/home/welcome/welcome.component.html
@@ -11,8 +11,8 @@
 
 <b>What can I do with Planscape?</b>
 <p>
-  This early preview of Planscape allows you to view and explore wildfire
-  relevant data on a set of maps. Most notably, the data from the
+  Planscape allows you to view and explore wildfire relevant data on a set of
+  maps. Most notably, the data from the
   <a href="https://wildfiretaskforce.org/regional-resource-kits-page/">
     Regional Resource Kits
   </a>

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.html
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.html
@@ -4,29 +4,6 @@
   </button>
   <span class="title">Planning Areas / {{ breadcrumbs.join(' / ') }}</span>
   <div class="actions">
-    <a
-      mat-icon-button
-      routerLink="/help"
-      target="_blank"
-      aria-label="help button"
-      rel="noopener noreferrer"
-      data-id="help"
-      class="help">
-      <mat-icon class="material-symbols-outlined" color="primary">
-        info
-      </mat-icon>
-    </a>
-
-    <button
-      mat-button
-      class="action-button"
-      (click)="copyLink()"
-      data-id="copy">
-      <mat-icon class="material-symbols-outlined" color="primary">
-        link
-      </mat-icon>
-      Copy link
-    </button>
     <button mat-button class="action-button" (click)="print()" data-id="print">
       <mat-icon class="material-symbols-outlined" color="primary">
         print

--- a/src/interface/src/app/top-bar/top-bar.component.html
+++ b/src/interface/src/app/top-bar/top-bar.component.html
@@ -63,8 +63,7 @@
       target="_blank"
       aria-label="help button"
       rel="noopener noreferrer"
-      data-id="help"
-      *featureFlag="'new_navigation'; hide: true">
+      data-id="help">
       <mat-icon class="material-symbols-outlined">help_outline</mat-icon>
     </a>
     <span class="username">{{ displayName$ | async }}</span>
@@ -72,7 +71,7 @@
     <button
       mat-icon-button
       [matMenuTriggerFor]="dotMenu"
-      *featureFlag="'new_navigation'">
+      *featureFlag="'login'">
       <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
     </button>
     <mat-menu #dotMenu="matMenu">

--- a/src/interface/src/app/top-bar/top-bar.component.scss
+++ b/src/interface/src/app/top-bar/top-bar.component.scss
@@ -52,7 +52,6 @@
 
 .nav-link {
   text-decoration: none;
-  margin-right: 32px;
   &:visited, &:active {
     color: white;
   }

--- a/src/interface/src/app/top-bar/top-bar.component.spec.ts
+++ b/src/interface/src/app/top-bar/top-bar.component.spec.ts
@@ -154,26 +154,6 @@ describe('TopBarComponent', () => {
     });
   });
 
-  describe('help button', () => {
-    it('should not show the help button when on new_navigation flag is on', () => {
-      TestBed.overrideProvider(FEATURES_JSON, {
-        useValue: { new_navigation: true },
-      });
-      setUpComponent();
-      const feedbackBtn = fixture.debugElement.query(
-        By.css('[data-id="help"]')
-      );
-      expect(feedbackBtn).toBeFalsy();
-    });
-    it('should show the help button when new_navigation flag is off ', () => {
-      setUpComponent();
-      const feedbackBtn = fixture.debugElement.query(
-        By.css('[data-id="help"]')
-      );
-      expect(feedbackBtn).toBeTruthy();
-    });
-  });
-
   describe('new logo', () => {
     it('should show the new logo when new_navigation flag is on', () => {
       TestBed.overrideProvider(FEATURES_JSON, {


### PR DESCRIPTION
- Updates top nav bar to show help icon again
- Removes information icon from navbar
- Hides kebab menu based on `login` feature flag
- Removes `copy link` button as its not done yet.


Login flag off, new navigation flag on.

<img width="1494" alt="Screen Shot 2023-09-18 at 15 35 39" src="https://github.com/PatManley/Planscape/assets/358892/47377374-a2c3-48b1-b714-14762125b7a1">
<img width="1496" alt="Screen Shot 2023-09-18 at 15 35 48" src="https://github.com/PatManley/Planscape/assets/358892/448d7b59-e9f4-42d0-913d-6354bdb8f923">
