### PR TITLE
disable other regions that are not Sierra Nevada on draw

### DIFF
--- a/src/interface/src/app/features/features.json
+++ b/src/interface/src/app/features/features.json
@@ -11,5 +11,8 @@
   "top_percent_slider": true,
   "unlaunched_layers": false,
   "upload_project_area": false,
-  "use_its": false
+  "use_its": false,
+  "draw_northcal": false,
+  "draw_socal": false,
+  "draw_centralcoast": false
 }

--- a/src/interface/src/app/home/region-selection/region-selection.component.spec.ts
+++ b/src/interface/src/app/home/region-selection/region-selection.component.spec.ts
@@ -49,22 +49,4 @@ describe('RegionSelectionComponent', () => {
 
     expect(setRegionSpy).toHaveBeenCalledWith(Region.SIERRA_NEVADA);
   });
-
-  it('should disable unavailable regions', async () => {
-    const regionButtons: MatButtonHarness[] =
-      await loader.getAllHarnesses(MatButtonHarness);
-
-    for (let regionButton of regionButtons) {
-      // Add regions here as they become available to avoid false failures
-      if (
-        (await regionButton.getText()).match(
-          /(SIERRA NEVADA)|(SOUTHERN CALIFORNIA)|(CENTRAL COAST)/
-        )
-      ) {
-        expect(await regionButton.isDisabled()).toBeFalse();
-      } else {
-        expect(await regionButton.isDisabled()).toBeTrue();
-      }
-    }
-  });
 });

--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -35,10 +35,10 @@
       <!-- Draw a planning area -->
       <div
         matTooltip="This feature is not available at this time."
-        [matTooltipDisabled]="login_enabled">
+        [matTooltipDisabled]="(drawRegionEnabled$ | async) || false">
         <button
           mat-button
-          [disabled]="!login_enabled"
+          [disabled]="(drawRegionEnabled$ | async) === false || false"
           class="draw-area-button"
           [ngClass]="{
             selected: selectedAreaCreationAction === AreaCreationAction.DRAW,
@@ -54,10 +54,10 @@
       <div class="upload-wrapper">
         <div
           matTooltip="This feature is not available at this time."
-          [matTooltipDisabled]="login_enabled">
+          [matTooltipDisabled]="(drawRegionEnabled$ | async) || false">
           <button
             mat-button
-            [disabled]="!login_enabled"
+            [disabled]="(drawRegionEnabled$ | async) === false || false"
             class="upload-area-button"
             [ngClass]="{
               selected:

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -62,6 +62,7 @@ import {
 import { PlanStateService } from '../services/plan-state.service';
 import { Breadcrumb } from '../shared/nav-bar/nav-bar.component';
 import { getPlanPath } from '../plan/plan-helpers';
+import { RegionService } from '../services/region.service';
 
 @UntilDestroy()
 @Component({
@@ -125,6 +126,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   showConfirmAreaButton$ = new BehaviorSubject(false);
   breadcrumbs$ = new BehaviorSubject<Breadcrumb[]>([{ name: 'New Plan' }]);
 
+  drawRegionEnabled$ = this.regionService.drawRegionEnabled$;
+
   constructor(
     public applicationRef: ApplicationRef,
     private authService: AuthService,
@@ -138,7 +141,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     private router: Router,
     private http: HttpClient,
     private cdr: ChangeDetectorRef,
-    private featureService: FeatureService
+    private featureService: FeatureService,
+    private regionService: RegionService
   ) {
     this.sessionService.mapViewOptions$
       .pipe(take(1))

--- a/src/interface/src/app/services/region.service.spec.ts
+++ b/src/interface/src/app/services/region.service.spec.ts
@@ -1,17 +1,52 @@
 import { TestBed } from '@angular/core/testing';
-
 import { RegionService } from './region.service';
 import { FeaturesModule } from '../features/features.module';
+import { FEATURES_JSON } from '../features/features-config';
+import { firstValueFrom } from 'rxjs';
+import { Region } from '../types';
+import { SessionService } from './session.service';
 
 describe('RegionService', () => {
   let service: RegionService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ imports: [FeaturesModule] });
+    TestBed.configureTestingModule({
+      imports: [FeaturesModule],
+      providers: [
+        {
+          provide: FEATURES_JSON,
+          useValue: {
+            login: true,
+            drawn_northcal: false,
+            draw_socal: true,
+            draw_centralcoast: false,
+          },
+        },
+        SessionService,
+      ],
+    });
     service = TestBed.inject(RegionService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('drawRegionEnabled$', () => {
+    it('should return true for enabled regions', async () => {
+      const session = TestBed.inject(SessionService);
+      session.region$.next(Region.NORTHERN_CALIFORNIA);
+
+      let regionEnabled = await firstValueFrom(service.drawRegionEnabled$);
+      expect(regionEnabled).toBe(false);
+
+      session.region$.next(Region.SOUTHERN_CALIFORNIA);
+      regionEnabled = await firstValueFrom(service.drawRegionEnabled$);
+      expect(regionEnabled).toBe(true);
+
+      session.region$.next(Region.CENTRAL_COAST);
+      regionEnabled = await firstValueFrom(service.drawRegionEnabled$);
+      expect(regionEnabled).toBe(false);
+    });
   });
 });

--- a/src/interface/src/app/services/region.service.ts
+++ b/src/interface/src/app/services/region.service.ts
@@ -1,12 +1,17 @@
 import { Injectable } from '@angular/core';
 import { FeatureService } from '../features/feature.service';
 import { Region, RegionOption, regions } from '../types';
+import { SessionService } from './session.service';
+import { map } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class RegionService {
-  constructor(private features: FeatureService) {}
+  constructor(
+    private features: FeatureService,
+    private sessionService: SessionService
+  ) {}
 
   private availableRegions = new Set([
     Region.SIERRA_NEVADA,
@@ -28,4 +33,23 @@ export class RegionService {
       available: this.availableRegions.has(region),
     };
   });
+
+  private regionDrawOptions: Record<Region, boolean> = {
+    [Region.SIERRA_NEVADA]: true,
+    [Region.SOUTHERN_CALIFORNIA]: this.features.isFeatureEnabled('draw_socal'),
+    [Region.NORTHERN_CALIFORNIA]:
+      this.features.isFeatureEnabled('draw_northcal'),
+    [Region.CENTRAL_COAST]: this.features.isFeatureEnabled('draw_centralcoast'),
+  };
+
+  drawRegionEnabled$ = this.sessionService.region$
+    .asObservable()
+    .pipe(
+      map((region) =>
+        region
+          ? this.features.isFeatureEnabled('login') &&
+            this.regionDrawOptions[region]
+          : false
+      )
+    );
 }


### PR DESCRIPTION
Disables creating planning areas that are not Sierra Nevada. using feature flags for each region.
<img width="1427" alt="Screen Shot 2023-12-08 at 10 18 20" src="https://github.com/OurPlanscape/Planscape/assets/358892/502e7383-38db-4045-a231-66f53f86b4a8">
<img width="1493" alt="Screen Shot 2023-12-08 at 10 18 29" src="https://github.com/OurPlanscape/Planscape/assets/358892/5e873dec-b7a2-46c5-975b-83a4b9e22410">
