### PR TITLE
remove animation on scenario results

### DIFF
--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -123,6 +123,7 @@ export class PlanMapComponent implements OnInit, AfterViewInit, OnDestroy {
     }).addTo(this.map);
     this.map.fitBounds(this.drawingLayer.getBounds(), {
       paddingTopLeft: this.mapPadding,
+      animate: false,
     });
   }
 


### PR DESCRIPTION
There is a jarring animation on the map when drawing the planning area / scenario results.
This pr removes the animation

**Before**

https://github.com/OurPlanscape/Planscape/assets/358892/dd9dbbd4-831e-4433-b922-7bb17db64bf9



**After**


https://github.com/OurPlanscape/Planscape/assets/358892/e39dbb4c-0e9a-4a1a-b564-52d8907bfdeb

