### PR TITLE
Fix download names with periods

### DIFF
--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.spec.ts
@@ -65,7 +65,7 @@ describe('ScenarioResultsComponent', () => {
       expect(scenarioService.downloadCsvData).toHaveBeenCalledWith('1234');
       expect(fileSaverService.saveAs).toHaveBeenCalledWith(
         jasmine.any(Blob),
-        'A_great_scenario_result.zip'
+        'A_great_scenario_result_csv.zip'
       );
     });
     it('should download shapefile file with scenario name', () => {

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.spec.ts
@@ -37,7 +37,7 @@ describe('ScenarioResultsComponent', () => {
     fixture = TestBed.createComponent(ScenarioResultsComponent);
     component = fixture.componentInstance;
     component.scenarioId = '1234';
-    component.scenarioName = 'A great scenario result';
+    component.scenarioName = 'A\\great.scenario/result';
 
     scenarioService = TestBed.inject(ScenarioService);
     fileSaverService = TestBed.inject(FileSaverService);
@@ -65,7 +65,7 @@ describe('ScenarioResultsComponent', () => {
       expect(scenarioService.downloadCsvData).toHaveBeenCalledWith('1234');
       expect(fileSaverService.saveAs).toHaveBeenCalledWith(
         jasmine.any(Blob),
-        'A great scenario result csv'
+        'A_great_scenario_result.zip'
       );
     });
     it('should download shapefile file with scenario name', () => {
@@ -76,7 +76,7 @@ describe('ScenarioResultsComponent', () => {
       expect(scenarioService.downloadShapeFiles).toHaveBeenCalledWith('1234');
       expect(fileSaverService.saveAs).toHaveBeenCalledWith(
         jasmine.any(Blob),
-        'A great scenario result shapefiles'
+        'A_great_scenario_result_shp.zip'
       );
     });
   });

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
@@ -44,7 +44,7 @@ export class ScenarioResultsComponent implements OnChanges {
   }
 
   downloadCsv() {
-    const filename = this.scenarioName + ' csv';
+    const filename = this.scenarioName.replace(/[\s./\\]/g, '_') + '.zip';
     if (this.scenarioId) {
       this.scenarioService
         .downloadCsvData(this.scenarioId)
@@ -58,7 +58,9 @@ export class ScenarioResultsComponent implements OnChanges {
   }
 
   downloadShapeFiles() {
-    const filename = this.scenarioName + ' shapefiles';
+    const filename =
+      this.scenarioName.replace(/[\s./\\/]/g, '_').replace(/_+/g, '_') +
+      '_shp.zip';
     if (this.scenarioId) {
       this.scenarioService
         .downloadShapeFiles(this.scenarioId)

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
@@ -44,7 +44,7 @@ export class ScenarioResultsComponent implements OnChanges {
   }
 
   downloadCsv() {
-    const filename = this.scenarioName.replace(/[\s./\\]/g, '_') + '.zip';
+    const filename = this.scenarioName.replace(/[\s./\\]/g, '_') + '_csv.zip';
     if (this.scenarioId) {
       this.scenarioService
         .downloadCsvData(this.scenarioId)

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.ts
@@ -58,9 +58,7 @@ export class ScenarioResultsComponent implements OnChanges {
   }
 
   downloadShapeFiles() {
-    const filename =
-      this.scenarioName.replace(/[\s./\\/]/g, '_').replace(/_+/g, '_') +
-      '_shp.zip';
+    const filename = this.scenarioName.replace(/[\s./\\/]/g, '_') + '_shp.zip';
     if (this.scenarioId) {
       this.scenarioService
         .downloadShapeFiles(this.scenarioId)


### PR DESCRIPTION
There are some inconsistencies with how `file-saver` is handling suffixes, depending on browser and platform, so this sidesteps that logic by adding a `.zip` suffix to these two functions where we expect to generate a zip.

Some browsers still have trouble with spaces, slashes, and periods, so this also adds a regex to replace those with underscores, which is what already happens for some special characters.

TODO: doublecheck with UX/Product about whether to include strings like "csv" or "shapefile" or "shp" in the zip name.