### PR TITLE
set paginator component to center align

### DIFF
--- a/src/interface/src/styleguide/paginator/paginator.component.scss
+++ b/src/interface/src/styleguide/paginator/paginator.component.scss
@@ -5,7 +5,7 @@
 :host {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   width: 100%;
 
@@ -19,8 +19,8 @@
   }
 
   ::ng-deep
-    .mat-mdc-text-field-wrapper.mdc-text-field--outlined
-    .mat-mdc-form-field-infix {
+  .mat-mdc-text-field-wrapper.mdc-text-field--outlined
+  .mat-mdc-form-field-infix {
     padding-top: 0px;
     padding-bottom: 0px;
   }
@@ -96,6 +96,7 @@
   border-top-left-radius: 10%;
   border-bottom-left-radius: 10%;
   padding-left: 12px;
+
   .mat-icon {
     font-size: 14px;
     height: 100%;
@@ -108,6 +109,7 @@
   border-top-right-radius: 10%;
   border-bottom-right-radius: 10%;
   border-right: 1px solid $color-soft-gray;
+
   .mat-icon {
     font-size: 14px;
     height: 100%;
@@ -120,7 +122,6 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  width: 100%;
 }
 
 .nav-control-container {
@@ -175,6 +176,7 @@
   --mat-select-trigger-text-font: 'Public Sans';
   --mdc-outlined-text-field-outline-color: $color-soft-gray;
   background-color: $color-white;
+
   &.disabled {
     opacity: 0.6;
   }


### PR DESCRIPTION
Just noticed that the sg-paginator should be center aligned 
<img width="1208" alt="Screen Shot 2024-07-24 at 12 52 03" src="https://github.com/user-attachments/assets/a7e7df1e-a7df-4aa9-b44c-f3f7167b4828">
