### PR TITLE
enable north cal behind feature flag

### DIFF
--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -4,6 +4,7 @@
   "show_centralcoast": true,
   "show_future_control_panel": false,
   "show_socal": true,
+  "show_north_cal": false,
   "show_translated_control_panel": false,
   "testFalseFeature": false,
   "testTrueFeature": true,

--- a/src/interface/src/app/home/welcome/welcome.component.html
+++ b/src/interface/src/app/home/welcome/welcome.component.html
@@ -18,7 +18,8 @@
       class="link">
       Regional Resource Kit
     </a>
-    layers for the Sierra Nevada, Southern California, and Central Coast
+    layers for the Sierra Nevada, Southern California,
+    {{ showsNorthCal ? ' Northern California, ' : '' }} and Central Coast
     regions.
   </p>
 

--- a/src/interface/src/app/home/welcome/welcome.component.spec.ts
+++ b/src/interface/src/app/home/welcome/welcome.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { WelcomeComponent } from './welcome.component';
+import { FeaturesModule } from '../../features/features.module';
 
 describe('WelcomeComponent', () => {
   let component: WelcomeComponent;
@@ -9,6 +9,7 @@ describe('WelcomeComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [WelcomeComponent],
+      imports: [FeaturesModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(WelcomeComponent);

--- a/src/interface/src/app/home/welcome/welcome.component.ts
+++ b/src/interface/src/app/home/welcome/welcome.component.ts
@@ -1,8 +1,13 @@
 import { Component } from '@angular/core';
+import { FeatureService } from '../../features/feature.service';
 
 @Component({
   selector: 'app-welcome',
   templateUrl: './welcome.component.html',
   styleUrls: ['./welcome.component.scss'],
 })
-export class WelcomeComponent {}
+export class WelcomeComponent {
+  showsNorthCal = this.features.isFeatureEnabled('show_north_cal');
+
+  constructor(private features: FeatureService) {}
+}

--- a/src/interface/src/app/types/region.types.ts
+++ b/src/interface/src/app/types/region.types.ts
@@ -24,6 +24,7 @@ const availableRegions = new Set([
   Region.SIERRA_NEVADA,
   features.show_socal ? Region.SOUTHERN_CALIFORNIA : null,
   features.show_centralcoast ? Region.CENTRAL_COAST : null,
+  features.show_north_cal ? Region.NORTHERN_CALIFORNIA : null,
 ]);
 
 export const regionOptions = regions.map((region) => {


### PR DESCRIPTION
Enables (behind fflag) north cal and updates home text
<img width="1094" alt="Screen Shot 2023-11-23 at 10 48 40" src="https://github.com/OurPlanscape/Planscape/assets/358892/9142346a-5f57-4c9b-a665-82a2c5154925">

