### PR TITLE
PLAN-556 - Remove all custom parameters for patchmax execution

### DIFF
--- a/src/planscape/rscripts/forsys.R
+++ b/src/planscape/rscripts/forsys.R
@@ -540,10 +540,6 @@ call_forsys <- function(
     patchmax_proj_size_min = min_area_project,
     patchmax_proj_size = max_area_project,
     patchmax_proj_number = number_of_projects,
-    patchmax_SDW = 0.5,
-    patchmax_EPW = 1,
-    patchmax_sample_frac = 0.1,
-    annual_target_value = max_treatment_area,
   )
   return(out)
 }


### PR DESCRIPTION
Right now these are just confusing for us. Letting patchmax run freely.