### PR TITLE
Handle dropdown menu close

### DIFF
--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
@@ -73,7 +73,7 @@
           sg-button
           variant="primary"
           type="submit"
-          (click)="done($event)">
+          (click)="applyChanges($event)">
           Apply
         </button>
       </div>

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
@@ -1,4 +1,5 @@
 <button
+  #triggerButton
   [matMenuTriggerFor]="multiSelectMenu"
   class="dropdown-button"
   [disabled]="disabled"
@@ -29,7 +30,10 @@
   </mat-icon>
 </button>
 
-<mat-menu #multiSelectMenu="matMenu" class="filtermenu">
+<mat-menu
+  #multiSelectMenu="matMenu"
+  class="filtermenu"
+  (closed)="handleClosedMenu($event)">
   <div
     class="search-section"
     *ngIf="hasSearch"
@@ -62,11 +66,15 @@
         clear all
       </button>
       <div class="button-box">
-        <button sg-button variant="ghost" (click)="handleCancel($event)">
+        <button sg-button variant="ghost" (click)="handleCancel()">
           Cancel
         </button>
-        <button sg-button variant="primary" type="submit" (click)="done()">
-          Done
+        <button
+          sg-button
+          variant="primary"
+          type="submit"
+          (click)="done($event)">
+          Apply
         </button>
       </div>
     </div>

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
+import { MatMenuModule, MenuCloseReason } from '@angular/material/menu';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ButtonComponent, InputFieldComponent } from '@styleguide';
 import { FormsModule } from '@angular/forms';
@@ -92,7 +92,7 @@ export class FilterDropdownComponent<T> implements OnInit {
     return this.selectedItems.length > 0;
   }
 
-  handleClosedMenu(e: any): void {
+  handleClosedMenu(e: MenuCloseReason): void {
     // if menu was closed because of the apply button,
     // we don't cancel the selections
     if (e !== 'click') {

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
@@ -115,6 +115,7 @@ export class FilterDropdownComponent<T> implements OnInit {
       this.selectedItems = this.selectedItems.filter((e) => e !== item);
     }
     e.stopPropagation();
+    this.changedSelection.emit(this.selectedItems);
   }
 
   get selectionText(): string {

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
@@ -67,7 +67,7 @@ export class FilterDropdownComponent<T> implements OnInit {
   @Output() changedSelection = new EventEmitter<T[]>();
 
   /**
-   *  Event that emits when the `done` button is clicked
+   *  Event that emits when the `apply` button is clicked
    */
   @Output() confirmedSelection = new EventEmitter<T[]>();
 
@@ -93,7 +93,7 @@ export class FilterDropdownComponent<T> implements OnInit {
   }
 
   handleClosedMenu(e: any): void {
-    // if menu was closed because of the done button,
+    // if menu was closed because of the apply button,
     // we don't cancel the selections
     if (e !== 'click') {
       this.handleCancel();
@@ -161,7 +161,7 @@ export class FilterDropdownComponent<T> implements OnInit {
     });
   }
 
-  done(e: Event) {
+  applyChanges(e: Event) {
     this.confirmedSelection.emit(this.selectedItems);
   }
 }

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
@@ -92,6 +92,14 @@ export class FilterDropdownComponent<T> implements OnInit {
     return this.selectedItems.length > 0;
   }
 
+  handleClosedMenu(e: any): void {
+    // if menu was closed because of the done button,
+    // we don't cancel the selections
+    if (e !== 'click') {
+      this.handleCancel();
+    }
+  }
+
   showCount(): boolean {
     return this.selectedItems.length > 1;
   }
@@ -107,7 +115,6 @@ export class FilterDropdownComponent<T> implements OnInit {
       this.selectedItems = this.selectedItems.filter((e) => e !== item);
     }
     e.stopPropagation();
-    this.changedSelection.emit(this.selectedItems);
   }
 
   get selectionText(): string {
@@ -118,7 +125,7 @@ export class FilterDropdownComponent<T> implements OnInit {
     return this.menuLabel;
   }
 
-  handleCancel(e: any) {
+  handleCancel() {
     this.selectedItems = this.previousSelections.slice();
     this.previousSelections = [];
   }
@@ -154,7 +161,7 @@ export class FilterDropdownComponent<T> implements OnInit {
     });
   }
 
-  done() {
+  done(e: Event) {
     this.confirmedSelection.emit(this.selectedItems);
   }
 }


### PR DESCRIPTION
This PR:
- changes the "Done" button to say "Apply" (per chat with UX)
- if the menu is closed (and not because the "Apply" button was closed), it cancels the newly selected/unselected changes