### PR TITLE
transform multipolygons to polygons when uploading area files

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -34,6 +34,7 @@ import {
   checkIfAreaInBoundaries,
   createMultiPolygonFeatureCollection,
   regionMapCenters,
+  transformCoordToLayer,
 } from './map.helper';
 import { satelliteTiles, stadiaAlidadeTiles, terrainTiles } from './map.tiles';
 import { createAndAddLegend } from './map.legends';
@@ -210,16 +211,7 @@ export class MapManager {
       onEachFeature: (feature, layer) => {
         if (feature.geometry.type === 'MultiPolygon') {
           feature.geometry.coordinates.forEach((coord) => {
-            const newFeature: GeoJSON.Feature = {
-              type: 'Feature',
-              geometry: {
-                type: 'Polygon',
-                coordinates: coord,
-              },
-              properties: {},
-            };
-
-            const newLayer = new L.GeoJSON(newFeature);
+            const newLayer = transformCoordToLayer(coord);
             newLayer.addTo(this.drawingLayer);
             this.addClonedPolygons(newLayer);
             newLayer.on('pm:edit', ({ layer }) => this.editHandler(layer));

--- a/src/interface/src/app/map/map.helper.ts
+++ b/src/interface/src/app/map/map.helper.ts
@@ -1,4 +1,10 @@
-import { Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson';
+import {
+  Feature,
+  FeatureCollection,
+  MultiPolygon,
+  Polygon,
+  Position,
+} from 'geojson';
 import * as L from 'leaflet';
 import booleanWithin from '@turf/boolean-within';
 import booleanIntersects from '@turf/boolean-intersects';
@@ -172,4 +178,15 @@ export function defaultMapConfigsDictionary(): Record<Region, MapConfig[]> {
   };
 }
 
-export function transformMultiPolygonToPolygon() {}
+export function transformCoordToLayer(coord: Position[][]) {
+  const newFeature: GeoJSON.Feature = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: coord,
+    },
+    properties: {},
+  };
+
+  return new L.GeoJSON(newFeature);
+}

--- a/src/interface/src/app/map/map.helper.ts
+++ b/src/interface/src/app/map/map.helper.ts
@@ -17,9 +17,36 @@ export function checkIfAreaInBoundaries(
   boundaries: Feature
 ): boolean {
   let overlappingAreas = area.features.map((feature) => {
+    // if we want to allow multipolygons we need to transform them to polygons
+    // to validate if in area.
+    // if (feature.geometry.type === 'MultiPolygon') {
+    //   return checkIfMultipolygonOverlaps(
+    //     feature as Feature<MultiPolygon>,
+    //     boundaries
+    //   );
+    // }
     return !booleanWithin(feature, boundaries);
   });
   return !overlappingAreas.some((overlap) => overlap);
+}
+
+// @ts-ignore
+function checkIfMultipolygonOverlaps(
+  feature: Feature<MultiPolygon>,
+  boundaries: Feature
+) {
+  const overlap = feature.geometry.coordinates.some((coord) => {
+    const newFeature: GeoJSON.Feature = {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: coord,
+      },
+      properties: {},
+    };
+    return !booleanWithin(newFeature, boundaries);
+  });
+  return overlap;
 }
 
 export function areaOverlaps(
@@ -144,3 +171,5 @@ export function defaultMapConfigsDictionary(): Record<Region, MapConfig[]> {
     ],
   };
 }
+
+export function transformMultiPolygonToPolygon() {}


### PR DESCRIPTION
There is a bug that prevents users for saving planning areas with multipolygons (when they upload area files).
This pr fixes the issue by transforming the multipolygons to polygons and adding each.

<img width="1496" alt="Screen Shot 2023-12-15 at 13 13 04" src="https://github.com/OurPlanscape/Planscape/assets/358892/a5f36380-ce23-4ac3-a882-eaa104468ef0">
<img width="1494" alt="Screen Shot 2023-12-15 at 13 23 07" src="https://github.com/OurPlanscape/Planscape/assets/358892/82a69bbd-36ce-4fb5-8a40-53888bb99885">
