### PR TITLE
saving url when not logged in and redirecting after log in

### DIFF
--- a/src/interface/src/app/login/login.component.spec.ts
+++ b/src/interface/src/app/login/login.component.spec.ts
@@ -60,7 +60,7 @@ describe('LoginComponent', () => {
     it('calls auth service if form is valid', () => {
       component.form.get('email')?.setValue('test@test.com');
       component.form.get('password')?.setValue('password');
-      fakeAuthService.login.and.returnValue(of(true));
+      fakeAuthService.login.and.returnValue(of('home'));
       const router = TestBed.inject(Router);
       spyOn(router, 'navigate');
       component.login();
@@ -76,7 +76,7 @@ describe('LoginComponent', () => {
       spyOn(router, 'navigate');
       component.form.get('email')?.setValue('test@test.com');
       component.form.get('password')?.setValue('password');
-      fakeAuthService.login.and.returnValue(of(true));
+      fakeAuthService.login.and.returnValue(of('home'));
       component.login();
       expect(router.navigate).toHaveBeenCalledOnceWith(['home']);
     });

--- a/src/interface/src/app/login/login.component.ts
+++ b/src/interface/src/app/login/login.component.ts
@@ -10,7 +10,6 @@ import {
   SNACK_ERROR_CONFIG,
   SNACK_NOTICE_CONFIG,
 } from '../../app/shared/constants';
-import { RedirectService } from '../services/redirect.service';
 
 @Component({
   selector: 'app-login',
@@ -29,8 +28,7 @@ export class LoginComponent {
     private authService: AuthService,
     private formBuilder: FormBuilder,
     private router: Router,
-    private snackbar: MatSnackBar,
-    private redirectService: RedirectService
+    private snackbar: MatSnackBar
   ) {
     this.form = this.formBuilder.group({
       email: this.formBuilder.control('', [
@@ -77,15 +75,8 @@ export class LoginComponent {
     const password: string = this.form.get('password')?.value;
 
     this.authService.login(email, password).subscribe(
-      (_) => {
-        const redirectUrl = this.redirectService.shouldRedirect(email);
-        // remove redirect
-        this.redirectService.removeRedirect();
-        if (redirectUrl) {
-          this.router.navigate([redirectUrl]);
-        } else {
-          this.router.navigate(['home']);
-        }
+      (redirect) => {
+        this.router.navigate([redirect]);
       },
       (error) => {
         // determine the cause of the error...

--- a/src/interface/src/app/login/login.component.ts
+++ b/src/interface/src/app/login/login.component.ts
@@ -6,10 +6,11 @@ import { AuthService } from '../services';
 import { FormMessageType } from '../types/data.types';
 
 import {
-  SNACK_NOTICE_CONFIG,
-  SNACK_ERROR_CONFIG,
   EMAIL_VALIDATION_REGEX,
+  SNACK_ERROR_CONFIG,
+  SNACK_NOTICE_CONFIG,
 } from '../../app/shared/constants';
+import { RedirectService } from '../services/redirect.service';
 
 @Component({
   selector: 'app-login',
@@ -28,7 +29,8 @@ export class LoginComponent {
     private authService: AuthService,
     private formBuilder: FormBuilder,
     private router: Router,
-    private snackbar: MatSnackBar
+    private snackbar: MatSnackBar,
+    private redirectService: RedirectService
   ) {
     this.form = this.formBuilder.group({
       email: this.formBuilder.control('', [
@@ -44,6 +46,7 @@ export class LoginComponent {
       this.emailError = 'Email must be in a proper format.';
     }
   }
+
   clearEmailErrors() {
     if (this.emailError !== '') {
       this.emailError = '';
@@ -74,7 +77,16 @@ export class LoginComponent {
     const password: string = this.form.get('password')?.value;
 
     this.authService.login(email, password).subscribe(
-      (_) => this.router.navigate(['home']),
+      (_) => {
+        const redirectUrl = this.redirectService.shouldRedirect(email);
+        // remove redirect
+        this.redirectService.removeRedirect();
+        if (redirectUrl) {
+          this.router.navigate([redirectUrl]);
+        } else {
+          this.router.navigate(['home']);
+        }
+      },
       (error) => {
         // determine the cause of the error...
         // errors from the backend can be in a variety of formats

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -1,7 +1,12 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { CanActivate, Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+} from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import { SNACK_NOTICE_CONFIG } from '../../app/shared/constants';
 import {
@@ -18,6 +23,7 @@ import {
 
 import { BackendConstants } from '../backend-constants';
 import { User } from '../types';
+import { RedirectService } from './redirect.service';
 
 interface LogoutResponse {
   detail: string;
@@ -343,13 +349,18 @@ export class AuthService {
 export class AuthGuard implements CanActivate {
   constructor(
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private redirectService: RedirectService
   ) {}
 
-  canActivate(): Observable<boolean> {
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean> {
     return this.authService.refreshLoggedInUser().pipe(
       map((_) => true),
       catchError((_) => {
+        this.redirectService.setRedirect(state.url);
         this.router.navigate(['login']);
         return of(false);
       })

--- a/src/interface/src/app/services/redirect.service.spec.ts
+++ b/src/interface/src/app/services/redirect.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RedirectService } from './redirect.service';
+
+describe('RedirectService', () => {
+  let service: RedirectService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RedirectService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/services/redirect.service.spec.ts
+++ b/src/interface/src/app/services/redirect.service.spec.ts
@@ -5,12 +5,84 @@ import { RedirectService } from './redirect.service';
 describe('RedirectService', () => {
   let service: RedirectService;
 
+  let store: any = {};
+  const mockLocalStorage = {
+    getItem: (key: string): string => {
+      return key in store ? store[key] : null;
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = `${value}`;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(RedirectService);
+    spyOn(localStorage, 'getItem').and.callFake(mockLocalStorage.getItem);
+    spyOn(localStorage, 'setItem').and.callFake(mockLocalStorage.setItem);
+    spyOn(localStorage, 'removeItem').and.callFake(mockLocalStorage.removeItem);
+    spyOn(localStorage, 'clear').and.callFake(mockLocalStorage.clear);
+    mockLocalStorage.clear();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('setRedirect', () => {
+    it('should save the url', () => {
+      const url = 'some-url/path/';
+      service.setRedirect(url);
+      const redirectData = service['getRedirectData']();
+      expect(redirectData).not.toBeNull();
+      expect(redirectData?.url).toEqual(url);
+      expect(redirectData?.userHash).toBeNull();
+    });
+
+    it('should save the url and hash the email if provided', () => {
+      const url = 'some-url/path/to/';
+      const email = 'someone@sig.com';
+      service.setRedirect(url, email);
+      const redirectData = service['getRedirectData']();
+      expect(redirectData).not.toBeNull();
+      expect(redirectData?.url).toEqual(url);
+      expect(redirectData?.userHash).not.toBeNull();
+      expect(redirectData?.userHash).not.toEqual(email);
+    });
+  });
+
+  describe('shouldRedirect', () => {
+    it('it should not redirect if no url saved', () => {
+      expect(service.shouldRedirect('someone@sig.com')).toEqual(false);
+    });
+
+    it('it should redirect if url is saved', () => {
+      const url = 'some-url/path/';
+      service.setRedirect(url);
+      const redirect = service.shouldRedirect('someone@sig.com');
+      expect(redirect).toEqual(url);
+    });
+
+    it('should not redirect if the emails mismatch', () => {
+      const url = 'some-url/path/to/';
+      const email = 'someone@sig.com';
+      service.setRedirect(url, email);
+      const redirect = service.shouldRedirect('someone-else@sig.com');
+      expect(redirect).toEqual(false);
+    });
+
+    it('should not redirect if the emails match', () => {
+      const url = 'some-url/path/to/';
+      const email = 'someone@sig.com';
+      service.setRedirect(url, email);
+      const redirect = service.shouldRedirect('someone@sig.com');
+      expect(redirect).toEqual(url);
+    });
   });
 });

--- a/src/interface/src/app/services/redirect.service.ts
+++ b/src/interface/src/app/services/redirect.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+
+export interface RedirectData {
+  url: string;
+  userHash?: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RedirectService {
+  readonly key = 'loginRedirect';
+
+  setRedirect(url: string, user?: string) {
+    const userHash = user ? Buffer.from(user).toString('base64') : null;
+    localStorage.setItem(this.key, JSON.stringify({ url, userHash }));
+  }
+
+  private getUrl(): string | null {
+    const redirectData = this.getRedirectData();
+    if (redirectData) {
+      return redirectData.url;
+    }
+    return null;
+  }
+
+  private getEmail(): string | null {
+    const redirectData = this.getRedirectData();
+    if (redirectData && redirectData.userHash) {
+      return Buffer.from(redirectData.userHash, 'base64').toString('utf-8');
+    }
+    return null;
+  }
+
+  private getRedirectData(): RedirectData | null {
+    const redirectData = localStorage.getItem(this.key);
+    if (redirectData) {
+      return JSON.parse(redirectData);
+    }
+    return null;
+  }
+
+  removeRedirect() {
+    localStorage.removeItem(this.key);
+  }
+
+  shouldRedirect(userEmail: string) {
+    const savedEmail = this.getEmail();
+    const savedUrl = this.getUrl();
+    // if we have a user stored, we need to check it's the same as the email provided.
+    if (savedEmail && savedEmail !== userEmail) {
+      return false;
+    }
+    return savedUrl || false;
+  }
+
+  constructor() {}
+}

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -8,7 +8,6 @@ import { timeout, TimeoutError } from 'rxjs';
 import { EMAIL_VALIDATION_REGEX } from '../shared/constants';
 import { passwordsMustMatchValidator } from '../validators/passwords';
 import { PasswordStateMatcher } from '../validators/error-matchers';
-import { RedirectService } from '../services/redirect.service';
 
 @Component({
   selector: 'app-signup',
@@ -33,8 +32,7 @@ export class SignupComponent {
   constructor(
     private authService: AuthService,
     private formBuilder: FormBuilder,
-    private router: Router,
-    private redirectService: RedirectService
+    private router: Router
   ) {
     this.form = this.formBuilder.group(
       {
@@ -106,11 +104,6 @@ export class SignupComponent {
       .pipe(timeout(10000))
       .subscribe({
         next: () => {
-          const redirect = this.redirectService.shouldRedirect(email);
-          if (redirect) {
-            // associate the redirect with the newly created user
-            this.redirectService.setRedirect(redirect, email);
-          }
           this.router.navigate(['thankyou']);
         },
         error: (error: HttpErrorResponse) => {

--- a/src/interface/src/app/signup/signup.component.ts
+++ b/src/interface/src/app/signup/signup.component.ts
@@ -4,10 +4,11 @@ import { Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FormMessageType } from '../types/data.types';
 import { AuthService } from './../services';
-import { TimeoutError, timeout } from 'rxjs';
+import { timeout, TimeoutError } from 'rxjs';
 import { EMAIL_VALIDATION_REGEX } from '../shared/constants';
 import { passwordsMustMatchValidator } from '../validators/passwords';
 import { PasswordStateMatcher } from '../validators/error-matchers';
+import { RedirectService } from '../services/redirect.service';
 
 @Component({
   selector: 'app-signup',
@@ -28,10 +29,12 @@ export class SignupComponent {
   ]);
 
   showHint = false;
+
   constructor(
     private authService: AuthService,
     private formBuilder: FormBuilder,
-    private router: Router
+    private router: Router,
+    private redirectService: RedirectService
   ) {
     this.form = this.formBuilder.group(
       {
@@ -103,6 +106,11 @@ export class SignupComponent {
       .pipe(timeout(10000))
       .subscribe({
         next: () => {
+          const redirect = this.redirectService.shouldRedirect(email);
+          if (redirect) {
+            // associate the redirect with the newly created user
+            this.redirectService.setRedirect(redirect, email);
+          }
           this.router.navigate(['thankyou']);
         },
         error: (error: HttpErrorResponse) => {


### PR DESCRIPTION
- When the user lands on a guarded page, we redirect to login. At that point, save the original url.
- If the user has an account, they log in. If we have a url saved, redirect the user to that url. If not, redirect to `/home`
- If the user does not have an account, and creates an account, we associate the saved url with the newly created account.
- If the user logs in with the newly created account, we redirect to the saved url, otherwise we redirect to `/home`