### PR TITLE
added password field on edit form

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -117,6 +117,15 @@
             matInput />
         </mat-form-field>
 
+        <mat-form-field>
+          <mat-label>Current password</mat-label>
+          <input
+            type="password"
+            required
+            formControlName="currentPassword"
+            matInput />
+        </mat-form-field>
+
         <div class="button-row">
           <button
             mat-raised-button

--- a/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.spec.ts
@@ -92,6 +92,7 @@ describe('AccountDialogComponent', () => {
       firstName: 'Foo',
       lastName: 'Bar',
       email: 'test@test.com',
+      currentPassword: '',
     });
   });
 
@@ -106,13 +107,17 @@ describe('AccountDialogComponent', () => {
 
   it('saving user changes calls AuthService', () => {
     component.editAccount();
+    component.editAccountForm.get('currentPassword')?.setValue('password');
     component.saveEdits();
 
-    expect(fakeAuthService.updateUser).toHaveBeenCalledOnceWith({
-      firstName: 'Foo',
-      lastName: 'Bar',
-      email: 'test@test.com',
-    });
+    expect(fakeAuthService.updateUser).toHaveBeenCalledOnceWith(
+      {
+        firstName: 'Foo',
+        lastName: 'Bar',
+        email: 'test@test.com',
+      },
+      'password'
+    );
   });
 
   it('saving new password calls AuthService', () => {

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -54,6 +54,7 @@ export class AccountDialogComponent implements OnInit {
       firstName: this.fb.control('', Validators.required),
       lastName: this.fb.control('', Validators.required),
       email: this.fb.control('', [Validators.required, Validators.email]),
+      currentPassword: this.fb.control('', [Validators.required]),
     });
   }
 
@@ -117,11 +118,14 @@ export class AccountDialogComponent implements OnInit {
     this.disableEditButton = true;
 
     this.authService
-      .updateUser({
-        firstName: this.editAccountForm.get('firstName')?.value,
-        lastName: this.editAccountForm.get('lastName')?.value,
-        email: this.editAccountForm.get('email')?.value,
-      })
+      .updateUser(
+        {
+          firstName: this.editAccountForm.get('firstName')?.value,
+          lastName: this.editAccountForm.get('lastName')?.value,
+          email: this.editAccountForm.get('email')?.value,
+        },
+        this.editAccountForm.get('currentPassword')?.value
+      )
       .pipe(take(1))
       .subscribe(
         (_) => {

--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -338,7 +338,7 @@ describe('AuthService', () => {
         email: 'test@test.com',
       };
 
-      service.updateUser(frontendUser).subscribe((res) => {
+      service.updateUser(frontendUser, 'currentpassword').subscribe((res) => {
         expect(res).toEqual(frontendUser);
         done();
       });
@@ -347,7 +347,10 @@ describe('AuthService', () => {
         BackendConstants.END_POINT + '/dj-rest-auth/user/'
       );
       expect(req.request.method).toEqual('PATCH');
-      expect(req.request.body).toEqual(backendUser);
+      expect(req.request.body).toEqual({
+        ...backendUser,
+        current_password: 'currentpassword',
+      });
       req.flush(backendUser);
       httpTestingController.verify();
     });
@@ -366,7 +369,7 @@ describe('AuthService', () => {
         email: 'test@test.com',
       };
 
-      service.updateUser(frontendUser).subscribe((_) => {
+      service.updateUser(frontendUser, 'currentpassword').subscribe((_) => {
         expect(service.loggedInUser$.value).toEqual(frontendUser);
         done();
       });

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -239,7 +239,7 @@ export class AuthService {
       );
   }
 
-  updateUser(newUser: User): Observable<User> {
+  updateUser(newUser: User, currentPassword: string): Observable<User> {
     return this.http
       .patch(
         this.API_ROOT.concat('user/'),
@@ -248,6 +248,7 @@ export class AuthService {
           username: newUser.username,
           first_name: newUser.firstName,
           last_name: newUser.lastName,
+          current_password: currentPassword,
         },
         {
           withCredentials: true,


### PR DESCRIPTION
PLAM-47

<img width="813" alt="Screen Shot 2023-10-11 at 13 28 21" src="https://github.com/OurPlanscape/Planscape/assets/358892/58c17250-7d3e-4c1a-a905-5d728eca6847">

<img width="456" alt="Screen Shot 2023-10-11 at 13 29 31" src="https://github.com/OurPlanscape/Planscape/assets/358892/9ef00e81-8192-48a6-8d41-ac5fdfcd7b78">

- Adds `current_password` to the payload.

**TODO**
Do something with this on the backend
Show error if password not valid