### PR TITLE
Change method used to return an empty queryset

### DIFF
--- a/src/planscape/stands/management/commands/load_metrics_v2.py
+++ b/src/planscape/stands/management/commands/load_metrics_v2.py
@@ -101,7 +101,7 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f"[WARN] Empty extent for condition {condition_id}. No metrics to load."
                 )
-                return Stand.objects.empty()
+                return Stand.objects.none()
 
             qs = qs.filter(geometry__intersects=extent)
 


### PR DESCRIPTION
Silly mistake, the name of the method is `none` not `empty`