### PR TITLE
clicking on links in account modal should close the modal

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.html
+++ b/src/interface/src/app/account-dialog/account-dialog.component.html
@@ -37,9 +37,9 @@
     <ng-template #noUser>
       <p class="no-user">
         Already have an account? Click
-        <a routerLink="/login">here</a>
+        <a routerLink="/login" (click)="close()">here</a>
         to login or
-        <a routerLink="/signup">create an account.</a>
+        <a routerLink="/signup" (click)="close()">create an account.</a>
       </p>
     </ng-template>
   </ng-container>

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -168,6 +168,10 @@ export class AccountDialogComponent implements OnInit {
         }
       });
   }
+
+  close() {
+    this.dialogRef.close();
+  }
 }
 
 const crossFieldValidators: ValidatorFn = (


### PR DESCRIPTION
found a bug, when you click on the links in the modal, the modal should close

<img width="738" alt="Screen Shot 2023-10-19 at 11 34 43" src="https://github.com/OurPlanscape/Planscape/assets/358892/6441d3d8-13cc-4581-8b24-ce2cef14ba01">
