### PR TITLE
Ensure scenario name is unique, add backend exception

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -10,12 +10,16 @@
         </mat-form-field>
       </form>
       <div
-        *ngIf="scenarioNameFormField?.invalid && scenarioNameFormField?.touched"
+        *ngIf="
+          scenarioNameFormField?.invalid &&
+          scenarioNameFormField?.touched &&
+          scenarioNameFormField?.errors?.['required']
+        "
         class="error">
         Please enter scenario name above
       </div>
-      <div *ngIf="checkExistingNames()" class="error">
-        Name is already in use.
+      <div *ngIf="scenarioNameFormField?.errors?.['duplicate']" class="error">
+        This name is already used by another scenario.
       </div>
     </div>
     <div class="tab-container">
@@ -35,6 +39,7 @@
                 color="primary"
                 type="submit"
                 [disabled]="
+                  scenarioNameFormField?.invalid ||
                   prioritiesForm?.invalid ||
                   constrainsForm?.invalid ||
                   generatingScenario

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -14,6 +14,9 @@
         class="error">
         Please enter scenario name above
       </div>
+      <div *ngIf="checkExistingNames()" class="error">
+        Name is already in use.
+      </div>
     </div>
     <div class="tab-container">
       <mat-tab-group

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -90,6 +90,18 @@ describe('CreateScenariosComponent', () => {
       {
         createScenario: of('1'),
         getScenario: of(fakeScenario),
+        getScenariosForPlan: of([
+          {
+            id: '1',
+            name: 'name',
+            planning_area: '1',
+            createdTimestamp: 100,
+            configuration: {
+              id: 1,
+              max_budget: 200,
+            },
+          },
+        ]),
       }
     );
     fakePlanStateService = jasmine.createSpyObj<PlanStateService>(

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -37,7 +37,7 @@ export class CreateScenariosComponent implements OnInit {
   scenarioId?: string | null;
   planId?: string | null;
   plan$ = new BehaviorSubject<Plan | null>(null);
-  existingScenarioNames : string[] = [];
+  existingScenarioNames: string[] = [];
   forms: FormGroup = this.fb.group({});
 
   project_area_upload_enabled = this.featureService.isFeatureEnabled(
@@ -128,7 +128,7 @@ export class CreateScenariosComponent implements OnInit {
         .getScenariosForPlan(this.planId)
         .pipe(take(1))
         .subscribe((scenarios) => {
-          this.existingScenarioNames = scenarios.map(s => s.name);;
+          this.existingScenarioNames = scenarios.map((s) => s.name);
         });
     }
   }

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -17,6 +17,7 @@ import { SNACK_ERROR_CONFIG } from '../../shared/constants';
 import { SetPrioritiesComponent } from './set-priorities/set-priorities.component';
 import { ConstraintsPanelComponent } from './constraints-panel/constraints-panel.component';
 import { FeatureService } from '../../features/feature.service';
+import { ScenarioService } from '../../services/scenario.service';
 
 enum ScenarioTabs {
   CONFIG,
@@ -36,7 +37,7 @@ export class CreateScenariosComponent implements OnInit {
   scenarioId?: string | null;
   planId?: string | null;
   plan$ = new BehaviorSubject<Plan | null>(null);
-
+  existingScenarioNames : string[] = [];
   forms: FormGroup = this.fb.group({});
 
   project_area_upload_enabled = this.featureService.isFeatureEnabled(
@@ -64,6 +65,7 @@ export class CreateScenariosComponent implements OnInit {
   constructor(
     private fb: FormBuilder,
     private planStateService: PlanStateService,
+    private scenarioService: ScenarioService,
     private router: Router,
     private matSnackBar: MatSnackBar,
     private featureService: FeatureService
@@ -120,6 +122,20 @@ export class CreateScenariosComponent implements OnInit {
         this.drawShapes(uploadedArea?.value);
       }
     });
+
+    if (typeof this.planId === 'string') {
+      this.scenarioService
+        .getScenariosForPlan(this.planId)
+        .pipe(take(1))
+        .subscribe((scenarios) => {
+          this.existingScenarioNames = scenarios.map(s => s.name);;
+        });
+    }
+  }
+
+  checkExistingNames() {
+    const scenarioNameValue = this.forms.get('scenarioName')?.value;
+    return this.existingScenarioNames.includes(scenarioNameValue);
   }
 
   pollForChanges() {

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -1,5 +1,11 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+  FormControl,
+  AbstractControl,
+} from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
 import { BehaviorSubject, catchError, interval, NEVER, take } from 'rxjs';
 import {
@@ -73,7 +79,11 @@ export class CreateScenariosComponent implements OnInit {
 
   createForms() {
     this.forms = this.fb.group({
-      scenarioName: [null, Validators.required],
+      scenarioName: new FormControl('', [
+        Validators.required,
+        (control: AbstractControl) =>
+          scenarioNameMustBeNew(control, this.existingScenarioNames),
+      ]),
       priorities: this.prioritiesComponent.createForm(),
       constrains: this.constraintsPanelComponent.createForm(),
       projectAreas: this.fb.group({
@@ -131,11 +141,6 @@ export class CreateScenariosComponent implements OnInit {
           this.existingScenarioNames = scenarios.map((s) => s.name);
         });
     }
-  }
-
-  checkExistingNames() {
-    const scenarioNameValue = this.forms.get('scenarioName')?.value;
-    return this.existingScenarioNames.includes(scenarioNameValue);
   }
 
   pollForChanges() {
@@ -368,4 +373,14 @@ export class CreateScenariosComponent implements OnInit {
   get constrainsForm() {
     return this.forms.get('constrains');
   }
+}
+
+function scenarioNameMustBeNew(
+  nameControl: AbstractControl,
+  existingNames: string[]
+): { [key: string]: any } | null {
+  if (existingNames.includes(nameControl.value)) {
+    return { duplicate: true };
+  }
+  return null;
 }

--- a/src/planscape/planning/tests/test_views.py
+++ b/src/planscape/planning/tests/test_views.py
@@ -1024,6 +1024,33 @@ class CreateScenarioTest(TransactionTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertRegex(str(response.content), r"This field is required")
 
+    def test_create_scenario_duplicate_name(self):
+        self.client.force_login(self.user)
+        first_response = self.client.post(
+            reverse("planning:create_scenario"),
+            {
+                "planning_area": self.planning_area.pk,
+                "configuration": self.configuration,
+                "name": "test scenario",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(first_response.status_code, 200)
+
+        second_response = self.client.post(
+            reverse("planning:create_scenario"),
+            {
+                "planning_area": self.planning_area.pk,
+                "configuration": self.configuration,
+                "name": "test scenario",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(second_response.status_code, 400)
+        self.assertRegex(
+            str(second_response.content), r"A scenario with this name already exists."
+        )
+
     def test_create_scenario_not_logged_in(self):
         response = self.client.post(
             reverse("planning:create_scenario"),

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.sites.shortcuts import get_current_site
+from django.db import IntegrityError
 from django.db.models import Count, Max
 from django.db.models.functions import Coalesce
 
@@ -40,7 +41,6 @@ from planning.services import (
 from planning.tasks import async_forsys_run
 from urllib.parse import urljoin
 from utils.cli_utils import call_forsys
-
 
 # Retrieve the logged in user from the HTTP request.
 def _get_user(request: HttpRequest) -> User:
@@ -530,8 +530,16 @@ def create_scenario(request: HttpRequest) -> HttpResponse:
         if settings.USE_CELERY_FOR_FORSYS:
             async_forsys_run.delay(scenario.pk)
 
+        return JsonResponse({"id": scenario.pk})
+
+    except IntegrityError as ve:
+        reason = ve.args[0]
+        if "(planning_area_id, name)" in ve.args[0]:
+            reason = "A scenario with this name already exists."
         return HttpResponse(
-            json.dumps({"id": scenario.pk}), content_type="application/json"
+            json.dumps({"reason": reason}),
+            content_type="application/json",
+            status=400,
         )
     except Exception as e:
         return HttpResponseBadRequest("Ill-formed request: " + str(e))

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -42,6 +42,7 @@ from planning.tasks import async_forsys_run
 from urllib.parse import urljoin
 from utils.cli_utils import call_forsys
 
+
 # Retrieve the logged in user from the HTTP request.
 def _get_user(request: HttpRequest) -> User:
     user = None


### PR DESCRIPTION
This PR:
- returns a clearer backend error for duplicate scenario names
- adds some frontend validation to guard against duplicate scenario names in the first place