### PR TITLE
add created at date on plan page

### DIFF
--- a/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.ts
+++ b/src/interface/src/app/plan/plan-summary/summary-panel/summary-panel.component.ts
@@ -13,7 +13,7 @@ export interface SummaryInput {
   region: Region;
   area: GeoJSON.GeoJSON;
   status?: string;
-  createdTime?: number;
+  createdTime?: Date;
   scenarios?: number;
   configs?: number;
   lastUpdated: Date;

--- a/src/interface/src/app/services/plan.service.ts
+++ b/src/interface/src/app/services/plan.service.ts
@@ -45,7 +45,7 @@ export interface BackendPlan {
   geometry?: GeoJSON.GeoJSON;
   scenario_count?: number;
   projects?: number;
-  creation_timestamp?: number; // in seconds since epoch
+  created_at?: string;
   latest_updated?: string;
 }
 
@@ -422,9 +422,7 @@ export class PlanService {
       scenarios: plan.scenario_count ?? 0,
       notes: plan.notes ?? '',
       configs: plan.projects ?? 0,
-      createdTimestamp: this.convertBackendTimestamptoFrontendTimestamp(
-        plan.creation_timestamp
-      ),
+      createdTimestamp: plan.created_at ? new Date(plan.created_at) : undefined,
       lastUpdated: plan.latest_updated
         ? new Date(plan.latest_updated)
         : undefined,

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -6,7 +6,7 @@ export interface Plan extends BasePlan {
   ownerId: string;
   region: Region;
   planningArea?: GeoJSON.GeoJSON;
-  createdTimestamp?: number;
+  createdTimestamp?: Date;
   lastUpdated?: Date;
   scenarios?: number;
   configs?: number;


### PR DESCRIPTION
Created date on plan page was missing, was using an old property.
Updated to use `created_at`
<img width="336" alt="Screen Shot 2023-10-05 at 10 58 24" src="https://github.com/OurPlanscape/Planscape/assets/358892/f0611db5-b50f-407b-9866-62b440b99e25">
