### PR TITLE
Allow drawing only when authenticated (PLAM-32)

### DIFF
--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -343,6 +343,9 @@ describe('MapComponent', () => {
 
     it('enables drawing on selected map and shows cloned layer on other maps', fakeAsync(async () => {
       component.ngAfterViewInit();
+      const auth = TestBed.inject(AuthService);
+      auth.loggedInStatus$.next(true);
+
       spyOn(component, 'onAreaCreationActionChange').and.callThrough();
       const button = await loader.getHarness(
         MatButtonHarness.with({
@@ -464,11 +467,16 @@ describe('MapComponent', () => {
     (drawnPolygon as any)._leaflet_id = TEST_ID;
 
     beforeEach(() => {
+
       component.ngAfterViewInit();
     });
 
     it('sets up drawing', fakeAsync(async () => {
       spyOn(component, 'onAreaCreationActionChange').and.callThrough();
+
+      const auth = TestBed.inject(AuthService);
+      auth.loggedInStatus$.next(true);
+
       const button = await loader.getHarness(
         MatButtonHarness.with({
           selector: '.draw-area-button',

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -368,7 +368,6 @@ describe('MapComponent', () => {
       component.ngAfterViewInit();
       userSignedIn$.next(true);
 
-
       spyOn(component, 'onAreaCreationActionChange').and.callThrough();
       const button = await loader.getHarness(
         MatButtonHarness.with({
@@ -490,7 +489,6 @@ describe('MapComponent', () => {
     (drawnPolygon as any)._leaflet_id = TEST_ID;
 
     beforeEach(() => {
-
       component.ngAfterViewInit();
     });
 

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -61,6 +61,7 @@ describe('MapComponent', () => {
       'https://dev-geo.planscape.org/geoserver/gwc/service/tms/1.0.0/sierra-nevada:vector_huc12@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf',
       {}
     );
+
     const fakeGeoJson: GeoJSON.GeoJSON = {
       type: 'FeatureCollection',
       features: [
@@ -341,10 +342,32 @@ describe('MapComponent', () => {
       });
     });
 
-    it('enables drawing on selected map and shows cloned layer on other maps', fakeAsync(async () => {
+    it('displays a login/signup dialog when user attempts to draw, but is not logged in', fakeAsync(async () => {
+      userSignedIn$.next(false);
+      const fakeMatDialog: MatDialog =
+        fixture.debugElement.injector.get(MatDialog);
       component.ngAfterViewInit();
-      const auth = TestBed.inject(AuthService);
-      auth.loggedInStatus$.next(true);
+      spyOn(component, 'onAreaCreationActionChange').and.callThrough();
+      //when user clicks draw button...
+      const button = await loader.getHarness(
+        MatButtonHarness.with({
+          selector: '.draw-area-button',
+        })
+      );
+      await button.click();
+      tick();
+      component.maps[3].instance?.fireEvent('click');
+      //then we ought to see a signin dialog
+      expect(fakeMatDialog.open).toHaveBeenCalledOnceWith(
+        SignInDialogComponent,
+        { maxWidth: '560px' }
+      );
+    }));
+
+    it('enables drawing on selected map and shows cloned layer on other maps, when logged in', fakeAsync(async () => {
+      component.ngAfterViewInit();
+      userSignedIn$.next(true);
+
 
       spyOn(component, 'onAreaCreationActionChange').and.callThrough();
       const button = await loader.getHarness(
@@ -500,7 +523,27 @@ describe('MapComponent', () => {
       ).toBeTrue();
     }));
 
-    it('enables polygon tool when drawing option is selected', fakeAsync(async () => {
+    it('disallows drawing when drawing option is selected and user is not logged in', fakeAsync(async () => {
+      userSignedIn$.next(false);
+      const fakeMatDialog: MatDialog =
+        fixture.debugElement.injector.get(MatDialog);
+
+      spyOn(component, 'onAreaCreationActionChange').and.callThrough();
+      const button = await loader.getHarness(
+        MatButtonHarness.with({
+          selector: '.draw-area-button',
+        })
+      );
+      await button.click();
+      tick();
+      expect(fakeMatDialog.open).toHaveBeenCalledOnceWith(
+        SignInDialogComponent,
+        { maxWidth: '560px' }
+      );
+    }));
+
+    it('enables polygon tool when drawing option is selected and user is logged in', fakeAsync(async () => {
+      userSignedIn$.next(true);
       spyOn(component, 'onAreaCreationActionChange').and.callThrough();
       const button = await loader.getHarness(
         MatButtonHarness.with({

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -467,12 +467,18 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     const selectedMapIndex = this.mapViewOptions$.getValue().selectedMapIndex;
     this.selectedAreaCreationAction = option;
     if (option === AreaCreationAction.DRAW) {
-      this.addDrawingControlToAllMaps();
-      this.mapManager.enablePolygonDrawingTool(
-        this.maps[selectedMapIndex].instance!
-      );
-      this.showUploader = false;
-      this.changeMapCount(1);
+
+      if (!this.authService.loggedInStatus$.value) {
+        this.cancelAreaCreationAction();
+        this.openSignInDialog();
+      } else {
+        this.addDrawingControlToAllMaps();
+        this.mapManager.enablePolygonDrawingTool(
+          this.maps[selectedMapIndex].instance!
+        );
+        this.showUploader = false;
+        this.changeMapCount(1);
+      }
     }
     if (option === AreaCreationAction.UPLOAD) {
       if (!this.showConfirmAreaButton$.value) {

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -467,7 +467,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     const selectedMapIndex = this.mapViewOptions$.getValue().selectedMapIndex;
     this.selectedAreaCreationAction = option;
     if (option === AreaCreationAction.DRAW) {
-
       if (!this.authService.loggedInStatus$.value) {
         this.cancelAreaCreationAction();
         this.openSignInDialog();


### PR DESCRIPTION
With these changes...

This is what happens when you're logged in:
![logged-in](https://github.com/OurPlanscape/Planscape/assets/100235124/a6fc9280-442a-4ed5-952e-1392c255e206)

This is what happens when you're not logged in:
![not-logged-in](https://github.com/OurPlanscape/Planscape/assets/100235124/233ffbb6-6896-4284-83e5-37e9e14635a2)

