### PR TITLE
PLAN-541 Fix persistent snackbars and logout dialog

### DIFF
--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -8,7 +8,7 @@ import {
   ValidatorFn,
 } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { SNACK_SUCCESS_CONFIG } from '../../app/shared/constants';
+import { SNACK_NOTICE_CONFIG } from '../../app/shared/constants';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Observable, take } from 'rxjs';
@@ -110,7 +110,7 @@ export class AccountDialogComponent implements OnInit {
           this.snackbar.open(
             'Updated password successfully',
             'Dismiss',
-            SNACK_SUCCESS_CONFIG
+            SNACK_NOTICE_CONFIG
           );
         },
         (err: any) => {
@@ -144,7 +144,7 @@ export class AccountDialogComponent implements OnInit {
           this.snackbar.open(
             'Successfully updated password',
             'Dismiss',
-            SNACK_SUCCESS_CONFIG
+            SNACK_NOTICE_CONFIG
           );
         },
         (err) => {

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -85,7 +85,10 @@ export class AccountDialogComponent implements OnInit {
   }
 
   logout(): void {
-    this.authService.logout().pipe(take(1)).subscribe((_) => this.close());
+    this.authService
+      .logout()
+      .pipe(take(1))
+      .subscribe((_) => this.close());
   }
 
   savePassword(): void {
@@ -104,9 +107,11 @@ export class AccountDialogComponent implements OnInit {
           this.changingPassword = false;
           this.disableChangeButton = false;
           this.error = null;
-          this.snackbar.open('Updated password successfully',
-           'Dismiss', 
-           SNACKBAR_SUCCESS_CONFIG);
+          this.snackbar.open(
+            'Updated password successfully',
+            'Dismiss',
+            SNACKBAR_SUCCESS_CONFIG
+          );
         },
         (err: any) => {
           this.error = Object.values(err.error);
@@ -136,7 +141,11 @@ export class AccountDialogComponent implements OnInit {
           this.disableEditButton = false;
           this.error = null;
 
-          this.snackbar.open('Successfully updated password', 'Dismiss', SNACKBAR_SUCCESS_CONFIG);
+          this.snackbar.open(
+            'Successfully updated password',
+            'Dismiss',
+            SNACKBAR_SUCCESS_CONFIG
+          );
         },
         (err) => {
           if (err.status == 401) {

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -84,7 +84,7 @@ export class AccountDialogComponent implements OnInit {
   }
 
   logout(): void {
-    this.authService.logout().pipe(take(1)).subscribe();
+    this.authService.logout().pipe(take(1)).subscribe((_) => this.close());
   }
 
   savePassword(): void {

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -8,6 +8,7 @@ import {
   ValidatorFn,
 } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { SNACKBAR_SUCCESS_CONFIG } from '../../app/shared/constants';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Observable, take } from 'rxjs';
@@ -103,10 +104,9 @@ export class AccountDialogComponent implements OnInit {
           this.changingPassword = false;
           this.disableChangeButton = false;
           this.error = null;
-          this.snackbar.open('Updated password successfully', undefined, {
-            duration: 10000,
-            verticalPosition: 'top',
-          });
+          this.snackbar.open('Updated password successfully',
+           'Dismiss', 
+           SNACKBAR_SUCCESS_CONFIG);
         },
         (err: any) => {
           this.error = Object.values(err.error);
@@ -136,9 +136,7 @@ export class AccountDialogComponent implements OnInit {
           this.disableEditButton = false;
           this.error = null;
 
-          this.snackbar.open('Successfully updated password', undefined, {
-            duration: 6000,
-          });
+          this.snackbar.open('Successfully updated password', 'Dismiss', SNACKBAR_SUCCESS_CONFIG);
         },
         (err) => {
           if (err.status == 401) {

--- a/src/interface/src/app/account-dialog/account-dialog.component.ts
+++ b/src/interface/src/app/account-dialog/account-dialog.component.ts
@@ -8,7 +8,7 @@ import {
   ValidatorFn,
 } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { SNACKBAR_SUCCESS_CONFIG } from '../../app/shared/constants';
+import { SNACK_SUCCESS_CONFIG } from '../../app/shared/constants';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Observable, take } from 'rxjs';
@@ -110,7 +110,7 @@ export class AccountDialogComponent implements OnInit {
           this.snackbar.open(
             'Updated password successfully',
             'Dismiss',
-            SNACKBAR_SUCCESS_CONFIG
+            SNACK_SUCCESS_CONFIG
           );
         },
         (err: any) => {
@@ -144,7 +144,7 @@ export class AccountDialogComponent implements OnInit {
           this.snackbar.open(
             'Successfully updated password',
             'Dismiss',
-            SNACKBAR_SUCCESS_CONFIG
+            SNACK_SUCCESS_CONFIG
           );
         },
         (err) => {

--- a/src/interface/src/app/home/plan-table/plan-table.component.ts
+++ b/src/interface/src/app/home/plan-table/plan-table.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { take } from 'rxjs';
@@ -10,6 +11,7 @@ import { PlanPreview } from '../../types/plan.types';
 import { calculateAcres } from '../../plan/plan-helpers';
 import { Router } from '@angular/router';
 import { DeleteDialogComponent } from '../../delete-dialog/delete-dialog.component';
+import { SNACK_NOTICE_CONFIG } from 'src/app/shared/constants';
 
 interface PlanRow extends PlanPreview {
   totalAcres: number;
@@ -39,7 +41,8 @@ export class PlanTableComponent implements OnInit {
     private dialog: MatDialog,
     private planService: PlanService,
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private snackbar: MatSnackBar
   ) {}
 
   ngOnInit(): void {
@@ -86,6 +89,12 @@ export class PlanTableComponent implements OnInit {
           this.planService
             .deletePlan(planIdsToDelete)
             .subscribe((_) => this.refresh());
+
+          this.snackbar.open(
+            `Successfully deleted plan: ${this.selectedPlan?.name}`,
+            'Dismiss',
+            SNACK_NOTICE_CONFIG
+          );
         }
       });
   }

--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -26,7 +26,7 @@ import {
   Region,
   regionMapCenters,
 } from '../types';
-import { ERROR_SNACK_CONFIG } from './map.constants';
+import { SNACK_ERROR_CONFIG } from '../../app/shared/constants';
 
 // Set to true so that layers are not editable by default
 L.PM.setOptIn(true);
@@ -402,7 +402,7 @@ export class MapManager {
     this.matSnackBar.open(
       '[Error] Planning areas cannot overlap!',
       'Dismiss',
-      ERROR_SNACK_CONFIG
+      SNACK_ERROR_CONFIG
     );
   }
 

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -46,11 +46,8 @@ import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dial
 import { ProjectCardComponent } from './project-card/project-card.component';
 import { SignInDialogComponent } from './sign-in-dialog/sign-in-dialog.component';
 import { FeatureService } from '../features/feature.service';
-import {
-  AreaCreationAction,
-  ERROR_SNACK_CONFIG,
-  LEGEND,
-} from './map.constants';
+import { AreaCreationAction, LEGEND } from './map.constants';
+import { SNACK_ERROR_CONFIG } from '../../app/shared/constants';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
 @UntilDestroy()
@@ -527,7 +524,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     this.matSnackBar.open(
       '[Error] Not a valid shapefile!',
       'Dismiss',
-      ERROR_SNACK_CONFIG
+      SNACK_ERROR_CONFIG
     );
   }
 

--- a/src/interface/src/app/map/map.constants.ts
+++ b/src/interface/src/app/map/map.constants.ts
@@ -28,9 +28,3 @@ export const LEGEND = {
     '#508295',
   ],
 };
-
-export const ERROR_SNACK_CONFIG: MatSnackBarConfig<any> = {
-  duration: 10000,
-  panelClass: ['snackbar-error'],
-  verticalPosition: 'top',
-};

--- a/src/interface/src/app/map/map.constants.ts
+++ b/src/interface/src/app/map/map.constants.ts
@@ -1,5 +1,3 @@
-import { MatSnackBarConfig } from '@angular/material/snack-bar';
-
 export enum AreaCreationAction {
   NONE = 0,
   DRAW = 1,

--- a/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.ts
+++ b/src/interface/src/app/map/plan-create-dialog/plan-create-dialog.component.ts
@@ -3,7 +3,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Component, Inject } from '@angular/core';
 import { PlanService, SessionService } from '../../services';
 import { firstValueFrom } from 'rxjs';
-import { ERROR_SNACK_CONFIG } from '../map.constants';
+import { SNACK_ERROR_CONFIG } from '../../../app/shared/constants';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Region } from '../../types';
 
@@ -51,7 +51,7 @@ export class PlanCreateDialogComponent {
         this.matSnackBar.open(
           '[Error] Please select a region!',
           'Dismiss',
-          ERROR_SNACK_CONFIG
+          SNACK_ERROR_CONFIG
         );
         this.submitting = false;
         return;
@@ -76,7 +76,7 @@ export class PlanCreateDialogComponent {
           this.matSnackBar.open(
             '[Error] Unable to create plan due to backend error.',
             'Dismiss',
-            ERROR_SNACK_CONFIG
+            SNACK_ERROR_CONFIG
           );
           this.submitting = false;
         },

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -19,7 +19,7 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { DeleteDialogComponent } from '../../../delete-dialog/delete-dialog.component';
 import {
   SNACK_ERROR_CONFIG,
-  SNACK_SUCCESS_CONFIG,
+  SNACK_NOTICE_CONFIG,
 } from '../../../../app/shared/constants';
 
 interface ScenarioRow extends Scenario {
@@ -136,7 +136,7 @@ export class SavedScenariosComponent implements OnInit {
         this.snackbar.open(
           `Deleted scenario${deletedIds.length > 1 ? 's' : ''}`,
           'Dismiss',
-          SNACK_SUCCESS_CONFIG
+          SNACK_NOTICE_CONFIG
         );
         this.fetchScenarios();
       },

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -17,7 +17,10 @@ import {
 } from '../../plan-helpers';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { DeleteDialogComponent } from '../../../delete-dialog/delete-dialog.component';
-import { SNACKBAR_SUCCESS_CONFIG } from '../../../../app/shared/constants';
+import {
+  SNACK_ERROR_CONFIG,
+  SNACK_SUCCESS_CONFIG,
+} from '../../../../app/shared/constants';
 
 interface ScenarioRow extends Scenario {
   selected?: boolean;
@@ -133,12 +136,12 @@ export class SavedScenariosComponent implements OnInit {
         this.snackbar.open(
           `Deleted scenario${deletedIds.length > 1 ? 's' : ''}`,
           'Dismiss',
-          SNACKBAR_SUCCESS_CONFIG
+          SNACK_SUCCESS_CONFIG
         );
         this.fetchScenarios();
       },
       error: (err) => {
-        this.snackbar.open(`Error: ${err}`, 'Dismiss');
+        this.snackbar.open(`Error: ${err}`, 'Dismiss', SNACK_ERROR_CONFIG);
       },
     });
   }

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -17,6 +17,7 @@ import {
 } from '../../plan-helpers';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { DeleteDialogComponent } from '../../../delete-dialog/delete-dialog.component';
+import { SNACKBAR_SUCCESS_CONFIG } from '../../../../app/shared/constants';
 
 interface ScenarioRow extends Scenario {
   selected?: boolean;
@@ -129,12 +130,14 @@ export class SavedScenariosComponent implements OnInit {
     this.planService.deleteScenarios(ids).subscribe({
       next: (deletedIds) => {
         this.snackbar.open(
-          `Deleted scenario${deletedIds.length > 1 ? 's' : ''}`
+          `Deleted scenario${deletedIds.length > 1 ? 's' : ''}`,
+          'Dismiss',
+          SNACKBAR_SUCCESS_CONFIG
         );
         this.fetchScenarios();
       },
       error: (err) => {
-        this.snackbar.open(`Error: ${err}`);
+        this.snackbar.open(`Error: ${err}`, 'Dismiss');
       },
     });
   }

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
@@ -7,7 +7,7 @@ import { Plan, ProjectConfig } from 'src/app/types';
 import { MapService } from './../../../services/map.service';
 import {
   SNACK_ERROR_CONFIG,
-  SNACK_SUCCESS_CONFIG,
+  SNACK_NOTICE_CONFIG,
 } from '../../../../app/shared/constants';
 
 interface ProjectConfigRow extends ProjectConfig {
@@ -79,7 +79,7 @@ export class ScenarioConfigurationsComponent implements OnInit {
               deletedIds.length > 1 ? 's' : ''
             }`,
             'Dismiss',
-            SNACK_SUCCESS_CONFIG
+            SNACK_NOTICE_CONFIG
           );
           this.fetchProjects();
         },

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
@@ -74,7 +74,8 @@ export class ScenarioConfigurationsComponent implements OnInit {
           this.snackbar.open(
             `Deleted ${deletedIds.length} configuration${
               deletedIds.length > 1 ? 's' : ''
-            }`,'Dismiss',
+            }`,
+            'Dismiss',
             SNACKBAR_SUCCESS_CONFIG
           );
           this.fetchProjects();

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
@@ -5,7 +5,10 @@ import { PlanService } from 'src/app/services';
 import { Plan, ProjectConfig } from 'src/app/types';
 
 import { MapService } from './../../../services/map.service';
-import { SNACKBAR_SUCCESS_CONFIG } from '../../../../app/shared/constants';
+import {
+  SNACK_ERROR_CONFIG,
+  SNACK_SUCCESS_CONFIG,
+} from '../../../../app/shared/constants';
 
 interface ProjectConfigRow extends ProjectConfig {
   selected?: boolean;
@@ -76,12 +79,12 @@ export class ScenarioConfigurationsComponent implements OnInit {
               deletedIds.length > 1 ? 's' : ''
             }`,
             'Dismiss',
-            SNACKBAR_SUCCESS_CONFIG
+            SNACK_SUCCESS_CONFIG
           );
           this.fetchProjects();
         },
         error: (err) => {
-          this.snackbar.open(`Error: ${err}`);
+          this.snackbar.open(`Error: ${err}`, 'Dismiss', SNACK_ERROR_CONFIG);
         },
       });
   }

--- a/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenario-configurations/scenario-configurations.component.ts
@@ -5,6 +5,7 @@ import { PlanService } from 'src/app/services';
 import { Plan, ProjectConfig } from 'src/app/types';
 
 import { MapService } from './../../../services/map.service';
+import { SNACKBAR_SUCCESS_CONFIG } from '../../../../app/shared/constants';
 
 interface ProjectConfigRow extends ProjectConfig {
   selected?: boolean;
@@ -73,7 +74,8 @@ export class ScenarioConfigurationsComponent implements OnInit {
           this.snackbar.open(
             `Deleted ${deletedIds.length} configuration${
               deletedIds.length > 1 ? 's' : ''
-            }`
+            }`,'Dismiss',
+            SNACKBAR_SUCCESS_CONFIG
           );
           this.fetchProjects();
         },

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CanActivate, Router } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
-import { SNACKBAR_SUCCESS_CONFIG } from '../../app/shared/constants';
+import { SNACK_SUCCESS_CONFIG } from '../../app/shared/constants';
 import {
   BehaviorSubject,
   catchError,
@@ -94,11 +94,7 @@ export class AuthService {
         tap((response) => {
           this.loggedInStatus$.next(false);
           this.loggedInUser$.next(null);
-          this.snackbar.open(
-            response.detail,
-            'Dismiss',
-            SNACKBAR_SUCCESS_CONFIG
-          );
+          this.snackbar.open(response.detail, 'Dismiss', SNACK_SUCCESS_CONFIG);
         })
       );
   }

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -94,7 +94,11 @@ export class AuthService {
         tap((response) => {
           this.loggedInStatus$.next(false);
           this.loggedInUser$.next(null);
-          this.snackbar.open(response.detail, 'Dismiss', SNACKBAR_SUCCESS_CONFIG);
+          this.snackbar.open(
+            response.detail,
+            'Dismiss',
+            SNACKBAR_SUCCESS_CONFIG
+          );
         })
       );
   }

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CanActivate, Router } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
+import { SNACKBAR_SUCCESS_CONFIG } from '../../app/shared/constants';
 import {
   BehaviorSubject,
   catchError,
@@ -93,7 +94,7 @@ export class AuthService {
         tap((response) => {
           this.loggedInStatus$.next(false);
           this.loggedInUser$.next(null);
-          this.snackbar.open(response.detail);
+          this.snackbar.open(response.detail, 'Dismiss', SNACKBAR_SUCCESS_CONFIG);
         })
       );
   }

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CanActivate, Router } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
-import { SNACK_SUCCESS_CONFIG } from '../../app/shared/constants';
+import { SNACK_NOTICE_CONFIG } from '../../app/shared/constants';
 import {
   BehaviorSubject,
   catchError,
@@ -94,7 +94,7 @@ export class AuthService {
         tap((response) => {
           this.loggedInStatus$.next(false);
           this.loggedInUser$.next(null);
-          this.snackbar.open(response.detail, 'Dismiss', SNACK_SUCCESS_CONFIG);
+          this.snackbar.open(response.detail, 'Dismiss', SNACK_NOTICE_CONFIG);
         })
       );
   }

--- a/src/interface/src/app/shared/constants.ts
+++ b/src/interface/src/app/shared/constants.ts
@@ -7,8 +7,14 @@ import { MatSnackBarConfig } from '@angular/material/snack-bar';
 export const MSG_RESET_PASSWORD_ERROR =
   'Unable to reset your password at this time. Please try again later.';
 
-export const SNACKBAR_SUCCESS_CONFIG: MatSnackBarConfig<any> = {
+export const SNACK_SUCCESS_CONFIG: MatSnackBarConfig<any> = {
   duration: 4000,
   panelClass: ['snackbar-success'],
+  verticalPosition: 'top',
+};
+
+export const SNACK_ERROR_CONFIG: MatSnackBarConfig<any> = {
+  duration: 10000,
+  panelClass: ['snackbar-error'],
   verticalPosition: 'top',
 };

--- a/src/interface/src/app/shared/constants.ts
+++ b/src/interface/src/app/shared/constants.ts
@@ -7,9 +7,9 @@ import { MatSnackBarConfig } from '@angular/material/snack-bar';
 export const MSG_RESET_PASSWORD_ERROR =
   'Unable to reset your password at this time. Please try again later.';
 
-export const SNACK_SUCCESS_CONFIG: MatSnackBarConfig<any> = {
+export const SNACK_NOTICE_CONFIG: MatSnackBarConfig<any> = {
   duration: 4000,
-  panelClass: ['snackbar-success'],
+  panelClass: ['snackbar-notice'],
   verticalPosition: 'top',
 };
 

--- a/src/interface/src/app/shared/constants.ts
+++ b/src/interface/src/app/shared/constants.ts
@@ -1,4 +1,4 @@
-import { MatSnackBarConfig } from "@angular/material/snack-bar";
+import { MatSnackBarConfig } from '@angular/material/snack-bar';
 
 /**
  * @desc Error message indicating some unknown error occurred while attempting a
@@ -7,7 +7,7 @@ import { MatSnackBarConfig } from "@angular/material/snack-bar";
 export const MSG_RESET_PASSWORD_ERROR =
   'Unable to reset your password at this time. Please try again later.';
 
-export const SNACKBAR_SUCCESS_CONFIG : MatSnackBarConfig<any> = {
+export const SNACKBAR_SUCCESS_CONFIG: MatSnackBarConfig<any> = {
   duration: 4000,
   panelClass: ['snackbar-success'],
   verticalPosition: 'top',

--- a/src/interface/src/app/shared/constants.ts
+++ b/src/interface/src/app/shared/constants.ts
@@ -1,6 +1,14 @@
+import { MatSnackBarConfig } from "@angular/material/snack-bar";
+
 /**
  * @desc Error message indicating some unknown error occurred while attempting a
  * password reset
  */
 export const MSG_RESET_PASSWORD_ERROR =
   'Unable to reset your password at this time. Please try again later.';
+
+export const SNACKBAR_SUCCESS_CONFIG : MatSnackBarConfig<any> = {
+  duration: 4000,
+  panelClass: ['snackbar-success'],
+  verticalPosition: 'top',
+};

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -46,6 +46,13 @@ body {
   }
 }
 
+.snackbar-success {
+  background: #000000;
+  button {
+    color: #ffffff;
+  }
+}
+
 // Leaflet attribution box
 .leaflet-control-attribution {
   max-width: calc(100% - 200px);

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -46,7 +46,7 @@ body {
   }
 }
 
-.snackbar-success {
+.snackbar-notice {
   background: #000000;
   button {
     color: #ffffff;


### PR DESCRIPTION
This PR:
- adds a uniform configuration to snackbars throughout the codebase
- moves the handy SNACK_ERROR_CONFIG to a shared constants file
- adds Dismiss option for all snackbars
- adds a snackbar to acknowledge Plan deletion 
- closes the logout dialog on success

Mmmm...snackbars... 