### PR TITLE
Plan-694 - Adjust login css

### DIFF
--- a/src/interface/src/app/account-validation/account-validation.component.scss
+++ b/src/interface/src/app/account-validation/account-validation.component.scss
@@ -62,3 +62,49 @@ p.regular {
   background-repeat: no-repeat;
   background-size: 50%;
 }
+
+
+
+@media screen and (max-width: 840px) {
+  :host {
+    display: flex;
+    flex-direction: column;
+    gap: 10%;
+    height: fit-content;
+  }
+
+  .validation-result-container {
+    width: 100%;
+    height: 100%;
+    min-height: calc(100vh - 48px);
+  }
+
+  .validation-result-subcontainer {
+    width: 80%;
+  }
+
+  .validation-result-card {
+    padding: 40px 4% 40px 4%;
+  }
+
+  .about-container {
+    width: 100%;
+    height: 100%;
+  }
+
+  .signup-form-subcontainer {
+    width: 90%;
+  }
+
+  .info-text-container {
+    width: 100%;
+  }
+  
+  .info-card {
+    margin: 4%;
+  }
+
+  .credits-blurb {
+    width: 100%;
+  }
+}

--- a/src/interface/src/app/account-validation/account-validation.component.scss
+++ b/src/interface/src/app/account-validation/account-validation.component.scss
@@ -12,6 +12,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   width: 50%;
+  position: relative;
 }
 
 .validation-result-subcontainer {

--- a/src/interface/src/app/forget-password/forget-password.component.html
+++ b/src/interface/src/app/forget-password/forget-password.component.html
@@ -63,8 +63,8 @@
         </form>
       </div>
     </div>
+    <app-credits-blurb></app-credits-blurb>
   </div>
-  <app-credits-blurb></app-credits-blurb>
 
   <div class="info-text-container">
     <app-planscape-about></app-planscape-about>

--- a/src/interface/src/app/forget-password/forget-password.component.html
+++ b/src/interface/src/app/forget-password/forget-password.component.html
@@ -1,72 +1,70 @@
-<div class="forget-password-root">
-  <div class="forget-password-container">
-    <div class="forget-password-subcontainer">
-      <div class="signin-card-logo">
-        <div class="planscape-white-logo">
-          <img src="assets/svg/planscape-white-logo.svg" alt="planscape logo" />
-        </div>
-      </div>
-      <div class="forget-password-card">
-        <h1 class="title">Reset Password</h1>
-
-        <form [formGroup]="form" (ngSubmit)="submit()" class="email-form">
-          <mat-label class="form-field-label"
-            >Email
-            <span class="required-blurb">required</span>
-          </mat-label>
-          <mat-form-field class="form-field-input" appearance="outline">
-            <input
-              type="text"
-              required
-              formControlName="email"
-              matInput
-              (blur)="checkEmailErrors()"
-              (keyup)="clearEmailErrors()" />
-          </mat-form-field>
-
-          <app-field-alert
-            *ngIf="
-              this.emailError !== '' &&
-              this.form.controls['email'].errors !== null
-                ? true
-                : false
-            "
-            message="{{ emailError }}"
-            title="email error"></app-field-alert>
-
-          <div class="reset-form-buttons">
-            <button
-              mat-flat-button
-              color="primary"
-              type="submit"
-              [disabled]="!form.valid"
-              class="send-email-button">
-              SEND EMAIL
-            </button>
-
-            <button
-              mat-stroked-button
-              color="secondary"
-              type="cancel"
-              class="cancel-button"
-              (click)="cancel()">
-              Cancel
-            </button>
-          </div>
-
-          <app-form-message
-            [messageType]="FormMessageType.ERROR"
-            *ngIf="accountError"
-            title="Password Reset Error"
-            message="{{ accountError }}">
-          </app-form-message>
-        </form>
+<div class="forget-password-container">
+  <div class="forget-password-subcontainer">
+    <div class="signin-card-logo">
+      <div class="planscape-white-logo">
+        <img src="assets/svg/planscape-white-logo.svg" alt="planscape logo" />
       </div>
     </div>
-    <app-credits-blurb></app-credits-blurb>
-  </div>
+    <div class="forget-password-card">
+      <h1 class="title">Reset Password</h1>
 
-  <div class="info-text-container">
-    <app-planscape-about></app-planscape-about>
+      <form [formGroup]="form" (ngSubmit)="submit()" class="email-form">
+        <mat-label class="form-field-label"
+          >Email
+          <span class="required-blurb">required</span>
+        </mat-label>
+        <mat-form-field class="form-field-input" appearance="outline">
+          <input
+            type="text"
+            required
+            formControlName="email"
+            matInput
+            (blur)="checkEmailErrors()"
+            (keyup)="clearEmailErrors()" />
+        </mat-form-field>
+
+        <app-field-alert
+          *ngIf="
+            this.emailError !== '' &&
+            this.form.controls['email'].errors !== null
+              ? true
+              : false
+          "
+          message="{{ emailError }}"
+          title="email error"></app-field-alert>
+
+        <div class="reset-form-buttons">
+          <button
+            mat-flat-button
+            color="primary"
+            type="submit"
+            [disabled]="!form.valid"
+            class="send-email-button">
+            SEND EMAIL
+          </button>
+
+          <button
+            mat-stroked-button
+            color="secondary"
+            type="cancel"
+            class="cancel-button"
+            (click)="cancel()">
+            Cancel
+          </button>
+        </div>
+
+        <app-form-message
+          [messageType]="FormMessageType.ERROR"
+          *ngIf="accountError"
+          title="Password Reset Error"
+          message="{{ accountError }}">
+        </app-form-message>
+      </form>
+    </div>
   </div>
+  <app-credits-blurb></app-credits-blurb>
+</div>
+
+<div class="info-text-container">
+  <app-planscape-about></app-planscape-about>
 </div>

--- a/src/interface/src/app/forget-password/forget-password.component.scss
+++ b/src/interface/src/app/forget-password/forget-password.component.scss
@@ -13,6 +13,7 @@
   background-size: cover;
   display: flex;
   width: 50%;
+  position: relative;
 }
 
 .forget-password-subcontainer {

--- a/src/interface/src/app/forget-password/forget-password.component.scss
+++ b/src/interface/src/app/forget-password/forget-password.component.scss
@@ -7,10 +7,6 @@
   height: 100%;
 }
 
-.forget-password-root {
-  display: flex;
-  height: 100%;
-}
 .forget-password-container {
   background-image: url('/assets/jpg/planscape-background.jpg');
   background-repeat: no-repeat;
@@ -103,13 +99,6 @@ mat-form-field {
     width: 100%;
     height: fit-content;
   }
-
-  .forget-password-root {
-    gap: 10%;
-    display: inline-block;
-    width: 100%;
-  }
-
 
   .forget-password-container {
     width: 100%;

--- a/src/interface/src/app/forget-password/forget-password.component.scss
+++ b/src/interface/src/app/forget-password/forget-password.component.scss
@@ -2,11 +2,15 @@
 @import '../../styles/mixins';
 @import '../../styles/forms';
 
-.forget-password-root {
+:host {
   display: flex;
   height: 100%;
 }
 
+.forget-password-root {
+  display: flex;
+  height: 100%;
+}
 .forget-password-container {
   background-image: url('/assets/jpg/planscape-background.jpg');
   background-repeat: no-repeat;
@@ -24,7 +28,7 @@
   padding: 20px 0px 20px 0px;
   gap: 20px;
   display: flex;
-  margin-top: 180px;
+  margin-top: 6%;
 }
 
 .planscape-white-logo {
@@ -80,7 +84,6 @@ mat-form-field {
   margin-top: 20px;
   margin-left: auto;
   margin-right: auto;
-  display: flex;
   width: 80%;
 }
 
@@ -91,4 +94,36 @@ mat-form-field {
 .info-text-container {
   background-color: $color-soft-purple;
   width: 50%;
+}
+
+@media screen and (max-width: 840px) {
+  :host {
+    gap: 10%;
+    flex-direction: column;
+    width: 100%;
+    height: fit-content;
+  }
+
+  .forget-password-root {
+    gap: 10%;
+    display: inline-block;
+    width: 100%;
+  }
+
+
+  .forget-password-container {
+    width: 100%;
+    height: 100%;
+    min-height: calc(100vh - 48px);
+  }
+  
+  .info-text-container {
+    position: relative;
+    width: 100%;
+  }
+
+  .credits-blurb {
+    width: 100%;
+  }
+  
 }

--- a/src/interface/src/app/home/about/about.component.scss
+++ b/src/interface/src/app/home/about/about.component.scss
@@ -1,11 +1,11 @@
-@import "../../../styles/colors";
-@import "../../../styles/mixins";
+@import '../../../styles/colors';
+@import '../../../styles/mixins';
 
 .about-container {
   gap: 30px;
   display: flex;
   flex-direction: column;
-  padding: 100px 60px 80px 60px;
+  margin: 15% 10% 4% 10%;
 }
 
 h3 {
@@ -50,4 +50,11 @@ p.regular {
 
 p.small {
   text-align: left;
+}
+
+@media screen and (max-width: 840px) {
+  ::root {
+    gap: 10%;
+  }
+
 }

--- a/src/interface/src/app/login/login.component.html
+++ b/src/interface/src/app/login/login.component.html
@@ -1,113 +1,111 @@
-<div class="signin-root">
-  <div class="signin-card-container">
-    <div class="signin-subcontainer">
-      <div class="signin-card-logo">
-        <div class="planscape-white-logo">
-          <img src="assets/svg/planscape-white-logo.svg" alt="planscape logo" />
-        </div>
-      </div>
-
-      <div class="signin-card">
-        <h1 class="signin-title">Sign in to Planscape</h1>
-
-        <form [formGroup]="form" (ngSubmit)="login()" autocomplete="on">
-          <mat-label class="standard-label"
-            >Email
-            <span class="required-blurb">required</span>
-          </mat-label>
-          <mat-form-field appearance="outline">
-            <input
-              type="text"
-              required
-              formControlName="email"
-              matInput
-              (blur)="checkEmailErrors()"
-              (keyup)="clearEmailErrors()"
-              autocomplete="email" />
-          </mat-form-field>
-          <app-field-alert
-            *ngIf="
-              this.emailError &&
-              this.form.controls['email'].errors &&
-              this.form.controls['email'].dirty
-            "
-            message="{{ emailError }}"
-            title="email error"></app-field-alert>
-
-          <mat-label class="standard-label"
-            >Password
-            <span class="required-blurb">required</span>
-          </mat-label>
-          <mat-form-field appearance="outline">
-            <input
-              type="password"
-              required
-              formControlName="password"
-              autocomplete="current-password"
-              matInput />
-          </mat-form-field>
-          <app-field-alert
-            *ngIf="passwordError"
-            message="{{ passwordError }}"
-            title="password error"></app-field-alert>
-
-          <app-form-message
-            [messageType]="FormMessageType.ERROR"
-            *ngIf="loginError ? true : false"
-            title="Credentials error"
-            message="{{ loginError }}">
-            <div *ngIf="offerReverify">
-              <a [routerLink]="[]" (click)="resendVerification()"
-                >Click here to re-send your verification email.</a
-              >
-            </div>
-          </app-form-message>
-
-          <mat-card-actions class="login-form-buttons">
-            <button
-              mat-flat-button
-              color="primary"
-              type="submit"
-              [disabled]="!form.valid"
-              class="login-form-button">
-              LOG IN
-            </button>
-          </mat-card-actions>
-
-          <p class="forget-password">
-            <a
-              i18n="Text on a button to reset password"
-              href="reset/"
-              class="forget-password-link"
-              >Forgot your password?</a
-            >
-          </p>
-
-          <div class="login-form-buttons">
-            <button
-              mat-stroked-button
-              color="primary"
-              data-id="explore"
-              [routerLink]="'/map'"
-              class="login-form-button guest-button">
-              Explore
-            </button>
-            <button
-              mat-stroked-button
-              color="primary"
-              data-id="create-account"
-              [routerLink]="'/signup'"
-              class="login-form-button guest-button">
-              Create an Account
-            </button>
-          </div>
-        </form>
+<div class="signin-card-container">
+  <div class="signin-subcontainer">
+    <div class="signin-card-logo">
+      <div class="planscape-white-logo">
+        <img src="assets/svg/planscape-white-logo.svg" alt="planscape logo" />
       </div>
     </div>
-    <app-credits-blurb></app-credits-blurb>
-  </div>
 
-  <div class="info-text-container">
-    <app-planscape-about></app-planscape-about>
+    <div class="signin-card">
+      <h1 class="signin-title">Sign in to Planscape</h1>
+
+      <form [formGroup]="form" (ngSubmit)="login()" autocomplete="on">
+        <mat-label class="standard-label"
+          >Email
+          <span class="required-blurb">required</span>
+        </mat-label>
+        <mat-form-field appearance="outline">
+          <input
+            type="text"
+            required
+            formControlName="email"
+            matInput
+            (blur)="checkEmailErrors()"
+            (keyup)="clearEmailErrors()"
+            autocomplete="email" />
+        </mat-form-field>
+        <app-field-alert
+          *ngIf="
+            this.emailError &&
+            this.form.controls['email'].errors &&
+            this.form.controls['email'].dirty
+          "
+          message="{{ emailError }}"
+          title="email error"></app-field-alert>
+
+        <mat-label class="standard-label"
+          >Password
+          <span class="required-blurb">required</span>
+        </mat-label>
+        <mat-form-field appearance="outline">
+          <input
+            type="password"
+            required
+            formControlName="password"
+            autocomplete="current-password"
+            matInput />
+        </mat-form-field>
+        <app-field-alert
+          *ngIf="passwordError"
+          message="{{ passwordError }}"
+          title="password error"></app-field-alert>
+
+        <app-form-message
+          [messageType]="FormMessageType.ERROR"
+          *ngIf="loginError ? true : false"
+          title="Credentials error"
+          message="{{ loginError }}">
+          <div *ngIf="offerReverify">
+            <a [routerLink]="[]" (click)="resendVerification()"
+              >Click here to re-send your verification email.</a
+            >
+          </div>
+        </app-form-message>
+
+        <mat-card-actions class="login-form-buttons">
+          <button
+            mat-flat-button
+            color="primary"
+            type="submit"
+            [disabled]="!form.valid"
+            class="login-form-button">
+            LOG IN
+          </button>
+        </mat-card-actions>
+
+        <p class="forget-password">
+          <a
+            i18n="Text on a button to reset password"
+            href="reset/"
+            class="forget-password-link"
+            >Forgot your password?</a
+          >
+        </p>
+
+        <div class="login-form-buttons">
+          <button
+            mat-stroked-button
+            color="primary"
+            data-id="explore"
+            [routerLink]="'/map'"
+            class="login-form-button guest-button">
+            Explore
+          </button>
+          <button
+            mat-stroked-button
+            color="primary"
+            data-id="create-account"
+            [routerLink]="'/signup'"
+            class="login-form-button guest-button">
+            Create an Account
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
+  <app-credits-blurb></app-credits-blurb>
+</div>
+
+<div class="info-text-container">
+  <app-planscape-about></app-planscape-about>
 </div>

--- a/src/interface/src/app/login/login.component.scss
+++ b/src/interface/src/app/login/login.component.scss
@@ -38,7 +38,7 @@
 
 .signin-card {
   margin: auto;
-  width: 300px;
+  max-width: 300px;
   border-radius: 8px;
   display: flex;
   flex-direction: column;
@@ -52,8 +52,7 @@
 h1 {
   &.signin-title {
     @include h1();
-    margin-bottom: 48px;
-    text-align: center;
+    margin-bottom: 6%;
     text-align: center;
     vertical-align: middle;
     color: $color-text-dark;
@@ -91,7 +90,6 @@ mat-divider {
 mat-form-field {
   width: 100%;
 }
-
 
 .forget-password {
   text-align: center;
@@ -142,6 +140,7 @@ mat-form-field {
   :host {
     gap: 10%;
     flex-direction: column;
+    height: fit-content;
   }
 
   .signin-card-container {
@@ -149,15 +148,24 @@ mat-form-field {
     height: 100%;
     min-height: calc(100vh - 48px);
   }
-  
+
   .info-text-container {
     position: relative;
     width: 100%;
-
   }
 
   .credits-blurb {
     width: 100%;
   }
-  
+}
+
+@media screen and (max-height: 700px) {
+  .signin-subcontainer {
+    margin-top: 1%;
+  }
+
+  .planscape-white-logo {
+    display: none;
+  }
+
 }

--- a/src/interface/src/app/login/login.component.scss
+++ b/src/interface/src/app/login/login.component.scss
@@ -1,12 +1,10 @@
 @import '../../styles/colors';
 @import '../../styles/mixins';
 
-.signin-root {
+:host {
   display: flex;
   height: 100%;
-}
 
-:host {
   ::ng-deep .mat-form-field-outline {
     background-color: $color-light-gray;
   }
@@ -141,11 +139,8 @@ mat-form-field {
 }
 
 @media screen and (max-width: 840px) {
-  ::root {
+  :host {
     gap: 10%;
-  }
-
-  .signin-root {
     flex-direction: column;
   }
 

--- a/src/interface/src/app/login/login.component.scss
+++ b/src/interface/src/app/login/login.component.scss
@@ -24,7 +24,7 @@
 .signin-subcontainer {
   flex-direction: column;
   margin: auto;
-  margin-top: 10%;
+  margin-top: 6%;
 }
 
 .signin-card-logo {
@@ -146,17 +146,13 @@ mat-form-field {
   }
 
   .signin-root {
-    display: inline-block;
+    flex-direction: column;
   }
 
   .signin-card-container {
-    background-image: url('/assets/jpg/planscape-background.jpg');
-    background-repeat: no-repeat;
-    background-size: cover;
-    display: flex;
-    position: relative;
     width: 100%;
     height: 100%;
+    min-height: calc(100vh - 48px);
   }
   
   .info-text-container {

--- a/src/interface/src/app/login/login.component.scss
+++ b/src/interface/src/app/login/login.component.scss
@@ -18,6 +18,7 @@
   background-size: cover;
   display: flex;
   width: 50%;
+  position: relative;
 }
 
 .signin-subcontainer {
@@ -137,4 +138,35 @@ mat-form-field {
 .post-error-option {
   padding: 1em;
   text-align: center;
+}
+
+@media screen and (max-width: 840px) {
+  ::root {
+    gap: 10%;
+  }
+
+  .signin-root {
+    display: inline-block;
+  }
+
+  .signin-card-container {
+    background-image: url('/assets/jpg/planscape-background.jpg');
+    background-repeat: no-repeat;
+    background-size: cover;
+    display: flex;
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+  
+  .info-text-container {
+    position: relative;
+    width: 100%;
+
+  }
+
+  .credits-blurb {
+    width: 100%;
+  }
+  
 }

--- a/src/interface/src/app/password-reset/password-reset.component.html
+++ b/src/interface/src/app/password-reset/password-reset.component.html
@@ -80,7 +80,6 @@
       </div>
     </div>
   </div>
-
   <app-credits-blurb></app-credits-blurb>
 </div>
 

--- a/src/interface/src/app/password-reset/password-reset.component.scss
+++ b/src/interface/src/app/password-reset/password-reset.component.scss
@@ -1,5 +1,5 @@
-@import "../../styles/colors";
-@import "../../styles/mixins";
+@import '../../styles/colors';
+@import '../../styles/mixins';
 
 :host {
   display: flex;
@@ -12,6 +12,7 @@
   background-size: cover;
   display: flex;
   width: 50%;
+  position: relative;
 }
 
 .reset-password-subcontainer {
@@ -22,7 +23,7 @@
   padding: 20px 0px 20px 0px;
   gap: 20px;
   display: flex;
-  margin-top: 10%;
+  margin-top: 6%;
 }
 
 .planscape-white-logo {
@@ -101,4 +102,26 @@ mat-form-field {
 .info-text-container {
   background-color: $color-soft-purple;
   width: 50%;
+}
+
+@media screen and (max-width: 840px) {
+  :host {
+    display: inline-block;
+    gap: 10%;
+  }
+
+  .forget-password-container {
+    width: 100%;
+    height: 100%;
+    position: relative;
+  }
+
+  .info-text-container {
+    position: relative;
+    width: 100%;
+  }
+
+  .credits-blurb {
+    width: 100%;
+  }
 }

--- a/src/interface/src/app/password-reset/password-reset.component.scss
+++ b/src/interface/src/app/password-reset/password-reset.component.scss
@@ -106,7 +106,7 @@ mat-form-field {
 
 @media screen and (max-width: 840px) {
   :host {
-    display: inline-block;
+    flex-direction: column;
     gap: 10%;
   }
 

--- a/src/interface/src/app/shared/credits-blurb/credits-blurb.component.scss
+++ b/src/interface/src/app/shared/credits-blurb/credits-blurb.component.scss
@@ -3,7 +3,7 @@
   box-sizing: border-box;
   padding: 1.5em 2em;
   position: absolute;
-  width: 50%;
+  width: 100%;
   background-color: rgba(0, 0, 0, 0.5);
 
   a {
@@ -24,4 +24,5 @@
     margin: 0;
     text-align: center;
   }
+  
 }

--- a/src/interface/src/app/shared/credits-blurb/credits-blurb.component.scss
+++ b/src/interface/src/app/shared/credits-blurb/credits-blurb.component.scss
@@ -1,7 +1,7 @@
 :host {
   bottom: 0px;
   box-sizing: border-box;
-  padding: 1.5em 2em;
+  padding: 2% 4% 2% 4%;
   position: absolute;
   width: 100%;
   background-color: rgba(0, 0, 0, 0.5);
@@ -24,5 +24,4 @@
     margin: 0;
     text-align: center;
   }
-  
 }

--- a/src/interface/src/app/signup/info-card/info-card.component.scss
+++ b/src/interface/src/app/signup/info-card/info-card.component.scss
@@ -48,3 +48,13 @@ h3 {
   @include standard-link();
   color: $color-standard-blue;
 }
+
+@media screen and (max-width: 840px) {
+  :host {
+    margin-top: 0;
+  }
+
+  .info-card {
+    margin: 10%;
+  }
+}

--- a/src/interface/src/app/signup/signup.component.scss
+++ b/src/interface/src/app/signup/signup.component.scss
@@ -111,3 +111,37 @@ button {
 :host ::ng-deep .mat-form-field-wrapper {
   padding-bottom: 5%;
 }
+
+
+
+@media screen and (max-width: 840px) {
+  :host {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 10%;
+  }
+
+  .signup-form-container {
+    width: 100%;
+    height: 100%;
+    min-height: calc(100vh - 48px);
+    position: relative;
+  }
+
+  .signup-form-subcontainer {
+    width: 90%;
+  }
+
+  .info-card-container {
+    position: relative;
+    width: 100%;
+  }
+  
+  .info-card {
+    margin: 4%;
+  }
+
+  .credits-blurb {
+    width: 100%;
+  }
+}

--- a/src/interface/src/app/signup/signup.component.scss
+++ b/src/interface/src/app/signup/signup.component.scss
@@ -138,7 +138,7 @@ button {
   }
   
   .info-card {
-    margin: 4%;
+    margin: 10%;
   }
 
   .credits-blurb {

--- a/src/interface/src/app/signup/thank-you/thank-you.component.scss
+++ b/src/interface/src/app/signup/thank-you/thank-you.component.scss
@@ -68,27 +68,27 @@ a.standard-link {
   background-size: 50%;
 }
 
-
 @media screen and (max-width: 840px) {
   :host {
     gap: 10%;
-    display: inline-block;
+    flex-direction: column;
     width: 100%;
   }
 
   .thankyou-container {
     width: 100%;
     height: 100%;
+    min-height: calc(100vh - 48px);
   }
 
-.thankyou-subcontainer {
-  width: 80%;
-}
+  .thankyou-subcontainer {
+    width: 80%;
+  }
 
   .thankyou-card {
     padding: 10% 8% 10% 10%;
   }
-  
+
   .info-text-container {
     position: relative;
     width: 100%;
@@ -97,5 +97,4 @@ a.standard-link {
   .credits-blurb {
     width: 100%;
   }
-  
 }

--- a/src/interface/src/app/signup/thank-you/thank-you.component.scss
+++ b/src/interface/src/app/signup/thank-you/thank-you.component.scss
@@ -67,3 +67,35 @@ a.standard-link {
   background-repeat: no-repeat;
   background-size: 50%;
 }
+
+
+@media screen and (max-width: 840px) {
+  :host {
+    gap: 10%;
+    display: inline-block;
+    width: 100%;
+  }
+
+  .thankyou-container {
+    width: 100%;
+    height: 100%;
+  }
+
+.thankyou-subcontainer {
+  width: 80%;
+}
+
+  .thankyou-card {
+    padding: 10% 8% 10% 10%;
+  }
+  
+  .info-text-container {
+    position: relative;
+    width: 100%;
+  }
+
+  .credits-blurb {
+    width: 100%;
+  }
+  
+}

--- a/src/interface/src/app/signup/thank-you/thank-you.component.scss
+++ b/src/interface/src/app/signup/thank-you/thank-you.component.scss
@@ -12,6 +12,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   width: 50%;
+  position: relative;
 }
 
 .thankyou-subcontainer {


### PR DESCRIPTION
This adjusts some of the login/signup screens, then adds some responsive media queries to ensure things behave well on even very small screens. I also standardized how some of these views are constructed, since they had a few inconsistencies.
While I was at it, I made a few quick changes so that the main pages aren't completely unusable on mobile -- basically just pushing horizontal content down. Not sure if that's what how long-term mobile layouts should look, but the old versions weren't functional at all and seemed very terrible, so this seemed like an easy improvement for now.

(I don't know why "Feedback" was highlighted on the before screenshots, just an accidental trackpad gesture, I think)

Before:
![Screenshot from 2024-04-09 10-23-18](https://github.com/OurPlanscape/Planscape/assets/100235124/8764297e-77ab-43d0-98ea-b488b0e46b62)

After:
![Screenshot from 2024-04-09 10-24-17](https://github.com/OurPlanscape/Planscape/assets/100235124/04ccb2bb-2223-4041-931e-153211f3d14f)

Before:
![Screenshot from 2024-04-09 10-23-06](https://github.com/OurPlanscape/Planscape/assets/100235124/472384cc-1c07-4a51-8488-6d3cfd629944)

After:
![Screenshot from 2024-04-09 10-26-58](https://github.com/OurPlanscape/Planscape/assets/100235124/dfa8ad47-e9a9-4c7a-afbf-3798ced675c3)


