### PR TITLE
fixes raster layer missing when zooming in

### DIFF
--- a/src/interface/src/app/map/map-manager.ts
+++ b/src/interface/src/app/map/map-manager.ts
@@ -554,8 +554,8 @@ export class MapManager {
       environment.tile_endpoint + region + '/wms?',
       {
         layers: region + layer,
-        minZoom: 7,
-        maxZoom: 13,
+        minZoom: FrontendConstants.MAP_MIN_ZOOM,
+        maxZoom: FrontendConstants.MAP_MAX_ZOOM,
         format: 'image/png',
         transparent: true,
         opacity:

--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -8,7 +8,13 @@ import {
 import * as L from 'leaflet';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { FrontendConstants, Plan, Region, regionToString } from '@types';
+import {
+  BaseLayerType,
+  FrontendConstants,
+  Plan,
+  Region,
+  regionToString,
+} from '@types';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { PlanStateService } from '@services';
 import { regionMapCenters } from '../../map/map.helper';
@@ -18,9 +24,9 @@ import polylabel from 'polylabel';
 import { environment } from '../../../environments/environment';
 import { MapLayerSelectDialogComponent } from '../map-layer-select-dialog/map-layer-select-dialog.component';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
-import { BaseLayerType } from '@types';
 import { satelliteTiles, terrainTiles } from 'src/app/map/map.tiles';
 import { MapLayerControlComponent } from './map-layer-control/map-layer-control-component';
+
 // Needed to keep references to div elements to remove
 export interface MapRef {
   legend?: HTMLElement | undefined;
@@ -56,6 +62,7 @@ export class PlanMapComponent implements OnInit, AfterViewInit, OnDestroy {
   private shapes: any | null = null;
   private layerControl = new MapLayerControlComponent();
   private currentBaseLayer: BaseLayerType = BaseLayerType.Road;
+
   constructor(
     private planStateService: PlanStateService,
     private http: HttpClient,
@@ -210,8 +217,8 @@ export class PlanMapComponent implements OnInit, AfterViewInit, OnDestroy {
       environment.tile_endpoint + region + '/wms?',
       {
         layers: region + filepath,
-        minZoom: 7,
-        maxZoom: 13,
+        minZoom: FrontendConstants.MAP_MIN_ZOOM,
+        maxZoom: FrontendConstants.MAP_MAX_ZOOM,
         format: 'image/png',
         transparent: true,
         opacity: 0.7,


### PR DESCRIPTION
There was a mismatch on min/max zoom between the map and the raster layers. So when zooming in, at some point the raster layer disappeared.
Using the same config value for all should fix it.