### PR TITLE
fix map async test using fakeAsync

### DIFF
--- a/src/interface/src/app/navigation/navigation.component.spec.ts
+++ b/src/interface/src/app/navigation/navigation.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NavigationComponent } from './navigation.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
@@ -9,6 +10,7 @@ describe('NavigationComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NavigationComponent],
+      imports: [RouterTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavigationComponent);

--- a/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SummaryPanelComponent } from './summary-panel.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('SummaryPanelComponent', () => {
   let component: SummaryPanelComponent;
@@ -9,6 +9,7 @@ describe('SummaryPanelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [SummaryPanelComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SummaryPanelComponent);

--- a/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.spec.ts
+++ b/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProjectAreasMetricsComponent } from './project-areas-metrics.component';
+import { MaterialModule } from '../../material/material.module';
 
 describe('ProjectAreasMetricsComponent', () => {
   let component: ProjectAreasMetricsComponent;
@@ -9,6 +10,7 @@ describe('ProjectAreasMetricsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ProjectAreasMetricsComponent],
+      imports: [MaterialModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProjectAreasMetricsComponent);

--- a/src/interface/src/app/plan/project-areas/project-areas.component.spec.ts
+++ b/src/interface/src/app/plan/project-areas/project-areas.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProjectAreasComponent } from './project-areas.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('ProjectAreasComponent', () => {
   let component: ProjectAreasComponent;
@@ -8,6 +9,7 @@ describe('ProjectAreasComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ProjectAreasComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProjectAreasComponent);

--- a/src/interface/src/app/plan/report-chart/report-chart.component.spec.ts
+++ b/src/interface/src/app/plan/report-chart/report-chart.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ReportChartComponent } from './report-chart.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgChartsModule } from 'ng2-charts';
 
 describe('ReportChartComponent', () => {
   let component: ReportChartComponent;
@@ -9,6 +11,8 @@ describe('ReportChartComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ReportChartComponent],
+      imports: [NgChartsModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ReportChartComponent);

--- a/src/interface/src/app/plan/scenario-pending/scenario-pending.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-pending/scenario-pending.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ScenarioPendingComponent } from './scenario-pending.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('ScenarioPendingComponent', () => {
   let component: ScenarioPendingComponent;
@@ -9,6 +10,7 @@ describe('ScenarioPendingComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ScenarioPendingComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ScenarioPendingComponent);

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ScenarioResultsComponent } from './scenario-results.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('ScenarioResultsComponent', () => {
   let component: ScenarioResultsComponent;
@@ -9,6 +10,7 @@ describe('ScenarioResultsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ScenarioResultsComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ScenarioResultsComponent);

--- a/src/interface/src/app/signup/validation-email-dialog/validation-email-dialog.component.spec.ts
+++ b/src/interface/src/app/signup/validation-email-dialog/validation-email-dialog.component.spec.ts
@@ -12,6 +12,8 @@ import { MaterialModule } from 'src/app/material/material.module';
 import { AuthService } from 'src/app/services';
 
 import { ValidationEmailDialogComponent } from './validation-email-dialog.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ValidationEmailDialogComponent', () => {
   let component: ValidationEmailDialogComponent;
@@ -42,7 +44,8 @@ describe('ValidationEmailDialogComponent', () => {
       {}
     );
     await TestBed.configureTestingModule({
-      imports: [MaterialModule],
+      imports: [MaterialModule, RouterTestingModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [ValidationEmailDialogComponent],
       providers: [
         {


### PR DESCRIPTION
I've noticed that some tests where failing when we re-ran the tests. Looks like some async functions where not properly flushed:

<img width="1142" alt="Screen Shot 2023-09-22 at 11 36 12" src="https://github.com/OurPlanscape/Planscape/assets/358892/59f39256-b27d-4ffc-87f7-4ec6cd1f9a25">


The map component has a `setTimeout` as well as some other interval with sessionService.sessionInterval$.

Looks like some of this timers are leaking or not completed, making the tests fail. Switched some async tests to use `fakeAsync` to flush and tick timers.
Not sure if this is the best way of solving this, probably the tests and the component needs some work (why do we have a setTimeout??) but this change hopefully fixes the issue on the tests.

Also, cleaned up a bunch of warnings that make output difficult to read.

