### PR TITLE
Metrics Service 

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.spec.ts
@@ -114,7 +114,6 @@ describe('CreateScenariosComponent', () => {
       'PlanStateService',
       {
         getScenario: fakeGetScenario,
-        getMetricData: of(null),
         updateStateWithShapes: undefined,
       },
       {

--- a/src/interface/src/app/plan/scenario-helpers.spec.ts
+++ b/src/interface/src/app/plan/scenario-helpers.spec.ts
@@ -1,0 +1,156 @@
+import { MetricConfig, ScenarioConfig, ScenarioResult } from '@types';
+import { ChartData } from './project-areas-metrics/chart-data';
+import { processScenarioResultsToChartData } from './scenario-helpers';
+
+describe('processScenarioResultsToChartData', () => {
+  const metrics: MetricConfig[] = [
+    {
+      metric_name: 'metric1',
+      display_name: 'Metric 1',
+      data_units: 'units',
+      raw_layer: 'layer1',
+    },
+    {
+      metric_name: 'metric2',
+      display_name: 'Metric 2',
+      data_units: 'units',
+      raw_layer: 'layer2',
+    },
+    {
+      metric_name: 'metric3',
+      display_name: 'Metric 3',
+      data_units: 'units',
+      raw_layer: 'layer3',
+    },
+  ];
+
+  const scenarioConfig: ScenarioConfig = {
+    scenario_priorities: ['metric1'],
+    scenario_output_fields: ['metric2', 'metric3'],
+  };
+
+  const scenarioResults: ScenarioResult = {
+    status: 'PENDING',
+    completed_at: '0',
+    result: {
+      type: 'Feature',
+      features: [
+        {
+          properties: { metric1: 10, metric2: 20, metric3: 30 },
+          type: 'FeatureCollection',
+          features: [],
+        },
+        {
+          properties: { metric1: 15, metric2: 25, metric3: 35 },
+          type: 'FeatureCollection',
+          features: [],
+        },
+        {
+          properties: { metric1: 20, metric2: 30, metric3: 40 },
+          type: 'FeatureCollection',
+          features: [],
+        },
+      ],
+    },
+  };
+
+  it('should process metrics and return ChartData correctly', () => {
+    const expectedOutput: ChartData[] = [
+      {
+        label: 'Metric 1',
+        measurement: 'units',
+        key: 'metric1',
+        values: [10, 15, 20],
+        metric_layer: 'layer1',
+        is_primary: true,
+      },
+      {
+        label: 'Metric 2',
+        measurement: 'units',
+        key: 'metric2',
+        values: [20, 25, 30],
+        metric_layer: 'layer2',
+        is_primary: false,
+      },
+      {
+        label: 'Metric 3',
+        measurement: 'units',
+        key: 'metric3',
+        values: [30, 35, 40],
+        metric_layer: 'layer3',
+        is_primary: false,
+      },
+    ];
+
+    const result = processScenarioResultsToChartData(
+      metrics,
+      scenarioConfig,
+      scenarioResults
+    );
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should handle empty metrics array', () => {
+    const emptyMetrics: MetricConfig[] = [];
+    const result = processScenarioResultsToChartData(
+      emptyMetrics,
+      scenarioConfig,
+      scenarioResults
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty scenario results', () => {
+    const emptyScenarioResults: ScenarioResult = {
+      status: 'PENDING',
+      completed_at: '0',
+      result: {
+        features: [],
+        type: '',
+      },
+    };
+    const expectedOutput: ChartData[] = [
+      {
+        label: 'Metric 1',
+        measurement: 'units',
+        key: 'metric1',
+        values: [],
+        metric_layer: 'layer1',
+        is_primary: true,
+      },
+      {
+        label: 'Metric 2',
+        measurement: 'units',
+        key: 'metric2',
+        values: [],
+        metric_layer: 'layer2',
+        is_primary: false,
+      },
+      {
+        label: 'Metric 3',
+        measurement: 'units',
+        key: 'metric3',
+        values: [],
+        metric_layer: 'layer3',
+        is_primary: false,
+      },
+    ];
+
+    const result = processScenarioResultsToChartData(
+      metrics,
+      scenarioConfig,
+      emptyScenarioResults
+    );
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should handle missing priorities and output fields', () => {
+    const emptyConfig: ScenarioConfig = {};
+    const result = processScenarioResultsToChartData(
+      metrics,
+      emptyConfig,
+      scenarioResults
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/src/interface/src/app/plan/scenario-helpers.ts
+++ b/src/interface/src/app/plan/scenario-helpers.ts
@@ -1,0 +1,32 @@
+import { MetricConfig, ScenarioConfig, ScenarioResult } from '@types';
+import { ChartData } from './project-areas-metrics/chart-data';
+
+export function processScenarioResultsToChartData(
+  metrics: MetricConfig[],
+  scenarioConfig: ScenarioConfig,
+  scenarioResults: ScenarioResult
+): ChartData[] {
+  const priorities = scenarioConfig.scenario_priorities;
+  const outputFields = new Set([
+    ...(scenarioConfig.scenario_output_fields || []),
+    ...(priorities || []),
+  ]);
+
+  return metrics
+    .filter((metric) => outputFields?.has(metric.metric_name))
+    .map((metric) => {
+      let metricData: number[] = [];
+      scenarioResults.result.features.map((featureCollection) => {
+        metricData.push(featureCollection.properties[metric.metric_name]);
+      });
+
+      return <ChartData>{
+        label: metric.display_name,
+        measurement: metric.data_units,
+        key: metric.metric_name,
+        values: metricData,
+        metric_layer: metric.raw_layer,
+        is_primary: priorities?.includes(metric.metric_name) || false,
+      };
+    });
+}

--- a/src/interface/src/app/plan/scenario-helpers.ts
+++ b/src/interface/src/app/plan/scenario-helpers.ts
@@ -8,12 +8,12 @@ export function processScenarioResultsToChartData(
 ): ChartData[] {
   const {
     scenario_priorities: priorities = [],
-    scenario_output_fields: outputFields = [],
+    scenario_output_fields: secondary = [],
   } = scenarioConfig;
-  const relevantFields = new Set([...outputFields, ...priorities]);
+  const outputFields = new Set([...secondary, ...priorities]);
 
   return metrics.reduce((acc: ChartData[], metric) => {
-    if (relevantFields.has(metric.metric_name)) {
+    if (outputFields.has(metric.metric_name)) {
       const metricData = scenarioResults.result.features.map(
         (featureCollection) => featureCollection.properties[metric.metric_name]
       );

--- a/src/interface/src/app/services/metrics.service.spec.ts
+++ b/src/interface/src/app/services/metrics.service.spec.ts
@@ -27,7 +27,7 @@ describe('MetricsService', () => {
 
   it('should return cached conditions if they exist', () => {
     const mockConditions: MetricConfig[] = [];
-    service.conditions[Region.CENTRAL_COAST] = mockConditions;
+    service['conditions'][Region.CENTRAL_COAST] = mockConditions;
 
     service
       .getMetricsForRegion(Region.CENTRAL_COAST)
@@ -45,13 +45,13 @@ describe('MetricsService', () => {
 
   it('should fetch conditions from the backend if not cached', () => {
     const mockConditions: MetricConfig[] = [];
-    service.conditions[Region.CENTRAL_COAST] = null;
+    service['conditions'][Region.CENTRAL_COAST] = null;
 
     service
       .getMetricsForRegion(Region.CENTRAL_COAST)
       .subscribe((conditions) => {
         expect(conditions).toEqual(mockConditions);
-        expect(service.conditions[Region.CENTRAL_COAST]).toEqual(
+        expect(service['conditions'][Region.CENTRAL_COAST]).toEqual(
           mockConditions
         );
       });

--- a/src/interface/src/app/services/metrics.service.spec.ts
+++ b/src/interface/src/app/services/metrics.service.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { MetricsService } from './metrics.service';
+import { ConditionsConfig, Region, regionToString } from '@types';
+import { environment } from '../../environments/environment';
+
+describe('MetricsService', () => {
+  let service: MetricsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [MetricsService],
+    });
+
+    service = TestBed.inject(MetricsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should return cached conditions if they exist', () => {
+    const mockConditions: ConditionsConfig = {
+      /* mock data here */
+    };
+    service.conditions[Region.CENTRAL_COAST] = mockConditions;
+
+    service
+      .getMetricsForRegion(Region.CENTRAL_COAST)
+      .subscribe((conditions) => {
+        expect(conditions).toEqual(mockConditions);
+      });
+
+    // Ensure no HTTP requests are made
+    httpMock.expectNone(
+      environment.backend_endpoint +
+        '/conditions/config/?region_name=' +
+        regionToString(Region.CENTRAL_COAST)
+    );
+  });
+
+  it('should fetch conditions from the backend if not cached', () => {
+    const mockConditions: ConditionsConfig = {
+      /* mock data here */
+    };
+    service.conditions[Region.CENTRAL_COAST] = null;
+
+    service
+      .getMetricsForRegion(Region.CENTRAL_COAST)
+      .subscribe((conditions) => {
+        expect(conditions).toEqual(mockConditions);
+        expect(service.conditions[Region.CENTRAL_COAST]).toEqual(
+          mockConditions
+        );
+      });
+
+    const req = httpMock.expectOne(
+      environment.backend_endpoint +
+        '/conditions/config/?region_name=' +
+        regionToString(Region.CENTRAL_COAST)
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(mockConditions);
+  });
+});

--- a/src/interface/src/app/services/metrics.service.spec.ts
+++ b/src/interface/src/app/services/metrics.service.spec.ts
@@ -4,7 +4,7 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { MetricsService } from './metrics.service';
-import { ConditionsConfig, Region, regionToString } from '@types';
+import { MetricConfig, Region, regionToString } from '@types';
 import { environment } from '../../environments/environment';
 
 describe('MetricsService', () => {
@@ -26,9 +26,7 @@ describe('MetricsService', () => {
   });
 
   it('should return cached conditions if they exist', () => {
-    const mockConditions: ConditionsConfig = {
-      /* mock data here */
-    };
+    const mockConditions: MetricConfig[] = [];
     service.conditions[Region.CENTRAL_COAST] = mockConditions;
 
     service
@@ -40,15 +38,13 @@ describe('MetricsService', () => {
     // Ensure no HTTP requests are made
     httpMock.expectNone(
       environment.backend_endpoint +
-        '/conditions/config/?region_name=' +
+        '/conditions/config/?flat=true&region_name=' +
         regionToString(Region.CENTRAL_COAST)
     );
   });
 
   it('should fetch conditions from the backend if not cached', () => {
-    const mockConditions: ConditionsConfig = {
-      /* mock data here */
-    };
+    const mockConditions: MetricConfig[] = [];
     service.conditions[Region.CENTRAL_COAST] = null;
 
     service
@@ -62,7 +58,7 @@ describe('MetricsService', () => {
 
     const req = httpMock.expectOne(
       environment.backend_endpoint +
-        '/conditions/config/?region_name=' +
+        '/conditions/config/?flat=true&region_name=' +
         regionToString(Region.CENTRAL_COAST)
     );
     expect(req.request.method).toBe('GET');

--- a/src/interface/src/app/services/metrics.service.ts
+++ b/src/interface/src/app/services/metrics.service.ts
@@ -8,10 +8,10 @@ import { of, tap } from 'rxjs';
   providedIn: 'root',
 })
 export class MetricsService {
-  // has a record of conditions for each region.
-  // if no value on the record, go fetch.
-
-  conditions: Record<Region, MetricConfig[] | null> = {
+  /**
+   * Stores a record of metrics for each region.
+   */
+  private conditions: Record<Region, MetricConfig[] | null> = {
     [Region.CENTRAL_COAST]: null,
     [Region.NORTHERN_CALIFORNIA]: null,
     [Region.SIERRA_NEVADA]: null,
@@ -20,6 +20,11 @@ export class MetricsService {
 
   constructor(private http: HttpClient) {}
 
+  /**
+   * Gets a flat list of metrics for a given region.
+   * Only fetches the metrics if we dont have a record already
+   * @param region
+   */
   public getMetricsForRegion(region: Region) {
     if (this.conditions[region] !== null) {
       return of(this.conditions[region] as MetricConfig[]);

--- a/src/interface/src/app/services/metrics.service.ts
+++ b/src/interface/src/app/services/metrics.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { ConditionsConfig, Region, regionToString } from '@types';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { of, tap } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MetricsService {
+  // has a record of conditions for each region.
+  // if no value on the record, go fetch.
+
+  conditions: Record<Region, ConditionsConfig | null> = {
+    [Region.CENTRAL_COAST]: null,
+    [Region.NORTHERN_CALIFORNIA]: null,
+    [Region.SIERRA_NEVADA]: null,
+    [Region.SOUTHERN_CALIFORNIA]: null,
+  };
+
+  constructor(private http: HttpClient) {}
+
+  public getMetricsForRegion(region: Region) {
+    if (this.conditions[region] !== null) {
+      return of(this.conditions[region] as ConditionsConfig);
+    }
+    return this.http
+      .get<ConditionsConfig>(
+        environment.backend_endpoint +
+          '/conditions/config/?region_name=' +
+          `${regionToString(region)}`
+      )
+      .pipe(
+        tap((conditionsConfig) => (this.conditions[region] = conditionsConfig))
+      );
+  }
+}

--- a/src/interface/src/app/services/metrics.service.ts
+++ b/src/interface/src/app/services/metrics.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ConditionsConfig, Region, regionToString } from '@types';
+import { MetricConfig, Region, regionToString } from '@types';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { of, tap } from 'rxjs';
@@ -11,7 +11,7 @@ export class MetricsService {
   // has a record of conditions for each region.
   // if no value on the record, go fetch.
 
-  conditions: Record<Region, ConditionsConfig | null> = {
+  conditions: Record<Region, MetricConfig[] | null> = {
     [Region.CENTRAL_COAST]: null,
     [Region.NORTHERN_CALIFORNIA]: null,
     [Region.SIERRA_NEVADA]: null,
@@ -22,14 +22,12 @@ export class MetricsService {
 
   public getMetricsForRegion(region: Region) {
     if (this.conditions[region] !== null) {
-      return of(this.conditions[region] as ConditionsConfig);
+      return of(this.conditions[region] as MetricConfig[]);
     }
     return this.http
-      .get<ConditionsConfig>(
-        environment.backend_endpoint +
-          '/conditions/config/?region_name=' +
-          `${regionToString(region)}`
-      )
+      .get<
+        MetricConfig[]
+      >(environment.backend_endpoint + '/conditions/config/?flat=true&region_name=' + `${regionToString(region)}`)
       .pipe(
         tap((conditionsConfig) => (this.conditions[region] = conditionsConfig))
       );

--- a/src/interface/src/app/services/plan-state.service.ts
+++ b/src/interface/src/app/services/plan-state.service.ts
@@ -157,13 +157,6 @@ export class PlanStateService {
     );
   }
 
-  getMetricData(metric_paths: any) {
-    return this.scenarioService.getMetricData(
-      metric_paths,
-      this.planRegion$.value
-    );
-  }
-
   /**
    * Updates planRegion and treatmentGoalsConfig if value is a valid Region
    */

--- a/src/interface/src/app/services/scenario.service.ts
+++ b/src/interface/src/app/services/scenario.service.ts
@@ -1,13 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { catchError, Observable, take } from 'rxjs';
-import {
-  Region,
-  regionToString,
-  Scenario,
-  SCENARIO_STATUS,
-  ScenarioConfig,
-} from '@types';
+import { Scenario, SCENARIO_STATUS, ScenarioConfig } from '@types';
 import { CreateScenarioError } from './errors';
 import { environment } from '../../environments/environment';
 
@@ -143,17 +137,6 @@ export class ScenarioService {
         responseType: 'arraybuffer',
       }
     );
-  }
-
-  /** Gets Metric Data For Scenario Output Fields */
-  getMetricData(metric_paths: any, region: Region): Observable<any> {
-    const url = environment.backend_endpoint.concat(
-      '/conditions/metrics/?region_name=' +
-        `${regionToString(region)}` +
-        '&metric_paths=' +
-        JSON.stringify(metric_paths)
-    );
-    return this.http.get<any>(url).pipe(take(1));
   }
 
   private convertConfigToScenario(config: ScenarioConfig): any {

--- a/src/interface/src/app/types/scenario.types.ts
+++ b/src/interface/src/app/types/scenario.types.ts
@@ -34,6 +34,7 @@ export interface ScenarioConfig {
   stand_size?: string;
   scenario_priorities?: string[];
   question_id?: number;
+  scenario_output_fields?: string[]; // this value comes from saved scenarios
 }
 
 export interface ScenarioResult {


### PR DESCRIPTION
Removes usages of `conditions/metric` endpoint, using `/conditions/config/?flat=true` instead.
The result of this is saved by region to avoid subsequent requests.
