### PR TITLE
add ngonchanges block for current page

### DIFF
--- a/src/interface/src/styleguide/paginator/paginator.component.html
+++ b/src/interface/src/styleguide/paginator/paginator.component.html
@@ -56,8 +56,8 @@
   <mat-form-field class="picker-field" appearance="outline">
     <mat-select
       panelClass="paginator-select-panel"
-      [(ngModel)]="selectedPage"
-      (selectionChange)="setPage(selectedPage)">
+      [(ngModel)]="currentPage"
+      (selectionChange)="changeSelection()">
       @for (page of navSelectRange; track page) {
         <mat-option class="nav-page-item" [value]="page">{{ page }}</mat-option>
       }

--- a/src/interface/src/styleguide/paginator/paginator.component.html
+++ b/src/interface/src/styleguide/paginator/paginator.component.html
@@ -57,7 +57,7 @@
     <mat-select
       panelClass="paginator-select-panel"
       [(ngModel)]="currentPage"
-      (selectionChange)="changeSelection()">
+      (selectionChange)="selectPageChange()">
       @for (page of navSelectRange; track page) {
         <mat-option class="nav-page-item" [value]="page">{{ page }}</mat-option>
       }
@@ -71,7 +71,7 @@
     <mat-select
       panelClass="paginator-select-panel"
       [(ngModel)]="recordsPerPage"
-      (selectionChange)="selectPageChange()">
+      (selectionChange)="perPageChanged()">
       @for (count of perPageOptions; track count) {
         <mat-option class="per-page-item" [value]="count">{{
           count

--- a/src/interface/src/styleguide/paginator/paginator.component.html
+++ b/src/interface/src/styleguide/paginator/paginator.component.html
@@ -71,7 +71,7 @@
     <mat-select
       panelClass="paginator-select-panel"
       [(ngModel)]="recordsPerPage"
-      (selectionChange)="perPageChanged()">
+      (selectionChange)="selectPageChange()">
       @for (count of perPageOptions; track count) {
         <mat-option class="per-page-item" [value]="count">{{
           count

--- a/src/interface/src/styleguide/paginator/paginator.component.ts
+++ b/src/interface/src/styleguide/paginator/paginator.component.ts
@@ -61,7 +61,6 @@ export class PaginatorComponent implements OnInit, OnChanges {
    */
   @Output() recordsPerPageChanged = new EventEmitter<number>();
 
-  selectedPage: number = 0;
   buttonsShown = 0;
   showFirstSpacer$ = new BehaviorSubject<boolean>(false);
   showLastSpacer$ = new BehaviorSubject<boolean>(false);
@@ -70,7 +69,6 @@ export class PaginatorComponent implements OnInit, OnChanges {
   defaultButtonsToShow = 6;
 
   ngOnInit(): void {
-    this.selectedPage = this.currentPage;
     this.navSelectRange = [1, ...Array(this.pageCount + 1).keys()].slice(2);
     this.calcButtonLabels();
   }
@@ -78,9 +76,6 @@ export class PaginatorComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['pageCount']) {
       this.calcButtonLabels();
-    }
-    if (changes['currentPage']) {
-      this.selectedPage = this.currentPage;
     }
   }
 
@@ -95,15 +90,12 @@ export class PaginatorComponent implements OnInit, OnChanges {
     const midCount = Math.ceil(buttonsToShow / 2);
     const rightRemainder = Math.max(
       0,
-      midCount + 1 - (curPages - this.selectedPage)
+      midCount + 1 - (curPages - this.currentPage)
     );
-    const leftRemainder = Math.max(0, midCount - (this.selectedPage - 1));
-    let buttonStart = Math.max(
-      this.selectedPage - midCount - rightRemainder,
-      2
-    );
+    const leftRemainder = Math.max(0, midCount - (this.currentPage - 1));
+    let buttonStart = Math.max(this.currentPage - midCount - rightRemainder, 2);
     let buttonEnd = Math.min(
-      this.selectedPage + midCount + 1 + leftRemainder,
+      this.currentPage + midCount + 1 + leftRemainder,
       curPages
     );
     this.showFirstSpacer$.next(buttonStart > 2);
@@ -118,15 +110,15 @@ export class PaginatorComponent implements OnInit, OnChanges {
   }
 
   setPage(pageNum: number) {
-    if (this.selectedPage !== pageNum) {
-      this.selectedPage = pageNum;
-      this.pageChanged.emit(this.selectedPage);
+    if (this.currentPage !== pageNum) {
+      this.currentPage = pageNum;
+      this.pageChanged.emit(this.currentPage);
       this.calcButtonLabels();
     }
   }
 
   isCurrentPage(elementPage: number): boolean {
-    return elementPage === this.selectedPage;
+    return elementPage === this.currentPage;
   }
 
   perPageChanged() {
@@ -134,11 +126,11 @@ export class PaginatorComponent implements OnInit, OnChanges {
   }
 
   handlePrevious() {
-    const pageNum = Math.max(this.selectedPage - 1, 1);
+    const pageNum = Math.max(this.currentPage - 1, 1);
     this.setPage(pageNum);
   }
   handleNext() {
-    const pageNum = Math.min(this.selectedPage + 1, this.pageCount);
+    const pageNum = Math.min(this.currentPage + 1, this.pageCount);
     this.setPage(pageNum);
   }
 }

--- a/src/interface/src/styleguide/paginator/paginator.component.ts
+++ b/src/interface/src/styleguide/paginator/paginator.component.ts
@@ -109,7 +109,8 @@ export class PaginatorComponent implements OnInit, OnChanges {
     this.buttonRange$.next(buttonArray);
   }
 
-  changeSelection() {
+  selectPageChange() {
+    this.calcButtonLabels();
     this.pageChanged.emit(this.currentPage);
   }
 

--- a/src/interface/src/styleguide/paginator/paginator.component.ts
+++ b/src/interface/src/styleguide/paginator/paginator.component.ts
@@ -79,6 +79,9 @@ export class PaginatorComponent implements OnInit, OnChanges {
     if (changes['pageCount']) {
       this.calcButtonLabels();
     }
+    if (changes['currentPage']) {
+      this.selectedPage = this.currentPage;
+    }
   }
 
   getTotalPages(): number {
@@ -88,11 +91,6 @@ export class PaginatorComponent implements OnInit, OnChanges {
   calcButtonLabels(): void {
     const curPages = this.pageCount;
     const buttonsToShow = Math.min(curPages, this.defaultButtonsToShow);
-
-    // in case the results-per-page changes, ensure that the
-    // currently selected page number doesn't exceed
-    // the number of pages available
-    this.selectedPage = Math.min(curPages, this.selectedPage);
 
     const midCount = Math.ceil(buttonsToShow / 2);
     const rightRemainder = Math.max(

--- a/src/interface/src/styleguide/paginator/paginator.component.ts
+++ b/src/interface/src/styleguide/paginator/paginator.component.ts
@@ -109,6 +109,10 @@ export class PaginatorComponent implements OnInit, OnChanges {
     this.buttonRange$.next(buttonArray);
   }
 
+  changeSelection() {
+    this.pageChanged.emit(this.currentPage);
+  }
+
   setPage(pageNum: number) {
     if (this.currentPage !== pageNum) {
       this.currentPage = pageNum;


### PR DESCRIPTION
This PR:
- updates currentPage when it's changed from the parent, instead of trying to reset it on per page changes
- removes local selectedPage var in favor of input var