### PR TITLE
TreatmentPrescription bulk delete endpoint + tests (PLAN-1504)

### DIFF
--- a/src/planscape/impacts/permissions.py
+++ b/src/planscape/impacts/permissions.py
@@ -114,6 +114,8 @@ class TreatmentPrescriptionViewPermission(PlanscapePermission):
         match view.action:
             case "create":
                 return TreatmentPlanPermission.can_add_scenario(request.user, tx_plan)
+            case "batch_delete":
+                return TreatmentPlanPermission.can_remove(request.user, tx_plan)
             case _:
                 return TreatmentPlanPermission.can_view(request.user, tx_plan)
 

--- a/src/planscape/impacts/serializers.py
+++ b/src/planscape/impacts/serializers.py
@@ -138,6 +138,12 @@ class TreatmentPrescriptionListSerializer(TreatmentPrescriptionSerializer):
         )
 
 
+class TreatmentPrescriptionBatchDeleteSerializer(serializers.Serializer):
+    stand_ids = serializers.ListField(
+        child=serializers.IntegerField(), allow_empty=False
+    )
+
+
 class SummarySerializer(serializers.Serializer):
     project_area = serializers.PrimaryKeyRelatedField(
         queryset=ProjectArea.objects.all(),

--- a/src/planscape/impacts/tests/test_views.py
+++ b/src/planscape/impacts/tests/test_views.py
@@ -6,7 +6,10 @@ from django.contrib.auth import get_user_model
 from collaboration.models import Permissions, Role, UserObjectRole
 from collaboration.services import get_content_type
 from impacts.models import TreatmentPlan
-from impacts.tests.factories import TreatmentPlanFactory, TreatmentPrescriptionFactory
+from impacts.tests.factories import (
+    TreatmentPlanFactory,
+    TreatmentPrescriptionFactory,
+)
 from planning.tests.factories import ScenarioFactory
 from planscape.tests.factories import UserFactory
 
@@ -207,12 +210,11 @@ class TxPrescriptionListTest(APITransactionTestCase):
         self.assertEqual(data["count"], 2)
 
 
-class TxPrescriptionDeleteTest(APITransactionTestCase):
+class TxPrescriptionBatchDeleteTest(APITransactionTestCase):
     def setUp(self):
         self.tx_plan = TreatmentPlanFactory.create()
         self.alt_tx_plan = TreatmentPlanFactory.create()
         self.client.force_authenticate(user=self.tx_plan.scenario.user)
-
         self.txrx_owned_list = TreatmentPrescriptionFactory.create_batch(
             10, treatment_plan=self.tx_plan
         )
@@ -222,10 +224,10 @@ class TxPrescriptionDeleteTest(APITransactionTestCase):
         )
 
     def test_batch_delete_tx_rx(self):
-        payload = {"ids": [txrx.id for txrx in self.txrx_owned_list]}
+        payload = {"stand_ids": [txrx.stand_id for txrx in self.txrx_owned_list]}
         response = self.client.post(
             reverse(
-                "api:impacts:tx-prescriptions-batch-delete",
+                "api:impacts:tx-prescriptions-delete-prescriptions",
                 kwargs={"tx_plan_pk": self.tx_plan.pk},
             ),
             data=payload,
@@ -235,11 +237,37 @@ class TxPrescriptionDeleteTest(APITransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response_data["result"][0], 10)
 
-    def test_batch_delete_nonowned_tx_rx(self):
-        payload = {"ids": [txrx.id for txrx in self.txrx_other_list]}
+    def test_batch_delete_tx_rx_bad_values(self):
+        payload = {"stand_ids": [None]}
         response = self.client.post(
             reverse(
-                "api:impacts:tx-prescriptions-batch-delete",
+                "api:impacts:tx-prescriptions-delete-prescriptions",
+                kwargs={"tx_plan_pk": self.tx_plan.pk},
+            ),
+            data=payload,
+            format="json",
+        )
+        response_data = response.json()
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_delete_tx_rx_empty_list(self):
+        payload = {"stand_ids": []}
+        response = self.client.post(
+            reverse(
+                "api:impacts:tx-prescriptions-delete-prescriptions",
+                kwargs={"tx_plan_pk": self.tx_plan.pk},
+            ),
+            data=payload,
+            format="json",
+        )
+        response_data = response.json()
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_delete_nonowned_tx_rx(self):
+        payload = {"stand_ids": [txrx.stand_id for txrx in self.txrx_other_list]}
+        response = self.client.post(
+            reverse(
+                "api:impacts:tx-prescriptions-delete-prescriptions",
                 kwargs={"tx_plan_pk": self.alt_tx_plan.pk},
             ),
             data=payload,
@@ -247,16 +275,16 @@ class TxPrescriptionDeleteTest(APITransactionTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    # Testing a request to delete various ids that don't match the treatment plan id
-    # TODO: current behavior is to only delete items matching the given tx_plan and quietly ignore the rest
+    # Testing a request to delete various stand_ids for some txrx records don't match the treatment plan id
+    # current behavior is to only delete items matching the given tx_plan and quietly ignore the rest
     def test_batch_delete_mixed_tx_rx(self):
-        owned_ids = [txrx.id for txrx in self.txrx_owned_list]
-        other_ids = [txrx.id for txrx in self.txrx_other_list]
+        owned_ids = [txrx.stand_id for txrx in self.txrx_owned_list]
+        other_ids = [txrx.stand_id for txrx in self.txrx_other_list]
 
-        payload = {"ids": owned_ids + other_ids}
+        payload = {"stand_ids": owned_ids + other_ids}
         response = self.client.post(
             reverse(
-                "api:impacts:tx-prescriptions-batch-delete",
+                "api:impacts:tx-prescriptions-delete-prescriptions",
                 kwargs={"tx_plan_pk": self.tx_plan.pk},
             ),
             data=payload,

--- a/src/planscape/impacts/views.py
+++ b/src/planscape/impacts/views.py
@@ -150,3 +150,32 @@ class TreatmentPrescriptionViewSet(
 
     def perform_create(self, serializer):
         return upsert_treatment_prescriptions(**serializer.validated_data)
+
+    # current implementation requires a tx_plan_id -- do we want to provide a non-nested option?
+    @action(detail=False, methods=["post"])
+    def batch_delete(self, request, tx_plan_pk=None):
+        ids = request.data.get("ids", [])
+
+        if not isinstance(ids, list):
+            return response.Response(
+                {"error": "Invalid input. Expected a list of IDs."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        delete_result = TreatmentPrescription.objects.filter(
+            id__in=ids, treatment_plan_id=tx_plan_pk
+        ).delete()
+
+        # Alt approach...?
+        # collect all proposed deletions...
+        # proposed_deleted = TreatmentPrescription.objects.filter(id__in=ids)
+        # get all treatment plans related to these..
+        # manually check for perms on each plan...
+
+        # deletable_ids = []
+        # for plans in proposed_deleted_plans:
+        #     if TreatmentPlanPermission.can_remove(request.user, txrx.treatment_plan):
+        #         deletable_ids.append(txrx.id)
+        # delete_result = TreatmentPrescription.objects.filter(id__in=deletable_ids).delete()
+
+        return response.Response({"result": delete_result}, status=status.HTTP_200_OK)


### PR DESCRIPTION
Per discussion, we changed this to accept stand_ids instead of ids, since that's preferable for FE needs.