### PR TITLE
Share map link

### DIFF
--- a/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.html
+++ b/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.html
@@ -1,0 +1,18 @@
+<div class="error-icon">
+  <mat-icon class="close-btn">close</mat-icon>
+</div>
+
+<h4>Invalid Link</h4>
+<p>
+  The link you are trying to accessed is invalid or may have expired. To access
+  the map, please contact the person who shared the link with you.
+</p>
+
+<button
+  mat-flat-button
+  type="button"
+  (click)="cancel()"
+  color="primary"
+  class="close">
+  CLOSE
+</button>

--- a/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.scss
+++ b/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.scss
@@ -1,0 +1,37 @@
+@import "../../../styles/mixins";
+@import "../../../styles/colors";
+
+:host {
+  display: block;
+  max-width: 535px;
+}
+
+h4 {
+  @include h4;
+  text-align: center;
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+
+.error-icon {
+  border-radius: 50px;
+  background: rgba(213, 0, 0, 0.20);
+  color: $color-error;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+}
+
+p {
+  @include small-paragraph;
+  text-align: center;
+}
+
+.close {
+  margin: 36px auto 0;
+  display: block;
+
+}

--- a/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.spec.ts
+++ b/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InvalidLinkDialogComponent } from './invalid-link-dialog.component';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '../../material/material.module';
+
+describe('InvalidLinkDialogComponent', () => {
+  let component: InvalidLinkDialogComponent;
+  let fixture: ComponentFixture<InvalidLinkDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [InvalidLinkDialogComponent],
+      imports: [MaterialModule],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {
+            close: () => {},
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InvalidLinkDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.ts
+++ b/src/interface/src/app/map/invalid-link-dialog/invalid-link-dialog.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-invalid-link-dialog',
+  templateUrl: './invalid-link-dialog.component.html',
+  styleUrls: ['./invalid-link-dialog.component.scss'],
+})
+export class InvalidLinkDialogComponent {
+  constructor(private dialogRef: MatDialogRef<InvalidLinkDialogComponent>) {}
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
+++ b/src/interface/src/app/map/map-control-panel/condition-tree/condition-tree.component.html
@@ -52,6 +52,7 @@
           </mat-menu>
         </div>
       </mat-tree-node>
+
       <!-- This is the tree node template for expandable nodes -->
       <mat-tree-node
         *matTreeNodeDef="let node; when: hasChild"

--- a/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
+++ b/src/interface/src/app/map/map-control-panel/map-control-panel.component.html
@@ -161,7 +161,7 @@
             "></app-condition-tree>
         </div>
 
-        <!-- Normalized current condition controls -->
+        <!-- Normalized current condition controls - not in use -->
         <div *ngIf="translated_control_panel_enabled && translatedDataEnabled">
           <app-condition-tree
             #conditionTreeNormalized
@@ -174,7 +174,7 @@
             "></app-condition-tree>
         </div>
 
-        <!-- Future condition controls -->
+        <!-- Future condition controls  - not in use -->
         <div *ngIf="future_control_panel_enabled && futureDataEnabled">
           <app-condition-tree
             #conditionTreeNormalized
@@ -187,7 +187,7 @@
             "></app-condition-tree>
         </div>
 
-        <!-- No Data Region controls -->
+        <!-- No Data Region controls  - not in use -->
         <div *ngIf="translated_control_panel_enabled && !translatedDataEnabled">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">
@@ -197,7 +197,7 @@
             </mat-expansion-panel-header>
           </mat-expansion-panel>
         </div>
-
+        <!--  not in use -->
         <div *ngIf="future_control_panel_enabled && !futureDataEnabled">
           <mat-expansion-panel disabled="true">
             <mat-expansion-panel-header class="layer-panel-header">

--- a/src/interface/src/app/map/map.component.spec.ts
+++ b/src/interface/src/app/map/map.component.spec.ts
@@ -13,7 +13,7 @@ import { FormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { featureCollection, point } from '@turf/helpers';
 import * as L from 'leaflet';
 import 'leaflet.vectorgrid';
@@ -50,6 +50,8 @@ import {
   defaultMapViewOptions,
 } from './map.helper';
 import * as esri from 'esri-leaflet';
+import { MockProvider } from 'ng-mocks';
+import { ShareMapService } from '../services/share-map.service';
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -192,6 +194,11 @@ describe('MapComponent', () => {
         { provide: PlanService, useValue: fakePlanStateService },
         { provide: SessionService, useValue: fakeSessionService },
         { provide: Router, useFactory: routerStub },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParams: {} } },
+        },
+        MockProvider(ShareMapService),
       ],
     });
     fixture = TestBed.createComponent(MapComponent);

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -140,7 +140,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
     // save map state before leaving page
     this.sessionService.setMapConfigs(this.maps.map((map: Map) => map.config));
     this.sessionService.setMapViewOptions(this.mapViewOptions$.getValue());
-    console.log(this.mapViewOptions$.value.center);
     return true;
   }
 
@@ -244,7 +243,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
 
   ngAfterViewInit(): void {
     const center = this.mapViewOptions$.value.center as LatLngTuple;
-    console.log(center);
     this.maps.forEach((map: Map) => {
       this.initMap(map, map.id, center, this.mapViewOptions$.value.zoom);
     });

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -311,6 +311,7 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
 
         this.sessionService.region$.pipe(take(1)).subscribe((region) => {
           if (result.mapViewOptions) {
+            this.changeMapCount(result.mapViewOptions?.numVisibleMaps);
             this.mapViewOptions$.next(result.mapViewOptions);
           }
 

--- a/src/interface/src/app/map/map.module.ts
+++ b/src/interface/src/app/map/map.module.ts
@@ -16,6 +16,7 @@ import { ConditionTreeComponent } from './map-control-panel/condition-tree/condi
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FeaturesModule } from '../features/features.module';
 import { OutsideRegionDialogComponent } from './outside-region-dialog/outside-region-dialog.component';
+import { InvalidLinkDialogComponent } from './invalid-link-dialog/invalid-link-dialog.component';
 
 @NgModule({
   declarations: [
@@ -31,6 +32,7 @@ import { OutsideRegionDialogComponent } from './outside-region-dialog/outside-re
     MapConfigSummaryComponent,
     ConditionTreeComponent,
     OutsideRegionDialogComponent,
+    InvalidLinkDialogComponent,
   ],
   imports: [
     CommonModule,

--- a/src/interface/src/app/map/outside-region-dialog/outside-region-dialog.component.html
+++ b/src/interface/src/app/map/outside-region-dialog/outside-region-dialog.component.html
@@ -3,11 +3,6 @@
   planning area to be inside the region.
 </p>
 
-<button
-  mat-button
-  type="submit"
-  (click)="cancel()"
-  color="primary"
-  data-id="save">
+<button mat-button type="submit" (click)="cancel()" color="primary">
   Close
 </button>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -167,6 +167,7 @@ export class CreateScenariosComponent implements OnInit {
         }
 
         this.disableForms();
+        console.log(scenario.configuration.treatment_question);
         if (scenario.scenario_result) {
           this.scenarioResults = scenario.scenario_result;
           this.scenarioState = scenario.scenario_result?.status;

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -167,7 +167,6 @@ export class CreateScenariosComponent implements OnInit {
         }
 
         this.disableForms();
-        console.log(scenario.configuration.treatment_question);
         if (scenario.scenario_result) {
           this.scenarioResults = scenario.scenario_result;
           this.scenarioState = scenario.scenario_result?.status;

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -27,7 +27,6 @@ export class SetPrioritiesComponent implements OnInit {
   treatmentGoals$ = this.planStateService.treatmentGoalsConfig$.pipe(
     distinctUntilChanged(),
     tap((s) => {
-      console.log(s);
       this._treatmentGoals = s;
       // if we got new treatment goals we'll need to find the item again and set it as selected
       const value = this.goalsForm.get('selectedQuestion')?.value;
@@ -79,7 +78,6 @@ export class SetPrioritiesComponent implements OnInit {
   }
 
   setFormData(question: TreatmentQuestionConfig) {
-    console.log('setting form data', question);
     if (this._treatmentGoals) {
       // We are losing the object reference somewhere (probably on this.planStateService.treatmentGoalsConfig$)
       // so when we simply `setValue` with `this.selectedTreatmentQuestion`, the object is

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.ts
@@ -27,6 +27,7 @@ export class SetPrioritiesComponent implements OnInit {
   treatmentGoals$ = this.planStateService.treatmentGoalsConfig$.pipe(
     distinctUntilChanged(),
     tap((s) => {
+      console.log(s);
       this._treatmentGoals = s;
       // if we got new treatment goals we'll need to find the item again and set it as selected
       const value = this.goalsForm.get('selectedQuestion')?.value;
@@ -78,6 +79,7 @@ export class SetPrioritiesComponent implements OnInit {
   }
 
   setFormData(question: TreatmentQuestionConfig) {
+    console.log('setting form data', question);
     if (this._treatmentGoals) {
       // We are losing the object reference somewhere (probably on this.planStateService.treatmentGoalsConfig$)
       // so when we simply `setValue` with `this.selectedTreatmentQuestion`, the object is

--- a/src/interface/src/app/services/session.service.ts
+++ b/src/interface/src/app/services/session.service.ts
@@ -8,7 +8,7 @@ import {
 } from '../map/map.helper';
 
 /** How often the user's session should be saved to local storage (in ms). */
-const SESSION_SAVE_INTERVAL = 60000;
+const SESSION_SAVE_INTERVAL = 600;
 
 /**
  * The session service keeps track of where the guest or logged-in user left

--- a/src/interface/src/app/services/session.service.ts
+++ b/src/interface/src/app/services/session.service.ts
@@ -52,8 +52,8 @@ export class SessionService {
   }
 
   /** Emits the map configs and saves them in local storage. */
-  setMapConfigs(value: MapConfig[]) {
-    var regionIndex: Region | null = this.region$.getValue();
+  setMapConfigs(value: MapConfig[], region?: Region) {
+    var regionIndex: Region | null = region || this.region$.getValue();
     if (!regionIndex) {
       regionIndex = Region.SIERRA_NEVADA;
     }

--- a/src/interface/src/app/services/share-map.service.spec.ts
+++ b/src/interface/src/app/services/share-map.service.spec.ts
@@ -4,6 +4,7 @@ import { ShareMapService } from './share-map.service';
 import { firstValueFrom, of } from 'rxjs';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { WINDOW } from './window.service';
+import { Region } from '../types';
 
 describe('ShareMapService', () => {
   let service: ShareMapService;
@@ -36,13 +37,21 @@ describe('ShareMapService', () => {
           created_at: '',
           link_code: 'superlink',
           updated_at: '',
-          view_state: {},
+          view_state: {
+            mapConfig: [],
+            region: Region.SIERRA_NEVADA,
+            mapViewOptions: null,
+          },
         })
       );
       const link = await firstValueFrom(
-        service.getSharedLink({ data: 'some data' })
+        service.getSharedLink({
+          mapConfig: [],
+          region: Region.SIERRA_NEVADA,
+          mapViewOptions: null,
+        })
       );
-      expect(link).toBe('http://testingurl.com/map/superlink');
+      expect(link).toBe('http://testingurl.com/map?link=superlink');
     });
   });
 });

--- a/src/interface/src/app/services/share-map.service.spec.ts
+++ b/src/interface/src/app/services/share-map.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ShareMapService } from './share-map.service';
+
+describe('ShareMapService', () => {
+  let service: ShareMapService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ShareMapService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/services/share-map.service.spec.ts
+++ b/src/interface/src/app/services/share-map.service.spec.ts
@@ -1,16 +1,48 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ShareMapService } from './share-map.service';
+import { firstValueFrom, of } from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { WINDOW } from './window.service';
 
 describe('ShareMapService', () => {
   let service: ShareMapService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: WINDOW,
+          useValue: {
+            location: {
+              origin: 'http://testingurl.com',
+            },
+          },
+        },
+      ],
+    });
     service = TestBed.inject(ShareMapService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('getSharedLink', () => {
+    it('should return a link with the right url', async () => {
+      spyOn(service, 'createShareLink').and.returnValue(
+        of({
+          created_at: '',
+          link_code: 'superlink',
+          updated_at: '',
+          view_state: {},
+        })
+      );
+      const link = await firstValueFrom(
+        service.getSharedLink({ data: 'some data' })
+      );
+      expect(link).toBe('http://testingurl.com/map/superlink');
+    });
   });
 });

--- a/src/interface/src/app/services/share-map.service.ts
+++ b/src/interface/src/app/services/share-map.service.ts
@@ -1,0 +1,40 @@
+import { Inject, Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+import { BackendConstants } from '../backend-constants';
+import { HttpClient } from '@angular/common/http';
+import { DOCUMENT } from '@angular/common';
+
+interface CreatedLink {
+  created_at: string;
+  link_code: string;
+  updated_at: string;
+  user_id?: string;
+  view_state: any;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ShareMapService {
+  constructor(
+    private http: HttpClient,
+    @Inject(DOCUMENT) private readonly document: Document
+  ) {}
+
+  getSharedLink(mapData: any): Observable<string> {
+    const origin = this.document.location.origin;
+    return this.createShareLink(mapData).pipe(
+      map((createdLink) => origin + '/map/' + createdLink.link_code)
+    );
+  }
+
+  private createShareLink(mapData: any): Observable<CreatedLink> {
+    return this.http.post<CreatedLink>(
+      BackendConstants.END_POINT + '/planning/create_link/',
+      {
+        view_state: mapData,
+      },
+      { withCredentials: true }
+    );
+  }
+}

--- a/src/interface/src/app/services/share-map.service.ts
+++ b/src/interface/src/app/services/share-map.service.ts
@@ -3,13 +3,20 @@ import { map, Observable } from 'rxjs';
 import { BackendConstants } from '../backend-constants';
 import { HttpClient } from '@angular/common/http';
 import { WINDOW } from './window.service';
+import { MapConfig, MapViewOptions, Region } from '../types';
+
+interface ViewState {
+  mapViewOptions: MapViewOptions | null;
+  mapConfig: MapConfig[];
+  region: Region;
+}
 
 interface CreatedLink {
   created_at: string;
   link_code: string;
   updated_at: string;
   user_id?: string;
-  view_state: any;
+  view_state: ViewState;
 }
 
 @Injectable({
@@ -21,19 +28,30 @@ export class ShareMapService {
     @Inject(WINDOW) private readonly window: Window
   ) {}
 
-  getSharedLink(mapData: any): Observable<string> {
+  getSharedLink(mapData: ViewState): Observable<string> {
     const origin = this.window.location.origin;
     return this.createShareLink(mapData).pipe(
-      map((createdLink) => origin + '/map/' + createdLink.link_code)
+      map((createdLink) => origin + '/map?link=' + createdLink.link_code)
     );
   }
 
-  createShareLink(mapData: any): Observable<CreatedLink> {
+  createShareLink(mapData: ViewState): Observable<CreatedLink> {
     return this.http.post<CreatedLink>(
       BackendConstants.END_POINT + '/planning/create_link/',
       {
         view_state: mapData,
       },
+      { withCredentials: true }
+    );
+  }
+
+  getMapDataFromLink(link: string) {
+    return this.loadSharedLink(link).pipe(map((data) => data.view_state));
+  }
+
+  loadSharedLink(link: string) {
+    return this.http.get<CreatedLink>(
+      BackendConstants.END_POINT.concat('/planning/shared_link/', link),
       { withCredentials: true }
     );
   }

--- a/src/interface/src/app/services/share-map.service.ts
+++ b/src/interface/src/app/services/share-map.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { map, Observable } from 'rxjs';
 import { BackendConstants } from '../backend-constants';
 import { HttpClient } from '@angular/common/http';
-import { DOCUMENT } from '@angular/common';
+import { WINDOW } from './window.service';
 
 interface CreatedLink {
   created_at: string;
@@ -18,17 +18,17 @@ interface CreatedLink {
 export class ShareMapService {
   constructor(
     private http: HttpClient,
-    @Inject(DOCUMENT) private readonly document: Document
+    @Inject(WINDOW) private readonly window: Window
   ) {}
 
   getSharedLink(mapData: any): Observable<string> {
-    const origin = this.document.location.origin;
+    const origin = this.window.location.origin;
     return this.createShareLink(mapData).pipe(
       map((createdLink) => origin + '/map/' + createdLink.link_code)
     );
   }
 
-  private createShareLink(mapData: any): Observable<CreatedLink> {
+  createShareLink(mapData: any): Observable<CreatedLink> {
     return this.http.post<CreatedLink>(
       BackendConstants.END_POINT + '/planning/create_link/',
       {

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.html
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.html
@@ -75,7 +75,12 @@
         </div>
       </mat-menu>
     </button>
-    <button mat-button class="action-button" (click)="share()" data-id="share">
+    <button
+      mat-button
+      class="action-button"
+      (click)="share()"
+      data-id="share"
+      *ngIf="area === 'EXPLORE'">
       Share
     </button>
 

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.html
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.html
@@ -75,6 +75,9 @@
         </div>
       </mat-menu>
     </button>
+    <button mat-button class="action-button" (click)="share()" data-id="share">
+      Share
+    </button>
 
     <button mat-button class="action-button" (click)="print()" data-id="print">
       <mat-icon class="material-symbols-outlined" color="primary">

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.ts
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Inject, Input, Output } from '@angular/core';
 import { WINDOW } from '../../services/window.service';
+import { MatDialog } from '@angular/material/dialog';
+import { ShareExploreDialogComponent } from '../share-explore-dialog/share-explore-dialog.component';
 
 export interface Breadcrumb {
   name: string;
@@ -16,9 +18,16 @@ export class NavBarComponent {
   @Input() area: 'SCENARIOS' | 'EXPLORE' | 'SCENARIO' = 'EXPLORE';
   @Output() goBack = new EventEmitter<void>();
 
-  constructor(@Inject(WINDOW) private window: Window) {}
+  constructor(
+    @Inject(WINDOW) private window: Window,
+    private dialog: MatDialog
+  ) {}
 
   print() {
     this.window.print();
+  }
+
+  share() {
+    this.dialog.open(ShareExploreDialogComponent);
   }
 }

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.ts
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.ts
@@ -28,6 +28,6 @@ export class NavBarComponent {
   }
 
   share() {
-    this.dialog.open(ShareExploreDialogComponent);
+    this.dialog.open(ShareExploreDialogComponent, { restoreFocus: false });
   }
 }

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.html
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.html
@@ -1,14 +1,13 @@
+<mat-icon class="close-btn" (click)="cancel()">close</mat-icon>
 <h1 mat-dialog-title>Share link</h1>
 <section>
-  <mat-form-field class="full">
-    <input
-      matInput
-      [disabled]="!link"
-      readonly
-      [value]="link || ''"
-      (click)="selectText($event)"
-      class="link-textfield" />
-  </mat-form-field>
+  <input
+    class="link-textfield"
+    readonly
+    [value]="link"
+    (click)="selectText($event)"
+    [disabled]="!link" />
+
   <mat-spinner diameter="24" *ngIf="!link" class="loader"></mat-spinner>
   <mat-error *ngIf="error"> There was an error generating the link.</mat-error>
 

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.html
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.html
@@ -1,0 +1,29 @@
+<h1 mat-dialog-title>Share link</h1>
+<section>
+  <mat-form-field class="full">
+    <input
+      matInput
+      [disabled]="!link"
+      readonly
+      [value]="link || ''"
+      (click)="selectText($event)"
+      class="link-textfield" />
+  </mat-form-field>
+  <mat-spinner diameter="24" *ngIf="!link" class="loader"></mat-spinner>
+  <mat-error *ngIf="error"> There was an error generating the link.</mat-error>
+
+  <button
+    mat-flat-button
+    type="button"
+    color="primary"
+    data-id="copy"
+    (click)="copy()"
+    [disabled]="!link">
+    COPY LINK
+  </button>
+</section>
+
+<div class="info">
+  <mat-icon>info</mat-icon>
+  <span>Link is valid for 60 days.</span>
+</div>

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.scss
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.scss
@@ -1,0 +1,35 @@
+:host {
+  display: block;
+  min-width: 480px;
+}
+
+section {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  position: relative;
+}
+
+
+.info {
+  align-items: center;
+
+  display: flex;
+  gap: 10px;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 15px;
+}
+
+.full {
+  flex: 1;
+}
+
+.link-textfield {
+  user-select: all;
+}
+
+.loader {
+  position: absolute;
+  bottom: 23px;
+}

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.scss
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.scss
@@ -1,6 +1,9 @@
+@import "../../../styles/colors";
+
 :host {
   display: block;
   min-width: 480px;
+  position: relative;
 }
 
 section {
@@ -8,28 +11,41 @@ section {
   align-items: baseline;
   gap: 10px;
   position: relative;
+  background-color: $color-light-gray;
+  padding: 8px;
+  border-radius: 3px;
 }
 
 
 .info {
   align-items: center;
-
   display: flex;
   gap: 10px;
   font-size: 13px;
   font-weight: 400;
   line-height: 15px;
+  padding: 10px 0;
 }
 
-.full {
-  flex: 1;
-}
 
 .link-textfield {
+  flex: 1;
   user-select: all;
+  cursor: pointer;
+  padding: 7px 0;
+  color: $color-text-dark;
+  background: none;
+  border: none;
 }
 
 .loader {
   position: absolute;
-  bottom: 23px;
+  top: 13px;
+}
+
+.close-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  cursor: pointer;
 }

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.spec.ts
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShareExploreDialogComponent } from './share-explore-dialog.component';
+
+describe('ShareExploreDialogComponent', () => {
+  let component: ShareExploreDialogComponent;
+  let fixture: ComponentFixture<ShareExploreDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ShareExploreDialogComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ShareExploreDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.spec.ts
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.spec.ts
@@ -2,15 +2,21 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ShareExploreDialogComponent } from './share-explore-dialog.component';
 
+import { MaterialModule } from '../../material/material.module';
+import { MockProvider } from 'ng-mocks';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ShareMapService } from '../../services/share-map.service';
+
 describe('ShareExploreDialogComponent', () => {
   let component: ShareExploreDialogComponent;
   let fixture: ComponentFixture<ShareExploreDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ShareExploreDialogComponent ]
-    })
-    .compileComponents();
+      declarations: [ShareExploreDialogComponent],
+      imports: [MaterialModule],
+      providers: [MockProvider(MatDialogRef), MockProvider(ShareMapService)],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ShareExploreDialogComponent);
     component = fixture.componentInstance;

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.ts
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { SessionService } from '../../services';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SNACK_ERROR_CONFIG, SNACK_NOTICE_CONFIG } from '../constants';
+import { firstValueFrom } from 'rxjs';
+import { ShareMapService } from '../../services/share-map.service';
+
+@Component({
+  selector: 'app-share-explore-dialog',
+  templateUrl: './share-explore-dialog.component.html',
+  styleUrls: ['./share-explore-dialog.component.scss'],
+})
+export class ShareExploreDialogComponent implements OnInit {
+  link: string | null = null;
+  error = false;
+  selectedRegion$ = this.sessionService.region$.asObservable();
+
+  constructor(
+    private dialogRef: MatDialogRef<ShareExploreDialogComponent>,
+    private sessionService: SessionService,
+    private shareMapService: ShareMapService,
+    private matSnackBar: MatSnackBar // @Inject(MAT_DIALOG_DATA) public data: PlanCreateDialogData
+  ) {}
+
+  async submit() {
+    this.matSnackBar.open(
+      '[Error] Unable to create plan due to backend error.',
+      'Dismiss',
+      SNACK_ERROR_CONFIG
+    );
+  }
+
+  //TODO add cancel button
+  cancel(): void {
+    this.dialogRef.close();
+  }
+
+  async ngOnInit() {
+    const mapViewOptions = await firstValueFrom(
+      this.sessionService.mapViewOptions$
+    );
+
+    const mapConfigs = await firstValueFrom(this.sessionService.mapConfigs$);
+
+    const data = { mapViewOptions, mapConfigs };
+    this.shareMapService.getSharedLink(data).subscribe((linkUrl) => {
+      this.link = linkUrl;
+    });
+  }
+
+  selectText(event: Event) {
+    const target = event.target as HTMLInputElement;
+    target.select();
+  }
+
+  copy() {
+    navigator.clipboard.writeText(this.link || '');
+    this.matSnackBar.open(
+      'Link copied to clipboard',
+      'Dismiss',
+      SNACK_NOTICE_CONFIG
+    );
+  }
+}

--- a/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.ts
+++ b/src/interface/src/app/shared/share-explore-dialog/share-explore-dialog.component.ts
@@ -20,7 +20,7 @@ export class ShareExploreDialogComponent implements OnInit {
     private dialogRef: MatDialogRef<ShareExploreDialogComponent>,
     private sessionService: SessionService,
     private shareMapService: ShareMapService,
-    private matSnackBar: MatSnackBar // @Inject(MAT_DIALOG_DATA) public data: PlanCreateDialogData
+    private matSnackBar: MatSnackBar
   ) {}
 
   async submit() {
@@ -42,11 +42,14 @@ export class ShareExploreDialogComponent implements OnInit {
     );
 
     const mapConfigs = await firstValueFrom(this.sessionService.mapConfigs$);
-
-    const data = { mapViewOptions, mapConfigs };
-    this.shareMapService.getSharedLink(data).subscribe((linkUrl) => {
-      this.link = linkUrl;
-    });
+    const region = await firstValueFrom(this.selectedRegion$);
+    if (mapConfigs && region) {
+      const mapConfig = mapConfigs[region];
+      const data = { mapViewOptions, mapConfig, region };
+      this.shareMapService.getSharedLink(data).subscribe((linkUrl) => {
+        this.link = linkUrl;
+      });
+    }
   }
 
   selectText(event: Event) {
@@ -56,10 +59,6 @@ export class ShareExploreDialogComponent implements OnInit {
 
   copy() {
     navigator.clipboard.writeText(this.link || '');
-    this.matSnackBar.open(
-      'Link copied to clipboard',
-      'Dismiss',
-      SNACK_NOTICE_CONFIG
-    );
+    this.matSnackBar.open('Link copied ', 'Dismiss', SNACK_NOTICE_CONFIG);
   }
 }

--- a/src/interface/src/app/shared/shared.module.ts
+++ b/src/interface/src/app/shared/shared.module.ts
@@ -13,6 +13,7 @@ import { TypeSafeMatCellDef } from './type-safe-mat-cell/type-safe-mat-cell-def.
 import { FieldAlertComponent } from './field-alert/field-alert.component';
 import { CreditsBlurbComponent } from './credits-blurb/credits-blurb.component';
 import { FormMessageBoxComponent } from './form-message-box/form-message-box.component';
+import { ShareExploreDialogComponent } from './share-explore-dialog/share-explore-dialog.component';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,7 @@ import { FormMessageBoxComponent } from './form-message-box/form-message-box.com
     FieldAlertComponent,
     CreditsBlurbComponent,
     FormMessageBoxComponent,
+    ShareExploreDialogComponent,
   ],
   exports: [
     FileUploaderComponent,

--- a/src/interface/src/app/types/data.types.ts
+++ b/src/interface/src/app/types/data.types.ts
@@ -5,6 +5,7 @@ export interface BoundaryConfig {
   boundary_name: string;
   vector_name: string;
   shape_name: string;
+  region_name?: string;
 }
 
 export interface ConditionsConfig extends DataLayerConfig {

--- a/src/planscape/config/boundary.json
+++ b/src/planscape/config/boundary.json
@@ -1,269 +1,269 @@
 {
-    "__comment1": "TODO: replace filename for SoCal's HUC10 when it loses its dash.",
-    "regions": [
+  "__comment1": "TODO: replace filename for SoCal's HUC10 when it loses its dash.",
+  "regions": [
+    {
+      "region_name": "southern-california",
+      "display_name": "Southern California",
+      "boundaries": [
         {
-            "region_name": "southern-california",
-            "display_name": "Southern California",
-            "boundaries": [
-                {
-                    "boundary_name": "southern_california-counties",
-                    "display_name": "Counties",
-                    "vector_name": "southern-california:vector_county",
-                    "region_name": "none",
-                    "filepath": "cnty19_1.shp",
-                    "source_srs": 3857,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "COUNTY_NAM"
-                },
-                {
-                    "boundary_name": "southern_california-huc12",
-                    "display_name": "HUC-12",
-                    "vector_name": "southern-california:vector_huc12",
-                    "region_name": "none",
-                    "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
-                    "source_srs": 4326,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "huc10",
-                    "display_name": "HUC-10",
-                    "vector_name": "southern-california:vector_huc-10",
-                    "region_name": "none",
-                    "filepath": "WBD_USGS_HUC10_CA.shp",
-                    "source_srs": 6414,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "southern_california-USFS",
-                    "display_name": "National Forests",
-                    "vector_name": "southern-california:vector_forests",
-                    "region_name": "none",
-                    "filepath": "California_USFS.shp",
-                    "source_srs": 4269,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FORESTNAME"
-                },
-                {
-                    "boundary_name": "southern_california-RecentFires",
-                    "display_name": "Fires (1990 through 2021)",
-                    "vector_name": "southern-california:vector_recent-fires",
-                    "region_name": "none",
-                    "filepath": "recent-fires.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FIRE_NAME"
-                },
-                {
-                    "boundary_name": "southern_california-PrescribedBurns",
-                    "display_name": "Prescribed Burns (through 2021)",
-                    "vector_name": "southern-california:vector_prescribed-burns",
-                    "region_name": "none",
-                    "filepath": "prescribed-burns.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "TREATMEN_1"
-                }
-            ]
+          "boundary_name": "southern_california-counties",
+          "display_name": "Counties",
+          "vector_name": "southern-california:vector_county",
+          "region_name": "Southern California",
+          "filepath": "cnty19_1.shp",
+          "source_srs": 3857,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "COUNTY_NAM"
         },
         {
-            "region_name": "sierra-nevada",
-            "display_name": "Sierra Nevada",
-            "boundaries": [
-                {
-                    "boundary_name": "sierra-nevada-counties",
-                    "display_name": "Counties",
-                    "vector_name": "sierra-nevada:vector_county",
-                    "region_name": "none",
-                    "filepath": "cnty19_1.shp",
-                    "source_srs": 3857,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "COUNTY_NAM"
-                },
-                {
-                    "boundary_name": "sierra-nevada-huc12",
-                    "display_name": "HUC-12",
-                    "vector_name": "sierra-nevada:vector_huc12",
-                    "region_name": "none",
-                    "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
-                    "source_srs": 4326,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "sierra-nevada-huc10",
-                    "display_name": "HUC-10",
-                    "vector_name": "sierra-nevada:vector_huc10",
-                    "region_name": "none",
-                    "filepath": "WBD_USGS_HUC10_CA.shp",
-                    "source_srs": 6414,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "sierra-nevada-USFS",
-                    "display_name": "National Forests",
-                    "vector_name": "sierra-nevada:vector_forests",
-                    "region_name": "none",
-                    "filepath": "California_USFS.shp",
-                    "source_srs": 4269,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FORESTNAME"
-                },
-                {
-                    "boundary_name": "sierra-nevada-RecentFires",
-                    "display_name": "Fires (1990 through 2021)",
-                    "vector_name": "sierra-nevada:vector_recent-fires",
-                    "region_name": "none",
-                    "filepath": "recent-fires.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FIRE_NAME"
-                },
-                {
-                    "boundary_name": "sierra-nevada-PrescribedBurns",
-                    "display_name": "Prescribed Burns (through 2021)",
-                    "vector_name": "sierra-nevada:vector_prescribed-burns",
-                    "region_name": "none",
-                    "filepath": "prescribed-burns.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "TREATMEN_1"
-                }
-            ]
+          "boundary_name": "southern_california-huc12",
+          "display_name": "HUC-12",
+          "vector_name": "southern-california:vector_huc12",
+          "region_name": "Southern California",
+          "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+          "source_srs": 4326,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
         },
         {
-            "region_name": "central-coast",
-            "display_name": "Central Coast",
-            "boundaries": [
-                {
-                    "boundary_name": "central-coast-counties",
-                    "display_name": "Counties",
-                    "vector_name": "central-coast:vector_county",
-                    "region_name": "none",
-                    "filepath": "cnty19_1.shp",
-                    "source_srs": 3857,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "COUNTY_NAM"
-                },
-                {
-                    "boundary_name": "central-coast-huc12",
-                    "display_name": "HUC-12",
-                    "vector_name": "central-coast:vector_huc12",
-                    "region_name": "none",
-                    "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
-                    "source_srs": 4326,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "central-coast-huc10",
-                    "display_name": "HUC-10",
-                    "vector_name": "central-coast:vector_huc10",
-                    "region_name": "none",
-                    "filepath": "WBD_USGS_HUC10_CA.shp",
-                    "source_srs": 6414,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "central-coast-USFS",
-                    "display_name": "National Forests",
-                    "vector_name": "central-coast:vector_forests",
-                    "region_name": "none",
-                    "filepath": "California_USFS.shp",
-                    "source_srs": 4269,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FORESTNAME"
-                },
-                {
-                    "boundary_name": "central-coast-RecentFires",
-                    "display_name": "Fires (1990 through 2021)",
-                    "vector_name": "central-coast:vector_recent-fires",
-                    "region_name": "none",
-                    "filepath": "recent-fires.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FIRE_NAME"
-                },
-                {
-                    "boundary_name": "central-coast-PrescribedBurns",
-                    "display_name": "Prescribed Burns (through 2021)",
-                    "vector_name": "central-coast:vector_prescribed-burns",
-                    "region_name": "none",
-                    "filepath": "prescribed-burns.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "TREATMEN_1"
-                }
-            ]
+          "boundary_name": "huc10",
+          "display_name": "HUC-10",
+          "vector_name": "southern-california:vector_huc-10",
+          "region_name": "Southern California",
+          "filepath": "WBD_USGS_HUC10_CA.shp",
+          "source_srs": 6414,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
         },
         {
-            "region_name": "northern-california",
-            "display_name": "Northern California",
-            "boundaries": [
-                {
-                    "boundary_name": "northern-california",
-                    "display_name": "Counties",
-                    "vector_name": "northern-california:vector_county",
-                    "region_name": "none",
-                    "filepath": "cnty19_1.shp",
-                    "source_srs": 3857,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "COUNTY_NAM"
-                },
-                {
-                    "boundary_name": "northern-california-huc12",
-                    "display_name": "HUC-12",
-                    "vector_name": "northern-california:vector_huc12",
-                    "region_name": "none",
-                    "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
-                    "source_srs": 4326,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "northern-california-huc10",
-                    "display_name": "HUC-10",
-                    "vector_name": "northern-california:vector_huc10",
-                    "region_name": "none",
-                    "filepath": "WBD_USGS_HUC10_CA.shp",
-                    "source_srs": 6414,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "Name"
-                },
-                {
-                    "boundary_name": "northern-california-USFS",
-                    "display_name": "National Forests",
-                    "vector_name": "northern-california:vector_forests",
-                    "region_name": "none",
-                    "filepath": "California_USFS.shp",
-                    "source_srs": 4269,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FORESTNAME"
-                },
-                {
-                    "boundary_name": "northern-california-RecentFires",
-                    "display_name": "Fires (1990 through 2021)",
-                    "vector_name": "northern-california:vector_recent-fires",
-                    "region_name": "none",
-                    "filepath": "recent-fires.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "FIRE_NAME"
-                },
-                {
-                    "boundary_name": "northern-california-PrescribedBurns",
-                    "display_name": "Prescribed Burns (through 2021)",
-                    "vector_name": "northern-california:vector_prescribed-burns",
-                    "region_name": "none",
-                    "filepath": "prescribed-burns.shp",
-                    "source_srs": 3310,
-                    "geometry_type": "MULTIPOLYGON",
-                    "shape_name": "TREATMEN_1"
-                }
-            ]
+          "boundary_name": "southern_california-USFS",
+          "display_name": "National Forests",
+          "vector_name": "southern-california:vector_forests",
+          "region_name": "Southern California",
+          "filepath": "California_USFS.shp",
+          "source_srs": 4269,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FORESTNAME"
+        },
+        {
+          "boundary_name": "southern_california-RecentFires",
+          "display_name": "Fires (1990 through 2021)",
+          "vector_name": "southern-california:vector_recent-fires",
+          "region_name": "Southern California",
+          "filepath": "recent-fires.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FIRE_NAME"
+        },
+        {
+          "boundary_name": "southern_california-PrescribedBurns",
+          "display_name": "Prescribed Burns (through 2021)",
+          "vector_name": "southern-california:vector_prescribed-burns",
+          "region_name": "Southern California",
+          "filepath": "prescribed-burns.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "TREATMEN_1"
         }
-    ]
+      ]
+    },
+    {
+      "region_name": "sierra-nevada",
+      "display_name": "Sierra Nevada",
+      "boundaries": [
+        {
+          "boundary_name": "sierra-nevada-counties",
+          "display_name": "Counties",
+          "vector_name": "sierra-nevada:vector_county",
+          "region_name": "Sierra Nevada",
+          "filepath": "cnty19_1.shp",
+          "source_srs": 3857,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "COUNTY_NAM"
+        },
+        {
+          "boundary_name": "sierra-nevada-huc12",
+          "display_name": "HUC-12",
+          "vector_name": "sierra-nevada:vector_huc12",
+          "region_name": "Sierra Nevada",
+          "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+          "source_srs": 4326,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
+        },
+        {
+          "boundary_name": "sierra-nevada-huc10",
+          "display_name": "HUC-10",
+          "vector_name": "sierra-nevada:vector_huc10",
+          "region_name": "Sierra Nevada",
+          "filepath": "WBD_USGS_HUC10_CA.shp",
+          "source_srs": 6414,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
+        },
+        {
+          "boundary_name": "sierra-nevada-USFS",
+          "display_name": "National Forests",
+          "vector_name": "sierra-nevada:vector_forests",
+          "region_name": "Sierra Nevada",
+          "filepath": "California_USFS.shp",
+          "source_srs": 4269,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FORESTNAME"
+        },
+        {
+          "boundary_name": "sierra-nevada-RecentFires",
+          "display_name": "Fires (1990 through 2021)",
+          "vector_name": "sierra-nevada:vector_recent-fires",
+          "region_name": "Sierra Nevada",
+          "filepath": "recent-fires.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FIRE_NAME"
+        },
+        {
+          "boundary_name": "sierra-nevada-PrescribedBurns",
+          "display_name": "Prescribed Burns (through 2021)",
+          "vector_name": "sierra-nevada:vector_prescribed-burns",
+          "region_name": "Sierra Nevada",
+          "filepath": "prescribed-burns.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "TREATMEN_1"
+        }
+      ]
+    },
+    {
+      "region_name": "central-coast",
+      "display_name": "Central Coast",
+      "boundaries": [
+        {
+          "boundary_name": "central-coast-counties",
+          "display_name": "Counties",
+          "vector_name": "central-coast:vector_county",
+          "region_name": "Central Coast",
+          "filepath": "cnty19_1.shp",
+          "source_srs": 3857,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "COUNTY_NAM"
+        },
+        {
+          "boundary_name": "central-coast-huc12",
+          "display_name": "HUC-12",
+          "vector_name": "central-coast:vector_huc12",
+          "region_name": "Central Coast",
+          "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+          "source_srs": 4326,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
+        },
+        {
+          "boundary_name": "central-coast-huc10",
+          "display_name": "HUC-10",
+          "vector_name": "central-coast:vector_huc10",
+          "region_name": "Central Coast",
+          "filepath": "WBD_USGS_HUC10_CA.shp",
+          "source_srs": 6414,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
+        },
+        {
+          "boundary_name": "central-coast-USFS",
+          "display_name": "National Forests",
+          "vector_name": "central-coast:vector_forests",
+          "region_name": "Central Coast",
+          "filepath": "California_USFS.shp",
+          "source_srs": 4269,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FORESTNAME"
+        },
+        {
+          "boundary_name": "central-coast-RecentFires",
+          "display_name": "Fires (1990 through 2021)",
+          "vector_name": "central-coast:vector_recent-fires",
+          "region_name": "Central Coast",
+          "filepath": "recent-fires.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FIRE_NAME"
+        },
+        {
+          "boundary_name": "central-coast-PrescribedBurns",
+          "display_name": "Prescribed Burns (through 2021)",
+          "vector_name": "central-coast:vector_prescribed-burns",
+          "region_name": "Central Coast",
+          "filepath": "prescribed-burns.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "TREATMEN_1"
+        }
+      ]
+    },
+    {
+      "region_name": "northern-california",
+      "display_name": "Northern California",
+      "boundaries": [
+        {
+          "boundary_name": "northern-california",
+          "display_name": "Counties",
+          "vector_name": "northern-california:vector_county",
+          "region_name": "Northern California",
+          "filepath": "cnty19_1.shp",
+          "source_srs": 3857,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "COUNTY_NAM"
+        },
+        {
+          "boundary_name": "northern-california-huc12",
+          "display_name": "HUC-12",
+          "vector_name": "northern-california:vector_huc12",
+          "region_name": "Northern California",
+          "filepath": "ACE_HUC12s_WebMerc_1mXY.shp",
+          "source_srs": 4326,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
+        },
+        {
+          "boundary_name": "northern-california-huc10",
+          "display_name": "HUC-10",
+          "vector_name": "northern-california:vector_huc10",
+          "region_name": "Northern California",
+          "filepath": "WBD_USGS_HUC10_CA.shp",
+          "source_srs": 6414,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "Name"
+        },
+        {
+          "boundary_name": "northern-california-USFS",
+          "display_name": "National Forests",
+          "vector_name": "northern-california:vector_forests",
+          "region_name": "Northern California",
+          "filepath": "California_USFS.shp",
+          "source_srs": 4269,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FORESTNAME"
+        },
+        {
+          "boundary_name": "northern-california-RecentFires",
+          "display_name": "Fires (1990 through 2021)",
+          "vector_name": "northern-california:vector_recent-fires",
+          "region_name": "Northern California",
+          "filepath": "recent-fires.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "FIRE_NAME"
+        },
+        {
+          "boundary_name": "northern-california-PrescribedBurns",
+          "display_name": "Prescribed Burns (through 2021)",
+          "vector_name": "northern-california:vector_prescribed-burns",
+          "region_name": "Northern California",
+          "filepath": "prescribed-burns.shp",
+          "source_srs": 3310,
+          "geometry_type": "MULTIPOLYGON",
+          "shape_name": "TREATMEN_1"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
- Adds option to share map
- Loads map state with link `/map?link={link_id}` 
- Shows modal with error if link is invalid, and removes `link_id` from the url

The shared link should
- Switch region to match the shared link
- Switch number of maps to match shared link
- Center maps according to link
- Show rrk layers according to link
- Show boundaries according to link
- Show existing projects according to link
- Select "active" map according to link (1 to 4)

