### PR TITLE
Polling on scenario list and scenario page

### DIFF
--- a/src/interface/package-lock.json
+++ b/src/interface/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/platform-browser-dynamic": "^14.2.0",
         "@angular/router": "^14.2.0",
         "@geoman-io/leaflet-geoman-free": "^2.13.1",
+        "@ngneat/until-destroy": "^10.0.0",
         "@turf/area": "^6.5.0",
         "@turf/boolean-intersects": "^6.5.0",
         "@turf/boolean-within": "^6.5.0",
@@ -3055,6 +3056,18 @@
       "dev": true,
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@ngneat/until-destroy": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/until-destroy/-/until-destroy-10.0.0.tgz",
+      "integrity": "sha512-xXFAabQ4YVJ82LYxdgUlaKZyR3dSbxqG3woSyaclzxfCgWMEDweCcM/GGYbNiHJa0WwklI98RXHvca+UyCxpeg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=13",
+        "rxjs": "^6.4.0 || ^7.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -15630,6 +15643,14 @@
       "dev": true,
       "requires": {
         "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "@ngneat/until-destroy": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/until-destroy/-/until-destroy-10.0.0.tgz",
+      "integrity": "sha512-xXFAabQ4YVJ82LYxdgUlaKZyR3dSbxqG3woSyaclzxfCgWMEDweCcM/GGYbNiHJa0WwklI98RXHvca+UyCxpeg==",
+      "requires": {
+        "tslib": "^2.3.0"
       }
     },
     "@ngtools/webpack": {

--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -26,6 +26,7 @@
     "@angular/platform-browser-dynamic": "^14.2.0",
     "@angular/router": "^14.2.0",
     "@geoman-io/leaflet-geoman-free": "^2.13.1",
+    "@ngneat/until-destroy": "^10.0.0",
     "@turf/area": "^6.5.0",
     "@turf/boolean-intersects": "^6.5.0",
     "@turf/boolean-within": "^6.5.0",

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.spec.ts
@@ -8,8 +8,9 @@ import {
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from 'src/app/material/material.module';
-
 import { ConstraintsPanelComponent } from './constraints-panel.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { FeaturesModule } from '../../../features/features.module';
 //TODO Add the following tests once implementation for tested behaviors is added/desired behavior is confirmed:
 /**
  * 'marks maxCost as not required input if maxArea is provided'
@@ -27,7 +28,9 @@ describe('ConstraintsPanelComponent', () => {
         MaterialModule,
         NoopAnimationsModule,
         MatButtonToggleModule,
+        FeaturesModule,
       ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [ConstraintsPanelComponent],
       providers: [FormBuilder],
     }).compileComponents();

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
+
 import {
   AbstractControl,
   FormBuilder,
@@ -7,9 +8,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
-import { BehaviorSubject, Subject, Observable } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
-
+import { BehaviorSubject, interval, Observable } from 'rxjs';
 import { PlanService } from 'src/app/services';
 import {
   Plan,
@@ -21,13 +20,15 @@ import {
   TreatmentQuestionConfig,
 } from 'src/app/types';
 import features from '../../features/features.json';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
+@UntilDestroy()
 @Component({
   selector: 'app-create-scenarios',
   templateUrl: './create-scenarios.component.html',
   styleUrls: ['./create-scenarios.component.scss'],
 })
-export class CreateScenariosComponent implements OnInit, OnDestroy {
+export class CreateScenariosComponent implements OnInit {
   @ViewChild(MatStepper) stepper: MatStepper | undefined;
   selectedTabIndex = 0;
   generatingScenario: boolean = false;
@@ -55,7 +56,6 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     'Tribal Lands',
   ];
 
-  private readonly destroy$ = new Subject<void>();
   project_area_upload_enabled = features.upload_project_area;
 
   // this value gets updated once we load the scenario result.
@@ -68,7 +68,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     private planService: PlanService
   ) {
     this.treatmentGoals = this.planService.treatmentGoalsConfig$.pipe(
-      takeUntil(this.destroy$)
+      untilDestroyed(this)
     );
 
     var excludedAreasChosen: { [key: string]: (boolean | Validators)[] } = {};
@@ -138,7 +138,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     // Get plan details and current config ID from plan state, then load the config.
     this.planService.planState$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(untilDestroyed(this))
       .subscribe((planState) => {
         this.plan$.next(planState.all[planState.currentPlanId!]);
         this.scenarioId = planState.currentScenarioId;
@@ -150,6 +150,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     if (this.scenarioId) {
       // Has to be outside of service subscription or else will cause infinite loop
       this.loadConfig();
+      this.pollForChanges();
     }
 
     // When an area is uploaded, issue an event to draw it on the map.
@@ -165,9 +166,10 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
+  private pollForChanges() {
+    interval(3000)
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.loadConfig());
   }
 
   private constraintsFormValidator(
@@ -181,6 +183,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
   }
 
   private loadConfig(): void {
+    console.log('loading config');
     this.planService.getScenario(this.scenarioId!).subscribe((scenario) => {
       if (scenario.scenario_result) {
         this.scenarioResults = scenario.scenario_result;
@@ -261,7 +264,7 @@ export class CreateScenariosComponent implements OnInit, OnDestroy {
     let scenarioNameConfig: string = '';
     let plan_id: string = '';
     this.planService.planState$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(untilDestroyed(this))
       .subscribe((planState) => {
         plan_id = planState.currentPlanId!;
       });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -171,8 +171,11 @@ export class CreateScenariosComponent implements OnInit {
     interval(POLLING_INTERVAL)
       .pipe(untilDestroyed(this))
       .subscribe(() => {
-        // only poll when scenario is pending
-        if (this.scenarioState === 'PENDING') {
+        // only poll when scenario is pending or running
+        if (
+          this.scenarioState === 'PENDING' ||
+          this.scenarioState === 'RUNNING'
+        ) {
           this.loadConfig();
         }
       });

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -21,6 +21,7 @@ import {
 } from 'src/app/types';
 import features from '../../features/features.json';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { POLLING_INTERVAL } from '../plan-helpers';
 
 @UntilDestroy()
 @Component({
@@ -166,10 +167,15 @@ export class CreateScenariosComponent implements OnInit {
     });
   }
 
-  private pollForChanges() {
-    interval(3000)
+  pollForChanges() {
+    interval(POLLING_INTERVAL)
       .pipe(untilDestroyed(this))
-      .subscribe(() => this.loadConfig());
+      .subscribe(() => {
+        // only poll when scenario is pending
+        if (this.scenarioState === 'PENDING') {
+          this.loadConfig();
+        }
+      });
   }
 
   private constraintsFormValidator(
@@ -182,8 +188,7 @@ export class CreateScenariosComponent implements OnInit {
     return valid ? null : { budgetOrAreaRequired: true };
   }
 
-  private loadConfig(): void {
-    console.log('loading config');
+  loadConfig(): void {
     this.planService.getScenario(this.scenarioId!).subscribe((scenario) => {
       if (scenario.scenario_result) {
         this.scenarioResults = scenario.scenario_result;

--- a/src/interface/src/app/plan/plan-helpers.ts
+++ b/src/interface/src/app/plan/plan-helpers.ts
@@ -1,6 +1,8 @@
 import area from '@turf/area';
 import { FeatureCollection } from 'geojson';
 
+export const POLLING_INTERVAL = 3000;
+
 const SQUARE_METERS_PER_ACRE = 0.0002471054;
 
 export function calculateAcres(planningArea: GeoJSON.GeoJSON) {

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.html
@@ -1,8 +1,6 @@
 <div class="plan-overview-container">
   <mat-divider></mat-divider>
   <div class="plan-scenario-panel">
-    <app-saved-scenarios
-      [plan]="plan$ | async"
-      (createScenarioEvent)="openConfig()"></app-saved-scenarios>
+    <app-saved-scenarios [plan]="plan$ | async"></app-saved-scenarios>
   </div>
 </div>

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
@@ -1,22 +1,16 @@
-import { HarnessLoader } from '@angular/cdk/testing';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatButtonHarness } from '@angular/material/button/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BehaviorSubject, of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
 import { PlanService, PlanState } from 'src/app/services';
-
-import { PlanModule } from './../../plan.module';
 import { PlanOverviewComponent } from './plan-overview.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('PlanOverviewComponent', () => {
   let component: PlanOverviewComponent;
   let fixture: ComponentFixture<PlanOverviewComponent>;
-  let loader: HarnessLoader;
   let fakePlanService: PlanService;
 
   beforeEach(async () => {
@@ -53,7 +47,6 @@ describe('PlanOverviewComponent', () => {
 
     fixture = TestBed.createComponent(PlanOverviewComponent);
     component = fixture.componentInstance;
-    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 

--- a/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-overview/plan-overview.component.spec.ts
@@ -11,6 +11,7 @@ import { PlanService, PlanState } from 'src/app/services';
 
 import { PlanModule } from './../../plan.module';
 import { PlanOverviewComponent } from './plan-overview.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('PlanOverviewComponent', () => {
   let component: PlanOverviewComponent;
@@ -39,12 +40,8 @@ describe('PlanOverviewComponent', () => {
     );
 
     await TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule,
-        MaterialModule,
-        PlanModule,
-        RouterTestingModule,
-      ],
+      imports: [HttpClientTestingModule, MaterialModule, RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [PlanOverviewComponent],
       providers: [
         {
@@ -62,21 +59,6 @@ describe('PlanOverviewComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('clicking new configuration button should call service and navigate', async () => {
-    const route = fixture.debugElement.injector.get(ActivatedRoute);
-    const router = fixture.debugElement.injector.get(Router);
-    spyOn(router, 'navigate');
-    let createScenarioButton = await loader.getHarness(
-      MatButtonHarness.with({ text: /NEW SCENARIO/ })
-    );
-
-    await createScenarioButton.click();
-
-    expect(router.navigate).toHaveBeenCalledOnceWith(['config', ''], {
-      relativeTo: route,
-    });
   });
 
   it('opening a config should navigate', () => {

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -7,6 +7,7 @@
           matSuffix
           mat-raised-button
           color="primary"
+          data-id="new-scenario"
           (click)="openConfig()">
           <mat-icon class="material-symbols-outlined">add_box</mat-icon>
           NEW SCENARIO

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -1,6 +1,12 @@
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
@@ -10,7 +16,7 @@ import { Region } from 'src/app/types';
 
 import { SavedScenariosComponent } from './saved-scenarios.component';
 
-describe('SavedScenariosComponent', () => {
+fdescribe('SavedScenariosComponent', () => {
   let component: SavedScenariosComponent;
   let fixture: ComponentFixture<SavedScenariosComponent>;
   let fakePlanService: PlanService;
@@ -71,25 +77,36 @@ describe('SavedScenariosComponent', () => {
       ownerId: '1',
       region: Region.SIERRA_NEVADA,
     };
-
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should call service for list of scenarios', () => {
+    fixture.detectChanges();
     expect(fakePlanService.getScenariosForPlan).toHaveBeenCalledOnceWith('1');
 
     expect(component.scenarios.length).toEqual(1);
   });
 
   it('should delete selected scenarios', () => {
+    fixture.detectChanges();
     component.highlightedId = '1';
 
     component.deleteSelectedScenarios();
 
     expect(fakePlanService.deleteScenarios).toHaveBeenCalledOnceWith(['1']);
   });
+
+  it('should poll for changes', fakeAsync(() => {
+    spyOn(component, 'fetchScenarios');
+    fixture.detectChanges();
+    expect(component.fetchScenarios).toHaveBeenCalledTimes(1);
+    tick(3000);
+    fixture.detectChanges();
+    expect(component.fetchScenarios).toHaveBeenCalledTimes(2);
+    discardPeriodicTasks();
+  }));
 });

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -16,16 +16,12 @@ import { Region } from 'src/app/types';
 
 import { SavedScenariosComponent } from './saved-scenarios.component';
 import { POLLING_INTERVAL } from '../../plan-helpers';
-import { MatButtonHarness } from '@angular/material/button/testing';
-import { HarnessLoader } from '@angular/cdk/testing';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { By } from '@angular/platform-browser';
 
 describe('SavedScenariosComponent', () => {
   let component: SavedScenariosComponent;
   let fixture: ComponentFixture<SavedScenariosComponent>;
   let fakePlanService: PlanService;
-  let loader: HarnessLoader;
 
   beforeEach(async () => {
     const fakeRoute = jasmine.createSpyObj(
@@ -83,8 +79,6 @@ describe('SavedScenariosComponent', () => {
       ownerId: '1',
       region: Region.SIERRA_NEVADA,
     };
-
-    loader = TestbedHarnessEnvironment.loader(fixture);
   });
 
   it('should create', () => {

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -8,7 +8,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { MaterialModule } from 'src/app/material/material.module';
 import { PlanService } from 'src/app/services';
@@ -16,11 +16,16 @@ import { Region } from 'src/app/types';
 
 import { SavedScenariosComponent } from './saved-scenarios.component';
 import { POLLING_INTERVAL } from '../../plan-helpers';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { By } from '@angular/platform-browser';
 
 describe('SavedScenariosComponent', () => {
   let component: SavedScenariosComponent;
   let fixture: ComponentFixture<SavedScenariosComponent>;
   let fakePlanService: PlanService;
+  let loader: HarnessLoader;
 
   beforeEach(async () => {
     const fakeRoute = jasmine.createSpyObj(
@@ -78,6 +83,8 @@ describe('SavedScenariosComponent', () => {
       ownerId: '1',
       region: Region.SIERRA_NEVADA,
     };
+
+    loader = TestbedHarnessEnvironment.loader(fixture);
   });
 
   it('should create', () => {
@@ -100,6 +107,22 @@ describe('SavedScenariosComponent', () => {
 
     expect(fakePlanService.deleteScenarios).toHaveBeenCalledOnceWith(['1']);
   });
+
+  it('clicking new configuration button should call service and navigate', fakeAsync(async () => {
+    const route = fixture.debugElement.injector.get(ActivatedRoute);
+    const router = fixture.debugElement.injector.get(Router);
+    spyOn(router, 'navigate');
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(
+      By.css('[data-id="new-scenario"]')
+    );
+    button.nativeElement.click();
+    expect(router.navigate).toHaveBeenCalledOnceWith(['config', ''], {
+      relativeTo: route,
+    });
+    discardPeriodicTasks();
+  }));
 
   it('should poll for changes', fakeAsync(() => {
     spyOn(component, 'fetchScenarios');

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -15,8 +15,9 @@ import { PlanService } from 'src/app/services';
 import { Region } from 'src/app/types';
 
 import { SavedScenariosComponent } from './saved-scenarios.component';
+import { POLLING_INTERVAL } from '../../plan-helpers';
 
-fdescribe('SavedScenariosComponent', () => {
+describe('SavedScenariosComponent', () => {
   let component: SavedScenariosComponent;
   let fixture: ComponentFixture<SavedScenariosComponent>;
   let fakePlanService: PlanService;
@@ -104,7 +105,7 @@ fdescribe('SavedScenariosComponent', () => {
     spyOn(component, 'fetchScenarios');
     fixture.detectChanges();
     expect(component.fetchScenarios).toHaveBeenCalledTimes(1);
-    tick(3000);
+    tick(POLLING_INTERVAL);
     fixture.detectChanges();
     expect(component.fetchScenarios).toHaveBeenCalledTimes(2);
     discardPeriodicTasks();

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -1,14 +1,15 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
-import { take } from 'rxjs';
+import { interval, take } from 'rxjs';
 import { PlanService } from 'src/app/services';
 import { Plan, Scenario } from 'src/app/types';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
 interface ScenarioRow extends Scenario {
   selected?: boolean;
 }
-
+@UntilDestroy()
 @Component({
   selector: 'app-saved-scenarios',
   templateUrl: './saved-scenarios.component.html',
@@ -44,6 +45,13 @@ export class SavedScenariosComponent implements OnInit {
 
   ngOnInit(): void {
     this.fetchScenarios();
+    this.pollForChanges();
+  }
+
+  private pollForChanges() {
+    interval(3000)
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.fetchScenarios());
   }
 
   fetchScenarios(): void {

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -5,6 +5,7 @@ import { interval, take } from 'rxjs';
 import { PlanService } from 'src/app/services';
 import { Plan, Scenario } from 'src/app/types';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { POLLING_INTERVAL } from '../../plan-helpers';
 
 interface ScenarioRow extends Scenario {
   selected?: boolean;
@@ -49,7 +50,8 @@ export class SavedScenariosComponent implements OnInit {
   }
 
   private pollForChanges() {
-    interval(3000)
+    // we might want to check if any scenario is still pending in order to poll
+    interval(POLLING_INTERVAL)
       .pipe(untilDestroyed(this))
       .subscribe(() => this.fetchScenarios());
   }


### PR DESCRIPTION
- Added polling on scenario list (plan page) and scenario page.
- Polling each 3 seconds.
- On scenario page, only poll if scenario si pending/running 
- Added https://github.com/ngneat/until-destroy to deal with destroying subscriptions
- Cleaned up some test 