### PR TITLE
Dependency changes for successful deploy-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,14 @@ taggit:
 	echo "Completed taggit"
 
 install-dependencies-frontend:
-	cd src/interface && npm install
-
+	@if [ "$(ENV)" == "development" ]; then \
+		echo 'Running npm install with dev dependencies.'; \
+		cd src/interface && npm install; \
+	else \
+		echo 'Running npm install and omitting dev dependencies.'; \
+		cd src/interface && npm install --omit=dev; \
+	fi
+	
 compile-angular:
 	cd src/interface && npm run build -- --configuration production --output-path=./dist/out
 

--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -21,7 +21,6 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^17.3.1",
-    
     "@angular/cdk": "^16.2.14",
     "@angular/common": "^17.3.1",
     "@angular/compiler": "^17.3.1",
@@ -33,7 +32,6 @@
     "@angular/platform-browser-dynamic": "^17.3.1",
     "@angular/router": "^17.3.1",
     "@angular-devkit/build-angular": "^17.3.1",
-
     "@geoman-io/leaflet-geoman-free": "^2.13.1",
     "@ngneat/until-destroy": "^10.0.0",
     "@turf/area": "^6.5.0",
@@ -62,7 +60,6 @@
     "shpjs": "^4.0.4",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4",
-
     "@types/leaflet": "^1.9.0",
     "@types/leaflet-draw": "^1.0.4",
     "@types/esri-leaflet": "^3.0.3",

--- a/src/interface/package.json
+++ b/src/interface/package.json
@@ -21,6 +21,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^17.3.1",
+    
     "@angular/cdk": "^16.2.14",
     "@angular/common": "^17.3.1",
     "@angular/compiler": "^17.3.1",
@@ -31,6 +32,8 @@
     "@angular/platform-browser": "^17.3.1",
     "@angular/platform-browser-dynamic": "^17.3.1",
     "@angular/router": "^17.3.1",
+    "@angular-devkit/build-angular": "^17.3.1",
+
     "@geoman-io/leaflet-geoman-free": "^2.13.1",
     "@ngneat/until-destroy": "^10.0.0",
     "@turf/area": "^6.5.0",
@@ -58,10 +61,14 @@
     "rxjs": "~7.5.0",
     "shpjs": "^4.0.4",
     "tslib": "^2.3.0",
-    "zone.js": "~0.14.4"
+    "zone.js": "~0.14.4",
+
+    "@types/leaflet": "^1.9.0",
+    "@types/leaflet-draw": "^1.0.4",
+    "@types/esri-leaflet": "^3.0.3",
+    "@types/shpjs": "^3.4.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.1",
     "@angular-eslint/builder": "17.3.0",
     "@angular-eslint/eslint-plugin": "17.3.0",
     "@angular-eslint/eslint-plugin-template": "17.3.0",
@@ -80,12 +87,8 @@
     "@storybook/angular": "^8.0.5",
     "@storybook/blocks": "^8.0.5",
     "@storybook/test": "^8.0.5",
-    "@types/esri-leaflet": "^3.0.3",
     "@types/geojson": "^7946.0.10",
     "@types/jasmine": "~4.0.0",
-    "@types/leaflet": "^1.9.0",
-    "@types/leaflet-draw": "^1.0.4",
-    "@types/shpjs": "^3.4.2",
     "@typescript-eslint/eslint-plugin": "7.2.0",
     "@typescript-eslint/parser": "7.2.0",
     "cypress": "^13.8.1",


### PR DESCRIPTION
This PR includes changes that are apparently needed to get `make deploy-all` to run with the `--omit=dev` flag.