### PR TITLE
fix bug with redirects and login

### DIFF
--- a/src/interface/src/app/services/auth.service.spec.ts
+++ b/src/interface/src/app/services/auth.service.spec.ts
@@ -15,6 +15,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 // Define a dummy component for the route
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   template: '',
@@ -564,22 +565,27 @@ describe('AuthGuard', () => {
       });
     });
 
-    it('returns false if user is not logged in', (done) => {
+    it('checks for getLoggedInUser if user is not logged in', (done) => {
       const authServiceStub: AuthService = TestBed.inject(AuthService);
       authServiceStub.isLoggedIn$ = of(false);
+      spyOn(authServiceStub, 'getLoggedInUser');
 
       service.canActivate().subscribe((result) => {
-        expect(result).toBeFalse();
+        expect(authServiceStub.getLoggedInUser).toHaveBeenCalled();
         done();
       });
     });
 
-    it('returns false if user logged in is null', (done) => {
+    it('goes to login if getLoggedInUser throws error ', (done) => {
       const authServiceStub: AuthService = TestBed.inject(AuthService);
+      const router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
       authServiceStub.isLoggedIn$ = of(null);
+      spyOn(authServiceStub, 'getLoggedInUser').and.throwError('some error');
 
       service.canActivate().subscribe((result) => {
         expect(result).toBeFalse();
+        expect(router.navigate).toHaveBeenCalledWith(['login']);
         done();
       });
     });

--- a/src/interface/src/app/services/auth.service.ts
+++ b/src/interface/src/app/services/auth.service.ts
@@ -15,6 +15,7 @@ import {
   map,
   Observable,
   of,
+  switchMap,
   take,
   tap,
   throwError,
@@ -387,11 +388,11 @@ export class AuthGuard {
     state?: RouterStateSnapshot
   ): Observable<boolean> {
     return this.authService.isLoggedIn$.pipe(
-      map((loggedIn) => {
-        if (!loggedIn) {
-          throw new Error('not logged in');
+      switchMap((loggedIn) => {
+        if (loggedIn) {
+          return of(true);
         }
-        return true;
+        return this.authService.getLoggedInUser().pipe(map(() => true));
       }),
       catchError((_) => {
         if (state) {


### PR DESCRIPTION
Fixes a bug when we need to load user before figuring out if we can redirect (for example, reloading a page like plan/{id}

The route of the bug is that isLoggedIn$ is not yet populated if we refresh the page, so to fix this we call to get the loggedInUser. If user is not logged in it will throw an error and we'll redirect.