### PR TITLE
gzipping files

### DIFF
--- a/src/interface/nginx/nginx.conf
+++ b/src/interface/nginx/nginx.conf
@@ -9,7 +9,9 @@ server {
 
   gzip on;
 
-  gzip_types text/plain application/javascript text/javascript text/xml text/css;
+  gzip_types text/plain application/javascript application/json text/javascript text/xml text/css;
+
+  gzip_min_length 1000;
 
   error_log /var/log/nginx/localhost.error_log info;
 

--- a/src/interface/nginx/nginx.conf
+++ b/src/interface/nginx/nginx.conf
@@ -8,6 +8,9 @@ server {
   server_name 'planscape_nginx'
 
   gzip on;
+
+  gzip_types text/plain application/javascript text/javascript text/xml text/css;
+
   error_log /var/log/nginx/localhost.error_log info;
 
   location /planscape-backend/ {


### PR DESCRIPTION
It looks like we already have gzip turned on, but didn't configure the `gzip_types` so its only compressing the default text/html

<img width="1495" alt="Screen Shot 2024-04-25 at 15 23 30" src="https://github.com/OurPlanscape/Planscape/assets/358892/c5b17dd0-2acb-4088-8f39-8d9c842241de">
