### PR TITLE
disable cypress screenshot saving

### DIFF
--- a/src/interface/cypress.config.ts
+++ b/src/interface/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   e2e: {
     baseUrl: process.env['CYPRESS_TEST_BASE_URL'] ?? 'http://localhost:4200',
   },
-
+  screenshotOnRunFailure: false,
   component: {
     devServer: {
       framework: 'angular',


### PR DESCRIPTION
Cypress, by default, tries to save screenshots of the errors it encounters into its own test suite directory. For the moment, I'd like to disable this by until we find a better place to put them.