### PR TITLE
allow dummy email backend in local dev env

### DIFF
--- a/src/planscape/planscape/.env-sample
+++ b/src/planscape/planscape/.env-sample
@@ -4,4 +4,11 @@ PLANSCAPE_DATABASE_HOST=databasehostaddress
 PLANSCAPE_DATABASE_NAME=databasename
 PLANSCAPE_DATABASE_USER=databaseusername
 PLANSCAPE_DATABASE_PASSWORD=databasepassword
-EMAIL_BACKEND=django.core.mail.backends.dummy.EmailBackend # to disable any emails locally
+
+### To disable the sending of emails in an environment, you can use a setting like the following:
+
+# To output emails to console instead of sending them:
+# EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+#
+# or to ignore them completely:
+# EMAIL_BACKEND=django.core.mail.backends.dummy.EmailBackend

--- a/src/planscape/planscape/.env-sample
+++ b/src/planscape/planscape/.env-sample
@@ -4,3 +4,4 @@ PLANSCAPE_DATABASE_HOST=databasehostaddress
 PLANSCAPE_DATABASE_NAME=databasename
 PLANSCAPE_DATABASE_USER=databaseusername
 PLANSCAPE_DATABASE_PASSWORD=databasepassword
+EMAIL_BACKEND=django.core.mail.backends.dummy.EmailBackend # to disable any emails locally

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -265,8 +265,9 @@ ACCOUNT_USERNAME_REQUIRED = False
 LOGOUT_ON_PASSWORD_CHANGE = False
 ACCOUNT_ADAPTER = "users.allauth_adapter.CustomAllauthAdapter"
 PASSWORD_RESET_TIMEOUT = 1800  # 30 minutes.
-
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+)
 EMAIL_HOST = "smtp.gmail.com"
 EMAIL_USE_TLS = True
 EMAIL_PORT = 587


### PR DESCRIPTION
Allow us to set a django dummy email backend for local dev environment with .env

https://docs.djangoproject.com/en/4.2/topics/email/#dummy-backend