### PR TITLE
Available stand sizes

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -128,7 +128,10 @@
           <mat-form-field class="input-field" appearance="outline">
             <mat-label>Stand size</mat-label>
             <mat-select formControlName="standSize" required>
-              <mat-option *ngFor="let size of standSizeOptions" [value]="size">
+              <mat-option
+                *ngFor="let size of standSizeOptions"
+                [value]="size"
+                [disabled]="standSizeDisabled(size)">
                 {{ size }}
               </mat-option>
             </mat-select>

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -279,9 +279,8 @@ export class ConstraintsPanelComponent implements OnChanges {
   private totalBudgetedValidator(planningAreaAcres: number): ValidatorFn {
     return (constraintsForm: AbstractControl): ValidationErrors | null => {
       const maxCost = constraintsForm.get('budgetForm.maxCost')?.value;
-      const estCostPerAcre = constraintsForm.get(
-        'budgetForm.estimatedCost'
-      )?.value;
+      const estCostPerAcre = constraintsForm.get('budgetForm.estimatedCost')
+        ?.value;
       if (!!maxCost) {
         const hasBudget = hasEnoughBudget(
           planningAreaAcres,

--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.ts
@@ -35,7 +35,7 @@ const customErrors: Record<'notEnoughBudget' | 'budgetOrAreaRequired', string> =
 export class ConstraintsPanelComponent implements OnChanges {
   constraintsForm: FormGroup = this.createForm();
   readonly excludedAreasOptions = EXCLUDED_AREAS;
-  readonly standSizeOptions = STAND_SIZES;
+  readonly standSizeOptions = Object.keys(STAND_SIZES);
 
   @Input() showWarning = false;
   @Input() planningAreaAcres = 0;
@@ -59,9 +59,23 @@ export class ConstraintsPanelComponent implements OnChanges {
         this.budgetOrAreaRequiredValidator,
         this.totalBudgetedValidator(this.planningAreaAcres),
       ]);
+
+      this.constraintsForm
+        .get('physicalConstraintForm.standSize')
+        ?.setValue(this.defaultStandSize());
       // refresh form
       this.constraintsForm.updateValueAndValidity();
     }
+  }
+
+  defaultStandSize() {
+    if (this.standSizeDisabled('MEDIUM')) {
+      return 'SMALL';
+    }
+    if (this.standSizeDisabled('LARGE')) {
+      return 'MEDIUM';
+    }
+    return 'LARGE';
   }
 
   createForm() {
@@ -126,6 +140,10 @@ export class ConstraintsPanelComponent implements OnChanges {
 
   get maxCost() {
     return this.constraintsForm.get('budgetForm.maxCost');
+  }
+
+  standSizeDisabled(standSize: string) {
+    return this.planningAreaAcres < STAND_SIZES[standSize] * 10;
   }
 
   togglMaxAreaAndMaxCost() {
@@ -261,8 +279,9 @@ export class ConstraintsPanelComponent implements OnChanges {
   private totalBudgetedValidator(planningAreaAcres: number): ValidatorFn {
     return (constraintsForm: AbstractControl): ValidationErrors | null => {
       const maxCost = constraintsForm.get('budgetForm.maxCost')?.value;
-      const estCostPerAcre = constraintsForm.get('budgetForm.estimatedCost')
-        ?.value;
+      const estCostPerAcre = constraintsForm.get(
+        'budgetForm.estimatedCost'
+      )?.value;
       if (!!maxCost) {
         const hasBudget = hasEnoughBudget(
           planningAreaAcres,

--- a/src/interface/src/app/plan/plan-helpers.ts
+++ b/src/interface/src/app/plan/plan-helpers.ts
@@ -1,5 +1,3 @@
-import area from '@turf/area';
-import { FeatureCollection } from 'geojson';
 import {
   ConditionsConfig,
   PriorityRow,
@@ -17,19 +15,12 @@ export const NOTE_SAVE_INTERVAL = 5000;
 
 export const POLLING_INTERVAL = 3000;
 
-export const STAND_SIZES = ['SMALL', 'MEDIUM', 'LARGE'];
-
-const SQUARE_METERS_PER_ACRE = 0.0002471054;
-
-/**
- * @deprecated do not use
- * @param planningArea
- */
-export function calculateAcres(planningArea: GeoJSON.GeoJSON) {
-  const squareMeters = area(planningArea as FeatureCollection);
-  const acres = squareMeters * SQUARE_METERS_PER_ACRE;
-  return Math.round(acres);
-}
+// sizes in hectares
+export const STAND_SIZES: Record<string, number> = {
+  SMALL: 10,
+  MEDIUM: 100,
+  LARGE: 500,
+};
 
 export function parseResultsToProjectAreas(
   results: ScenarioResult

--- a/src/interface/src/styles/_theme.scss
+++ b/src/interface/src/styles/_theme.scss
@@ -64,7 +64,7 @@ $planscape-frontend-theme: mat.define-light-theme(
       color: (
         primary: $planscape-frontend-primary,
         accent: $planscape-frontend-primary, // not really used
-        warn: $planscape-frontend-primary, // not really used
+        warn: mat.define-palette(mat.$red-palette)
       ),
     )
 );


### PR DESCRIPTION
<img width="617" alt="Screen Shot 2024-04-09 at 15 22 07" src="https://github.com/OurPlanscape/Planscape/assets/358892/cc8894e4-a287-481f-a8c7-851ad4bae5b5">

Disables stand sizes based on PA size, and select the appropiate one as default

Additionally, I've noticed that I've introduced a bug on styles on another pr, so restoring the warning palette.