### PR TITLE
Add PlanningArea::updated_at and Scenario::(updated|created)_at to List/Get API output.

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -8,13 +8,17 @@ from planning.models import (PlanningArea, Scenario, ScenarioResult)
 # TODO: flesh all serializers more for better maintainability.
 class PlanningAreaSerializer(gis_serializers.GeoFeatureModelSerializer):
     scenario_count = IntegerField(read_only=True, required=False)
+
+    # latest_updated takes into account the plan's scenario's updated timestamps and should
+    # be used by clients rather than the row-level updated_at field.
     latest_updated = serializers.SerializerMethodField()
     notes = CharField(required = False)
+    created_at = DateTimeField(required = False)
 
     def get_latest_updated(self, instance):
         return instance.scenario_latest_updated_at or instance.updated_at
     class Meta:
-        fields = ("id", "user", "name", "notes", "region_name", "scenario_count", "latest_updated")
+        fields = ("id", "user", "name", "notes", "region_name", "scenario_count", "latest_updated", "created_at")
         model = PlanningArea
         geo_field = "geometry"
 
@@ -22,8 +26,11 @@ class PlanningAreaSerializer(gis_serializers.GeoFeatureModelSerializer):
 class ScenarioSerializer(serializers.ModelSerializer):
     configuration = JSONField()
     notes = CharField(required = False)
+    updated_at = DateTimeField(required = False)
+    created_at = DateTimeField(required = False)
+
     class Meta:
-        fields = ("id", "planning_area", "name", "notes", "configuration")
+        fields = ("id", "planning_area", "name", "notes", "configuration", "updated_at", "created_at")
         model = Scenario
 
 class ScenarioResultSerializer(serializers.ModelSerializer):

--- a/src/planscape/planning/tests/test_views.py
+++ b/src/planscape/planning/tests/test_views.py
@@ -504,6 +504,7 @@ class ListPlanningAreaTest(TransactionTestCase):
         self.assertIsNotNone(planning_areas[0]['latest_updated'])
         self.assertEqual(planning_areas[1]['scenario_count'],1)
         self.assertIsNotNone(planning_areas[1]['latest_updated'])
+        self.assertIsNotNone(planning_areas[0]['created_at'])
 
     def test_list_planning_areas_not_logged_in(self):
         response = self.client.get(reverse('planning:list_planning_areas'), {},

--- a/src/planscape/planning/tests/test_views.py
+++ b/src/planscape/planning/tests/test_views.py
@@ -440,6 +440,7 @@ class GetPlanningAreaTest(TransactionTestCase):
         returned_planning_area = response.json()
         self.assertEqual(returned_planning_area['name'], 'test plan')
         self.assertEqual(returned_planning_area['region_name'], 'Sierra Nevada')
+        self.assertIsNotNone(returned_planning_area['created_at'])
 
     def test_get_nonexistent_planning_area(self):
         self.client.force_login(self.user)
@@ -1150,6 +1151,8 @@ class ListScenariosForPlanningAreaTest(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         scenarios = response.json()
         self.assertEqual(len(scenarios), 3)
+        self.assertIsNotNone(scenarios[0]['created_at'])
+        self.assertIsNotNone(scenarios[0]['updated_at'])
 
     def test_list_scenario_not_logged_in(self):
         response = self.client.get(
@@ -1217,6 +1220,9 @@ class GetScenarioTest(TransactionTestCase):
             {'id': self.scenario.pk},
             content_type="application/json")
         self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.content)
+        self.assertIsNotNone(response_json['created_at'])
+        self.assertIsNotNone(response_json['updated_at'])
 
     def test_get_scenario_not_logged_in(self):
         response = self.client.get(


### PR DESCRIPTION
Add created_at into both PlanningArea and Scenario serializers so that they are returned in Get/List APIs.

Add updated_at into the Scenario seralizer.  Don't do this for the PlanningArea since we want clients to rely on the latest_updated field instead which combines a PlanningArea's updated timestamp along with all of its scenarios' updated timestamps.

Update tests as needed.