### PR TITLE
Remove auth requirement from create share link

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -151,7 +151,7 @@ class ScenarioSerializer(serializers.ModelSerializer):
 class SharedLinkSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = self.context["user"] or None
-        # allow anonymous link creation, but don't include a user record on creatoin
+        # allow anonymous link creation, but don't include a user record on creation
         if user.is_anonymous or user is None:
             link_obj = SharedLink.objects.create(**validated_data)
         else:

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -151,7 +151,11 @@ class ScenarioSerializer(serializers.ModelSerializer):
 class SharedLinkSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = self.context["user"] or None
-        link_obj = SharedLink.objects.create(**validated_data, user=user)
+        # allow anonymous link creation, but don't include a user record on creatoin
+        if user.is_anonymous:
+            link_obj = SharedLink.objects.create(**validated_data)
+        else:
+            link_obj = SharedLink.objects.create(**validated_data, user=user)
         return link_obj
 
     class Meta:

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -152,7 +152,7 @@ class SharedLinkSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = self.context["user"] or None
         # allow anonymous link creation, but don't include a user record on creatoin
-        if user.is_anonymous:
+        if user.is_anonymous or user is None:
             link_obj = SharedLink.objects.create(**validated_data)
         else:
             link_obj = SharedLink.objects.create(**validated_data, user=user)

--- a/src/planscape/planning/tests/test_views.py
+++ b/src/planscape/planning/tests/test_views.py
@@ -37,6 +37,7 @@ class CreateSharedLinkTest(APITransactionTestCase):
         self.assertTrue(
             json_response["link_code"].isalnum(), "Returned string is not alphanumeric"
         )
+        self.assertEqual(json_response["user_id"], self.user.pk)
 
     def test_create_shared_link_without_auth(self):
         view_state = {
@@ -63,6 +64,7 @@ class CreateSharedLinkTest(APITransactionTestCase):
         self.assertTrue(
             json_response["link_code"].isalnum(), "Returned string is not alphanumeric"
         )
+        self.assertEqual(json_response["user_id"], None)
 
     def test_getting_new_link(self):
         view_state = {

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -781,8 +781,6 @@ def get_shared_link(request: HttpRequest, link_code: str) -> HttpResponse:
 def create_shared_link(request: HttpRequest) -> HttpResponse:
     try:
         user = request.user
-        if not user.is_authenticated:
-            return JsonResponse({"error": "Authentication Required"}, status=401)
 
         body = json.loads(request.body)
         serializer = SharedLinkSerializer(data=body, context={"user": user})


### PR DESCRIPTION
This PR:
-removes auth requirement from create_share_link
-properly handles anonymous or missing user
-adds tests for these cases