### PR TITLE
undo this ENV condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,7 @@ taggit:
 	echo "Completed taggit"
 
 install-dependencies-frontend:
-	@if [ "$(ENV)" == "development" ]; then \
-		echo 'Running npm install with dev dependencies.'; \
-		cd src/interface && npm install; \
-	else \
-		echo 'Running npm install and omitting dev dependencies.'; \
-		cd src/interface && npm install --omit=dev; \
-	fi
+	cd src/interface && npm install
 
 compile-angular:
 	cd src/interface && npm run build -- --configuration production --output-path=./dist/out


### PR DESCRIPTION
Reverting this until future notice.

It looks like we might have two issues:
- Jenkins might not see the ENV variable that Sentry can see
- it looks like some of our build process relies on npm components that are in devDependencies
