### PR TITLE
Refactor load_conditions

### DIFF
--- a/src/planscape/conditions/management/commands/load_conditions.py
+++ b/src/planscape/conditions/management/commands/load_conditions.py
@@ -81,9 +81,9 @@ class Command(BaseCommand):
 
         condition, _created = Condition.objects.update_or_create(
             condition_dataset=base_condition,
-            raster_name=raster_name,
             condition_score_type=score_type,
             is_raw=raw,
+            defaults={"raster_name": raster_name},
         )
 
         self.stdout.write(f"[OK] {metric['region_name']}:{metric['metric_name']}")


### PR DESCRIPTION
1. Change the `load_conditions` command to avoid the duplication of `Condition` models. The reason is that Forsys will probably get lost with many nested conditions to a base condition.

This relationship between BaseCondition and Condition needs to be over - the reason is that each metric is independent and for now makes no sense to group them together under the same view. We can get much better results with a denormalized model.