### PR TITLE
hide support message if no message is provided

### DIFF
--- a/src/interface/src/styleguide/input/input-field.component.spec.ts
+++ b/src/interface/src/styleguide/input/input-field.component.spec.ts
@@ -94,6 +94,7 @@ describe('InputFieldComponent', () => {
       By.directive(InputFieldComponent)
     ).componentInstance as InputFieldComponent;
     inputComponent.error = true;
+    inputComponent.supportMessage = 'some message';
     inputComponent.showSupportMessage = 'on-error';
     hostFixture.detectChanges();
     expect(inputComponent.displaysSupportMessage).toBeTrue();
@@ -103,6 +104,15 @@ describe('InputFieldComponent', () => {
     expect(inputComponent.displaysSupportMessage).toBeTrue();
 
     inputComponent.showSupportMessage = false;
+    hostFixture.detectChanges();
+    expect(inputComponent.displaysSupportMessage).toBeFalse();
+  });
+
+  it('should not display support messages if no message is provided', () => {
+    const inputComponent = hostFixture.debugElement.query(
+      By.directive(InputFieldComponent)
+    ).componentInstance as InputFieldComponent;
+
     hostFixture.detectChanges();
     expect(inputComponent.displaysSupportMessage).toBeFalse();
   });

--- a/src/interface/src/styleguide/input/input-field.component.ts
+++ b/src/interface/src/styleguide/input/input-field.component.ts
@@ -117,8 +117,9 @@ export class InputFieldComponent implements AfterContentInit {
 
   get displaysSupportMessage() {
     return (
-      this.showSupportMessage === 'always' ||
-      (this.showSupportMessage === 'on-error' && this.error)
+      !!this.supportMessage &&
+      (this.showSupportMessage === 'always' ||
+        (this.showSupportMessage === 'on-error' && this.error))
     );
   }
 


### PR DESCRIPTION
Noticed that the element for the support message was not hidden when _not_ providing support message, adding an extra margin to the component.