### PR TITLE
Update treatment validation messages

### DIFF
--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -39,16 +39,18 @@ class MaxTreatableAreaTest(TestCase):
 
 
 class ValidateScenarioTreatmentRatioTest(TransactionTestCase):
-    def test_validate_scenario_between_20_and_80(self):
-        unit_poly = GEOSGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", srid=4269)
-        planning_area = PlanningArea.objects.create(
+    def setUp(self) -> None:
+        # Note: Test Polygon is 12163249.414195888 acres
+        self.test_poly = GEOSGeometry("POLYGON ((0 0, 0 2, 2 2, 2 0, 0 0))", srid=4269)
+        self.test_area = PlanningArea.objects.create(
             region_name="sierra-nevada",
             name="mytest",
-            geometry=MultiPolygon([unit_poly]),
+            geometry=MultiPolygon([self.test_poly]),
         )
-        conf_just_above_20 = {
+
+    def get_basic_conf(self):
+        return {
             "est_cost": 2470,
-            "max_budget": 1502470420,
             "min_distance_from_road": None,
             "max_slope": None,
             "global_thresholds": [],
@@ -56,73 +58,76 @@ class ValidateScenarioTreatmentRatioTest(TransactionTestCase):
             "excluded_areas": [],
             "stand_size": StandSizeChoices.LARGE,
         }
+
+    # 20% of acreage should be 2432649.882839178
+    def test_validate_acres_just_above_20pct(self):
+        conf_just_above_20 = self.get_basic_conf()
+        conf_just_above_20["max_treatment_area_ratio"] = 2432650
         result, reason = validate_scenario_treatment_ratio(
-            planning_area, conf_just_above_20
+            self.test_area, conf_just_above_20
         )
         self.assertTrue(result)
         self.assertEqual("Treatment ratio is valid.", reason)
 
-        conf_just_below_80 = {
-            "est_cost": 2470,
-            "max_budget": 6009867880,
-            "min_distance_from_road": None,
-            "max_slope": None,
-            "global_thresholds": [],
-            "weights": [],
-            "excluded_areas": [],
-            "stand_size": StandSizeChoices.LARGE,
-        }
+    def test_validate_acres_just_below_20pct(self):
+        conf_acres_below_20pct = self.get_basic_conf()
+        conf_acres_below_20pct["max_treatment_area_ratio"] = 2432640
         result, reason = validate_scenario_treatment_ratio(
-            planning_area, conf_just_below_80
+            self.test_area, conf_acres_below_20pct
         )
-        self.assertTrue(result)
-        self.assertEqual("Treatment ratio is valid.", reason)
-
-    def test_validate_scenario_false_below_20(self):
-        unit_poly = GEOSGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", srid=4269)
-        planning_area = PlanningArea.objects.create(
-            region_name="sierra-nevada",
-            name="mytest",
-            geometry=MultiPolygon([unit_poly]),
-        )
-
-        # This will be be less than 2433144 acres
-        conf = {
-            "est_cost": 2470,
-            "max_budget": 1200,
-            "min_distance_from_road": None,
-            "max_slope": None,
-            "global_thresholds": [],
-            "weights": [],
-            "excluded_areas": [],
-            "stand_size": StandSizeChoices.LARGE,
-        }
-        result, reason = validate_scenario_treatment_ratio(planning_area, conf)
         self.assertFalse(result)
         self.assertIn("at least", reason)
 
-    def test_validate_scenario_false_above_80(self):
-        unit_poly = GEOSGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", srid=4269)
-        planning_area = PlanningArea.objects.create(
-            region_name="sierra-nevada",
-            name="mytest",
-            geometry=MultiPolygon([unit_poly]),
+    # 80% of area is 9730599.531356712
+    def test_validate_acres_just_below_80pct(self):
+        conf_just_below_80 = self.get_basic_conf()
+        conf_just_below_80["max_treatment_area_ratio"] = 9730590
+        result, reason = validate_scenario_treatment_ratio(
+            self.test_area, conf_just_below_80
         )
+        self.assertTrue(result)
+        self.assertEqual("Treatment ratio is valid.", reason)
 
-        # This will be more than 2433144 acres
-        conf = {
-            "est_cost": 2470,
-            "max_budget": 8009867656,
-            "min_distance_from_road": None,
-            "max_slope": None,
-            "global_thresholds": [],
-            "weights": [],
-            "excluded_areas": [],
-            "stand_size": StandSizeChoices.LARGE,
-        }
-        result, reason = validate_scenario_treatment_ratio(planning_area, conf)
+    def test_validate_acres_just_above_80pct(self):
+        conf_acres_above_80 = self.get_basic_conf()
+        conf_acres_above_80["max_treatment_area_ratio"] = 9730600
+        result, reason = validate_scenario_treatment_ratio(
+            self.test_area, conf_acres_above_80
+        )
         self.assertFalse(result)
         self.assertIn("less than", reason)
+        self.assertIn("80%", reason)
+
+    # 20% of acreage should be 2432649.882839178
+    #  so, with cost of 2470/acre, this requires $ 6,008,645,200.61
+    def test_validate_budget_below_20pct(self):
+        conf_budget_below_20pct = self.get_basic_conf()
+        conf_budget_below_20pct["max_budget"] = 6008641030
+        result, reason = validate_scenario_treatment_ratio(
+            self.test_area, conf_budget_below_20pct
+        )
+        self.assertFalse(result)
+        self.assertIn("at least", reason)
+
+    def test_validate_budget_above_20pct(self):
+        conf_budget_above_20pct = self.get_basic_conf()
+        conf_budget_above_20pct["max_budget"] = 6008645211
+        result, reason = validate_scenario_treatment_ratio(
+            self.test_area, conf_budget_above_20pct
+        )
+        self.assertTrue(result)
+        self.assertEqual("Treatment ratio is valid.", reason)
+
+    # 99% of acreage should be 12041616.9200539311
+    #  so, at cost of 2470/acre, this requires $ 29,742,793,792.53
+    def test_validate_budget_above_99pct(self):
+        conf_budget_above_99 = self.get_basic_conf()
+        conf_budget_above_99["max_budget"] = 29742793793
+        result, reason = validate_scenario_treatment_ratio(
+            self.test_area, conf_budget_above_99
+        )
+        self.assertTrue(result)
+        self.assertIn("Treatment ratio is valid.", reason)
 
 
 class GetSchemaTest(TestCase):


### PR DESCRIPTION
After a chat w/ Michele, we decided to keep the new, detailed wording for validation errors, add another slightly different message for when someone enters a budget, and remove the >80% message when someone enters a budget.

This PR adds some conditions and messages, adds a few new tests, and refactors existing tests.