### PR TITLE
PLAN-639 - change configs for 90-day JWT expiration

### DIFF
--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -21,7 +21,7 @@ These settings are
 import multiprocessing
 import os
 from pathlib import Path
-
+from datetime import timedelta
 import sentry_sdk
 from corsheaders.defaults import default_headers
 from decouple import config
@@ -149,7 +149,6 @@ LOCKDOWN_REMOTE_ADDR_EXCEPTIONS = [
     "::1",
 ]
 
-
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators
 
@@ -237,12 +236,19 @@ REST_AUTH = {
     "JWT_AUTH_COOKIE": "my-app-auth",
     "JWT_AUTH_REFRESH_COOKIE": "my-refresh-token",
     "JWT_AUTH_HTTPONLY": False,
+    "JWT_SERIALIZER_WITH_EXPIRATION": "dj_rest_auth.serializers.JWTSerializerWithExpiration",
     "REGISTER_SERIALIZER": "users.serializers.NameRegistrationSerializer",
     "OLD_PASSWORD_FIELD_ENABLED": True,
     "PASSWORD_CHANGE_SERIALIZER": "users.serializers.CustomPasswordChangeSerializer",
     "PASSWORD_RESET_SERIALIZER": "users.serializers.CustomPasswordResetSerializer",
     "PASSWORD_RESET_CONFIRM_SERIALIZER": "users.serializers.CustomPasswordResetConfirmSerializer",
     "LANGUAGE_CODE": "en-us",
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=90),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=90),
+    'ROTATE_REFRESH_TOKENS': True, # ensure the Refresh token is invalidated each time
 }
 
 AUTHENTICATION_BACKENDS = [

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -248,7 +248,7 @@ REST_AUTH = {
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(days=90),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=90),
-    'ROTATE_REFRESH_TOKENS': True, # ensure the Refresh token is invalidated each time
+    'ROTATE_REFRESH_TOKENS': True, # ensure the Refresh token is invalidated at each login
 }
 
 AUTHENTICATION_BACKENDS = [

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -246,9 +246,9 @@ REST_AUTH = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(days=90),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=90),
-    'ROTATE_REFRESH_TOKENS': True, # ensure the Refresh token is invalidated at each login
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=90),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=90),
+    "ROTATE_REFRESH_TOKENS": True,  # ensure the Refresh token is invalidated at each login
 }
 
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
This modifies our use of dj-rest-auth to let user authentication persist for 90 days.