### PR TITLE
hide-help-icon-on-print

### DIFF
--- a/src/interface/src/app/map/map.component.scss
+++ b/src/interface/src/app/map/map.component.scss
@@ -224,7 +224,9 @@
     flex-direction: column;
   }
 
-  app-map-control-panel, app-nav-bar, .map-actions-bar {
+  app-map-control-panel,
+  app-nav-bar,
+  .map-actions-bar {
     display: none;
   }
   .map-box.selected {

--- a/src/interface/src/app/top-bar/top-bar.component.html
+++ b/src/interface/src/app/top-bar/top-bar.component.html
@@ -22,6 +22,7 @@
 
     <!-- Account Name & Button -->
     <a
+      class="help"
       mat-icon-button
       routerLink="/help"
       target="_blank"

--- a/src/interface/src/app/top-bar/top-bar.component.scss
+++ b/src/interface/src/app/top-bar/top-bar.component.scss
@@ -70,9 +70,13 @@
 }
 
 @media print {
-  .nav-link, .username, .mat-menu-trigger , .avatar {
+  .nav-link, .username, .mat-menu-trigger , .avatar , .help{
     display: none;
   }
+  .mat-toolbar {
+    background-color: white;
+  }
+
   .mat-toolbar .site-link {
     color: black;
   }


### PR DESCRIPTION
Quick one, noticed that now that we added the (?) icon on the top bar, we need to hide it on the print version.

before
<img width="711" alt="Screen Shot 2023-09-22 at 18 26 07" src="https://github.com/OurPlanscape/Planscape/assets/358892/fce6362e-1ff6-4470-958d-29337f23c708">

After
the same, without the icon on the top bar