### PR TITLE
fix chart sizes when resizing window

### DIFF
--- a/src/interface/src/app/plan/plan.component.scss
+++ b/src/interface/src/app/plan/plan.component.scss
@@ -48,7 +48,8 @@
 .plan-content-panel {
   overflow: auto;
   width: 45%;
-
+  min-width: 450px;
+  max-width: 800px;
 }
 
 .scenario-details {

--- a/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.scss
+++ b/src/interface/src/app/plan/project-areas-metrics/project-areas-metrics.component.scss
@@ -27,13 +27,14 @@
 
 .chart-holder {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
   position: relative;
 }
 
 .mat-form-field {
   width: 100%;
+  overflow: hidden;
 }
 
 .map-selector {


### PR DESCRIPTION
Fixes chart sizing when resizing viewport. 
Adds min and max width to side panel
<img width="888" alt="Screen Shot 2023-09-28 at 13 32 38" src="https://github.com/OurPlanscape/Planscape/assets/358892/eccc1601-fcea-4e5f-9477-dbbec7c1f645">
<img width="1496" alt="Screen Shot 2023-09-28 at 13 32 47" src="https://github.com/OurPlanscape/Planscape/assets/358892/6119e39c-1a9f-4616-98d3-90036ab77da8">
