### PR TITLE
Calculate max acres from budget and estimated cost per acre

### DIFF
--- a/src/planscape/rscripts/forsys.R
+++ b/src/planscape/rscripts/forsys.R
@@ -350,7 +350,14 @@ get_min_project_area <- function(scenario) {
     min_area <- 10
   }
 
-  log_info(paste0(stand_size, " chosen. Minimum project area is ", min_area))
+  log_info(
+    paste0(
+      "Stand size ",
+      stand_size,
+      " chosen. Minimum project area is ",
+      min_area
+    )
+  )
   return(min_area)
 }
 


### PR DESCRIPTION
This PR changes how we determine all the min/max project areas and planning area max treatments.

1. extracted everything into it's own function. I've standardized for these functions to receive the scenario and return whatever they calculate. there is some extra work here, but we can change and try to standardize it differently.
2. there is an order here. if budget is filled, it will be used to calculate the max treatment area. if it's not, but we do have max_treatment_area_ratio, that will be used instead. If none of these are present we will use a default. I did it like because we don't validate these things properly yet. When we do, we can stop this nonsense and just return what needs to happen.