### PR TITLE
remove the pw expiration middleware

### DIFF
--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -89,7 +89,6 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "password_policies.middleware.PasswordExpirationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "lockdown.middleware.LockdownMiddleware",


### PR DESCRIPTION
This doesn't appear to be getting used anyway, but it adds an unknown when we're testing password issues, so we decided to remove this.

fyi: We need to keep the `password_policies` package installed, since it's used for other things, but the PasswordExpirationMiddleware class isn't necessary for us.