### PR TITLE
snap map to uploaded area and fix loading layers after changing maps

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -203,7 +203,7 @@ export class MapManager {
    * Adds a GeoJSON to the drawing layer.
    * @param area: The geojson of the area to add to the drawing layer.
    */
-  addGeoJsonToDrawing(area: GeoJSON.GeoJSON) {
+  addGeoJsonToDrawing(area: GeoJSON.GeoJSON, map: Map) {
     L.geoJSON(area, {
       style: (_) => DRAWING_STYLES,
       pmIgnore: false,
@@ -213,6 +213,9 @@ export class MapManager {
         layer.on('pm:edit', ({ layer }) => this.editHandler(layer));
       },
     });
+
+    map.instance?.fitBounds(this.drawingLayer.getBounds());
+
     this.polygonsCreated$.next(true);
   }
 

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -242,14 +242,15 @@ describe('MapComponent', () => {
       expect(component.mapViewOptions$.getValue().selectedMapIndex).toBe(0);
     });
 
-    it('can select another map', () => {
+    it('can select another map', fakeAsync(() => {
       component.ngAfterViewInit();
 
       // Clicking the initialized map should select it
       component.maps[2].instance?.fireEvent('click');
-
+      tick();
+      flush();
       expect(component.mapViewOptions$.getValue().selectedMapIndex).toBe(2);
-    });
+    }));
 
     it('selected map is always visible', () => {
       [0, 1, 2, 3].forEach((selectedMapIndex: number) => {
@@ -770,34 +771,34 @@ describe('MapComponent', () => {
         );
       });
 
-      it('attaches popup when feature polygon is clicked', () => {
+      it('attaches popup when feature polygon is clicked', fakeAsync(() => {
         // Click on the polygon
         component.maps[3].instance?.fireEvent('click', {
           latlng: [0, 0],
         });
-
+        flush();
         expect(applicationRef.attachView).toHaveBeenCalledTimes(1);
-      });
+      }));
 
-      it('does not attach popup when map is clicked outside the polygon', () => {
+      it('does not attach popup when map is clicked outside the polygon', fakeAsync(() => {
         // Click outside the polygon
         component.maps[3].instance?.fireEvent('click', {
           latlng: [2, 2],
         });
-
+        flush();
         expect(applicationRef.attachView).toHaveBeenCalledTimes(0);
-      });
+      }));
 
-      it('does not attach popup if drawing mode is active', () => {
+      it('does not attach popup if drawing mode is active', fakeAsync(() => {
         component.mapManager.isInDrawingMode = true;
 
         // Click on the polygon
         component.maps[3].instance?.fireEvent('click', {
           latlng: [0, 0],
         });
-
+        flush();
         expect(applicationRef.attachView).toHaveBeenCalledTimes(0);
-      });
+      }));
     });
 
     it('popup is removed when existing project layer is removed', () => {

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -88,7 +88,9 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
 
   mapManager: MapManager;
   regionRecord: string = '';
-  loadingIndicators: { [layerName: string]: boolean } = {
+  loadingIndicators: {
+    [layerName: string]: boolean;
+  } = {
     existing_projects: true,
   };
   selectedAreaCreationAction = AreaCreationAction.NONE;
@@ -526,7 +528,13 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
           fileAsArrayBuffer
         )) as GeoJSON.GeoJSON;
         if (geojson.type == 'FeatureCollection') {
-          this.mapManager.addGeoJsonToDrawing(geojson);
+          const selectedMapIndex =
+            this.mapViewOptions$.getValue().selectedMapIndex;
+          this.mapManager.addGeoJsonToDrawing(
+            geojson,
+            this.maps[selectedMapIndex]
+          );
+
           this.showUploader = false;
           this.addDrawingControlToAllMaps();
         } else {
@@ -641,6 +649,11 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
         this.mapManager.addDrawingControl(this.maps[mapIndex].instance!);
         this.mapManager.hideClonedDrawing(this.maps[mapIndex]);
       }
+      setTimeout(() => {
+        this.maps.forEach((map: Map) => {
+          map.instance?.invalidateSize();
+        });
+      }, 0);
     }
   }
 


### PR DESCRIPTION
This pr fixes two things: 
- Centers the map after uploading an area
<img width="1496" alt="Screen Shot 2023-12-14 at 18 54 02" src="https://github.com/OurPlanscape/Planscape/assets/358892/5d4dfeae-7ffe-4d00-93f9-f5afa43ea487">

- Fixes an issue with loading the map tiles when you switch maps:
This is a screenshot of the issue. 
<img width="1494" alt="Screen Shot 2023-12-14 at 18 54 21" src="https://github.com/OurPlanscape/Planscape/assets/358892/7499bf44-5b3a-4825-aee7-c90ede46fcd7">
