### PR TITLE
PLAN-1065 Bugfix: Move myscenarios toggle

### DIFF
--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.html
@@ -15,8 +15,10 @@
         </button>
       </div>
     </div>
+
     <app-section-loader
       [isLoading]="loading"
+      (onlyMyScenariosToggle)="onMyScenariosToggle($event)"
       [hasData]="activeScenarios.length + archivedScenarios.length > 0"
       [ngClass]="{
         'margin-top': activeScenarios.length + archivedScenarios.length === 0
@@ -27,13 +29,6 @@
           ? 'Click “New scenario” to start creating your scenarios.'
           : ''
       ">
-      <mat-slide-toggle
-        color="primary"
-        class="slide-toggle-my-scenarios"
-        [(ngModel)]="showOnlyMyScenarios"
-        (change)="fetchScenarios()">
-        Show only my scenarios
-      </mat-slide-toggle>
       <mat-tab-group
         mat-align-tabs="start"
         *appFeatureFlag="'show_share_modal'">

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
@@ -54,14 +54,9 @@
   align-items: center;
 }
 
-.margin-top {
-  margin-top: 30px;
-}
 
 .empty-state {
   @include standard-input-label();
   color: $color-dark-gray;
-  padding: 40px 20px;
-  margin: 20px;
   text-align: center;
 }

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.scss
@@ -8,14 +8,6 @@
   position: relative;
 }
 
-.slide-toggle-my-scenarios {
-  @include standard-input-label();
-  position: absolute;
-  right: 0px;
-  top: 12px;
-  z-index: 10;
-}
-
 .mat-card {
   border-radius: 16px;
   min-height: 180px;

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -78,6 +78,11 @@ export class SavedScenariosComponent implements OnInit {
       });
   }
 
+  onMyScenariosToggle(showingOnlyMine: boolean) {
+    this.showOnlyMyScenarios = showingOnlyMine;
+    this.fetchScenarios();
+  }
+
   canAddScenarioForPlan(): boolean {
     if (!this.plan) {
       return false;

--- a/src/interface/src/app/shared/section-loader/section-loader.component.html
+++ b/src/interface/src/app/shared/section-loader/section-loader.component.html
@@ -1,7 +1,13 @@
+<mat-slide-toggle
+  color="primary"
+  class="slide-toggle-my-scenarios"
+  [(ngModel)]="showOnlyMine"
+  (change)="handleShowOnlyMineToggle()">
+  Show only my scenarios
+</mat-slide-toggle>
 <div *ngIf="isLoading; else loaded" class="spinner">
   <mat-spinner diameter="40"></mat-spinner>
 </div>
-
 <ng-template #loaded>
   <ng-container *ngIf="hasData; else noData">
     <ng-content></ng-content>

--- a/src/interface/src/app/shared/section-loader/section-loader.component.scss
+++ b/src/interface/src/app/shared/section-loader/section-loader.component.scss
@@ -1,7 +1,7 @@
-@import "../../../styles/mixins";
-@import "../../../styles/colors";
+@import '../../../styles/mixins';
+@import '../../../styles/colors';
 
-:host{
+:host {
   display: block;
   height: 100%;
   position: relative;
@@ -15,7 +15,8 @@
   z-index: 10;
 }
 
-.spinner, .empty-state {
+.spinner,
+.empty-state {
   align-items: center;
   justify-content: flex-end;
   display: flex;
@@ -29,14 +30,13 @@
   padding-top: 20px;
 }
 
-
 .empty-state {
-
+  position: relative;
+  padding: 40px;
   h4 {
     @include standard-input-label();
     margin: 0 0 8px;
     color: $color-black;
-
   }
 
   p {
@@ -46,4 +46,3 @@
     max-width: 560px;
   }
 }
-

--- a/src/interface/src/app/shared/section-loader/section-loader.component.scss
+++ b/src/interface/src/app/shared/section-loader/section-loader.component.scss
@@ -7,6 +7,14 @@
   position: relative;
 }
 
+.slide-toggle-my-scenarios {
+  @include standard-input-label();
+  position: absolute;
+  right: 0px;
+  top: 12px;
+  z-index: 10;
+}
+
 .spinner, .empty-state {
   align-items: center;
   justify-content: flex-end;

--- a/src/interface/src/app/shared/section-loader/section-loader.component.ts
+++ b/src/interface/src/app/shared/section-loader/section-loader.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-section-loader',
@@ -6,6 +6,8 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./section-loader.component.scss'],
 })
 export class SectionLoaderComponent {
+  showOnlyMine = false;
+
   @Input() isLoading = false;
   @Input() hasData = false;
   @Input() emptyStateTitle = '';
@@ -13,4 +15,9 @@ export class SectionLoaderComponent {
   @Input() hasError? = false;
   @Input() errorMsg?: string;
   @Input() errorTitle?: string;
+  @Output() onlyMyScenariosToggle = new EventEmitter<boolean>();
+
+  handleShowOnlyMineToggle() {
+    this.onlyMyScenariosToggle.emit(this.showOnlyMine);
+  }
 }


### PR DESCRIPTION
This moves the `slide-toggle-my-scenarios` to the SectionLoaderComponent, so that it continues to appear even when no scenarios exist.

Of course, now that I think about it, I'm not sure if there's much need for this SectionLoaderComponent anymore, since it means we now how have two sections to handle a situation when no results exist:  the `empty-state` on saved-scenarios, and the `empty-state` on section-loader. 

If we later add filters / sorting / custom UI for this view, that's just going to be more complicated. In the interest of just fixing this bug, maybe we can leave it for now, but when we refactor this UI to handle other filters, maybe this is something to think about.


