### PR TITLE
Small fixes for signup errors

### DIFF
--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -87,8 +87,8 @@
           mat-flat-button
           type="submit"
           color="primary"
-          [disabled]="!form.valid || submitted">
-          {{ submitted ? 'Please wait...' : 'Create account' }}
+          [disabled]="!form.valid || submitting">
+          {{ submitting ? 'Please wait...' : 'Create account' }}
         </button>
       </form>
     </div>

--- a/src/interface/src/app/signup/signup.component.html
+++ b/src/interface/src/app/signup/signup.component.html
@@ -4,17 +4,29 @@
       <h3><b>With a Planscape account, you can:</b></h3>
 
       <ul>
-        <li><h3>Save planning areas</h3></li>
-        <li><h3>Create plans, configurations, and scenarios</h3></li>
-        <li><h3>Download shapefiles & metadata</h3></li>
-        <li><h3>Share work with collaborators</h3></li>
+        <li>
+          <h3>Save planning areas</h3>
+        </li>
+        <li>
+          <h3>Create plans, configurations, and scenarios</h3>
+        </li>
+        <li>
+          <h3>Download shapefiles & metadata</h3>
+        </li>
+        <li>
+          <h3>Share work with collaborators</h3>
+        </li>
       </ul>
 
       <h3><b>As a guest user, you can:</b></h3>
 
       <ul>
-        <li><h3>Explore regional data on the map</h3></li>
-        <li><h3>View plans and/or scenarios that are publicly visible*</h3></li>
+        <li>
+          <h3>Explore regional data on the map</h3>
+        </li>
+        <li>
+          <h3>View plans and/or scenarios that are publicly visible*</h3>
+        </li>
       </ul>
 
       <p><i>*Accessible only via direct links</i></p>
@@ -66,7 +78,6 @@
         </mat-form-field>
 
         <mat-error *ngIf="errors.length > 0">
-          <p>Please correct the following errors:</p>
           <ul>
             <li *ngFor="let error of errors">{{ error }}</li>
           </ul>

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -80,9 +80,11 @@ export class SignupComponent {
             this.errors = Object.values([
               'An unexpected server error has occured.',
             ]);
-          } else if (error.message && error.message == "Timeout has occurred"){
-            this.errors = Object.values(['The server was not able to send a validation email at this time.']);
-          }else {
+          } else if (error.message && error.message == 'Timeout has occurred') {
+            this.errors = Object.values([
+              'The server was not able to send a validation email at this time.',
+            ]);
+          } else {
             this.errors = Object.values(['An unexpected error has occured.']);
           }
         },

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -78,10 +78,10 @@ export class SignupComponent {
             this.errors = Object.values(error.error);
           } else if (error.status == 500) {
             this.errors = Object.values([
-              'An unepxected server error has occured.',
+              'An unexpected server error has occured.',
             ]);
           } else {
-            this.errors = Object.values(['An unepxected error has occured.']);
+            this.errors = Object.values(['An unexpected error has occured.']);
           }
         },
       });

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -11,7 +11,7 @@ import { MatDialog } from '@angular/material/dialog';
 
 import { AuthService } from './../services';
 import { ValidationEmailDialogComponent } from './validation-email-dialog/validation-email-dialog.component';
-import { timeout } from 'rxjs';
+import { TimeoutError, timeout } from 'rxjs';
 
 @Component({
   selector: 'app-signup',
@@ -80,7 +80,7 @@ export class SignupComponent {
             this.errors = Object.values([
               'An unexpected server error has occured.',
             ]);
-          } else if (error.message && error.message == 'Timeout has occurred') {
+          } else if (error instanceof TimeoutError) {
             this.errors = Object.values([
               'The server was not able to send a validation email at this time.',
             ]);

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -22,7 +22,7 @@ export class SignupComponent {
   errors: string[] = [];
 
   form: FormGroup;
-  submitted: boolean = false;
+  submitting: boolean = false;
 
   constructor(
     private authService: AuthService,
@@ -51,9 +51,9 @@ export class SignupComponent {
   }
 
   signup() {
-    if (this.submitted) return;
+    if (this.submitting) return;
 
-    this.submitted = true;
+    this.submitting = true;
 
     const email: string = this.form.get('email')?.value;
     const password1: string = this.form.get('password1')?.value;
@@ -73,14 +73,16 @@ export class SignupComponent {
           this.router.navigate(['home']);
         },
         error: (error: HttpErrorResponse) => {
-          this.submitted = false;
+          this.submitting = false;
           if (error.status == 400) {
             this.errors = Object.values(error.error);
           } else if (error.status == 500) {
             this.errors = Object.values([
               'An unexpected server error has occured.',
             ]);
-          } else {
+          } else if (error.message && error.message == "Timeout has occurred"){
+            this.errors = Object.values(['The server was not able to send a validation email at this time.']);
+          }else {
             this.errors = Object.values(['An unexpected error has occured.']);
           }
         },


### PR DESCRIPTION
Some small changes related to handling unexpected issues at sign-up:

- It looks like a failure to send emails (for instance, because of an inability to reach an SMTP server) will sometimes generate a 500/Server Error -- but sometimes that's delayed by several minutes. And sometimes there's no response.
- Meanwhile, the "Create Account" button remains active, allowing the user to attempt to create a new account, which then generates an error that claims an account already exists.
- And occasionally, when a 500 response does occur, the return format of the backend is just raw HTML, which doesn't fit the expected format of any responses for errors.

So this PR disables the Create Account button after submission. It also adds a timeout (currently 10 seconds), and presents a more user-friendly error in the case of a 500 or non-response.