### PR TITLE
PLAN-1526, PLAN-1527, PLAN-1528

### DIFF
--- a/src/planscape/planning/permissions.py
+++ b/src/planscape/planning/permissions.py
@@ -21,7 +21,7 @@ class ScenarioViewPermission(PlanscapePermission):
                 pa_id = request.data.get("planning_area") or None
                 if not pa_id:
                     return False
-                planning_area = PlanningArea.objects.get("planning_area")
+                planning_area = PlanningArea.objects.get(id=pa_id)
                 return PlanningAreaPermission.can_add_scenario(
                     request.user, planning_area
                 )

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -70,10 +70,9 @@ class ListPlanningAreaSerializer(serializers.ModelSerializer):
         model = PlanningArea
 
 
-class PlanningAreaSerializer(
-    ListPlanningAreaSerializer,
-    gis_serializers.GeoModelSerializer,
-):
+class CreatePlanningAreaSerializer(serializers.ModelSerializer):
+    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
     def validate_geometry(self, geometry):
         if not isinstance(geometry, GEOSGeometry):
             geometry = GEOSGeometry(
@@ -94,9 +93,23 @@ class PlanningAreaSerializer(
         return geometry
 
     class Meta:
+        model = PlanningArea
+        fields = (
+            "user",
+            "name",
+            "region_name",
+            "geometry",
+            "notes",
+        )
+
+
+class PlanningAreaSerializer(
+    ListPlanningAreaSerializer,
+    gis_serializers.GeoModelSerializer,
+):
+    class Meta:
         fields = (
             "id",
-            "planning_area",
             "user",
             "name",
             "notes",
@@ -184,14 +197,16 @@ class ConfigurationSerializer(serializers.Serializer):
         required=False,
     )
     max_slope = serializers.FloatField(
-        min_value=1,
+        min_value=0,
         max_value=100,
         allow_null=True,
+        required=False,
     )
     min_distance_from_road = serializers.FloatField(
-        min_value=1,
+        min_value=0,
         max_value=100000,
         allow_null=True,
+        required=False,
     )
     stand_size = serializers.ChoiceField(choices=StandSizeChoices.choices)
     excluded_areas = serializers.ListField(

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -5,12 +5,13 @@ from django.urls import reverse
 from rest_framework.test import APITransactionTestCase
 from collaboration.tests.helpers import create_collaborator_record
 from collaboration.models import Permissions, Role
-from planning.models import RegionChoices
+from planning.models import PlanningArea, RegionChoices
 from planning.tests.factories import PlanningAreaFactory
 from planning.tests.helpers import (
     _create_scenario,
     reset_permissions,
 )
+from planscape.tests.factories import UserFactory
 
 
 class CreatorsTest(APITransactionTestCase):
@@ -667,6 +668,37 @@ class ListPlanningAreaSortingTest(APITransactionTestCase):
             525377875.28772503,
         ]
         self.assertListEqual(acres, expected_acres)
+
+
+class CreatePlanningAreaTest(APITransactionTestCase):
+    def setUp(self):
+        self.user = UserFactory()
+        self.valid_data = {
+            "region_name": "sierra-nevada",
+            "name": "my dear planning area",
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-120.27761490835294, 39.15564209283124],
+                        [-120.27761490835294, 39.038416306024885],
+                        [-120.16134706569323, 39.038416306024885],
+                        [-120.16134706569323, 39.15564209283124],
+                        [-120.27761490835294, 39.15564209283124],
+                    ]
+                ],
+                "type": "Polygon",
+            },
+        }
+
+    def test_create_returns_200(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            reverse("api:planning:planningareas-list"),
+            self.valid_data,
+            format="json",
+        )
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(1, PlanningArea.objects.count())
 
 
 class ListPlanningAreasWithPermissionsTest(APITransactionTestCase):

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -119,8 +119,8 @@ def create_planning_area(request: Request) -> Response:
                 status=status.HTTP_400_BAD_REQUEST,
             )
         # Get the geometry of the planning area.
-        geojson = body.get("geometry")
-        if geojson is None:
+        geometry = body.get("geometry")
+        if geometry is None:
             return Response(
                 {"message": "Must specify the planning area geometry."},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -130,7 +130,7 @@ def create_planning_area(request: Request) -> Response:
             user=user,
             name=name,
             region_name=region_name,
-            geojson=geojson,
+            geometry=geometry,
             notes=notes,
         )
         serializer = PlanningAreaSerializer(


### PR DESCRIPTION
* fixes silly silly mistake on `has_permission` in `planning/permissions.py`
* creates a new `CreatePlanningAreaSerializer` that works properly with v2
* adjusts the possible values for `ConfigurationSerializer`
* adjusts v1 create planning area endpoint so it works better with the service layer