### PR TITLE
email template wording changes

### DIFF
--- a/src/planscape/collaboration/tasks.py
+++ b/src/planscape/collaboration/tasks.py
@@ -28,6 +28,7 @@ def send_invitation(
             ),
             "planning_area": planning_area,
             "message": message,
+            "frontend_url": get_frontend_url("home"),
             "frontend_assets": get_frontend_url("assets"),
             "planning_area_link": get_frontend_url(f"plan/{planning_area.pk}"),
             "create_account_link": get_frontend_url(

--- a/src/planscape/templates/invites/new_invite_message.html
+++ b/src/planscape/templates/invites/new_invite_message.html
@@ -94,9 +94,8 @@
     </td></tr><tr><td>
     <![endif]-->
     <div style="width: 100%; padding: 10px">
-      <span style="color: #4a4a4a; font-weight: 400; line-height: 22px">Log in to Planscape.org is required to view the
-        planning area. If
-        you don’t have a Planscape account, please </span><span
+      <span style="color: #4a4a4a; font-weight: 400; line-height: 22px">Log in to <a href="{{ frontend_url }}">Planscape</a> is required to view the
+        planning area. If you don’t have a Planscape account, please </span><span
         style="color: #064bba; font-weight: 500; text-decoration: underline"><a href="{{ create_account_link }}">click
           here</a></span><span style="color: #4a4a4a; font-weight: 400; line-height: 22px">.</span>
     </div>

--- a/src/planscape/templates/invites/new_invite_message.txt
+++ b/src/planscape/templates/invites/new_invite_message.txt
@@ -1,12 +1,13 @@
 {{inviter.get_full_name }} invited you to collaborate on "{{planning_area.name}}".
 
-Log in to Planscape.org is required to view the planning area.  If you don't have a Planscape account, please {{create_account_link}}.
+Log in to Planscape is required to view the planning area.  If you don't have a Planscape account, please click here: {{create_account_link}}.
 
 Can’t access the planning area? Please contact {{inviter.get_full_name }}.
-
-{{ planning_area_url }}.
 
 {% if message %}
 Message:
 {{ message }}
 {% endif %}
+
+You can access the Planning Area "{{planning_area.name}}" here:
+{{ planning_area_link }}.


### PR DESCRIPTION
I noticed that some email clients were automatically transforming the domain in "Log in to Planscape.org..." into a link to the main public website, even though that's not what our template nor [the Figma design](https://www.figma.com/file/3l52SKCTn6JHeOG7rB9Md5/Collaboration-Feature?type=design&node-id=833-15524&mode=design&t=eZSjpPVo515u5jHo-4) intended.

<img width="300" alt="Screen Shot 2024-03-20 at 4 15 53 PM" src="https://github.com/OurPlanscape/Planscape/assets/100235124/b822ba68-0d67-4bbb-9290-6fff79879f2a">

I thought this was confusing, especially for anyone skimming the email, so after chatting with UX, we decided to change the wording to just say "Planscape" with an intentional href to the app home page:

<img width="300" alt="Screen Shot 2024-03-20 at 4 17 09 PM" src="https://github.com/OurPlanscape/Planscape/assets/100235124/85e2ff74-e882-4fd0-b34a-5f7114c3cfae">

This PR clarifies some text on the non-html template, as well.