### PR TITLE
added outlined option to button component

### DIFF
--- a/src/interface/src/styleguide/button/button.component.html
+++ b/src/interface/src/styleguide/button/button.component.html
@@ -1,2 +1,4 @@
-<mat-icon *ngIf="icon">{{ icon }}</mat-icon>
+<mat-icon *ngIf="icon" [ngClass]="{ 'material-symbols-outlined': outlined }">{{
+  icon
+}}</mat-icon>
 <ng-content></ng-content>

--- a/src/interface/src/styleguide/button/button.component.ts
+++ b/src/interface/src/styleguide/button/button.component.ts
@@ -29,6 +29,11 @@ export class ButtonComponent {
    */
   @Input() icon: string = '';
 
+  /**
+   * If the icon uses the outline version
+   */
+  @Input() outlined = false;
+
   @Input() hasError = false;
 
   @HostBinding('class.ghost-button')

--- a/src/interface/src/styleguide/button/button.stories.ts
+++ b/src/interface/src/styleguide/button/button.stories.ts
@@ -67,7 +67,16 @@ export const Negative: Story = {
 export const Text: Story = {
   args: {
     variant: 'text',
-    icon: 'help_outline',
+    icon: 'help',
     content: 'A text-only button',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: 'ghost',
+    icon: 'explore',
+    outlined: true,
+    content: 'A button with outline icon',
   },
 };


### PR DESCRIPTION
_some_ icons have by default the "normal" and outlined version with prefixing _outlined to the name, but not all.
The "right" way is to switch the style (via a class name)

This pr adds an additional property on the button component to specify if we want to use the outlined version