### PR TITLE
reverts previous thrown error

### DIFF
--- a/src/planscape/planning/e2e/scenario_test.py
+++ b/src/planscape/planning/e2e/scenario_test.py
@@ -35,11 +35,10 @@ class E2EScenarioTest:
             self.fixtures_path = fixtures_path
 
     def initiate_tests(self):
-        raise SystemError("Intentional Error to test failures")
-        # self.load_test_definitions()
-        # self.upsert_test_user()
-        # self.create_areas()
-        # self.run_tests()
+        self.load_test_definitions()
+        self.upsert_test_user()
+        self.create_areas()
+        self.run_tests()
 
     def load_test_definitions(self):
         """Reads the JSON file that describes our test areas, scenarios and expected results"""


### PR DESCRIPTION
This reverts https://github.com/OurPlanscape/Planscape/pull/1555/files
I'm not sure if we prefer to just rollback PRs like this, but this seems less risky and more transparent.