### PR TITLE
MVP Scenario Config Page Update

### DIFF
--- a/src/interface/src/app/features/README.md
+++ b/src/interface/src/app/features/README.md
@@ -54,6 +54,9 @@ features that require login to use (e.g planning) when set to false. When login
 is disabled it also replaces the plans on the homepage with a message
 explaining that some buttons and features are disabled.  
 
+### scenario_constraints
+This flag will display the Max slope, Distance from roads, and Stand size inputs on the Scenario configuration page. 
+
 ### show_centralcoast
 This flag will display the option to switch to the Central Coast region,
 and therefore allow for the display of Central Coast data.
@@ -94,6 +97,7 @@ for angular tests to pass.  You can start with this, but later enable settings.
 ```
 {
   "login": true,
+  "scenario_constraints": false,
   "show_centralcoast": false,
   "show_future_control_panel": false,
   "show_socal": false,

--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -1,5 +1,6 @@
 {
   "login": true,
+  "scenario_constraints": false,
   "show_centralcoast": true,
   "show_future_control_panel": false,
   "show_socal": true,

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -2,96 +2,61 @@
   <!-- Form -->
   <form class="constraints-form" [formGroup]="constraintsForm!">
     <div class="constraints-content">
-      <div formGroupName="budgetForm" class="flex-column">
+      <div class="flex-column">
         <div class="top-label">
-          <label class="form-label">ESTIMATED COSTS</label>
-          <label class="optional">(optional)</label>
+          <label class="form-label">CONSTRAINTS</label>
         </div>
-        <div class="flex-row">
+      </div>
+      <div class="flex-row">
+        <div formGroupName="physicalConstraintForm">
           <div>
-            <mat-form-field
-              class="input-field"
-              appearance="outline"
-              floatLabel="always">
-              <mat-label>Treatment cost</mat-label>
-              <input
-                id="estimatedCost"
-                class="right-align"
-                formControlName="estimatedCost"
-                matInput
-                type="number"
-                (input)="toggleMaxCost()" />
-              <span matPrefix>$&nbsp;</span>
-              <span matSuffix>/acre</span>
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+              <mat-label>Max acres to be treated</mat-label>
+              <input class="right-align" formControlName="maxArea" matInput type="number" (input)="togglMaxAreaAndMaxCost()"/>
             </mat-form-field>
           </div>
+        </div>
+        or
+        <div formGroupName="budgetForm">
           <div>
-            <mat-form-field
-              class="input-field"
-              appearance="outline"
-              floatLabel="always">
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
               <mat-label>Max total cost</mat-label>
-              <input
-                id="maxCost"
-                class="right-align"
-                formControlName="maxCost"
-                matInput
-                type="number" />
+              <input id="maxCost" class="right-align" formControlName="maxCost" matInput type="number" (input)="togglMaxAreaAndMaxCost()"/>
               <span matPrefix>$&nbsp;</span>
             </mat-form-field>
           </div>
         </div>
       </div>
-    </div>
-    <div class="constraints-content">
-      <div formGroupName="physicalConstraintForm" class="flex-column">
-        <div class="top-label">
-          <label class="form-label">PHYSICAL CONSTRAINTS</label>
-        </div>
-        <div class="flex-row">
-          <div>
-            <mat-form-field
-              class="input-field"
-              appearance="outline"
-              floatLabel="always">
+      <div class="flex-row">
+        <div *appFeatureFlag="'scenario_constraints'" formGroupName="physicalConstraintForm">
+          <div >
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
               <mat-label>Max slope</mat-label>
-              <input
-                class="right-align"
-                formControlName="maxSlope"
-                matInput
-                type="number" />
+              <input class="right-align" formControlName="maxSlope" matInput type="number" [value]="37"/>
               <span matSuffix>%</span>
             </mat-form-field>
           </div>
+        </div>
+        <div formGroupName="budgetForm">
           <div>
-            <mat-form-field
-              class="input-field"
-              appearance="outline"
-              floatLabel="always">
-              <mat-label>Distance from roads</mat-label>
-              <input
-                class="right-align"
-                formControlName="minDistanceFromRoad"
-                matInput
-                type="number" />
-              <span matSuffix>yds</span>
+            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+              <mat-label>Treatment cost</mat-label>
+              <input id="estimatedCost" class="right-align" formControlName="estimatedCost" matInput type="number" />
+              <span matPrefix>$&nbsp;</span>
+              <span matSuffix>/acre</span>
             </mat-form-field>
           </div>
         </div>
-        <div class="flex-row">
-          <div>
-            <mat-form-field
-              class="input-field"
-              appearance="outline"
-              floatLabel="always">
-              <mat-label>Max acres to be treated</mat-label>
-              <input
-                class="right-align"
-                formControlName="maxArea"
-                matInput
-                type="number" />
-            </mat-form-field>
-          </div>
+      </div>
+      <div *appFeatureFlag="'scenario_constraints'" formGroupName="physicalConstraintForm" class="flex-row">
+        <div>
+          <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-label>Distance from roads</mat-label>
+            <input class="right-align" formControlName="minDistanceFromRoad" matInput type="number" [value]=""/>
+            <span matSuffix>yds</span>
+          </mat-form-field>
+        </div>
+        <div>
           <mat-form-field class="input-field" appearance="outline">
             <mat-label>Stand size</mat-label>
             <mat-select formControlName="standSize" required>
@@ -110,10 +75,7 @@
         </div>
         <section class="area-selection">
           <div class="checkbox-column">
-            <mat-checkbox
-              [color]="'primary'"
-              *ngFor="let item of excludedAreasOptions"
-              [formControlName]="item"
+            <mat-checkbox [color]="'primary'" *ngFor="let item of excludedAreasOptions" [formControlName]="item"
               [value]="item">
               {{ item }}
             </mat-checkbox>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -10,49 +10,95 @@
       <div class="flex-row">
         <div formGroupName="physicalConstraintForm">
           <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Max acres to be treated</mat-label>
-              <input class="right-align" formControlName="maxArea" matInput type="number" (input)="togglMaxAreaAndMaxCost()"/>
+              <input
+                class="right-align"
+                formControlName="maxArea"
+                matInput
+                type="number"
+                (input)="togglMaxAreaAndMaxCost()" />
             </mat-form-field>
           </div>
         </div>
         or
         <div formGroupName="budgetForm">
           <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Max total cost</mat-label>
-              <input id="maxCost" class="right-align" formControlName="maxCost" matInput type="number" (input)="togglMaxAreaAndMaxCost()"/>
+              <input
+                id="maxCost"
+                class="right-align"
+                formControlName="maxCost"
+                matInput
+                type="number"
+                (input)="togglMaxAreaAndMaxCost()" />
               <span matPrefix>$&nbsp;</span>
             </mat-form-field>
           </div>
         </div>
       </div>
       <div class="flex-row">
-        <div *appFeatureFlag="'scenario_constraints'" formGroupName="physicalConstraintForm">
-          <div >
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+        <div
+          *appFeatureFlag="'scenario_constraints'"
+          formGroupName="physicalConstraintForm">
+          <div>
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Max slope</mat-label>
-              <input class="right-align" formControlName="maxSlope" matInput type="number" [value]="37"/>
+              <input
+                class="right-align"
+                formControlName="maxSlope"
+                matInput
+                type="number"
+                [value]="37" />
               <span matSuffix>%</span>
             </mat-form-field>
           </div>
         </div>
         <div formGroupName="budgetForm">
           <div>
-            <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+            <mat-form-field
+              class="input-field"
+              appearance="outline"
+              floatLabel="always">
               <mat-label>Treatment cost</mat-label>
-              <input id="estimatedCost" class="right-align" formControlName="estimatedCost" matInput type="number" />
+              <input
+                id="estimatedCost"
+                class="right-align"
+                formControlName="estimatedCost"
+                matInput
+                type="number" />
               <span matPrefix>$&nbsp;</span>
               <span matSuffix>/acre</span>
             </mat-form-field>
           </div>
         </div>
       </div>
-      <div *appFeatureFlag="'scenario_constraints'" formGroupName="physicalConstraintForm" class="flex-row">
+      <div
+        *appFeatureFlag="'scenario_constraints'"
+        formGroupName="physicalConstraintForm"
+        class="flex-row">
         <div>
-          <mat-form-field class="input-field" appearance="outline" floatLabel="always">
+          <mat-form-field
+            class="input-field"
+            appearance="outline"
+            floatLabel="always">
             <mat-label>Distance from roads</mat-label>
-            <input class="right-align" formControlName="minDistanceFromRoad" matInput type="number" [value]=""/>
+            <input
+              class="right-align"
+              formControlName="minDistanceFromRoad"
+              matInput
+              type="number"
+              [value]="" />
             <span matSuffix>yds</span>
           </mat-form-field>
         </div>
@@ -75,7 +121,10 @@
         </div>
         <section class="area-selection">
           <div class="checkbox-column">
-            <mat-checkbox [color]="'primary'" *ngFor="let item of excludedAreasOptions" [formControlName]="item"
+            <mat-checkbox
+              [color]="'primary'"
+              *ngFor="let item of excludedAreasOptions"
+              [formControlName]="item"
               [value]="item">
               {{ item }}
             </mat-checkbox>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
@@ -65,18 +65,18 @@ describe('ConstraintsPanelComponent', () => {
       }),
       budgetForm: fb.group({
         // Estimated cost in $ per acre
-        estimatedCost: ['', [Validators.min(0), Validators.required]],
+        estimatedCost: [2470, [Validators.min(0), Validators.required]],
         // Max cost of treatment for entire planning area
-        maxCost: [{ value: '', disabled: true }, Validators.min(0)],
+        maxCost: ['', Validators.min(0)],
       }),
       physicalConstraintForm: fb.group({
         // Maximum slope allowed for planning area
-        maxSlope: ['', Validators.min(0)],
+        maxSlope: [37, Validators.min(0)],
         // Minimum distance from road allowed for planning area
         // TODO: Update variable name to minDistanceFromRoad
-        minDistanceFromRoad: ['', Validators.min(0)],
+        minDistanceFromRoad: [1000, Validators.min(0)],
         // Maximum area to be treated in acres
-        maxArea: ['', [Validators.min(0), Validators.required]],
+        maxArea: ['', [Validators.min(0)]],
         standSize: ['Large', Validators.required],
       }),
       excludedAreasForm: fb.group(excludedAreasChosen),
@@ -91,29 +91,5 @@ describe('ConstraintsPanelComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should disable maxCost input when no estimatedCost input is provided', async () => {
-    let estimatedCostinput = fixture.debugElement.query(
-      By.css('#estimatedCost')
-    ).nativeElement;
-    estimatedCostinput.value = null;
-    estimatedCostinput.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    expect(component.constraintsForm!.get('budgetForm.maxCost')!.disabled).toBe(
-      true
-    );
-  });
-
-  it('should enable maxCost input when estimatedCost input is provided', async () => {
-    let estimatedCostinput = fixture.debugElement.query(
-      By.css('#estimatedCost')
-    ).nativeElement;
-    estimatedCostinput.value = 1;
-    estimatedCostinput.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    expect(component.constraintsForm!.get('budgetForm.maxCost')!.enabled).toBe(
-      true
-    );
   });
 });

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -14,18 +14,14 @@ export class ConstraintsPanelComponent {
   constructor() {}
 
   togglMaxAreaAndMaxCost() {
-    console.log('in toggle')
-    console.log(this.constraintsForm!.get('budgetForm.maxCost')!.value);
-    console.log(this.constraintsForm!.get('physicalConstraintForm.maxArea')!.value);
     if (this.constraintsForm!.get('budgetForm.maxCost')!.value) {
-    
-      (this.constraintsForm!.get('physicalConstraintForm') as FormGroup).controls[
-        'maxArea'
-      ].disable();
+      (
+        this.constraintsForm!.get('physicalConstraintForm') as FormGroup
+      ).controls['maxArea'].disable();
     } else {
-      (this.constraintsForm!.get('physicalConstraintForm') as FormGroup).controls[
-        'maxArea'
-      ].enable();
+      (
+        this.constraintsForm!.get('physicalConstraintForm') as FormGroup
+      ).controls['maxArea'].enable();
     }
     if (this.constraintsForm!.get('physicalConstraintForm.maxArea')!.value) {
       (this.constraintsForm!.get('budgetForm') as FormGroup).controls[

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -13,15 +13,28 @@ export class ConstraintsPanelComponent {
 
   constructor() {}
 
-  toggleMaxCost() {
-    if (this.constraintsForm!.get('budgetForm.estimatedCost')!.value) {
-      (this.constraintsForm!.get('budgetForm') as FormGroup).controls[
-        'maxCost'
-      ].enable();
+  togglMaxAreaAndMaxCost() {
+    console.log('in toggle')
+    console.log(this.constraintsForm!.get('budgetForm.maxCost')!.value);
+    console.log(this.constraintsForm!.get('physicalConstraintForm.maxArea')!.value);
+    if (this.constraintsForm!.get('budgetForm.maxCost')!.value) {
+    
+      (this.constraintsForm!.get('physicalConstraintForm') as FormGroup).controls[
+        'maxArea'
+      ].disable();
     } else {
+      (this.constraintsForm!.get('physicalConstraintForm') as FormGroup).controls[
+        'maxArea'
+      ].enable();
+    }
+    if (this.constraintsForm!.get('physicalConstraintForm.maxArea')!.value) {
       (this.constraintsForm!.get('budgetForm') as FormGroup).controls[
         'maxCost'
       ].disable();
+    } else {
+      (this.constraintsForm!.get('budgetForm') as FormGroup).controls[
+        'maxCost'
+      ].enable();
     }
   }
 }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -122,23 +122,23 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
         {
           budgetForm: this.fb.group({
             // Estimated cost in $ per acre
-            estimatedCost: ['', Validators.min(0)],
+            estimatedCost: [2470, Validators.min(0)],
             // Max cost of treatment for entire planning area
             // Initially disabled, estimatedCost is required as input before maxCost is enabled
-            maxCost: [{ value: '', disabled: true }, Validators.min(0.01)],
+            maxCost: ['', Validators.min(0.01)],
           }),
           physicalConstraintForm: this.fb.group({
+            // TODO Update if needed once we have confirmation if this is the correct default %
             // Maximum slope allowed for planning area
             maxSlope: [
-              '',
+              37,
               [Validators.min(0), Validators.max(100), Validators.required],
             ],
             // Minimum distance from road allowed for planning area
-            minDistanceFromRoad: ['', [Validators.min(0), Validators.required]],
+            minDistanceFromRoad: [1000, [Validators.min(0), Validators.required]],
             // Maximum area to be treated in acres
-            maxArea: ['', [Validators.min(0), Validators.required]],
+            maxArea: ['', [Validators.min(0)]],
             // Stand Size selection
-            // TODO validate to make sure standSize is only 'Small', 'Medium', or 'Large'
             standSize: ['Large', Validators.required],
           }),
           excludedAreasForm: this.fb.group(excludedAreasChosen),
@@ -202,15 +202,10 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     constraintsForm: AbstractControl
   ): ValidationErrors | null {
     // Only one of budget or treatment area constraints is required.
-
-    // TODO Add maxArea input and make required, this extra validator may be deprecated
-    // const estimatedCost = constraintsForm.get('budgetForm.estimatedCost');
-    // const maxArea = constraintsForm.get('treatmentForm.maxArea');
-    const maxSlope = constraintsForm.get('physicalConstraintForm.maxSlope');
-    const maxDistance = constraintsForm.get(
-      'physicalConstraintForm.minDistanceFromRoad'
-    );
-    const valid = !!maxSlope?.value || !!maxDistance?.value;
+    const maxCost = constraintsForm.get('budgetForm.maxCost');
+    const maxArea = constraintsForm.get('physicalConstraintForm.maxArea');
+    
+    const valid = !!maxCost?.value || !!maxArea?.value;
     return valid ? null : { budgetOrAreaRequired: true };
   }
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -135,7 +135,10 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
               [Validators.min(0), Validators.max(100), Validators.required],
             ],
             // Minimum distance from road allowed for planning area
-            minDistanceFromRoad: [1000, [Validators.min(0), Validators.required]],
+            minDistanceFromRoad: [
+              1000,
+              [Validators.min(0), Validators.required],
+            ],
             // Maximum area to be treated in acres
             maxArea: ['', [Validators.min(0)]],
             // Stand Size selection
@@ -204,7 +207,6 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     // Only one of budget or treatment area constraints is required.
     const maxCost = constraintsForm.get('budgetForm.maxCost');
     const maxArea = constraintsForm.get('physicalConstraintForm.maxArea');
-    
     const valid = !!maxCost?.value || !!maxArea?.value;
     return valid ? null : { budgetOrAreaRequired: true };
   }


### PR DESCRIPTION
- Add 'scenario_constraints' to features.json
- Update feature flag README
- Have scenario_constraints flag toggle max slope, distance from road, stand size inputs on scenario config page
- Enforce requirement for max area OR max cost as an input
- Remove requirement for estimated cost to be input before max cost can be input
- Set default values for estimated cost, max slope, and distance from road
- Update tests

  "scenario_constraints": true
<img width="1790" alt="Screenshot 2023-09-21 at 2 43 33 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/5b0dc72a-f9fe-4b9c-af7e-9b8925f8cf7a">


  "scenario_constraints": false
<img width="1791" alt="Screenshot 2023-09-21 at 2 43 56 PM" src="https://github.com/OurPlanscape/Planscape/assets/18537927/2bbba0c5-1eae-41a1-9aa6-b5fe42e74f07">
