### PR TITLE
Tx prescription viewset endpoint

### DIFF
--- a/src/planscape/impacts/routers.py
+++ b/src/planscape/impacts/routers.py
@@ -1,10 +1,16 @@
 from rest_framework.routers import SimpleRouter
 
-from impacts.views import TreatmentPlanViewSet
+from impacts.views import TreatmentPlanViewSet, TreatmentPrescriptionViewSet
 
 router = SimpleRouter()
 router.register(
     "treatment_plans",
     TreatmentPlanViewSet,
     basename="tx-plans",
+)
+
+router.register(
+    "treatment_plans/(?P<tx_plan_pk>\d+)/treatment_prescriptions",
+    TreatmentPrescriptionViewSet,
+    basename="tx-prescriptions",
 )

--- a/src/planscape/impacts/serializers.py
+++ b/src/planscape/impacts/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from core.fields import UUIDRelatedField
-from impacts.models import TreatmentPlan
+from impacts.models import TreatmentPlan, TreatmentPrescription
 from planning.models import Scenario
 
 
@@ -32,3 +32,25 @@ class TreatmentPlanSerializer(serializers.ModelSerializer):
 
 class TreatmentPlanListSerializer(serializers.ModelSerializer):
     pass
+
+
+class TreatmentPrescriptionSerializer(serializers.ModelSerializer):
+    pass
+
+
+class TreatmentPrescriptionListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TreatmentPrescription
+        fields = (
+            "created_at",
+            "updated_at",
+            "deleted_at",
+            "uuid",
+            "type",
+            "action",
+            "geometry",
+            "stand",
+            "created_by",
+            "project_area",
+            "treatment_plan",
+        )

--- a/src/planscape/impacts/serializers.py
+++ b/src/planscape/impacts/serializers.py
@@ -35,7 +35,8 @@ class TreatmentPlanListSerializer(serializers.ModelSerializer):
 
 
 class TreatmentPrescriptionSerializer(serializers.ModelSerializer):
-    pass
+    class Meta:
+        model = TreatmentPrescription
 
 
 class TreatmentPrescriptionListSerializer(serializers.ModelSerializer):
@@ -44,13 +45,9 @@ class TreatmentPrescriptionListSerializer(serializers.ModelSerializer):
         fields = (
             "created_at",
             "updated_at",
-            "deleted_at",
             "uuid",
             "type",
             "action",
-            "geometry",
             "stand",
             "created_by",
-            "project_area",
-            "treatment_plan",
         )

--- a/src/planscape/impacts/tests/factories.py
+++ b/src/planscape/impacts/tests/factories.py
@@ -1,0 +1,26 @@
+import factory
+from django.contrib.gis.geos import Polygon, MultiPolygon
+from impacts.models import TreatmentPlan, TreatmentPrescription
+from planscape.tests.factories import UserFactory
+from planning.tests.factories import ScenarioFactory, ProjectAreaFactory
+
+
+class TreatmentPlanFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = TreatmentPlan
+
+    name = factory.Sequence(lambda n: "treatment plan %s" % n)
+    scenario = factory.SubFactory(ScenarioFactory)
+    created_by = factory.SubFactory(UserFactory)
+
+
+class TreatmentPrescriptionFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = TreatmentPrescription
+
+    uuid = factory.Faker("uuid4")
+    treatment_plan = factory.SubFactory(TreatmentPlanFactory)
+    created_by = factory.SubFactory(UserFactory)
+    project_area = factory.SubFactory(ProjectAreaFactory)
+    geometry = Polygon(((1, 1), (1, 2), (2, 2), (1, 1)))
+    updated_by = factory.SubFactory(UserFactory)  # this needs to be not-null?

--- a/src/planscape/impacts/tests/test_views.py
+++ b/src/planscape/impacts/tests/test_views.py
@@ -4,11 +4,12 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from planning.tests.factories import ScenarioFactory
 from impacts.models import TreatmentPlan
+from impacts.tests.factories import TreatmentPlanFactory, TreatmentPrescriptionFactory
 
 User = get_user_model()
 
 
-class TxPlanVioewSetTest(APITransactionTestCase):
+class TxPlanViewSetTest(APITransactionTestCase):
     def setUp(self):
         self.scenario = ScenarioFactory.create()
         self.client.force_authenticate(user=self.scenario.user)
@@ -28,3 +29,27 @@ class TxPlanVioewSetTest(APITransactionTestCase):
             data.get("created_by"),
             tx_plan.created_by.id,
         )
+
+
+class TxPrescriptionListTest(APITransactionTestCase):
+    def setUp(self):
+        self.tx_plan = TreatmentPlanFactory.create()
+        self.client.force_authenticate(user=self.tx_plan.scenario.user)
+
+        self.tx_rx1 = TreatmentPrescriptionFactory.create(treatment_plan=self.tx_plan)
+        self.tx_rx2 = TreatmentPrescriptionFactory.create(treatment_plan=self.tx_plan)
+
+    def test_list_tx_rx(self):
+        response = self.client.get(
+            reverse(
+                "api:impacts:tx-prescriptions-list",
+                kwargs={"tx_plan_pk": self.tx_plan.pk},
+            ),
+            content_type="application/json",
+        )
+
+        data = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(data["count"], 2)
+        self.assertEqual(data["results"][0]["treatment_plan"], self.tx_plan.pk)
+        self.assertEqual(data["results"][1]["treatment_plan"], self.tx_plan.pk)

--- a/src/planscape/impacts/tests/test_views.py
+++ b/src/planscape/impacts/tests/test_views.py
@@ -51,5 +51,3 @@ class TxPrescriptionListTest(APITransactionTestCase):
         data = response.json()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(data["count"], 2)
-        self.assertEqual(data["results"][0]["treatment_plan"], self.tx_plan.pk)
-        self.assertEqual(data["results"][1]["treatment_plan"], self.tx_plan.pk)

--- a/src/planscape/impacts/views.py
+++ b/src/planscape/impacts/views.py
@@ -1,9 +1,11 @@
 from rest_framework import mixins, viewsets, response, status
-from impacts.models import TreatmentPlan
+from impacts.models import TreatmentPlan, TreatmentPrescription
 from impacts.serializers import (
     CreateTreatmentPlanSerializer,
     TreatmentPlanListSerializer,
     TreatmentPlanSerializer,
+    TreatmentPrescriptionSerializer,
+    TreatmentPrescriptionListSerializer,
 )
 from impacts.services import create_treatment_plan
 
@@ -45,3 +47,38 @@ class TreatmentPlanViewSet(
         serializer.instance = create_treatment_plan(
             **serializer.validated_data,
         )
+
+
+class TreatmentPrescriptionViewSet(
+    mixins.CreateModelMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    queryset = TreatmentPrescription.objects.all()
+    serializer_class = TreatmentPrescriptionSerializer
+    serializer_classes = {
+        "list": TreatmentPrescriptionListSerializer,
+        "create": TreatmentPrescriptionSerializer,
+        "retrieve": TreatmentPrescriptionSerializer,
+    }
+
+    def get_serializer_class(self):
+        try:
+            return self.serializer_classes[self.action]
+        except KeyError:
+            return self.serializer_class
+
+    def get_queryset(self):
+        tx_plan_pk = self.kwargs.get("tx_plan_pk")
+        if tx_plan_pk:
+            try:
+                tx_prescriptions = TreatmentPrescription.objects.filter(
+                    treatment_plan_id=tx_plan_pk,
+                )
+                return tx_prescriptions
+            except TreatmentPrescription.DoesNotExist:
+                return TreatmentPrescription.objects.none()
+        else:
+            return TreatmentPrescription.objects.none()

--- a/src/planscape/planning/tests/factories.py
+++ b/src/planscape/planning/tests/factories.py
@@ -2,8 +2,8 @@ import factory
 from django.contrib.gis.geos import Polygon, MultiPolygon
 from planning.models import (
     PlanningArea,
+    ProjectArea,
     Scenario,
-    ScenarioResult,
     ScenarioResultStatus,
     ScenarioStatus,
 )
@@ -41,3 +41,12 @@ class ScenarioFactory(factory.django.DjangoModelFactory):
 
     status = ScenarioStatus.ACTIVE
     result_status = ScenarioResultStatus.PENDING
+
+
+class ProjectAreaFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ProjectArea
+
+    geometry = MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1))))
+    created_by = factory.SubFactory(UserFactory)
+    scenario = factory.SubFactory(ScenarioFactory)


### PR DESCRIPTION
Adds an viewset endpoint, router, and various tests using factory_boy.
Obviously, there are a few ways we could arrange this viewset, but this seemed like the most sustainable approach, although different from [this approach](https://github.com/OurPlanscape/Planscape/pull/1601)