### PR TITLE
Plan table hover and css cleanup

### DIFF
--- a/src/interface/src/app/home/plan-table/plan-table.component.scss
+++ b/src/interface/src/app/home/plan-table/plan-table.component.scss
@@ -36,11 +36,16 @@ h2 {
 
 .table-row {
   cursor: pointer;
+
+  &:hover {
+    background-color: #f1f5fd;
+  }
+
 }
 
 .selected .mat-column-name,
 .selected {
-  background-color: #f1f5fd;
+
   border-left-color: #3b78e7;
 }
 

--- a/src/interface/src/app/home/plan-table/plan-table.component.scss
+++ b/src/interface/src/app/home/plan-table/plan-table.component.scss
@@ -1,3 +1,6 @@
+@use '@angular/material' as mat;
+@import "../../../theme";
+
 :host {
   display: block;
 }
@@ -38,7 +41,10 @@ h2 {
   cursor: pointer;
 
   &:hover {
-    background-color: #f1f5fd;
+    background-color: transparentize(
+      $color: mat.get-color-from-palette($primary-palette, 500),
+      $amount: 0.9
+    );
   }
 
 }
@@ -46,7 +52,14 @@ h2 {
 .selected .mat-column-name,
 .selected {
 
-  border-left-color: #3b78e7;
+  border-left-color: mat.get-color-from-palette($primary-palette, 500);
+}
+
+.selected {
+  background-color: transparentize(
+    $color: mat.get-color-from-palette($primary-palette, 500),
+    $amount: 0.9
+  );
 }
 
 mat-header-row {

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.scss
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use '@angular/material' as mat;
 
-@import '../../../styles.scss';
+@import '../../../theme.scss';
 
 $color-config: mat.get-color-config($planscape-frontend-theme);
 $primary-palette: map.get($color-config, 'primary');

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
@@ -1,10 +1,6 @@
 @use 'sass:map';
 @use '@angular/material' as mat;
-
-@import '../../../../styles.scss';
-
-$color-config: mat.get-color-config($planscape-frontend-theme);
-$primary-palette: map.get($color-config, 'primary');
+@import "../../../../theme";
 
 .name-column {
   justify-content: left;
@@ -14,6 +10,7 @@ mat-header-cell,
 mat-cell {
   justify-content: center;
 }
+
 .saved-scenarios-wrapper {
   position: relative;
 }
@@ -27,7 +24,12 @@ mat-cell {
     $color: mat.get-color-from-palette($primary-palette, 500),
     $amount: 0.9
   );
+
+  mat-cell div.hover-indicator {
+    background-color: mat.get-color-from-palette($primary-palette, 500);
+  }
 }
+
 .mat-card-content {
   padding: 8px;
 }
@@ -77,10 +79,6 @@ mat-cell {
       $color: mat.get-color-from-palette($primary-palette, 500),
       $amount: 0.9
     );
-
-    mat-cell div.hover-indicator {
-      background-color: mat.get-color-from-palette($primary-palette, 500);
-    }
   }
 }
 

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.scss
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use '@angular/material' as mat;
 
-@import '../../../../styles.scss';
+@import '../../../../theme.scss';
 
 $color-config: mat.get-color-config($planscape-frontend-theme);
 $primary-palette: map.get($color-config, 'primary');

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -10,98 +10,7 @@
 // Be sure that you only ever include this mixin once!
 @include mat.core();
 
-// CUSTOM
-// $primary-palette: (
-//     50 : #e9e9e9,
-//     100 : #c8c8c8,
-//     200 : #a4a4a4,
-//     300 : #808080,
-//     400 : #646464,
-//     500 : #494949,
-//     600 : #424242,
-//     700 : #393939,
-//     800 : #313131,
-//     900 : #212121,
-//     A100 : #f17d7d,
-//     A200 : #eb4f4f,
-//     A400 : #ff0808,
-//     A700 : #ee0000,
-//     contrast: (
-//         50 : #000000,
-//         100 : #000000,
-//         200 : #000000,
-//         300 : #000000,
-//         400 : #ffffff,
-//         500 : #ffffff,
-//         600 : #ffffff,
-//         700 : #ffffff,
-//         800 : #ffffff,
-//         900 : #ffffff,
-//         A100 : #000000,
-//         A200 : #ffffff,
-//         A400 : #ffffff,
-//         A700 : #ffffff,
-//     )
-// );
-
-// $secondary-palette: (
-//     50 : #e7edfa,
-//     100 : #c2d1f3,
-//     200 : #99b3eb,
-//     300 : #7095e2,
-//     400 : #527edc,
-//     500 : #3367d6,
-//     600 : #2e5fd1,
-//     700 : #2754cc,
-//     800 : #204ac6,
-//     900 : #1439bc,
-//     A100 : #edf0ff,
-//     A200 : #bac7ff,
-//     A400 : #879dff,
-//     A700 : #6e88ff,
-//     contrast: (
-//         50 : #000000,
-//         100 : #000000,
-//         200 : #000000,
-//         300 : #000000,
-//         400 : #ffffff,
-//         500 : #ffffff,
-//         600 : #ffffff,
-//         700 : #ffffff,
-//         800 : #ffffff,
-//         900 : #ffffff,
-//         A100 : #000000,
-//         A200 : #000000,
-//         A400 : #000000,
-//         A700 : #000000,
-//     )
-// );
-
-// Define the palettes for your theme using the Material Design palettes available in palette.scss
-// (imported above). For each palette, you can optionally specify a default, lighter, and darker
-// hue. Available color palettes: https://material.io/design/color/
-$planscape-frontend-primary: mat.define-palette(mat.$indigo-palette);
-$planscape-frontend-accent: mat.define-palette(
-  mat.$pink-palette,
-  A200,
-  A100,
-  A400
-);
-
-// The warn palette is optional (defaults to red).
-$planscape-frontend-warn: mat.define-palette(mat.$red-palette);
-
-// Create the theme object. A theme consists of configurations for individual
-// theming systems such as "color" or "typography".
-$planscape-frontend-theme: mat.define-light-theme(
-  (
-    color: (
-      primary: $planscape-frontend-primary,
-      accent: $planscape-frontend-accent,
-      warn: $planscape-frontend-warn,
-    ),
-  )
-);
+@import "theme";
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
@@ -115,6 +24,7 @@ html,
 body {
   height: 100%;
 }
+
 body {
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
@@ -130,6 +40,7 @@ body {
 
 .snackbar-error {
   background: #b00020;
+
   button {
     color: #ffffff;
   }

--- a/src/interface/src/theme.scss
+++ b/src/interface/src/theme.scss
@@ -1,0 +1,99 @@
+@use '@angular/material' as mat;
+@use 'sass:map';
+
+// CUSTOM
+// $primary-palette: (
+//     50 : #e9e9e9,
+//     100 : #c8c8c8,
+//     200 : #a4a4a4,
+//     300 : #808080,
+//     400 : #646464,
+//     500 : #494949,
+//     600 : #424242,
+//     700 : #393939,
+//     800 : #313131,
+//     900 : #212121,
+//     A100 : #f17d7d,
+//     A200 : #eb4f4f,
+//     A400 : #ff0808,
+//     A700 : #ee0000,
+//     contrast: (
+//         50 : #000000,
+//         100 : #000000,
+//         200 : #000000,
+//         300 : #000000,
+//         400 : #ffffff,
+//         500 : #ffffff,
+//         600 : #ffffff,
+//         700 : #ffffff,
+//         800 : #ffffff,
+//         900 : #ffffff,
+//         A100 : #000000,
+//         A200 : #ffffff,
+//         A400 : #ffffff,
+//         A700 : #ffffff,
+//     )
+// );
+
+// $secondary-palette: (
+//     50 : #e7edfa,
+//     100 : #c2d1f3,
+//     200 : #99b3eb,
+//     300 : #7095e2,
+//     400 : #527edc,
+//     500 : #3367d6,
+//     600 : #2e5fd1,
+//     700 : #2754cc,
+//     800 : #204ac6,
+//     900 : #1439bc,
+//     A100 : #edf0ff,
+//     A200 : #bac7ff,
+//     A400 : #879dff,
+//     A700 : #6e88ff,
+//     contrast: (
+//         50 : #000000,
+//         100 : #000000,
+//         200 : #000000,
+//         300 : #000000,
+//         400 : #ffffff,
+//         500 : #ffffff,
+//         600 : #ffffff,
+//         700 : #ffffff,
+//         800 : #ffffff,
+//         900 : #ffffff,
+//         A100 : #000000,
+//         A200 : #000000,
+//         A400 : #000000,
+//         A700 : #000000,
+//     )
+// );
+
+
+// Define the palettes for your theme using the Material Design palettes available in palette.scss
+// (imported above). For each palette, you can optionally specify a default, lighter, and darker
+// hue. Available color palettes: https://material.io/design/color/
+$planscape-frontend-primary: mat.define-palette(mat.$indigo-palette);
+$planscape-frontend-accent: mat.define-palette(
+    mat.$pink-palette,
+    A200,
+    A100,
+    A400
+);
+
+// The warn palette is optional (defaults to red).
+$planscape-frontend-warn: mat.define-palette(mat.$red-palette);
+
+// Create the theme object. A theme consists of configurations for individual
+// theming systems such as "color" or "typography".
+$planscape-frontend-theme: mat.define-light-theme(
+    (
+      color: (
+        primary: $planscape-frontend-primary,
+        accent: $planscape-frontend-accent,
+        warn: $planscape-frontend-warn,
+      ),
+    )
+);
+
+$color-config: mat.get-color-config($planscape-frontend-theme);
+$primary-palette: map.get($color-config, 'primary');


### PR DESCRIPTION
Unify UI behavior between planning areas and scenarios (they both had similar but different highlight ux)
Removed a bunch of imports of `styles.scss` (which in turn where adding `@include mat.core();` several times...) and created a theme.scss file to import instead.
Haven't taken a look at bundle sizes but pretty sure this was adding a bunch of css