### PR TITLE
[PLAM-43] Verify password reset token

### DIFF
--- a/src/planscape/planscape/urls.py
+++ b/src/planscape/planscape/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from dj_rest_auth.registration.views import VerifyEmailView
+from users import views as user_views
 
 urlpatterns = [
     path("planscape-backend/admin/", admin.site.urls),
@@ -27,6 +28,11 @@ urlpatterns = [
     path("planscape-backend/projects/", include("existing_projects.urls")),
     # Auth URLs
     path("planscape-backend/users/", include("users.urls")),
+    path(
+        "planscape-backend/dj-rest-auth/password/reset/<slug:user_id>/<slug:token>",
+        user_views.verify_password_reset_token,
+        name="verify_password_reset_token",
+    ),
     path("planscape-backend/dj-rest-auth/", include("dj_rest_auth.urls")),
     path(
         "planscape-backend/dj-rest-auth/registration/",

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -146,7 +146,7 @@ class PasswordResetTest(TransactionTestCase):
         # POST request to get reset password link.
         self.client.post(reverse("rest_password_reset"), {"email": "testuser@test.com"})
 
-        # Check that reset email was sink and extract reset token.
+        # Check that reset email was sent and extract reset token.
         self.assertEqual(len(mail.outbox), 1)
         token_search = re.search("/reset/([a-z0-9]+)/([a-z0-9-]+)", mail.outbox[0].body)
         self.assertIsNotNone(token_search)
@@ -191,7 +191,7 @@ class PasswordResetTest(TransactionTestCase):
         # POST request to get reset password link.
         self.client.post(reverse("rest_password_reset"), {"email": "testuser@test.com"})
 
-        # Check that reset email was sink and extract reset token.
+        # Check that reset email was sent and extract reset token.
         self.assertEqual(len(mail.outbox), 1)
         token_search = re.search("/reset/([a-z0-9]+)/([a-z0-9-]+)", mail.outbox[0].body)
         self.assertIsNotNone(token_search)

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -153,6 +153,14 @@ class PasswordResetTest(TransactionTestCase):
         uid = token_search.group(1)
         token = token_search.group(2)
 
+        # Verifying the token is valid.
+        response = self.client.get(
+            reverse(
+                "verify_password_reset_token", kwargs={"user_id": uid, "token": token}
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+
         # POST request to set new password with token.
         response = self.client.post(
             reverse("rest_password_reset_confirm"),
@@ -169,6 +177,43 @@ class PasswordResetTest(TransactionTestCase):
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(mail.outbox[1].subject, "[Planscape] Password Reset")
         self.assertIn("Team Planscape", mail.outbox[1].body)
+
+    def test_verify_with_invalid_password_reset_token(self):
+        # Invalid uid and token
+        response = self.client.get(
+            reverse(
+                "verify_password_reset_token",
+                kwargs={"user_id": "1b", "token": "abcdefg"},
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # POST request to get reset password link.
+        self.client.post(reverse("rest_password_reset"), {"email": "testuser@test.com"})
+
+        # Check that reset email was sink and extract reset token.
+        self.assertEqual(len(mail.outbox), 1)
+        token_search = re.search("/reset/([a-z0-9]+)/([a-z0-9-]+)", mail.outbox[0].body)
+        self.assertIsNotNone(token_search)
+        uid = token_search.group(1)
+        token = token_search.group(2)
+
+        # Valid uid, but invalid token.
+        response = self.client.get(
+            reverse(
+                "verify_password_reset_token",
+                kwargs={"user_id": uid, "token": "abcdefg"},
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # Valid token, but not the right uid.
+        response = self.client.get(
+            reverse(
+                "verify_password_reset_token", kwargs={"user_id": "1b", "token": token}
+            )
+        )
+        self.assertEqual(response.status_code, 400)
 
 
 class PasswordChangeTest(TransactionTestCase):

--- a/src/planscape/users/views.py
+++ b/src/planscape/users/views.py
@@ -70,6 +70,10 @@ def verify_password_reset_token(
     # Get the UserModel
     UserModel = get_user_model()
 
+    # dj-rest-auth supports both allauth and non-allauth methods of generating
+    # password reset tokens. In order to mirror the validation done on the token
+    # we also handle both methods.
+    # https://github.com/iMerica/dj-rest-auth/blob/master/dj_rest_auth/serializers.py#L276-L291
     if "allauth" in settings.INSTALLED_APPS:
         from allauth.account.forms import default_token_generator
         from allauth.account.utils import url_str_to_user_pk as uid_decoder

--- a/src/planscape/users/views.py
+++ b/src/planscape/users/views.py
@@ -70,7 +70,7 @@ def verify_password_reset_token(
     # Get the UserModel
     UserModel = get_user_model()
 
-    if 'allauth' in settings.INSTALLED_APPS:
+    if "allauth" in settings.INSTALLED_APPS:
         from allauth.account.forms import default_token_generator
         from allauth.account.utils import url_str_to_user_pk as uid_decoder
     else:
@@ -82,10 +82,9 @@ def verify_password_reset_token(
         uid = force_str(uid_decoder(user_id))
         user = UserModel._default_manager.get(pk=uid)
     except (TypeError, ValueError, OverflowError, UserModel.DoesNotExist):
-        raise HttpResponseBadRequest("Invalid url.")
+        return HttpResponseBadRequest("Invalid url.")
 
     if not default_token_generator.check_token(user, token):
-        raise HttpResponseBadRequest("Invalid token.")
-    
-    return JsonResponse({"valid": True})
+        return HttpResponseBadRequest("Invalid token.")
 
+    return JsonResponse({"valid": True})


### PR DESCRIPTION
https://sig-gis.atlassian.net/browse/PLAM-43

Uses the same validator as the password reset confirmation serializer. 

The token will expire and no longer pass validation after 30 minutes as set here: https://github.com/OurPlanscape/Planscape/blob/main/src/planscape/planscape/settings.py#L267. 