### PR TITLE
moved plan creation to plan create dialog, added loader on modal

### DIFF
--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -164,10 +164,7 @@ describe('MapComponent', () => {
       'MatDialog',
       {
         open: {
-          afterClosed: () =>
-            of({
-              value: 'test name',
-            }),
+          afterClosed: () => of('temp'),
         } as MatDialogRef<any>,
       },
       {}
@@ -657,8 +654,6 @@ describe('MapComponent', () => {
       userSignedIn$.next(true);
       const fakeMatDialog: MatDialog =
         fixture.debugElement.injector.get(MatDialog);
-      const planServiceStub: PlanService =
-        fixture.debugElement.injector.get(PlanService);
       component.selectedAreaCreationAction = component.AreaCreationAction.DRAW;
       fixture.componentInstance.showConfirmAreaButton$ =
         new BehaviorSubject<boolean>(true);
@@ -673,32 +668,23 @@ describe('MapComponent', () => {
 
       expect(fakeMatDialog.open).toHaveBeenCalledOnceWith(
         PlanCreateDialogComponent,
-        { maxWidth: '560px' }
+        {
+          maxWidth: '560px',
+          data: {
+            shape: { type: 'FeatureCollection', features: [] },
+          },
+        }
       );
-      expect(planServiceStub.createPlan).toHaveBeenCalled();
     }));
 
     it('dialog calls create plan with name and planning area', fakeAsync(async () => {
       userSignedIn$.next(true);
-      const planServiceStub: PlanService =
-        fixture.debugElement.injector.get(PlanService);
+
       const routerStub: Router = fixture.debugElement.injector.get(Router);
       spyOn(routerStub, 'navigate').and.callThrough();
 
-      const emptyGeoJson: GeoJSON.GeoJSON = {
-        type: 'FeatureCollection',
-        features: [],
-      };
-      const createPlanSpy = spyOn<any>(
-        component,
-        'createPlan'
-      ).and.callThrough();
-
       fixture.componentInstance.openCreatePlanDialog();
       tick();
-
-      expect(createPlanSpy).toHaveBeenCalledWith('test name', emptyGeoJson);
-      expect(planServiceStub.createPlan).toHaveBeenCalled();
       expect(routerStub.navigate).toHaveBeenCalledOnceWith(['plan', 'temp']);
     }));
   });

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -421,11 +421,14 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
 
     const openedDialog = this.dialog.open(PlanCreateDialogComponent, {
       maxWidth: '560px',
+      data: {
+        shape: this.mapManager.convertToPlanningArea(),
+      },
     });
 
-    openedDialog.afterClosed().subscribe((result) => {
-      if (result) {
-        this.createPlan(result.value, this.mapManager.convertToPlanningArea());
+    openedDialog.afterClosed().subscribe((id) => {
+      if (id) {
+        this.router.navigate(['plan', id]);
       }
     });
   }
@@ -433,39 +436,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   private openSignInDialog() {
     this.dialog.open(SignInDialogComponent, {
       maxWidth: '560px',
-    });
-  }
-
-  private createPlan(name: string, shape: GeoJSON.GeoJSON) {
-    this.selectedRegion$.pipe(take(1)).subscribe((selectedRegion) => {
-      if (!selectedRegion) {
-        this.matSnackBar.open(
-          '[Error] Please select a region!',
-          'Dismiss',
-          ERROR_SNACK_CONFIG
-        );
-        return;
-      }
-
-      this.planService
-        .createPlan({
-          name: name,
-          region: selectedRegion,
-          planningArea: shape,
-        })
-        .pipe(take(1))
-        .subscribe({
-          next: (result) => {
-            this.router.navigate(['plan', result.result!.id]);
-          },
-          error: (e) => {
-            this.matSnackBar.open(
-              '[Error] Unable to create plan due to backend error.',
-              'Dismiss',
-              ERROR_SNACK_CONFIG
-            );
-          },
-        });
     });
   }
 

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.html
@@ -14,11 +14,22 @@
     </mat-error>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button mat-button color="primary" type="button" (click)="cancel()">
+    <button
+      mat-button
+      color="primary"
+      type="button"
+      (click)="cancel()"
+      [disabled]="submitting">
       CANCEL
     </button>
-    <button mat-button type="submit" color="primary" data-id="save">
-      SAVE
+    <button
+      mat-button
+      type="submit"
+      color="primary"
+      data-id="save"
+      [disabled]="submitting">
+      <mat-spinner *ngIf="submitting" diameter="24"></mat-spinner>
+      <span *ngIf="!submitting">SAVE</span>
     </button>
   </mat-dialog-actions>
 </form>

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.spec.ts
@@ -5,32 +5,75 @@ import {
   TestBed,
   tick,
 } from '@angular/core/testing';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
 import { PlanCreateDialogComponent } from './plan-create-dialog.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { PlanService } from '../../services';
-import { of } from 'rxjs';
+import { PlanService, SessionService } from '../../services';
+import { BehaviorSubject, of } from 'rxjs';
+import { MaterialModule } from '../../material/material.module';
+import { DialogModule } from '@angular/cdk/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Region } from '../../types';
 
 describe('PlanCreateDialogComponent', () => {
   let component: PlanCreateDialogComponent;
   let fixture: ComponentFixture<PlanCreateDialogComponent>;
+  const fakeGeoJson: GeoJSON.GeoJSON = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'MultiPolygon',
+          coordinates: [
+            [
+              [
+                [10, 20],
+                [10, 30],
+                [15, 15],
+              ],
+            ],
+          ],
+        },
+        properties: {
+          shape_name: 'Test',
+        },
+      },
+    ],
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule],
+      imports: [
+        ReactiveFormsModule,
+        MaterialModule,
+        DialogModule,
+        NoopAnimationsModule,
+      ],
       declarations: [PlanCreateDialogComponent],
       providers: [
         {
           provide: PlanService,
-          useValue: { planNameExists: () => of(false) },
+          useValue: {
+            planNameExists: () => of(false),
+            createPlan: () => new BehaviorSubject({ result: { id: 'planId' } }),
+          },
         },
         {
           provide: MatDialogRef,
           useValue: {
             close: () => {},
           },
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { shape: fakeGeoJson },
+        },
+        {
+          provide: SessionService,
+          useValue: { region$: new BehaviorSubject(Region.SIERRA_NEVADA) },
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -82,4 +125,25 @@ describe('PlanCreateDialogComponent', () => {
     saveBtn.click();
     expect(dialogRef.close).not.toHaveBeenCalled();
   });
+
+  it('should save plan', fakeAsync(() => {
+    const dialogRef = TestBed.inject(MatDialogRef<PlanCreateDialogComponent>);
+    spyOn(dialogRef, 'close');
+    component.planForm.setValue({
+      planName: 'some plan',
+    });
+    const planService = TestBed.inject(PlanService);
+    spyOn(planService, 'createPlan').and.callThrough();
+
+    const saveBtn = fixture.debugElement.query(
+      By.css('[data-id="save"]')
+    ).nativeElement;
+    saveBtn.click();
+    tick();
+    expect(planService.createPlan).toHaveBeenCalledWith({
+      name: 'some plan',
+      region: Region.SIERRA_NEVADA,
+      planningArea: fakeGeoJson,
+    });
+  }));
 });


### PR DESCRIPTION
Moves plan creation to the plan create dialog, adding a spinner on the CTA while it runs.
After saved, redirects to newly created planning area (same behavior as before)

<img width="1076" alt="Screen Shot 2023-10-31 at 15 39 15" src="https://github.com/OurPlanscape/Planscape/assets/358892/41d6cbcd-9be3-4f4e-9d67-9e6183fba16e">
