### PR TITLE
Password Reset Error styling

### DIFF
--- a/src/interface/src/app/password-reset/password-reset.component.scss
+++ b/src/interface/src/app/password-reset/password-reset.component.scss
@@ -35,7 +35,7 @@ h1 {
   }
 }
 
-p {
+.reset-text {
   color: #888888;
   font-family: 'Roboto';
   font-size: 13px;
@@ -54,6 +54,7 @@ mat-form-field {
 
 .reset-form-buttons {
   margin-top: 20px;
+  margin-bottom: 20px;
   display: flex;
   justify-content: space-between;
   gap: 10px;


### PR DESCRIPTION
Before:
![image](https://github.com/OurPlanscape/Planscape/assets/1364489/23068b88-bae2-470d-9637-23f4b6999e4b)


Now:
![image](https://github.com/PatManley/Planscape/assets/1364489/7c5c177b-0c45-4640-afb4-8bad323441aa)

Makes it consistent with create account error message. 