### PR TITLE
load stand size on scenario config

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -222,6 +222,9 @@ export class CreateScenariosComponent implements OnInit {
       const maxSlope = this.constraintsFormGroup.get(
         'physicalConstraintForm.maxSlope'
       );
+      const standSize = this.constraintsFormGroup.get(
+        'physicalConstraintForm.standSize'
+      );
       this.excludedAreasOptions.forEach((area: string) => {
         if (config.excluded_areas && config.excluded_areas.indexOf(area) > -1) {
           this.constraintsFormGroup
@@ -255,6 +258,10 @@ export class CreateScenariosComponent implements OnInit {
       }
       if (config.treatment_question) {
         selectedQuestion?.setValue(config.treatment_question);
+      }
+      console.log(config);
+      if (config.stand_size) {
+        standSize?.setValue(config.stand_size);
       }
     });
   }

--- a/src/interface/src/app/services/plan.service.spec.ts
+++ b/src/interface/src/app/services/plan.service.spec.ts
@@ -174,6 +174,7 @@ describe('PlanService', () => {
         created_timestamp: undefined,
         project_areas: [],
         excluded_areas: undefined,
+        stand_size: 'MEDIUM',
       };
       const scenario: Scenario = {
         id: '1',

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -498,6 +498,7 @@ export class PlanService {
       max_treatment_area_ratio: config.max_treatment_area_ratio,
       treatment_question: selectedQuestion,
       excluded_areas: config.excluded_areas,
+      stand_size: config.stand_size,
       created_timestamp: this.convertBackendTimestamptoFrontendTimestamp(
         config.creation_timestamp
       ),


### PR DESCRIPTION
Looks like we where not populating this value back when loading the scenario. 

<img width="1471" alt="Screen Shot 2023-10-05 at 10 50 25" src="https://github.com/OurPlanscape/Planscape/assets/358892/78d0656c-b010-4a3d-a6bd-5ce30b341e29">
