### PR TITLE
updated file name

### DIFF
--- a/src/interface/src/app/services/map.service.ts
+++ b/src/interface/src/app/services/map.service.ts
@@ -22,7 +22,7 @@ const regionToGeojsonMap: Record<Region, Record<string, string>> = {
     boundary: 'assets/geojson/sierra_nevada_region.geojson',
   },
   [Region.CENTRAL_COAST]: {
-    boundary: 'assets/geojson/central_california_region.geojson',
+    boundary: 'assets/geojson/central_coast_region.geojson',
   },
   [Region.NORTHERN_CALIFORNIA]: {
     boundary: 'assets/geojson/northern_california_region.geojson',
@@ -150,6 +150,7 @@ export class MapService {
 
     return vector;
   }
+
   // Queries the CalMAPPER ArcGIS Web Feature Service for known land management projects without filtering.
   getExistingProjects(): Observable<GeoJSON.GeoJSON> {
     return this.http


### PR DESCRIPTION
<img width="852" alt="Screen Shot 2023-11-21 at 16 14 59" src="https://github.com/PatManley/Planscape/assets/358892/de803929-f773-4e2f-be64-789ace4a6b22">

Just noticed that we where not finding this file, so the area borders for central california was not being drawn on the map