### PR TITLE
propagates soft deletion to all planning area hierarchy

### DIFF
--- a/src/planscape/collaboration/permissions.py
+++ b/src/planscape/collaboration/permissions.py
@@ -134,4 +134,6 @@ class ScenarioPermission(CheckPermissionMixin):
 
     @staticmethod
     def can_remove(user: User, scenario: Scenario):
-        return is_creator(user, scenario.planning_area) or scenario.user.pk == user.pk
+        planning_creator = is_creator(user, scenario.planning_area)
+        scenario_creator = scenario.user.pk == user.pk
+        return any([planning_creator, scenario_creator])

--- a/src/planscape/planning/migrations/0021_planningarea_deleted_at_scenario_deleted_at_and_more.py
+++ b/src/planscape/planning/migrations/0021_planningarea_deleted_at_scenario_deleted_at_and_more.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("planning", "0020_scenario_result_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="planningarea",
+            name="deleted_at",
+            field=models.DateTimeField(
+                help_text="Define if the entity has been deleted or not and when",
+                null=True,
+                verbose_name="Deleted at",
+            ),
+        ),
+        migrations.AddField(
+            model_name="scenario",
+            name="deleted_at",
+            field=models.DateTimeField(
+                help_text="Define if the entity has been deleted or not and when",
+                null=True,
+                verbose_name="Deleted at",
+            ),
+        ),
+        migrations.AddField(
+            model_name="scenarioresult",
+            name="deleted_at",
+            field=models.DateTimeField(
+                help_text="Define if the entity has been deleted or not and when",
+                null=True,
+                verbose_name="Deleted at",
+            ),
+        ),
+    ]

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -10,10 +10,13 @@ from django.conf import settings
 from django.db import transaction
 from fiona.crs import from_epsg
 from django.contrib.gis.geos import GEOSGeometry
+from django.utils.timezone import now
 from collaboration.permissions import PlanningAreaPermission, ScenarioPermission
 from planning.geometry import coerce_geojson
 from planning.models import (
     PlanningArea,
+    PlanningAreaType,
+    ProjectArea,
     Scenario,
     ScenarioResult,
     ScenarioResultStatus,
@@ -53,7 +56,7 @@ def create_planning_area(
 @transaction.atomic
 def delete_planning_area(
     user: UserType,
-    planning_area: Type[PlanningArea],
+    planning_area: PlanningAreaType,
 ):
     if not PlanningAreaPermission.can_remove(user, planning_area):
         logger.error(f"User {user} has no permission to delete {planning_area.pk}")
@@ -62,8 +65,18 @@ def delete_planning_area(
             f"User does not have permission to delete planning area {planning_area.pk}.",
         )
 
+    right_now = now()
     action.send(user, verb="deleted", action_object=planning_area)
     planning_area.delete()
+    Scenario.objects.filter(planning_area__pk=planning_area.pk).update(
+        deleted_at=right_now
+    )
+    ScenarioResult.objects.filter(scenario__planning_area__pk=planning_area.pk).update(
+        deleted_at=right_now
+    )
+    ProjectArea.objects.filter(scenario__planning_area__pk=planning_area.pk).update(
+        deleted_at=right_now
+    )
     return (True, "deleted")
 
 
@@ -106,7 +119,10 @@ def delete_scenario(
         action_object=scenario,
         target=scenario.planning_area,
     )
+    right_now = now()
     scenario.delete()
+    ScenarioResult.objects.filter(scenario__pk=scenario.pk).update(deleted_at=right_now)
+    ProjectArea.objects.filter(scenario__pk=scenario.pk).update(deleted_at=right_now)
     return (True, "deleted")
 
 


### PR DESCRIPTION
Due to [this](https://sentry.sig-gis.com/organizations/sig/issues/64/?environment=production&project=2&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=3) error, we need to propagate the soft deletion mechanism to all children of planning area.

1. Adds deleted_at fields to some models that did not have them before.
2. Changes service layer to mark `deleted_at = now()` upon deletion of it's parent object (planning area & scenario)