### PR TITLE
validate scenario name

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -6,9 +6,12 @@
           <input
             formControlName="scenarioName"
             matInput
-            placeholder="Scenario Name" />
+            placeholder="Scenario Name:" />
         </mat-form-field>
       </form>
+      <div *ngIf="formGroups[0].invalid && formGroups[0].touched" class="error">
+        Please enter scenario name above
+      </div>
     </div>
     <div class="tab-container">
       <mat-tab-group [selectedIndex]="selectedTabIndex">
@@ -33,8 +36,8 @@
               <button
                 mat-raised-button
                 color="primary"
+                type="submit"
                 [disabled]="
-                  !formGroups[0].valid ||
                   !formGroups[1].valid ||
                   !formGroups[2].valid ||
                   !formGroups[3].valid ||

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -14,7 +14,9 @@
       </div>
     </div>
     <div class="tab-container">
-      <mat-tab-group [selectedIndex]="selectedTabIndex">
+      <mat-tab-group
+        [selectedIndex]="selectedTabIndex"
+        [animationDuration]="tabAnimation">
         <mat-tab label="Configuration">
           <div class="create-scenarios-inner-wrapper">
             <app-set-priorities
@@ -54,6 +56,7 @@
         </mat-tab>
         <mat-tab label="Results">
           <ng-container [ngSwitch]="scenarioState">
+            <ng-container *ngSwitchCase="'LOADING'"></ng-container>
             <app-scenario-not-started
               *ngSwitchCase="'NOT_STARTED'"></app-scenario-not-started>
             <app-scenario-pending

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -111,6 +111,10 @@
   width: 100%;
   padding: 10px 16px 0 32px;
   box-sizing: border-box;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: white;
 
 }
 

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -72,16 +72,26 @@
 }
 
 ::ng-deep .mat-tab-body-wrapper {
-  padding: 1px 16px 32px 32px;
+
   background-color: #e6e9f4;
+  flex-grow: 1;
+}
+
+::ng-deep .mat-tab-group {
+  height: 100%;
 }
 
 ::ng-deep mat-tab-header {
   padding: 0 32px;
 }
 
+::ng-deep .mat-tab-body {
+  padding-bottom: 10px;
+}
+
 ::ng-deep .mat-tab-body-content {
-  overflow-x: hidden;
+  padding: 0 20px;
+
 }
 
 .flex-row {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -11,6 +11,7 @@
   position: absolute;
   right: -24px;
   top: 12px;
+
   &.collapsed {
     transform: rotate(180deg);
   }
@@ -22,17 +23,11 @@
   flex-direction: column;
   align-items: center;
   height: 100%;
-  padding: 1px 16px 32px 32px;
+
   width: 100%;
   z-index: 5;
   top: 0;
   left: 0;
-  background-color: #e6e9f4;
-  background-image: linear-gradient(
-    to bottom,
-    white 95px,
-    rgba(0, 0, 0, 0) 95px
-  );
 }
 
 /** Always show scrollbar. */
@@ -72,6 +67,17 @@
   display: block;
   width: 100%;
   height: 100%;
+
+  box-sizing: border-box;
+}
+
+::ng-deep .mat-tab-body-wrapper {
+  padding: 1px 16px 32px 32px;
+  background-color: #e6e9f4;
+}
+
+::ng-deep mat-tab-header {
+  padding: 0 32px;
 }
 
 ::ng-deep .mat-tab-body-content {
@@ -93,10 +99,19 @@
   flex-direction: row;
   height: fit-content;
   width: 100%;
-  padding-top: 10px;
+  padding: 10px 16px 0 32px;
+  box-sizing: border-box;
+
 }
 
 .scenario-name-input {
   width: 100%;
   height: 40px;
+  font-weight: bold;
 }
+
+.error {
+  color: #f44336;
+}
+
+

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -142,10 +142,12 @@ describe('CreateScenariosComponent', () => {
       // spy on polling to avoid dealing with async and timeouts
       spyOn(component, 'pollForChanges');
       fixture.detectChanges();
+      component.selectedTabIndex = 0;
     });
 
     it('should emit create scenario event on Generate button click', async () => {
       spyOn(component, 'createScenario');
+
       component.formGroups[0].get('scenarioName')?.setValue('scenarioName');
       component.formGroups[1]
         .get('selectedQuestion')

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -333,6 +333,10 @@ export class CreateScenariosComponent implements OnInit {
   /** Creates the scenario */
   // TODO Add support for uploaded Project Area shapefiles
   createScenario(): void {
+    this.formGroups.forEach((form) => form.markAllAsTouched());
+    if (this.formGroups.some((form) => form.invalid)) {
+      return;
+    }
     this.generatingScenario = true;
     // TODO Add error catching for failed scenario creation
     this.planService

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -66,6 +66,12 @@ export class CreateScenariosComponent implements OnInit {
   scenarioState: ScenarioResultStatus = 'NOT_STARTED';
   scenarioResults: ScenarioResult | null = null;
   scenarioChartData: any[] = [];
+  tabAnimationOptions: Record<'on' | 'off', string> = {
+    on: '500ms',
+    off: '0ms',
+  };
+
+  tabAnimation = this.tabAnimationOptions.off;
 
   constructor(
     private fb: FormBuilder,
@@ -157,6 +163,11 @@ export class CreateScenariosComponent implements OnInit {
       // Has to be outside of service subscription or else will cause infinite loop
       this.loadConfig();
       this.pollForChanges();
+      // if we have an id go to the results tab.
+      this.selectedTabIndex = 1;
+    } else {
+      // enable animation
+      this.tabAnimation = this.tabAnimationOptions.on;
     }
 
     // When an area is uploaded, issue an event to draw it on the map.
@@ -197,6 +208,7 @@ export class CreateScenariosComponent implements OnInit {
   }
 
   loadConfig(): void {
+    this.scenarioState = 'LOADING';
     this.planService.getScenario(this.scenarioId!).subscribe((scenario) => {
       if (scenario.scenario_result) {
         this.scenarioResults = scenario.scenario_result;
@@ -206,6 +218,8 @@ export class CreateScenariosComponent implements OnInit {
         if (this.scenarioState == 'SUCCESS') {
           this.processScenarioResults(scenario);
         }
+        // enable animation
+        this.tabAnimation = this.tabAnimationOptions.on;
       }
 
       var config = scenario.configuration;

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -48,6 +48,7 @@ export class SavedScenariosComponent implements OnInit {
   ];
 
   statusLabels: Record<ScenarioResultStatus, string> = {
+    LOADING: 'Loading',
     NOT_STARTED: 'Not Started',
     PENDING: 'Running',
     RUNNING: 'Running',

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.scss
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.scss
@@ -1,4 +1,5 @@
 .actions {
-  margin-top: 20px;
+  margin: 20px;
   text-align: center;
+
 }

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -43,6 +43,7 @@ export interface FeatureCollection {
 }
 
 export type ScenarioResultStatus =
+  | 'LOADING' // when loading results
   | 'NOT_STARTED' // Added by FE when the scenario is not created yet.
   | 'PENDING' // Scenario created, in queue
   | 'RUNNING' // Scenario created, being processed


### PR DESCRIPTION
- Changes validation to show scenario name as missing on scenario creation
- Updates how we render the tab background (was using a gradient instead of targeting the right element) and sizing to match
- Fixes animations between tabs (was kinda wonky, similar issue paddings/margins where on the wrong element)
- Fixes loading results. Starting with 0 animation time on tabs so the first tab change isn't animated. Adding an empty loading state to avoid jittering
- Makes scenario name sticky
