### PR TITLE
Modal confirmation dialog (PLAN-1535)

### DIFF
--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -12,7 +12,7 @@ import { canAddScenario } from '../../permissions';
 import { SNACK_BOTTOM_NOTICE_CONFIG, SNACK_ERROR_CONFIG } from '@shared';
 import { MatTab } from '@angular/material/tabs';
 import { UploadProjectAreasModalComponent } from '../../upload-project-areas-modal/upload-project-areas-modal.component';
-
+import { ScenarioCreateConfirmationComponent } from '../../scenario-create-confirmation/scenario-create-confirmation.component';
 export interface ScenarioRow extends Scenario {
   selected?: boolean;
 }
@@ -164,6 +164,19 @@ export class SavedScenariosComponent implements OnInit {
     return isValidTotalArea(this.plan.area_acres);
   }
 
+  openConfirmationDialog(): void {
+    this.dialog
+      .open(ScenarioCreateConfirmationComponent, {})
+      .afterClosed()
+      .subscribe((response) => {
+        this.goToTreatmentPlans();
+      });
+  }
+
+  goToTreatmentPlans(): void {
+    // TODO: route to next page
+  }
+
   openUploadDialog(): void {
     this.dialog
       .open(UploadProjectAreasModalComponent, {
@@ -173,9 +186,9 @@ export class SavedScenariosComponent implements OnInit {
         },
       })
       .afterClosed()
-      .subscribe(() => {
-        // TODO: Placeholder -- handle response.
-        // if scenario was created, open another dialog
+      .subscribe((response) => {
+        // TODO: if there's not an error...we open the confirmation dialog
+        this.openConfirmationDialog();
       });
   }
 }

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -168,8 +168,10 @@ export class SavedScenariosComponent implements OnInit {
     this.dialog
       .open(ScenarioCreateConfirmationComponent, {})
       .afterClosed()
-      .subscribe((response) => {
-        this.goToTreatmentPlans();
+      .subscribe((response: any) => {
+        if (response) {
+          this.goToTreatmentPlans();
+        }
       });
   }
 
@@ -186,9 +188,11 @@ export class SavedScenariosComponent implements OnInit {
         },
       })
       .afterClosed()
-      .subscribe((response) => {
-        // TODO: if there's not an error...we open the confirmation dialog
-        this.openConfirmationDialog();
+      .subscribe((response: any) => {
+        if (response) {
+          // if there's not an error...we open the confirmation dialog
+          this.openConfirmationDialog();
+        }
       });
   }
 }

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.html
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.html
@@ -1,8 +1,12 @@
 <sg-modal
+  title=""
   [shortHeader]="true"
   [showBorders]="false"
   [centerFooter]="true"
-  primaryButtonText="Proceed To Treatment Plan">
+  primaryButtonText="Proceed To Treatment Plan"
+  (clickedPrimary)="goToTreatmentPlans()"
+  (clickedSecondary)="closeModal()"
+  (clickedClose)="closeModal()">
   <div modalBodyContent>
     <sg-modal-confirmation-dialog
       infoType="success"

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.html
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.html
@@ -1,0 +1,9 @@
+<sg-modal [shortHeader]="true" [showBorders]="false" [centerFooter]="true">
+  <div modalBodyContent>
+    <sg-modal-confirmation-dialog
+      infoType="success"
+      title="&ldquo;{{ scenarioName }}&rdquo; successfully uploaded"
+      message="You can now create a new treatment plan for your project areas or close this modal.">
+    </sg-modal-confirmation-dialog>
+  </div>
+</sg-modal>

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.html
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.html
@@ -1,4 +1,8 @@
-<sg-modal [shortHeader]="true" [showBorders]="false" [centerFooter]="true">
+<sg-modal
+  [shortHeader]="true"
+  [showBorders]="false"
+  [centerFooter]="true"
+  primaryButtonText="Proceed To Treatment Plan">
   <div modalBodyContent>
     <sg-modal-confirmation-dialog
       infoType="success"

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ScenarioCreateConfirmationComponent } from './scenario-create-confirmation.component';
+
+describe('ScenarioCreateConfirmationComponent', () => {
+  let component: ScenarioCreateConfirmationComponent;
+  let fixture: ComponentFixture<ScenarioCreateConfirmationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ScenarioCreateConfirmationComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ScenarioCreateConfirmationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.spec.ts
@@ -15,8 +15,8 @@ describe('ScenarioCreateConfirmationComponent', () => {
       imports: [ScenarioCreateConfirmationComponent, MatDialogModule],
       declarations: [],
       providers: [
-        { provide: MatDialogRef, useValue: {} }, // Mock or stub MatDialogRef
-        { provide: MAT_DIALOG_DATA, useValue: {} }, // Mock or stub the data
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
       ],
     }).compileComponents();
 

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.spec.ts
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.spec.ts
@@ -1,5 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import {
+  MatDialogModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
 import { ScenarioCreateConfirmationComponent } from './scenario-create-confirmation.component';
 
 describe('ScenarioCreateConfirmationComponent', () => {
@@ -8,7 +12,12 @@ describe('ScenarioCreateConfirmationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ScenarioCreateConfirmationComponent],
+      imports: [ScenarioCreateConfirmationComponent, MatDialogModule],
+      declarations: [],
+      providers: [
+        { provide: MatDialogRef, useValue: {} }, // Mock or stub MatDialogRef
+        { provide: MAT_DIALOG_DATA, useValue: {} }, // Mock or stub the data
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ScenarioCreateConfirmationComponent);

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.ts
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.ts
@@ -1,0 +1,15 @@
+import { Input, Component } from '@angular/core';
+import { ModalConfirmationDialogComponent } from '../../../styleguide/modal-dialog-section/modal-confirmation-dialog.component
+import { ModalComponent } from '../../../styleguide/modal/modal.component';
+
+@Component({
+  selector: 'app-scenario-create-confirmation',
+  standalone: true,
+  imports: [ModalComponent, ModalConfirmationDialogComponent],
+  templateUrl: './scenario-create-confirmation.component.html',
+  styleUrl: './scenario-create-confirmation.component.scss',
+})
+export class ScenarioCreateConfirmationComponent {
+  @Input() scenarioName = '';
+
+}

--- a/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.ts
+++ b/src/interface/src/app/plan/scenario-create-confirmation/scenario-create-confirmation.component.ts
@@ -1,6 +1,7 @@
-import { Input, Component } from '@angular/core';
-import { ModalConfirmationDialogComponent } from '../../../styleguide/modal-dialog-section/modal-confirmation-dialog.component
+import { Component, EventEmitter, Input, inject, Output } from '@angular/core';
+import { ModalConfirmationDialogComponent } from '../../../styleguide/modal-dialog-section/modal-confirmation-dialog.component';
 import { ModalComponent } from '../../../styleguide/modal/modal.component';
+import { MatDialogRef } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-scenario-create-confirmation',
@@ -11,5 +12,16 @@ import { ModalComponent } from '../../../styleguide/modal/modal.component';
 })
 export class ScenarioCreateConfirmationComponent {
   @Input() scenarioName = '';
+  @Output() proceed = new EventEmitter<boolean>();
+  readonly dialogRef = inject(
+    MatDialogRef<ScenarioCreateConfirmationComponent>
+  );
 
+  closeModal(): void {
+    this.dialogRef.close(false);
+  }
+
+  goToTreatmentPlans(): void {
+    this.dialogRef.close(true);
+  }
 }

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.html
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.html
@@ -1,0 +1,5 @@
+<div class="icon-row" *ngIf="displayIcon() !== null">
+  <mat-icon class="centered-icon">{{ displayIcon() }}</mat-icon>
+</div>
+<div class="headline">{{ headline }}</div>
+<div class="message">{{ message }}</div>

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
@@ -20,6 +20,9 @@
     text-align: left;
     padding: 2em;
     height: 120px;
+    .message {
+      text-align: left;
+    }
   }
   &.error {
     color: $color-dark-red;
@@ -42,9 +45,6 @@
     font-weight: 400;
     line-height: 22px;
     text-align: center;
-    &.alert {
-      text-align: left;
-    }
   }
 
   .centered-icon {

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
@@ -22,12 +22,12 @@
     height: 120px;
   }
   &.error {
-    color: red;
+    color: $color-dark-red;
     justify-content: center;
     text-align: center;
   }
   &.success {
-    color: green;
+    color: $color-brand-green;
   }
 
   .headline {

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
@@ -1,0 +1,55 @@
+@import 'colors';
+@import 'mixins';
+
+:host {
+  @include xs-label();
+  width: 100%;
+  height: 150px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 2em;
+  border-bottom: 1px;
+  box-sizing: border-box;
+  justify-content: center;
+  text-align: center;
+
+  &.alert {
+    justify-content: left;
+    text-align: left;
+    padding: 2em;
+    height: 120px;
+  }
+  &.error {
+    color: red;
+    justify-content: center;
+    text-align: center;
+  }
+  &.success {
+    color: green;
+  }
+
+  .headline {
+    @include h3();
+    color: $color-black;
+    width: 100%;
+  }
+
+  .message {
+    @include small-paragraph();
+    color: black;
+    font-weight: 400;
+    line-height: 22px;
+    text-align: center;
+    &.alert {
+      text-align: left;
+    }
+  }
+
+  .centered-icon {
+    width: 36px;
+    height: 36px;
+    font-size: 36px;
+  }
+}

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.scss
@@ -19,7 +19,13 @@
     justify-content: left;
     text-align: left;
     padding: 2em;
-    height: 120px;
+    padding-top: 2em;
+    padding-bottom: 2em;
+    height: 80px;
+    margin: 0;
+    padding-top: 0px;
+    padding-bottom: 0px;
+
     .message {
       text-align: left;
     }

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
@@ -1,0 +1,68 @@
+import { Component, HostBinding, Input } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+export type ModalDialogVariant = 'success' | 'error' | 'pending' | 'alert';
+
+/**
+ * Modal Info Box
+ * A component to be used within the modal body to express various states
+ */
+@Component({
+  selector: 'sg-modal-confirmation-dialog',
+  standalone: true,
+  imports: [NgIf, MatIconModule, MatProgressSpinnerModule],
+  templateUrl: './modal-confirmation-dialog.component.html',
+  styleUrl: './modal-confirmation-dialog.component.scss',
+})
+export class ModalConfirmationDialogComponent {
+  /**
+   * The status
+   */
+  @Input() infoType: ModalDialogVariant = 'alert';
+
+  /**
+   * The status
+   */
+  @Input() dialogIcon?: string | null;
+  /**
+   * Headline
+   */
+  @Input() headline?: string | null = '';
+  /**
+   * Message
+   */
+  @Input() message?: string | null = '';
+  readonly IconByVariant: Record<ModalDialogVariant, string | null> = {
+    success: 'check_circle',
+    error: 'error',
+    pending: 'pending_actions',
+    alert: null,
+  };
+
+  displayIcon() {
+    if (!this.dialogIcon) {
+      // if there isn't one specified, use the default
+      return this.IconByVariant[this.infoType];
+    }
+    return this.dialogIcon;
+  }
+
+  @HostBinding('class.success')
+  get isInfo() {
+    return this.infoType === 'success';
+  }
+  @HostBinding('class.error')
+  get isError() {
+    return this.infoType === 'error';
+  }
+  @HostBinding('class.pending')
+  get isWarning() {
+    return this.infoType === 'pending';
+  }
+  @HostBinding('class.alert')
+  get isComplete() {
+    return this.infoType === 'alert';
+  }
+}

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
@@ -6,8 +6,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 export type ModalDialogVariant = 'success' | 'error' | 'pending' | 'alert';
 
 /**
- * Modal Info Box
- * A component to be used within the modal body to express various states
+ * Modal Confirmation Dialog
+ * A component that can be used within the modal body as a confirmation dialog
  */
 @Component({
   selector: 'sg-modal-confirmation-dialog',
@@ -41,9 +41,9 @@ export class ModalConfirmationDialogComponent {
     alert: null,
   };
 
+  // if there isn't one specified, use the default
   displayIcon() {
     if (!this.dialogIcon) {
-      // if there isn't one specified, use the default
       return this.IconByVariant[this.infoType];
     }
     return this.dialogIcon;

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
@@ -18,20 +18,19 @@ export type ModalDialogVariant = 'success' | 'error' | 'pending' | 'alert';
 })
 export class ModalConfirmationDialogComponent {
   /**
-   * The status
+   * The variant of the dialog
    */
   @Input() infoType: ModalDialogVariant = 'alert';
-
   /**
-   * The status
+   * Icon to display, if not one of the defaults for this variant
    */
   @Input() dialogIcon?: string | null;
   /**
-   * Headline
+   * The content of the headling
    */
   @Input() headline?: string | null = '';
   /**
-   * Message
+   * The smaller message to display
    */
   @Input() message?: string | null = '';
   readonly IconByVariant: Record<ModalDialogVariant, string | null> = {

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.component.ts
@@ -30,7 +30,7 @@ export class ModalConfirmationDialogComponent {
    */
   @Input() headline?: string | null = '';
   /**
-   * The smaller message to display
+   * The message content to display
    */
   @Input() message?: string | null = '';
   readonly IconByVariant: Record<ModalDialogVariant, string | null> = {
@@ -40,7 +40,7 @@ export class ModalConfirmationDialogComponent {
     alert: null,
   };
 
-  // if there isn't one specified, use the default
+  // if there an icon specified, use the default for the dialog variant
   displayIcon() {
     if (!this.dialogIcon) {
       return this.IconByVariant[this.infoType];

--- a/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.stories.ts
+++ b/src/interface/src/styleguide/modal-dialog-section/modal-confirmation-dialog.stories.ts
@@ -1,0 +1,95 @@
+import {
+  Meta,
+  StoryObj,
+  moduleMetadata,
+  argsToTemplate,
+} from '@storybook/angular';
+import { ModalComponent } from '../modal/modal.component';
+import { ModalConfirmationDialogComponent } from './modal-confirmation-dialog.component';
+import {
+  MatDialogModule,
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+const meta: Meta<ModalConfirmationDialogComponent> = {
+  title: 'Components/Modal Confirmation Dialog',
+  component: ModalConfirmationDialogComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [
+        MatDialogModule,
+        ModalComponent,
+        BrowserAnimationsModule,
+        ModalConfirmationDialogComponent,
+        MatProgressSpinnerModule,
+      ],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialogRef, useValue: {} },
+      ],
+    }),
+  ],
+  render: ({ ...args }) => ({
+    props: args,
+    template: `<div ${containerStyle}>
+        <sg-modal title=""
+        [shortHeader]="true"
+        [showBorders]="false"
+        [centerFooter]="true">
+        <div modalBodyContent>
+          <sg-modal-confirmation-dialog ${argsToTemplate(args)}>
+          </sg-modal-confirmation-dialog>
+          </div>
+        </sg-modal><div>`,
+  }),
+};
+
+export default meta;
+
+type Story = StoryObj<ModalConfirmationDialogComponent>;
+
+const containerStyle = `style="background-color: gray;
+      height: 400px;
+      align-content: center;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;"`;
+
+export const InfoBox: Story = {
+  args: {
+    headline: 'Information Title',
+    message:
+      'Insert a message to inform users about a situation that requires acknowledgement.',
+    infoType: 'alert',
+  },
+};
+
+export const ErrorBox: Story = {
+  args: {
+    headline: 'Error Title',
+    message: 'Insert a message that the performed action was unsuccessful.',
+    infoType: 'error',
+  },
+};
+
+export const SuccessBox: Story = {
+  args: {
+    headline: 'Success Title',
+    message:
+      'Insert a message about the performed action was completed/successful.',
+    infoType: 'success',
+  },
+};
+
+export const PendingBox: Story = {
+  args: {
+    headline: 'Pending Action Title',
+    message: 'Insert a message about the performed action in progress.',
+    infoType: 'pending',
+  },
+};

--- a/src/interface/src/styleguide/modal/modal.component.html
+++ b/src/interface/src/styleguide/modal/modal.component.html
@@ -1,4 +1,4 @@
-<section class="header" *ngIf="hasHeader">
+<section class="header" *ngIf="hasHeader" [ngClass]="{ short: shortHeader }">
   <div class="header-title">
     <mat-icon
       *ngIf="leadingIcon"
@@ -31,7 +31,10 @@
   }">
   <ng-content select="[modalBodyContent]"> </ng-content>
 </main>
-<section class="footer" *ngIf="hasFooter">
+<section
+  class="footer"
+  *ngIf="hasFooter"
+  [ngClass]="{ centered: centerFooter }">
   <button
     *ngIf="hasSecondaryButton"
     sg-button

--- a/src/interface/src/styleguide/modal/modal.component.scss
+++ b/src/interface/src/styleguide/modal/modal.component.scss
@@ -150,7 +150,9 @@
   align-items: center;
   justify-content: flex-end;
   gap: 16px;
+
   &.centered {
     justify-content: center;
+    gap: 8px;
   }
 }

--- a/src/interface/src/styleguide/modal/modal.component.scss
+++ b/src/interface/src/styleguide/modal/modal.component.scss
@@ -40,12 +40,19 @@
   font-weight: 600;
   line-height: 32px;
   text-align: left;
-
   padding: 16px;
   padding-bottom: 10px;
   padding-top: 10px;
   border-bottom: 1px solid $color-soft-gray;
   height: 64px;
+
+  // short header
+  &.short {
+    height: 20px;
+    padding: 20px;
+    padding-bottom: 20px;
+    padding-bottom: 0;
+  }
 
   .leading-icon {
     &.info {
@@ -143,6 +150,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 16px;
+  &.centered {
+    justify-content: center;
+  }
 }
-
-

--- a/src/interface/src/styleguide/modal/modal.component.ts
+++ b/src/interface/src/styleguide/modal/modal.component.ts
@@ -93,9 +93,17 @@ export class ModalComponent {
    */
   @Input() hasHeader? = true;
   /**
+   * Short header
+   */
+  @Input() shortHeader? = false;
+  /**
    * Whether or not to show the footer at all
    */
   @Input() hasFooter? = true;
+  /**
+   * Whether the buttons should be centered
+   */
+  @Input() centerFooter? = false;
   /**
    * Whether or not to use default padding for the projected content
    */

--- a/src/interface/src/styleguide/modal/modal.stories.ts
+++ b/src/interface/src/styleguide/modal/modal.stories.ts
@@ -195,6 +195,21 @@ export const WithoutHeader: Story = {
   }),
 };
 
+export const CenteredFooter: Story = {
+  args: {
+    ...Default,
+    title: 'This has a centered footer',
+    centerFooter: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `<div ${containerStyle}>
+      <sg-modal ${argsToTemplate(args)}>
+        <div modalBodyContent>Are you sure you want to delete this?</div>
+      </sg-modal><div>`,
+  }),
+};
+
 export const WithScrollableContent: Story = {
   args: {
     ...Default,


### PR DESCRIPTION
Adding a confirmation dialog component that can be used within the existing sg-modal.

<img width="478" alt="Screenshot 2024-08-09 at 4 24 35 PM" src="https://github.com/user-attachments/assets/3ae13e35-a741-4cc4-93d6-4f2287f3a8c5">
<img width="523" alt="Screenshot 2024-08-09 at 4 24 31 PM" src="https://github.com/user-attachments/assets/eec75626-821d-4c9d-a010-edc7118afff4">

Also includes a version of this component into the saved scenarios page, after successful scenario creation:

<img width="669" alt="Screenshot 2024-08-13 at 9 11 17 PM" src="https://github.com/user-attachments/assets/fc0e451d-dbb5-427e-93d6-7e0367574f51">
