### PR TITLE
Disable IP lockdown for APIs for now

### DIFF
--- a/src/planscape/existing_projects/tests.py
+++ b/src/planscape/existing_projects/tests.py
@@ -19,7 +19,8 @@ class ITSTest(TestCase):
             self.assertRegex(str(response.content), r"key")
             self.assertNotRegex(str(response.content), r"Coming soon")
 
-    def test_wrong_ip(self):
+    # TODO: re-enable when we fix the lockdown IP issues.
+    def disabled_test_wrong_ip(self):
         response = Response()
         response.code = 200
         response._content = b'{ "key" : "a" }'

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -137,7 +137,7 @@ DATABASES = {
 
 
 # Locking down API calls to only itself.
-LOCKDOWN_ENABLED = True
+LOCKDOWN_ENABLED = False
 
 # if we ever needed to make some backend APIs (views) available to anyone.
 LOCKDOWN_VIEW_EXCEPTIONS = []


### PR DESCRIPTION
The lockdown config doesn't work for non-local boxes.