### PR TITLE
Apply and remove treatments

### DIFF
--- a/src/interface/src/app/services/treatments.service.ts
+++ b/src/interface/src/app/services/treatments.service.ts
@@ -58,4 +58,24 @@ export class TreatmentsService {
       withCredentials: true,
     });
   }
+
+  setTreatments(
+    treatmentPlanId: number,
+    projectAreaId: number,
+    action: string,
+    standIds: number[]
+  ) {
+    return this.http.post(
+      this.baseUrl + treatmentPlanId + '/treatment_prescriptions/',
+      {
+        project_area: projectAreaId,
+        action: action,
+        stands: standIds,
+        treatment_plan: treatmentPlanId,
+      },
+      {
+        withCredentials: true,
+      }
+    );
+  }
 }

--- a/src/interface/src/app/services/treatments.service.ts
+++ b/src/interface/src/app/services/treatments.service.ts
@@ -69,4 +69,19 @@ export class TreatmentsService {
       }
     );
   }
+
+  removeTreatments(treatmentPlanId: number, standIds: number[]) {
+    return this.http.post(
+      this.baseUrl +
+        treatmentPlanId +
+        '/treatment_prescriptions/delete_prescriptions/',
+      {
+        stand_ids: standIds,
+        treatment_plan: treatmentPlanId,
+      },
+      {
+        withCredentials: true,
+      }
+    );
+  }
 }

--- a/src/interface/src/app/services/treatments.service.ts
+++ b/src/interface/src/app/services/treatments.service.ts
@@ -7,7 +7,20 @@ interface ProjectArea {
   project_area_id: number;
   project_area_name: string;
   total_stand_count: number;
-  prescriptions: [];
+  prescriptions: Prescription[];
+}
+
+interface Prescription {
+  action: string;
+  area_acres: number;
+  treated_stand_count: number;
+  type: string;
+  stand_ids: number[];
+}
+
+export interface TreatedStand {
+  id: number;
+  action: string;
 }
 
 export interface Summary {
@@ -53,9 +66,11 @@ export class TreatmentsService {
     });
   }
 
-  getTreatmentPlanSummary(id: number) {
+  getTreatmentPlanSummary(id: number, projectArea?: number) {
     return this.http.get<Summary>(this.baseUrl + id + '/summary', {
       withCredentials: true,
+      params:
+        projectArea !== undefined ? { project_area: projectArea } : undefined,
     });
   }
 

--- a/src/interface/src/app/services/treatments.service.ts
+++ b/src/interface/src/app/services/treatments.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
-import { Summary, TreatmentPlan } from '@types';
+import { TreatmentPlan, TreatmentSummary } from '@types';
 
 @Injectable({
   providedIn: 'root',
@@ -43,7 +43,7 @@ export class TreatmentsService {
   }
 
   getTreatmentPlanSummary(id: number, projectArea?: number) {
-    return this.http.get<Summary>(this.baseUrl + id + '/summary', {
+    return this.http.get<TreatmentSummary>(this.baseUrl + id + '/summary', {
       withCredentials: true,
       params:
         projectArea !== undefined ? { project_area: projectArea } : undefined,

--- a/src/interface/src/app/services/treatments.service.ts
+++ b/src/interface/src/app/services/treatments.service.ts
@@ -1,31 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
-import { TreatmentPlan } from '@types';
-
-interface ProjectArea {
-  project_area_id: number;
-  project_area_name: string;
-  total_stand_count: number;
-  prescriptions: Prescription[];
-}
-
-interface Prescription {
-  action: string;
-  area_acres: number;
-  treated_stand_count: number;
-  type: string;
-  stand_ids: number[];
-}
-
-export interface TreatedStand {
-  id: number;
-  action: string;
-}
-
-export interface Summary {
-  project_areas: ProjectArea[];
-}
+import { Summary, TreatmentPlan } from '@types';
 
 @Injectable({
   providedIn: 'root',

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.spec.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.spec.ts
@@ -2,11 +2,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapStandsComponent } from './map-stands.component';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
-import { MockDeclarations } from 'ng-mocks';
+import { MockDeclarations, MockProviders } from 'ng-mocks';
 import {
   LayerComponent,
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
+import { TreatmentsState } from '../treatments.state';
 
 describe('MapStandsComponent', () => {
   let component: MapStandsComponent;
@@ -15,7 +16,7 @@ describe('MapStandsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MapStandsComponent],
-      providers: [SelectedStandsState],
+      providers: [MockProviders(SelectedStandsState, TreatmentsState)],
       declarations: MockDeclarations(VectorSourceComponent, LayerComponent),
     }).compileComponents();
 

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -14,7 +14,7 @@ import { AsyncPipe } from '@angular/common';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { getBoundingBox } from '../maplibre.helper';
 import { environment } from '../../../environments/environment';
-import { PrescriptionAction, SEQUENCE_COLORS } from '../prescriptions';
+import { PrescriptionSingleAction, SEQUENCE_COLORS } from '../prescriptions';
 import { TreatmentsState } from '../treatments.state';
 import { TreatedStand } from '@types';
 
@@ -98,7 +98,7 @@ export class MapStandsComponent implements OnChanges {
     this.treatedStands.forEach((stand) => {
       matchExpression.push(
         stand.id,
-        SEQUENCE_COLORS[stand.action as PrescriptionAction]
+        SEQUENCE_COLORS[stand.action as PrescriptionSingleAction]
       );
     });
     matchExpression.push(defaultColor);

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -14,9 +14,9 @@ import { AsyncPipe } from '@angular/common';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { getBoundingBox } from '../maplibre.helper';
 import { environment } from '../../../environments/environment';
-import { TreatedStand } from '@services/treatments.service';
 import { PrescriptionAction, SEQUENCE_COLORS } from '../prescriptions';
 import { TreatmentsState } from '../treatments.state';
+import { TreatedStand } from '@types';
 
 @Component({
   selector: 'app-map-stands',

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -15,6 +15,7 @@ import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { getBoundingBox } from '../maplibre.helper';
 import { environment } from '../../../environments/environment';
 import { TreatedStand } from '@services/treatments.service';
+import { PrescriptionAction, SEQUENCE_COLORS } from '../prescriptions';
 
 @Component({
   selector: 'app-map-stands',
@@ -90,7 +91,10 @@ export class MapStandsComponent implements OnChanges {
     ];
 
     this.treatedStands.forEach((stand) => {
-      matchExpression.push(stand.id, '#ff0000'); // TODO ACTUAL COLOR ASSIGMENT
+      matchExpression.push(
+        stand.id,
+        SEQUENCE_COLORS[stand.action as PrescriptionAction]
+      ); // TODO ACTUAL COLOR ASSIGMENT
     });
     matchExpression.push(defaultColor);
 

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -16,6 +16,7 @@ import { getBoundingBox } from '../maplibre.helper';
 import { environment } from '../../../environments/environment';
 import { TreatedStand } from '@services/treatments.service';
 import { PrescriptionAction, SEQUENCE_COLORS } from '../prescriptions';
+import { TreatmentsState } from '../treatments.state';
 
 @Component({
   selector: 'app-map-stands',
@@ -24,14 +25,15 @@ import { PrescriptionAction, SEQUENCE_COLORS } from '../prescriptions';
   templateUrl: './map-stands.component.html',
 })
 export class MapStandsComponent implements OnChanges {
-  @Input() treatmentPlanId = 0;
-  @Input() projectAreaId: number | null = null;
   @Input() mapLibreMap!: MapLibreMap;
   @Input() selectStart!: Point | null;
   @Input() selectEnd!: Point | null;
   @Input() treatedStands: TreatedStand[] = [];
 
-  selectedStands$ = this.mapStandsService.selectedStands$;
+  treatmentPlanId = this.treatmentsState.getTreatmentPlanId();
+  projectAreaId = this.treatmentsState.getProjectAreaId();
+
+  selectedStands$ = this.selectedStandsState.selectedStands$;
   private initialSelectedStands: number[] = [];
 
   // TODO project_area_aggregate only applies when looking at a specific project area
@@ -45,7 +47,10 @@ export class MapStandsComponent implements OnChanges {
     selectedStands: 'stands-layer-selected',
   };
 
-  constructor(private mapStandsService: SelectedStandsState) {}
+  constructor(
+    private selectedStandsState: SelectedStandsState,
+    private treatmentsState: TreatmentsState
+  ) {}
 
   get vectorLayerUrl() {
     return (
@@ -57,7 +62,7 @@ export class MapStandsComponent implements OnChanges {
   }
 
   private updateSelectedStands(selectedStands: number[]) {
-    this.mapStandsService.updateSelectedStands(selectedStands);
+    this.selectedStandsState.updateSelectedStands(selectedStands);
   }
 
   clickOnLayer(event: MapMouseEvent) {
@@ -71,7 +76,7 @@ export class MapStandsComponent implements OnChanges {
     });
 
     const standId = features[0].properties['id'];
-    this.mapStandsService.toggleStand(standId);
+    this.selectedStandsState.toggleStand(standId);
   }
 
   paint: LayerSpecification['paint'] = {
@@ -104,7 +109,7 @@ export class MapStandsComponent implements OnChanges {
   selectStandsWithinRectangle(): void {
     if (!this.selectStart || !this.selectEnd) {
       this.initialSelectedStands = [
-        ...this.mapStandsService.getSelectedStands(),
+        ...this.selectedStandsState.getSelectedStands(),
       ];
       return;
     }

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -14,6 +14,7 @@ import { AsyncPipe } from '@angular/common';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { getBoundingBox } from '../maplibre.helper';
 import { environment } from '../../../environments/environment';
+import { TreatedStand } from '@services/treatments.service';
 
 @Component({
   selector: 'app-map-stands',
@@ -27,7 +28,7 @@ export class MapStandsComponent implements OnChanges {
   @Input() mapLibreMap!: MapLibreMap;
   @Input() selectStart!: Point | null;
   @Input() selectEnd!: Point | null;
-  @Input() treatedStands: { id: number; assigment: string }[] = [];
+  @Input() treatedStands: TreatedStand[] = [];
 
   selectedStands$ = this.mapStandsService.selectedStands$;
   private initialSelectedStands: number[] = [];

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -99,7 +99,7 @@ export class MapStandsComponent implements OnChanges {
       matchExpression.push(
         stand.id,
         SEQUENCE_COLORS[stand.action as PrescriptionAction]
-      ); // TODO ACTUAL COLOR ASSIGMENT
+      );
     });
     matchExpression.push(defaultColor);
 

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.html
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.html
@@ -4,4 +4,5 @@
     (click)="applyTreatments(action.key)">
     {{ action.value }}
   </button>
+  <button (click)="removeTreatments()">REMOVE TREATMENT</button>
 </div>

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.html
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.html
@@ -1,5 +1,7 @@
 <div *ngIf="prescriptions$ | async; let prescriptions" class="prescriptions">
-  <button *ngFor="let action of prescriptions.SINGLE | keyvalue" [value]="">
+  <button
+    *ngFor="let action of prescriptions.SINGLE | keyvalue"
+    (click)="applyTreatments(action.key)">
     {{ action.value }}
   </button>
 </div>

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.spec.ts
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { PrescriptionActionsComponent } from './prescription-actions.component';
-import { MockProvider } from 'ng-mocks';
+import { MockProviders } from 'ng-mocks';
 import { LookupService } from '@services/lookup.service';
+import { TreatmentsState } from '../treatments.state';
+import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 
 describe('PrescriptionActionsComponent', () => {
   let component: PrescriptionActionsComponent;
@@ -11,7 +12,9 @@ describe('PrescriptionActionsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PrescriptionActionsComponent],
-      providers: [MockProvider(LookupService)],
+      providers: [
+        MockProviders(LookupService, TreatmentsState, SelectedStandsState),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PrescriptionActionsComponent);

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
@@ -32,13 +32,6 @@ export class PrescriptionActionsComponent {
   applyTreatments(action: string) {
     const stands = this.selectedStandsState.getSelectedStands();
     this.selectedStandsState.clearStands();
-    return this.treatmentsState
-      .updateTreatedStands(
-        this.treatmentPlanId,
-        this.projectAreaId,
-        action,
-        stands
-      )
-      .subscribe();
+    return this.treatmentsState.updateTreatedStands(action, stands).subscribe();
   }
 }

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { LookupService } from '@services/lookup.service';
 import {
   AsyncPipe,
@@ -19,8 +19,6 @@ import { TreatmentsState } from '../treatments.state';
   styleUrl: './prescription-actions.component.scss',
 })
 export class PrescriptionActionsComponent {
-  @Input() treatmentPlanId!: number;
-  @Input() projectAreaId!: number;
   prescriptions$ = this.lookupService.getPrescriptions();
 
   constructor(

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
@@ -39,8 +39,6 @@ export class PrescriptionActionsComponent {
         action,
         stands
       )
-      .subscribe(() => {
-        // TODO clear after
-      });
+      .subscribe();
   }
 }

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
@@ -8,8 +8,8 @@ import {
   NgIf,
 } from '@angular/common';
 import { ButtonComponent } from '@styleguide';
-import { TreatmentsService } from '@services/treatments.service';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
+import { TreatmentsState } from '../treatments.state';
 
 @Component({
   selector: 'app-prescription-actions',
@@ -25,15 +25,22 @@ export class PrescriptionActionsComponent {
 
   constructor(
     private lookupService: LookupService,
-    private treatmentsService: TreatmentsService,
+    private treatmentsState: TreatmentsState,
     private selectedStandsState: SelectedStandsState
   ) {}
 
   applyTreatments(action: string) {
     const stands = this.selectedStandsState.getSelectedStands();
-    console.log(stands);
-    return this.treatmentsService
-      .setTreatments(this.treatmentPlanId, this.projectAreaId, action, stands)
-      .subscribe();
+    this.selectedStandsState.clearStands();
+    return this.treatmentsState
+      .updateTreatedStands(
+        this.treatmentPlanId,
+        this.projectAreaId,
+        action,
+        stands
+      )
+      .subscribe(() => {
+        // TODO clear after
+      });
   }
 }

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
@@ -32,4 +32,10 @@ export class PrescriptionActionsComponent {
     this.selectedStandsState.clearStands();
     return this.treatmentsState.updateTreatedStands(action, stands).subscribe();
   }
+
+  removeTreatments() {
+    const stands = this.selectedStandsState.getSelectedStands();
+    this.selectedStandsState.clearStands();
+    this.treatmentsState.removeTreatments(stands).subscribe();
+  }
 }

--- a/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
+++ b/src/interface/src/app/treatments/prescription-actions/prescription-actions.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { LookupService } from '@services/lookup.service';
 import {
   AsyncPipe,
@@ -8,6 +8,8 @@ import {
   NgIf,
 } from '@angular/common';
 import { ButtonComponent } from '@styleguide';
+import { TreatmentsService } from '@services/treatments.service';
+import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 
 @Component({
   selector: 'app-prescription-actions',
@@ -17,7 +19,21 @@ import { ButtonComponent } from '@styleguide';
   styleUrl: './prescription-actions.component.scss',
 })
 export class PrescriptionActionsComponent {
+  @Input() treatmentPlanId!: number;
+  @Input() projectAreaId!: number;
   prescriptions$ = this.lookupService.getPrescriptions();
 
-  constructor(private lookupService: LookupService) {}
+  constructor(
+    private lookupService: LookupService,
+    private treatmentsService: TreatmentsService,
+    private selectedStandsState: SelectedStandsState
+  ) {}
+
+  applyTreatments(action: string) {
+    const stands = this.selectedStandsState.getSelectedStands();
+    console.log(stands);
+    return this.treatmentsService
+      .setTreatments(this.treatmentPlanId, this.projectAreaId, action, stands)
+      .subscribe();
+  }
 }

--- a/src/interface/src/app/treatments/prescriptions.ts
+++ b/src/interface/src/app/treatments/prescriptions.ts
@@ -1,0 +1,30 @@
+export const SEQUENCE_COLORS = {
+  SINGLE: {
+    MODERATE_THINNING_BIOMASS: '#3A86FF',
+    HEAVY_THINNING_BIOMASS: '#8338EC',
+    MODERATE_THINNING_BURN: '#F77F00',
+    HEAVY_THINNING_BURN: '#FFBE0B',
+    MODERATE_MASTICATION: '#2A9D8F',
+    HEAVY_MASTICATION: '#90BE6D',
+    RX_FIRE: '#EF233C',
+    HEAVY_THINNING_RX_FIRE: '#780000',
+    MASTICATION_RX_FIRE: '#FB6F92',
+  },
+  SEQUENCE: {
+    MODERATE_THINNING_BURN_PLUS_RX_FIRE:
+      'Moderate Thinning & Pile Burn (year 0), Prescribed Burn (year 10)',
+    MODERATE_THINNING_BURN_PLUS_MODERATE_THINNING_BURN:
+      'Moderate Thinning & Pile Burn (year 0), Moderate Thinning & Pile Burn (year 10)',
+    HEAVY_THINNING_BURN_PLUS_RX_FIRE:
+      'Heavy Thinning & Pile Burn (year 0), Prescribed Burn (year 10)',
+    HEAVY_THINNING_BURN_PLUS_HEAVY_THINNING_BURN:
+      'Heavy Thinning & Pile Burn (year 0), Heavy Thinning & Pile Burn (year 10)',
+    RX_FIRE_PLUS_RX_FIRE: 'Prescribed Fire (year 0), Prescribed Fire (year 10)',
+    MODERATE_MASTICATION_PLUS_MODERATE_MASTICATION:
+      'Moderate Mastication (year 0), Moderate Mastication (year 10)',
+    HEAVY_THINNING_BIOMASS_PLUS_RX_FIRE:
+      'Heavy Thinning & Biomass Removal (year 0), Prescribed Fire (year 10)',
+    MODERATE_MASTICATION_PLUS_RX_FIRE:
+      'Moderate Mastication (year 0), Prescribed Fire (year 10)',
+  },
+};

--- a/src/interface/src/app/treatments/prescriptions.ts
+++ b/src/interface/src/app/treatments/prescriptions.ts
@@ -1,30 +1,22 @@
-export const SEQUENCE_COLORS = {
-  SINGLE: {
-    MODERATE_THINNING_BIOMASS: '#3A86FF',
-    HEAVY_THINNING_BIOMASS: '#8338EC',
-    MODERATE_THINNING_BURN: '#F77F00',
-    HEAVY_THINNING_BURN: '#FFBE0B',
-    MODERATE_MASTICATION: '#2A9D8F',
-    HEAVY_MASTICATION: '#90BE6D',
-    RX_FIRE: '#EF233C',
-    HEAVY_THINNING_RX_FIRE: '#780000',
-    MASTICATION_RX_FIRE: '#FB6F92',
-  },
-  SEQUENCE: {
-    MODERATE_THINNING_BURN_PLUS_RX_FIRE:
-      'Moderate Thinning & Pile Burn (year 0), Prescribed Burn (year 10)',
-    MODERATE_THINNING_BURN_PLUS_MODERATE_THINNING_BURN:
-      'Moderate Thinning & Pile Burn (year 0), Moderate Thinning & Pile Burn (year 10)',
-    HEAVY_THINNING_BURN_PLUS_RX_FIRE:
-      'Heavy Thinning & Pile Burn (year 0), Prescribed Burn (year 10)',
-    HEAVY_THINNING_BURN_PLUS_HEAVY_THINNING_BURN:
-      'Heavy Thinning & Pile Burn (year 0), Heavy Thinning & Pile Burn (year 10)',
-    RX_FIRE_PLUS_RX_FIRE: 'Prescribed Fire (year 0), Prescribed Fire (year 10)',
-    MODERATE_MASTICATION_PLUS_MODERATE_MASTICATION:
-      'Moderate Mastication (year 0), Moderate Mastication (year 10)',
-    HEAVY_THINNING_BIOMASS_PLUS_RX_FIRE:
-      'Heavy Thinning & Biomass Removal (year 0), Prescribed Fire (year 10)',
-    MODERATE_MASTICATION_PLUS_RX_FIRE:
-      'Moderate Mastication (year 0), Prescribed Fire (year 10)',
-  },
+export type PrescriptionAction =
+  | 'MODERATE_THINNING_BIOMASS'
+  | 'HEAVY_THINNING_BIOMASS'
+  | 'MODERATE_THINNING_BURN'
+  | 'HEAVY_THINNING_BURN'
+  | 'MODERATE_MASTICATION'
+  | 'HEAVY_MASTICATION'
+  | 'RX_FIRE'
+  | 'HEAVY_THINNING_RX_FIRE'
+  | 'MASTICATION_RX_FIRE';
+
+export const SEQUENCE_COLORS: Record<PrescriptionAction, string> = {
+  MODERATE_THINNING_BIOMASS: '#3A86FF',
+  HEAVY_THINNING_BIOMASS: '#8338EC',
+  MODERATE_THINNING_BURN: '#F77F00',
+  HEAVY_THINNING_BURN: '#FFBE0B',
+  MODERATE_MASTICATION: '#2A9D8F',
+  HEAVY_MASTICATION: '#90BE6D',
+  RX_FIRE: '#EF233C',
+  HEAVY_THINNING_RX_FIRE: '#780000',
+  MASTICATION_RX_FIRE: '#FB6F92',
 };

--- a/src/interface/src/app/treatments/prescriptions.ts
+++ b/src/interface/src/app/treatments/prescriptions.ts
@@ -1,6 +1,6 @@
 // placeholder for adding colors based on prescription actions
 
-export type PrescriptionAction =
+export type PrescriptionSingleAction =
   | 'MODERATE_THINNING_BIOMASS'
   | 'HEAVY_THINNING_BIOMASS'
   | 'MODERATE_THINNING_BURN'
@@ -11,7 +11,21 @@ export type PrescriptionAction =
   | 'HEAVY_THINNING_RX_FIRE'
   | 'MASTICATION_RX_FIRE';
 
-export const SEQUENCE_COLORS: Record<PrescriptionAction, string> = {
+export type PrescriptionSequenceAction =
+  | 'MODERATE_THINNING_BURN_PLUS_RX_FIRE'
+  | 'MODERATE_THINNING_BURN_PLUS_MODERATE_THINNING_BURN'
+  | 'HEAVY_THINNING_BURN_PLUS_RX_FIRE'
+  | 'HEAVY_THINNING_BURN_PLUS_HEAVY_THINNING_BURN'
+  | 'RX_FIRE_PLUS_RX_FIRE'
+  | 'MODERATE_MASTICATION_PLUS_MODERATE_MASTICATION'
+  | 'HEAVY_THINNING_BIOMASS_PLUS_RX_FIRE'
+  | 'MODERATE_MASTICATION_PLUS_RX_FIRE';
+
+export type PrescriptionAction =
+  | PrescriptionSingleAction
+  | PrescriptionSequenceAction;
+
+export const SEQUENCE_COLORS: Record<PrescriptionSingleAction, string> = {
   MODERATE_THINNING_BIOMASS: '#3A86FF',
   HEAVY_THINNING_BIOMASS: '#8338EC',
   MODERATE_THINNING_BURN: '#F77F00',

--- a/src/interface/src/app/treatments/prescriptions.ts
+++ b/src/interface/src/app/treatments/prescriptions.ts
@@ -1,3 +1,5 @@
+// placeholder for adding colors based on prescription actions
+
 export type PrescriptionAction =
   | 'MODERATE_THINNING_BIOMASS'
   | 'HEAVY_THINNING_BIOMASS'

--- a/src/interface/src/app/treatments/treatment-map/selected-stands.state.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/selected-stands.state.spec.ts
@@ -1,0 +1,72 @@
+import { TestBed } from '@angular/core/testing';
+import { SelectedStandsState } from './selected-stands.state';
+
+describe('SelectedStandsState', () => {
+  let service: SelectedStandsState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = new SelectedStandsState();
+  });
+
+  it('should initialize with an empty list of selected stands', () => {
+    expect(service.getSelectedStands()).toEqual([]);
+  });
+
+  it('should update selected stands', () => {
+    const stands = [1, 2, 3];
+    service.updateSelectedStands(stands);
+
+    expect(service.getSelectedStands()).toEqual(stands);
+  });
+
+  it('should clear selected stands', () => {
+    service.updateSelectedStands([1, 2, 3]);
+    service.clearStands();
+
+    expect(service.getSelectedStands()).toEqual([]);
+  });
+
+  it('should get the current selected stands', () => {
+    const stands = [1, 2, 3];
+    service.updateSelectedStands(stands);
+
+    expect(service.getSelectedStands()).toEqual(stands);
+  });
+
+  it('should toggle a stand on if not already selected', () => {
+    const standId = 1;
+    service.toggleStand(standId);
+
+    expect(service.getSelectedStands()).toContain(standId);
+  });
+
+  it('should toggle a stand off if already selected', () => {
+    const standId = 1;
+    service.updateSelectedStands([standId]);
+    service.toggleStand(standId);
+
+    expect(service.getSelectedStands()).not.toContain(standId);
+  });
+
+  it('should toggle multiple stands correctly', () => {
+    const standId1 = 1;
+    const standId2 = 2;
+
+    // Add standId1
+    service.toggleStand(standId1);
+    expect(service.getSelectedStands()).toEqual([standId1]);
+
+    // Add standId2
+    service.toggleStand(standId2);
+    expect(service.getSelectedStands()).toEqual([standId1, standId2]);
+
+    // Remove standId1
+    service.toggleStand(standId1);
+    expect(service.getSelectedStands()).toEqual([standId2]);
+
+    // Remove standId2
+    service.toggleStand(standId2);
+    expect(service.getSelectedStands()).toEqual([]);
+  });
+});

--- a/src/interface/src/app/treatments/treatment-map/selected-stands.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/selected-stands.state.ts
@@ -1,6 +1,9 @@
 import { BehaviorSubject } from 'rxjs';
 import { Injectable } from '@angular/core';
 
+/**
+ * Manages the selected stands on a map
+ */
 @Injectable()
 export class SelectedStandsState {
   private _selectedStands$ = new BehaviorSubject<number[]>([]);

--- a/src/interface/src/app/treatments/treatment-map/treated-stands.state.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/treated-stands.state.spec.ts
@@ -1,0 +1,84 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TreatedStand } from '@services/treatments.service';
+import { TreatedStandsState } from './treated-stands.state';
+
+describe('TreatedStandsState', () => {
+  let service: TreatedStandsState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = new TreatedStandsState();
+  });
+
+  it('should initialize with an empty list of treated stands', () => {
+    expect(service.getTreatedStands()).toEqual([]);
+  });
+
+  it('should set treated stands', () => {
+    const stands: TreatedStand[] = [
+      { id: 1, action: 'Treatment A' },
+      { id: 2, action: 'Treatment B' },
+    ];
+    service.setTreatedStands(stands);
+
+    expect(service.getTreatedStands()).toEqual(stands);
+  });
+
+  it('should update treated stands and replace existing ones with the same ID', () => {
+    const initialStands: TreatedStand[] = [
+      { id: 1, action: 'Treatment A' },
+      { id: 2, action: 'Treatment B' },
+    ];
+    service.setTreatedStands(initialStands);
+
+    const newStands: TreatedStand[] = [
+      { id: 2, action: 'Updated Treatment' },
+      { id: 3, action: 'Treatment C' },
+    ];
+    service.updateTreatedStands(newStands);
+
+    expect(service.getTreatedStands()).toEqual([
+      { id: 1, action: 'Treatment A' },
+      { id: 2, action: 'Updated Treatment' },
+      { id: 3, action: 'Treatment C' },
+    ]);
+  });
+
+  it('should update treated stands and add new ones without affecting others', () => {
+    const initialStands: TreatedStand[] = [{ id: 1, action: 'Treatment A' }];
+    service.setTreatedStands(initialStands);
+
+    const newStands: TreatedStand[] = [
+      { id: 2, action: 'Treatment B' },
+      { id: 3, action: 'Treatment C' },
+    ];
+    service.updateTreatedStands(newStands);
+
+    expect(service.getTreatedStands()).toEqual([
+      { id: 1, action: 'Treatment A' },
+      { id: 2, action: 'Treatment B' },
+      { id: 3, action: 'Treatment C' },
+    ]);
+  });
+
+  it('should update treated stands if the same ID is provided', () => {
+    const initialStands: TreatedStand[] = [
+      { id: 1, action: 'Treatment A' },
+      { id: 2, action: 'Treatment B' },
+    ];
+    service.setTreatedStands(initialStands);
+
+    const newStands: TreatedStand[] = [
+      { id: 2, action: 'Treatment C' },
+      { id: 3, action: 'Treatment D' },
+    ];
+    service.updateTreatedStands(newStands);
+
+    expect(service.getTreatedStands()).toEqual([
+      { id: 1, action: 'Treatment A' },
+      { id: 2, action: 'Treatment C' },
+      { id: 3, action: 'Treatment D' },
+    ]);
+  });
+});

--- a/src/interface/src/app/treatments/treatment-map/treated-stands.state.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/treated-stands.state.spec.ts
@@ -81,4 +81,22 @@ describe('TreatedStandsState', () => {
       { id: 3, action: 'Treatment D' },
     ]);
   });
+
+  it('should remove treated stands', () => {
+    const initialStands: TreatedStand[] = [
+      { id: 1, action: 'Treatment A' },
+      { id: 2, action: 'Treatment B' },
+      { id: 3, action: 'Treatment C' },
+      { id: 4, action: 'Treatment D' },
+    ];
+    service.setTreatedStands(initialStands);
+
+    const stands = [2, 4];
+    service.removeTreatments(stands);
+
+    expect(service.getTreatedStands()).toEqual([
+      { id: 1, action: 'Treatment A' },
+      { id: 3, action: 'Treatment C' },
+    ]);
+  });
 });

--- a/src/interface/src/app/treatments/treatment-map/treated-stands.state.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/treated-stands.state.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
-import { TreatedStand } from '@services/treatments.service';
 import { TreatedStandsState } from './treated-stands.state';
+import { TreatedStand } from '@types';
 
 describe('TreatedStandsState', () => {
   let service: TreatedStandsState;

--- a/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
@@ -19,10 +19,7 @@ export class TreatedStandsState {
       (currentStand) => !stands.some((stand) => stand.id === currentStand.id)
     );
 
-    // Add the new stands
     const updatedStands = [...filteredStands, ...stands];
-
-    // Update the BehaviorSubject
     this._treatedStands$.next(updatedStands);
   }
 
@@ -32,5 +29,13 @@ export class TreatedStandsState {
 
   getTreatedStands() {
     return this._treatedStands$.value;
+  }
+
+  removeTreatments(standId: number[]) {
+    const currentStands = this.getTreatedStands();
+    const filteredStands = currentStands.filter(
+      (currentStand) => !standId.some((standId) => standId === currentStand.id)
+    );
+    this._treatedStands$.next(filteredStands);
   }
 }

--- a/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject } from 'rxjs';
 import { Injectable } from '@angular/core';
-import { TreatedStand } from '@services/treatments.service';
+
+import { TreatedStand } from '@types';
 
 /**
  * Manages the stands that have treatment, to be displayed on the map.

--- a/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
@@ -1,0 +1,19 @@
+import { BehaviorSubject } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { TreatedStand } from '@services/treatments.service';
+
+@Injectable()
+export class TreatedStandsState {
+  private _treatedStands$ = new BehaviorSubject<TreatedStand[]>([]);
+  treatedStands$ = this._treatedStands$.asObservable();
+
+  updateTreatedStands(stands: TreatedStand[]) {
+    const treatedStands = [...this.getTreatedStands(), ...stands];
+    console.log(treatedStands);
+    this._treatedStands$.next(treatedStands);
+  }
+
+  getTreatedStands() {
+    return this._treatedStands$.value;
+  }
+}

--- a/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/treated-stands.state.ts
@@ -2,15 +2,31 @@ import { BehaviorSubject } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { TreatedStand } from '@services/treatments.service';
 
+/**
+ * Manages the stands that have treatment, to be displayed on the map.
+ */
 @Injectable()
 export class TreatedStandsState {
   private _treatedStands$ = new BehaviorSubject<TreatedStand[]>([]);
   treatedStands$ = this._treatedStands$.asObservable();
 
   updateTreatedStands(stands: TreatedStand[]) {
-    const treatedStands = [...this.getTreatedStands(), ...stands];
-    console.log(treatedStands);
-    this._treatedStands$.next(treatedStands);
+    const currentStands = this.getTreatedStands();
+
+    // Remove any existing stands with the same IDs as the new ones
+    const filteredStands = currentStands.filter(
+      (currentStand) => !stands.some((stand) => stand.id === currentStand.id)
+    );
+
+    // Add the new stands
+    const updatedStands = [...filteredStands, ...stands];
+
+    // Update the BehaviorSubject
+    this._treatedStands$.next(updatedStands);
+  }
+
+  setTreatedStands(stands: TreatedStand[]) {
+    this._treatedStands$.next(stands);
   }
 
   getTreatedStands() {

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -17,9 +17,7 @@
   (mapMouseUp)="onMapMouseUp($event)">
   <app-map-stands
     [mapLibreMap]="mapLibreMap"
-    [projectAreaId]="projectAreaId"
     [treatedStands]="(treatedStands$ | async) || []"
-    [treatmentPlanId]="treatmentPlanId"
     [selectStart]="start ? start.point : null"
     [selectEnd]="end ? end.point : null"></app-map-stands>
 

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -18,6 +18,7 @@
   <app-map-stands
     [mapLibreMap]="mapLibreMap"
     [projectAreaId]="projectAreaId"
+    [treatedStands]="(treatedStands$ | async) || []"
     [treatmentPlanId]="treatmentPlanId"
     [selectStart]="start ? start.point : null"
     [selectEnd]="end ? end.point : null"></app-map-stands>

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
@@ -7,6 +7,7 @@ import { MapStandsComponent } from '../map-stands/map-stands.component';
 import { MapRectangleComponent } from '../map-rectangle/map-rectangle.component';
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
 import { SelectedStandsState } from './selected-stands.state';
+import { CommonModule } from '@angular/common';
 
 describe('TreatmentMapComponent', () => {
   let component: TreatmentMapComponent;
@@ -14,7 +15,7 @@ describe('TreatmentMapComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TreatmentMapComponent],
+      imports: [TreatmentMapComponent, CommonModule],
       providers: [
         MockProviders(MapConfigState, TreatedStandsState, SelectedStandsState),
       ],

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
@@ -1,8 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { TreatmentMapComponent } from './treatment-map.component';
-import { MockProvider } from 'ng-mocks';
+import { MockDeclarations, MockProviders } from 'ng-mocks';
 import { MapConfigState } from './map-config.state';
+import { TreatedStandsState } from './treated-stands.state';
+import { MapStandsComponent } from '../map-stands/map-stands.component';
+import { MapRectangleComponent } from '../map-rectangle/map-rectangle.component';
+import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
+import { SelectedStandsState } from './selected-stands.state';
 
 describe('TreatmentMapComponent', () => {
   let component: TreatmentMapComponent;
@@ -11,7 +15,16 @@ describe('TreatmentMapComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TreatmentMapComponent],
-      providers: [MockProvider(MapConfigState)],
+      providers: [
+        MockProviders(MapConfigState, TreatedStandsState, SelectedStandsState),
+      ],
+      declarations: [
+        MockDeclarations(
+          MapStandsComponent,
+          MapRectangleComponent,
+          MapProjectAreasComponent
+        ),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TreatmentMapComponent);

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -12,7 +12,6 @@ import {
 import { Map as MapLibreMap, MapMouseEvent } from 'maplibre-gl';
 import { MapStandsComponent } from '../map-stands/map-stands.component';
 import { MapRectangleComponent } from '../map-rectangle/map-rectangle.component';
-import { SelectedStandsState } from './selected-stands.state';
 import { MapControlsComponent } from '../map-controls/map-controls.component';
 import { environment } from '../../../environments/environment';
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
@@ -37,7 +36,6 @@ import { MapConfigState } from './map-config.state';
     NgIf,
     AsyncPipe,
   ],
-  providers: [SelectedStandsState],
   templateUrl: './treatment-map.component.html',
   styleUrl: './treatment-map.component.scss',
 })

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -15,7 +15,10 @@ import { MapRectangleComponent } from '../map-rectangle/map-rectangle.component'
 import { MapControlsComponent } from '../map-controls/map-controls.component';
 import { environment } from '../../../environments/environment';
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
+
 import { MapConfigState } from './map-config.state';
+
+import { TreatedStandsState } from './treated-stands.state';
 
 @Component({
   selector: 'app-treatment-map',
@@ -48,8 +51,6 @@ export class TreatmentMapComponent {
   @Input() treatmentPlanId = 0;
   @Input() scenarioId: number | null = null;
 
-  treatedStands: { id: number; assigment: string }[] = [];
-
   mapDragging = true;
 
   private isDragging = false;
@@ -58,7 +59,12 @@ export class TreatmentMapComponent {
 
   styleUrl$ = this.mapConfigState.baseLayerUrl$;
 
-  constructor(private mapConfigState: MapConfigState) {}
+  treatedStands$ = this.treatedStandsState.treatedStands$;
+
+  constructor(
+    private mapConfigState: MapConfigState,
+    private treatedStandsState: TreatedStandsState
+  ) {}
 
   onMapMouseDown(event: MapMouseEvent): void {
     if (event.originalEvent.button === 2) {

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -19,6 +19,7 @@ import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas
 import { MapConfigState } from './map-config.state';
 
 import { TreatedStandsState } from './treated-stands.state';
+import { TreatmentsState } from '../treatments.state';
 
 @Component({
   selector: 'app-treatment-map',
@@ -46,9 +47,9 @@ export class TreatmentMapComponent {
   mapLibreMap!: MapLibreMap;
   readonly key = environment.stadiamaps_key;
 
-  // TODO: should we keep using prop drilling here? Consider using a provider service to hold these values
-  @Input() projectAreaId: number | null = null;
-  @Input() treatmentPlanId = 0;
+  treatmentPlanId = this.treatmentsState.getTreatmentPlanId();
+  projectAreaId = this.treatmentsState.getProjectAreaId();
+
   @Input() scenarioId: number | null = null;
 
   mapDragging = true;
@@ -62,8 +63,13 @@ export class TreatmentMapComponent {
   treatedStands$ = this.treatedStandsState.treatedStands$;
 
   constructor(
+<<<<<<< HEAD
     private mapConfigState: MapConfigState,
     private treatedStandsState: TreatedStandsState
+=======
+    private treatedStandsState: TreatedStandsState,
+    private treatmentsState: TreatmentsState
+>>>>>>> 712d2ac6 (moved treatment and project area ids to state)
   ) {}
 
   onMapMouseDown(event: MapMouseEvent): void {

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -15,9 +15,7 @@ import { MapRectangleComponent } from '../map-rectangle/map-rectangle.component'
 import { MapControlsComponent } from '../map-controls/map-controls.component';
 import { environment } from '../../../environments/environment';
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
-
 import { MapConfigState } from './map-config.state';
-
 import { TreatedStandsState } from './treated-stands.state';
 
 @Component({

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -19,7 +19,6 @@ import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas
 import { MapConfigState } from './map-config.state';
 
 import { TreatedStandsState } from './treated-stands.state';
-import { TreatmentsState } from '../treatments.state';
 
 @Component({
   selector: 'app-treatment-map',
@@ -47,9 +46,6 @@ export class TreatmentMapComponent {
   mapLibreMap!: MapLibreMap;
   readonly key = environment.stadiamaps_key;
 
-  treatmentPlanId = this.treatmentsState.getTreatmentPlanId();
-  projectAreaId = this.treatmentsState.getProjectAreaId();
-
   @Input() scenarioId: number | null = null;
 
   mapDragging = true;
@@ -63,13 +59,8 @@ export class TreatmentMapComponent {
   treatedStands$ = this.treatedStandsState.treatedStands$;
 
   constructor(
-<<<<<<< HEAD
     private mapConfigState: MapConfigState,
     private treatedStandsState: TreatedStandsState
-=======
-    private treatedStandsState: TreatedStandsState,
-    private treatmentsState: TreatmentsState
->>>>>>> 712d2ac6 (moved treatment and project area ids to state)
   ) {}
 
   onMapMouseDown(event: MapMouseEvent): void {

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
@@ -1,6 +1,7 @@
 <div class="left-side">
+  <div>{{ treatmentPlan$ | async | json }}</div>
   <app-treatment-summary></app-treatment-summary>
   <app-map-base-layer></app-map-base-layer>
 </div>
-<div>{{ treatmentPlan$ | async | json }}</div>
+
 <app-treatment-map [scenarioId]="scenarioId"></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
@@ -1,9 +1,16 @@
+<<<<<<< HEAD
 <div class="left-side">
   <app-treatment-summary
     [treatmentPlanId]="treatmentPlanId"></app-treatment-summary>
 
   <app-map-base-layer></app-map-base-layer>
 </div>
+=======
+<div>{{ treatmentPlan$ | async | json }}</div>
+
+<app-treatment-summary
+  [treatmentPlanId]="treatmentPlanId"></app-treatment-summary>
+>>>>>>> 091b970c (cleanup and comments)
 
 <app-treatment-map
   [treatmentPlanId]="treatmentPlanId"

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
@@ -1,17 +1,6 @@
-<<<<<<< HEAD
 <div class="left-side">
-  <app-treatment-summary
-    [treatmentPlanId]="treatmentPlanId"></app-treatment-summary>
-
+  <app-treatment-summary></app-treatment-summary>
   <app-map-base-layer></app-map-base-layer>
 </div>
-=======
 <div>{{ treatmentPlan$ | async | json }}</div>
-
-<app-treatment-summary
-  [treatmentPlanId]="treatmentPlanId"></app-treatment-summary>
->>>>>>> 091b970c (cleanup and comments)
-
-<app-treatment-map
-  [treatmentPlanId]="treatmentPlanId"
-  [scenarioId]="scenarioId"></app-treatment-map>
+<app-treatment-map [scenarioId]="scenarioId"></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
@@ -1,5 +1,9 @@
 <div class="left-side">
-  <div>{{ treatmentPlan$ | async | json }}</div>
+  <div *ngIf="treatmentPlan$ | async; let treatmentPlan">
+    {{ treatmentPlan.id }}. {{ treatmentPlan.name }}
+    <div>{{ treatmentPlan.status }}</div>
+  </div>
+
   <app-treatment-summary></app-treatment-summary>
   <app-map-base-layer></app-map-base-layer>
 </div>

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
@@ -1,9 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TreatmentOverviewComponent } from './treatment-overview.component';
-import { MockProvider } from 'ng-mocks';
-import { TreatmentsService } from '@services/treatments.service';
+import { MockDeclarations, MockProviders } from 'ng-mocks';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TreatmentsState } from '../treatments.state';
+
+import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
+import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 
 describe('TreatmentOverviewComponent', () => {
   let component: TreatmentOverviewComponent;
@@ -12,7 +15,10 @@ describe('TreatmentOverviewComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TreatmentOverviewComponent, RouterTestingModule],
-      providers: [MockProvider(TreatmentsService)],
+      declarations: [
+        MockDeclarations(TreatmentSummaryComponent, TreatmentMapComponent),
+      ],
+      providers: [MockProviders(TreatmentsState)],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TreatmentOverviewComponent);

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
@@ -7,6 +7,7 @@ import { TreatmentsState } from '../treatments.state';
 
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
+import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
 
 describe('TreatmentOverviewComponent', () => {
   let component: TreatmentOverviewComponent;
@@ -16,7 +17,11 @@ describe('TreatmentOverviewComponent', () => {
     await TestBed.configureTestingModule({
       imports: [TreatmentOverviewComponent, RouterTestingModule],
       declarations: [
-        MockDeclarations(TreatmentSummaryComponent, TreatmentMapComponent),
+        MockDeclarations(
+          TreatmentSummaryComponent,
+          TreatmentMapComponent,
+          MapBaseLayerComponent
+        ),
       ],
       providers: [MockProviders(TreatmentsState)],
     }).compileComponents();

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -1,20 +1,20 @@
-import { Component, OnInit } from '@angular/core';
-import { TreatmentsService } from '@services/treatments.service';
+import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { JsonPipe } from '@angular/common';
-import { TreatmentPlan } from '@types';
+import { AsyncPipe, JsonPipe } from '@angular/common';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
 import { MapConfigState } from '../treatment-map/map-config.state';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { TreatedStandsState } from '../treatment-map/treated-stands.state';
+import { TreatmentsState } from '../treatments.state';
 
 @Component({
   selector: 'app-treatment-overview',
   standalone: true,
   imports: [
     JsonPipe,
+    AsyncPipe,
     TreatmentMapComponent,
     TreatmentSummaryComponent,
     MapBaseLayerComponent,
@@ -23,21 +23,14 @@ import { TreatedStandsState } from '../treatment-map/treated-stands.state';
   templateUrl: './treatment-overview.component.html',
   styleUrl: './treatment-overview.component.scss',
 })
-export class TreatmentOverviewComponent implements OnInit {
+export class TreatmentOverviewComponent {
   treatmentPlanId: number = this.route.snapshot.data['treatmentId'];
-  treatmentPlan: TreatmentPlan | null = null;
   scenarioId: number = this.route.snapshot.data['scenarioId'];
 
-  constructor(
-    private treatmentsService: TreatmentsService,
-    private route: ActivatedRoute
-  ) {}
+  treatmentPlan$ = this.treatmentsState.treatmentPlan;
 
-  ngOnInit(): void {
-    if (this.treatmentPlanId) {
-      this.treatmentsService
-        .getTreatmentPlan(Number(this.treatmentPlanId))
-        .subscribe((r) => (this.treatmentPlan = r));
-    }
-  }
+  constructor(
+    private route: ActivatedRoute,
+    private treatmentsState: TreatmentsState
+  ) {}
 }

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { AsyncPipe, JsonPipe } from '@angular/common';
+import { AsyncPipe, JsonPipe, NgIf } from '@angular/common';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
@@ -15,6 +15,7 @@ import { TreatmentsState } from '../treatments.state';
     TreatmentMapComponent,
     TreatmentSummaryComponent,
     MapBaseLayerComponent,
+    NgIf,
   ],
   templateUrl: './treatment-overview.component.html',
   styleUrl: './treatment-overview.component.scss',

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -22,7 +22,7 @@ import { TreatmentsState } from '../treatments.state';
 export class TreatmentOverviewComponent {
   scenarioId: number = this.route.snapshot.data['scenarioId'];
 
-  treatmentPlan$ = this.treatmentsState.treatmentPlan;
+  treatmentPlan$ = this.treatmentsState.treatmentPlan$;
 
   constructor(
     private route: ActivatedRoute,

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -7,17 +7,20 @@ import { TreatmentMapComponent } from '../treatment-map/treatment-map.component'
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
 import { MapConfigState } from '../treatment-map/map-config.state';
+import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 
 @Component({
   selector: 'app-treatment-overview',
   standalone: true,
+
   imports: [
     JsonPipe,
     TreatmentMapComponent,
     TreatmentSummaryComponent,
     MapBaseLayerComponent,
   ],
-  providers: [MapConfigState],
+  providers: [MapConfigState, SelectedStandsState],
+
   templateUrl: './treatment-overview.component.html',
   styleUrl: './treatment-overview.component.scss',
 })

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { AsyncPipe, JsonPipe, NgIf } from '@angular/common';
+import { AsyncPipe, NgIf } from '@angular/common';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
@@ -10,7 +10,6 @@ import { TreatmentsState } from '../treatments.state';
   selector: 'app-treatment-overview',
   standalone: true,
   imports: [
-    JsonPipe,
     AsyncPipe,
     TreatmentMapComponent,
     TreatmentSummaryComponent,

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -4,9 +4,6 @@ import { AsyncPipe, JsonPipe } from '@angular/common';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
-import { MapConfigState } from '../treatment-map/map-config.state';
-import { SelectedStandsState } from '../treatment-map/selected-stands.state';
-import { TreatedStandsState } from '../treatment-map/treated-stands.state';
 import { TreatmentsState } from '../treatments.state';
 
 @Component({
@@ -19,7 +16,6 @@ import { TreatmentsState } from '../treatments.state';
     TreatmentSummaryComponent,
     MapBaseLayerComponent,
   ],
-  providers: [MapConfigState, SelectedStandsState, TreatedStandsState],
   templateUrl: './treatment-overview.component.html',
   styleUrl: './treatment-overview.component.scss',
 })

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -8,19 +8,18 @@ import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summar
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
 import { MapConfigState } from '../treatment-map/map-config.state';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
+import { TreatedStandsState } from '../treatment-map/treated-stands.state';
 
 @Component({
   selector: 'app-treatment-overview',
   standalone: true,
-
   imports: [
     JsonPipe,
     TreatmentMapComponent,
     TreatmentSummaryComponent,
     MapBaseLayerComponent,
   ],
-  providers: [MapConfigState, SelectedStandsState],
-
+  providers: [MapConfigState, SelectedStandsState, TreatedStandsState],
   templateUrl: './treatment-overview.component.html',
   styleUrl: './treatment-overview.component.scss',
 })

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -24,7 +24,6 @@ import { TreatmentsState } from '../treatments.state';
   styleUrl: './treatment-overview.component.scss',
 })
 export class TreatmentOverviewComponent {
-  treatmentPlanId: number = this.route.snapshot.data['treatmentId'];
   scenarioId: number = this.route.snapshot.data['scenarioId'];
 
   treatmentPlan$ = this.treatmentsState.treatmentPlan;

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
@@ -1,5 +1,3 @@
 <p>Project Area</p>
-<app-prescription-actions
-  [treatmentPlanId]="treatmentPlanId"
-  [projectAreaId]="projectAreaId"></app-prescription-actions>
+<app-prescription-actions></app-prescription-actions>
 <app-treatment-map></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
@@ -2,6 +2,4 @@
 <app-prescription-actions
   [treatmentPlanId]="treatmentPlanId"
   [projectAreaId]="projectAreaId"></app-prescription-actions>
-<app-treatment-map
-  [treatmentPlanId]="treatmentPlanId"
-  [projectAreaId]="projectAreaId"></app-treatment-map>
+<app-treatment-map></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
@@ -1,5 +1,7 @@
 <p>Project Area</p>
-<app-prescription-actions></app-prescription-actions>
+<app-prescription-actions
+  [treatmentPlanId]="treatmentPlanId"
+  [projectAreaId]="projectAreaId"></app-prescription-actions>
 <app-treatment-map
   [treatmentPlanId]="treatmentPlanId"
   [projectAreaId]="projectAreaId"></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ProjectAreaComponent } from './project-area.component';
+
 import { MockDeclarations, MockProviders } from 'ng-mocks';
+
+import { TreatmentProjectAreaComponent } from './treatment-project-area.component';
+
 import { TreatmentsService } from '@services/treatments.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LookupService } from '@services/lookup.service';
@@ -8,19 +11,19 @@ import { TreatmentMapComponent } from '../treatment-map/treatment-map.component'
 import { PrescriptionActionsComponent } from '../prescription-actions/prescription-actions.component';
 
 describe('ProjectAreaComponent', () => {
-  let component: ProjectAreaComponent;
-  let fixture: ComponentFixture<ProjectAreaComponent>;
+  let component: TreatmentProjectAreaComponent;
+  let fixture: ComponentFixture<TreatmentProjectAreaComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProjectAreaComponent, RouterTestingModule],
+      imports: [TreatmentProjectAreaComponent, RouterTestingModule],
       providers: [MockProviders(TreatmentsService, LookupService)],
       declarations: [
         MockDeclarations(TreatmentMapComponent, PrescriptionActionsComponent),
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(ProjectAreaComponent);
+    fixture = TestBed.createComponent(TreatmentProjectAreaComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.spec.ts
@@ -1,9 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { MockDeclarations, MockProviders } from 'ng-mocks';
-
 import { TreatmentProjectAreaComponent } from './treatment-project-area.component';
-
 import { TreatmentsService } from '@services/treatments.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LookupService } from '@services/lookup.service';

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -1,8 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
-import { TreatmentPlan } from '@types';
-import { TreatmentsService } from '@services/treatments.service';
 import { ActivatedRoute } from '@angular/router';
 import { AsyncPipe, JsonPipe } from '@angular/common';
 import { PrescriptionActionsComponent } from '../prescription-actions/prescription-actions.component';
@@ -20,22 +18,9 @@ import { PrescriptionActionsComponent } from '../prescription-actions/prescripti
   templateUrl: './treatment-project-area.component.html',
   styleUrl: './treatment-project-area.component.scss',
 })
-export class TreatmentProjectAreaComponent implements OnInit {
+export class TreatmentProjectAreaComponent {
   treatmentPlanId: number = this.route.snapshot.data['treatmentId'];
   projectAreaId: number = this.route.snapshot.data['projectAreaId'];
 
-  treatmentPlan: TreatmentPlan | null = null;
-
-  constructor(
-    private treatmentsService: TreatmentsService,
-    private route: ActivatedRoute
-  ) {}
-
-  ngOnInit(): void {
-    if (this.treatmentPlanId) {
-      this.treatmentsService
-        .getTreatmentPlan(Number(this.treatmentPlanId))
-        .subscribe((r) => (this.treatmentPlan = r));
-    }
-  }
+  constructor(private route: ActivatedRoute) {}
 }

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -6,8 +6,6 @@ import { TreatmentsService } from '@services/treatments.service';
 import { ActivatedRoute } from '@angular/router';
 import { AsyncPipe, JsonPipe } from '@angular/common';
 import { PrescriptionActionsComponent } from '../prescription-actions/prescription-actions.component';
-import { SelectedStandsState } from '../treatment-map/selected-stands.state';
-import { TreatedStandsState } from '../treatment-map/treated-stands.state';
 
 @Component({
   selector: 'app-treatment-project-area',
@@ -19,7 +17,6 @@ import { TreatedStandsState } from '../treatment-map/treated-stands.state';
     AsyncPipe,
     PrescriptionActionsComponent,
   ],
-  providers: [SelectedStandsState, TreatedStandsState],
   templateUrl: './treatment-project-area.component.html',
   styleUrl: './treatment-project-area.component.scss',
 })

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
-import { ActivatedRoute } from '@angular/router';
 import { AsyncPipe, JsonPipe } from '@angular/common';
 import { PrescriptionActionsComponent } from '../prescription-actions/prescription-actions.component';
 
@@ -19,8 +18,5 @@ import { PrescriptionActionsComponent } from '../prescription-actions/prescripti
   styleUrl: './treatment-project-area.component.scss',
 })
 export class TreatmentProjectAreaComponent {
-  treatmentPlanId: number = this.route.snapshot.data['treatmentId'];
-  projectAreaId: number = this.route.snapshot.data['projectAreaId'];
-
-  constructor(private route: ActivatedRoute) {}
+  constructor() {}
 }

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -6,9 +6,10 @@ import { TreatmentsService } from '@services/treatments.service';
 import { ActivatedRoute } from '@angular/router';
 import { AsyncPipe, JsonPipe } from '@angular/common';
 import { PrescriptionActionsComponent } from '../prescription-actions/prescription-actions.component';
+import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 
 @Component({
-  selector: 'app-project-area',
+  selector: 'app-treatment-project-area',
   standalone: true,
   imports: [
     TreatmentMapComponent,
@@ -17,10 +18,11 @@ import { PrescriptionActionsComponent } from '../prescription-actions/prescripti
     AsyncPipe,
     PrescriptionActionsComponent,
   ],
-  templateUrl: './project-area.component.html',
-  styleUrl: './project-area.component.scss',
+  providers: [SelectedStandsState],
+  templateUrl: './treatment-project-area.component.html',
+  styleUrl: './treatment-project-area.component.scss',
 })
-export class ProjectAreaComponent implements OnInit {
+export class TreatmentProjectAreaComponent implements OnInit {
   treatmentPlanId: number = this.route.snapshot.data['treatmentId'];
   projectAreaId: number = this.route.snapshot.data['projectAreaId'];
 

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute } from '@angular/router';
 import { AsyncPipe, JsonPipe } from '@angular/common';
 import { PrescriptionActionsComponent } from '../prescription-actions/prescription-actions.component';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
+import { TreatedStandsState } from '../treatment-map/treated-stands.state';
 
 @Component({
   selector: 'app-treatment-project-area',
@@ -18,7 +19,7 @@ import { SelectedStandsState } from '../treatment-map/selected-stands.state';
     AsyncPipe,
     PrescriptionActionsComponent,
   ],
-  providers: [SelectedStandsState],
+  providers: [SelectedStandsState, TreatedStandsState],
   templateUrl: './treatment-project-area.component.html',
   styleUrl: './treatment-project-area.component.scss',
 })

--- a/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
@@ -1,19 +1,79 @@
 import { TestBed } from '@angular/core/testing';
-import { ResolveFn } from '@angular/router';
-
 import { treatmentStateResolver } from './treatment-state.resolver';
+import { TreatmentsState } from './treatments.state';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { MockProvider } from 'ng-mocks';
 
 describe('treatmentStateResolver', () => {
-  const executeResolver: ResolveFn<boolean> = (...resolverParameters) =>
-    TestBed.runInInjectionContext(() =>
-      treatmentStateResolver(...resolverParameters)
-    );
+  let treatmentsState: TreatmentsState;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [MockProvider(TreatmentsState)],
+    });
+
+    treatmentsState = TestBed.inject(TreatmentsState);
+    spyOn(treatmentsState, 'setTreatmentPlanId').and.callThrough();
+    spyOn(treatmentsState, 'setProjectAreaId').and.callThrough();
+    spyOn(treatmentsState, 'loadSummary').and.callThrough();
+    spyOn(treatmentsState, 'loadTreatmentPlan').and.callThrough();
   });
 
-  it('should be created', () => {
-    expect(executeResolver).toBeTruthy();
+  it('should resolve and call TreatmentsState methods correctly', () => {
+    const route = {
+      paramMap: {
+        get: jasmine.createSpy('get').and.callFake((key: string) => {
+          switch (key) {
+            case 'treatmentId':
+              return '123';
+            case 'projectAreaId':
+              return '456';
+            default:
+              return null;
+          }
+        }),
+      },
+    } as unknown as ActivatedRouteSnapshot;
+
+    const state = {} as RouterStateSnapshot;
+
+    TestBed.runInInjectionContext(() => {
+      const result = treatmentStateResolver(route, state);
+
+      expect(treatmentsState.setTreatmentPlanId).toHaveBeenCalledWith(123);
+      expect(treatmentsState.setProjectAreaId).toHaveBeenCalledWith(456);
+      expect(treatmentsState.loadSummary).toHaveBeenCalled();
+      expect(treatmentsState.loadTreatmentPlan).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+
+  it('should handle undefined projectAreaId', () => {
+    const route = {
+      paramMap: {
+        get: jasmine.createSpy('get').and.callFake((key: string) => {
+          switch (key) {
+            case 'treatmentId':
+              return '123';
+            case 'projectAreaId':
+              return null;
+            default:
+              return null;
+          }
+        }),
+      },
+    } as unknown as ActivatedRouteSnapshot;
+
+    const state = {} as RouterStateSnapshot;
+
+    TestBed.runInInjectionContext(() => {
+      const result = treatmentStateResolver(route, state);
+
+      expect(treatmentsState.setTreatmentPlanId).toHaveBeenCalledWith(123);
+      expect(treatmentsState.setProjectAreaId).toHaveBeenCalledWith(undefined);
+      expect(treatmentsState.loadSummary).toHaveBeenCalled();
+      expect(treatmentsState.loadTreatmentPlan).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
   });
 });

--- a/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
@@ -4,8 +4,10 @@ import { ResolveFn } from '@angular/router';
 import { treatmentStateResolver } from './treatment-state.resolver';
 
 describe('treatmentStateResolver', () => {
-  const executeResolver: ResolveFn<boolean> = (...resolverParameters) => 
-      TestBed.runInInjectionContext(() => treatmentStateResolver(...resolverParameters));
+  const executeResolver: ResolveFn<boolean> = (...resolverParameters) =>
+    TestBed.runInInjectionContext(() =>
+      treatmentStateResolver(...resolverParameters)
+    );
 
   beforeEach(() => {
     TestBed.configureTestingModule({});

--- a/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { ResolveFn } from '@angular/router';
+
+import { treatmentStateResolver } from './treatment-state.resolver';
+
+describe('treatmentStateResolver', () => {
+  const executeResolver: ResolveFn<boolean> = (...resolverParameters) => 
+      TestBed.runInInjectionContext(() => treatmentStateResolver(...resolverParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeResolver).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -2,19 +2,20 @@ import { ResolveFn } from '@angular/router';
 import { inject } from '@angular/core';
 import { TreatmentsState } from './treatments.state';
 
+/**
+ * Resolves that kickoff loading data via TreatmentsState.
+ * @param route
+ * @param state
+ */
 export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
   const treatmentsState = inject(TreatmentsState);
   const treatmentPlanId = Number(route.paramMap.get('treatmentId'));
   const projectAreaId = route.paramMap.get('projectAreaId');
-  console.log(
-    'im loading treatment ',
-    treatmentPlanId,
-    'and project ',
-    projectAreaId
-  );
+
   treatmentsState.loadSummary(
     treatmentPlanId,
     projectAreaId ? Number(projectAreaId) : undefined
   );
+  treatmentsState.loadTreatmentPlan(treatmentPlanId);
   return true;
 };

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -1,0 +1,20 @@
+import { ResolveFn } from '@angular/router';
+import { inject } from '@angular/core';
+import { TreatmentsState } from './treatments.state';
+
+export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
+  const treatmentsState = inject(TreatmentsState);
+  const treatmentPlanId = Number(route.paramMap.get('treatmentId'));
+  const projectAreaId = route.paramMap.get('projectAreaId');
+  console.log(
+    'im loading treatment ',
+    treatmentPlanId,
+    'and project ',
+    projectAreaId
+  );
+  treatmentsState.loadSummary(
+    treatmentPlanId,
+    projectAreaId ? Number(projectAreaId) : undefined
+  );
+  return true;
+};

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -3,19 +3,19 @@ import { inject } from '@angular/core';
 import { TreatmentsState } from './treatments.state';
 
 /**
- * Resolves that kickoff loading data via TreatmentsState.
- * @param route
- * @param state
+ * Resolver that kickoff loading data via TreatmentsState.
  */
 export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
   const treatmentsState = inject(TreatmentsState);
   const treatmentPlanId = Number(route.paramMap.get('treatmentId'));
   const projectAreaId = route.paramMap.get('projectAreaId');
 
-  treatmentsState.loadSummary(
-    treatmentPlanId,
+  treatmentsState.setTreatmentPlanId(treatmentPlanId);
+  treatmentsState.setProjectAreaId(
     projectAreaId ? Number(projectAreaId) : undefined
   );
-  treatmentsState.loadTreatmentPlan(treatmentPlanId);
+
+  treatmentsState.loadSummary();
+  treatmentsState.loadTreatmentPlan();
   return true;
 };

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.html
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="summary">
+<div *ngIf="summary$ | async; let summary">
   <div class="project-areas">
     <a
       *ngFor="let projectArea of summary.project_areas"

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.html
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.html
@@ -1,6 +1,8 @@
 <div *ngIf="summary">
-  <div *ngFor="let projectArea of summary.project_areas">
-    <a [routerLink]="['project-area', projectArea.project_area_id]">
+  <div class="project-areas">
+    <a
+      *ngFor="let projectArea of summary.project_areas"
+      [routerLink]="['project-area', projectArea.project_area_id]">
       {{ projectArea.project_area_name }}
     </a>
   </div>

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.html
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.html
@@ -1,8 +1,6 @@
 <div *ngIf="summary$ | async; let summary">
-  <div class="project-areas">
-    <a
-      *ngFor="let projectArea of summary.project_areas"
-      [routerLink]="['project-area', projectArea.project_area_id]">
+  <div class="project-areas" *ngFor="let projectArea of summary.project_areas">
+    <a [routerLink]="['project-area', projectArea.project_area_id]">
       {{ projectArea.project_area_name }}
     </a>
   </div>

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.scss
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.scss
@@ -1,4 +1,0 @@
-.project-areas {
-  display: flex;
-  gap: 10px;
-}

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.scss
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.scss
@@ -1,0 +1,4 @@
+.project-areas {
+  display: flex;
+  gap: 10px;
+}

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TreatmentSummaryComponent } from './treatment-summary.component';
 import { MockProvider } from 'ng-mocks';
-import { TreatmentsService } from '@services/treatments.service';
+import { TreatmentsState } from '../treatments.state';
 
 describe('TreatmentSummaryComponent', () => {
   let component: TreatmentSummaryComponent;
@@ -11,7 +11,7 @@ describe('TreatmentSummaryComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TreatmentSummaryComponent],
-      providers: [MockProvider(TreatmentsService)],
+      providers: [MockProvider(TreatmentsState)],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TreatmentSummaryComponent);

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
@@ -1,8 +1,17 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { Summary, TreatmentsService } from '@services/treatments.service';
+import {
+  Summary,
+  TreatedStand,
+  TreatmentsService,
+} from '@services/treatments.service';
 import { JsonPipe, NgForOf, NgIf } from '@angular/common';
 import { RouterLink } from '@angular/router';
+import { TreatedStandsState } from '../treatment-map/treated-stands.state';
 
+/**
+ * placeholder component to display project areas.
+ * To be replaced with project area expander
+ */
 @Component({
   selector: 'app-treatment-summary',
   standalone: true,
@@ -12,16 +21,35 @@ import { RouterLink } from '@angular/router';
 })
 export class TreatmentSummaryComponent implements OnInit {
   @Input() treatmentPlanId!: number;
+  @Input() projectAreaId?: number;
 
   summary: Summary | null = null;
 
-  constructor(private treatmentsService: TreatmentsService) {}
+  constructor(
+    private treatmentsService: TreatmentsService,
+    private treatedStandsState: TreatedStandsState
+  ) {}
 
   ngOnInit(): void {
     if (this.treatmentPlanId) {
       this.treatmentsService
-        .getTreatmentPlanSummary(this.treatmentPlanId)
-        .subscribe((r) => (this.summary = r));
+        .getTreatmentPlanSummary(this.treatmentPlanId, this.projectAreaId)
+        .subscribe((summary) => this.processSummary(summary));
     }
+  }
+
+  processSummary(summary: Summary) {
+    this.summary = summary;
+    // now process the treated stands
+    const treatedStands: TreatedStand[] = this.summary.project_areas.flatMap(
+      (pa) =>
+        pa.prescriptions.flatMap((prescription) =>
+          // treated stands, at least action + stand id
+          prescription.stand_ids.map((standId) => {
+            return { id: standId, action: prescription.action };
+          })
+        )
+    );
+    this.treatedStandsState.updateTreatedStands(treatedStands);
   }
 }

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
@@ -15,9 +15,6 @@ import { TreatmentsState } from '../treatments.state';
   styleUrl: './treatment-summary.component.scss',
 })
 export class TreatmentSummaryComponent {
-  treatmentPlanId = this.treatmentsState.getTreatmentPlanId();
-  projectAreaId = this.treatmentsState.getProjectAreaId();
-
   summary$ = this.treatmentsState.summary$;
 
   constructor(private treatmentsState: TreatmentsState) {}

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
@@ -1,12 +1,7 @@
-import { Component, Input, OnInit } from '@angular/core';
-import {
-  Summary,
-  TreatedStand,
-  TreatmentsService,
-} from '@services/treatments.service';
-import { JsonPipe, NgForOf, NgIf } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { AsyncPipe, JsonPipe, NgForOf, NgIf } from '@angular/common';
 import { RouterLink } from '@angular/router';
-import { TreatedStandsState } from '../treatment-map/treated-stands.state';
+import { TreatmentsState } from '../treatments.state';
 
 /**
  * placeholder component to display project areas.
@@ -15,41 +10,15 @@ import { TreatedStandsState } from '../treatment-map/treated-stands.state';
 @Component({
   selector: 'app-treatment-summary',
   standalone: true,
-  imports: [JsonPipe, NgForOf, NgIf, RouterLink],
+  imports: [JsonPipe, NgForOf, NgIf, RouterLink, AsyncPipe],
   templateUrl: './treatment-summary.component.html',
   styleUrl: './treatment-summary.component.scss',
 })
-export class TreatmentSummaryComponent implements OnInit {
+export class TreatmentSummaryComponent {
   @Input() treatmentPlanId!: number;
   @Input() projectAreaId?: number;
 
-  summary: Summary | null = null;
+  summary$ = this.treatmentsState.summary$;
 
-  constructor(
-    private treatmentsService: TreatmentsService,
-    private treatedStandsState: TreatedStandsState
-  ) {}
-
-  ngOnInit(): void {
-    if (this.treatmentPlanId) {
-      this.treatmentsService
-        .getTreatmentPlanSummary(this.treatmentPlanId, this.projectAreaId)
-        .subscribe((summary) => this.processSummary(summary));
-    }
-  }
-
-  processSummary(summary: Summary) {
-    this.summary = summary;
-    // now process the treated stands
-    const treatedStands: TreatedStand[] = this.summary.project_areas.flatMap(
-      (pa) =>
-        pa.prescriptions.flatMap((prescription) =>
-          // treated stands, at least action + stand id
-          prescription.stand_ids.map((standId) => {
-            return { id: standId, action: prescription.action };
-          })
-        )
-    );
-    this.treatedStandsState.updateTreatedStands(treatedStands);
-  }
+  constructor(private treatmentsState: TreatmentsState) {}
 }

--- a/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
+++ b/src/interface/src/app/treatments/treatment-summary/treatment-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { AsyncPipe, JsonPipe, NgForOf, NgIf } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { TreatmentsState } from '../treatments.state';
@@ -15,8 +15,8 @@ import { TreatmentsState } from '../treatments.state';
   styleUrl: './treatment-summary.component.scss',
 })
 export class TreatmentSummaryComponent {
-  @Input() treatmentPlanId!: number;
-  @Input() projectAreaId?: number;
+  treatmentPlanId = this.treatmentsState.getTreatmentPlanId();
+  projectAreaId = this.treatmentsState.getProjectAreaId();
 
   summary$ = this.treatmentsState.summary$;
 

--- a/src/interface/src/app/treatments/treatments-routing.module.ts
+++ b/src/interface/src/app/treatments/treatments-routing.module.ts
@@ -4,16 +4,24 @@ import { TreatmentOverviewComponent } from './treatment-overview/treatment-overv
 import { NgModule } from '@angular/core';
 import { numberResolver } from '../resolvers/number.resolver';
 import { TreatmentProjectAreaComponent } from './treatment-project-area/treatment-project-area.component';
+import { TreatmentsState } from './treatments.state';
+import { SelectedStandsState } from './treatment-map/selected-stands.state';
+import { TreatedStandsState } from './treatment-map/treated-stands.state';
+import { treatmentStateResolver } from './treatment-state.resolver';
 
 const routes: Routes = [
   {
     path: '',
     title: 'Treatment plan overview',
+    providers: [TreatmentsState, SelectedStandsState, TreatedStandsState],
     children: [
       {
         path: '',
         title: 'Treatment plan overview',
         component: TreatmentOverviewComponent,
+        resolve: {
+          initializeStates: treatmentStateResolver,
+        },
       },
       { path: 'project-area', redirectTo: '', pathMatch: 'full' },
       {
@@ -22,6 +30,7 @@ const routes: Routes = [
         component: TreatmentProjectAreaComponent,
         resolve: {
           projectAreaId: numberResolver('projectAreaId', ''),
+          initializeStates: treatmentStateResolver,
         },
       },
     ],

--- a/src/interface/src/app/treatments/treatments-routing.module.ts
+++ b/src/interface/src/app/treatments/treatments-routing.module.ts
@@ -8,12 +8,18 @@ import { TreatmentsState } from './treatments.state';
 import { SelectedStandsState } from './treatment-map/selected-stands.state';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
 import { treatmentStateResolver } from './treatment-state.resolver';
+import { MapConfigState } from './treatment-map/map-config.state';
 
 const routes: Routes = [
   {
     path: '',
     title: 'Treatment plan overview',
-    providers: [TreatmentsState, SelectedStandsState, TreatedStandsState],
+    providers: [
+      TreatmentsState,
+      SelectedStandsState,
+      TreatedStandsState,
+      MapConfigState,
+    ],
     children: [
       {
         path: '',

--- a/src/interface/src/app/treatments/treatments-routing.module.ts
+++ b/src/interface/src/app/treatments/treatments-routing.module.ts
@@ -1,8 +1,9 @@
 import { RouterModule, Routes } from '@angular/router';
 import { TreatmentOverviewComponent } from './treatment-overview/treatment-overview.component';
-import { ProjectAreaComponent } from './project-area/project-area.component';
+
 import { NgModule } from '@angular/core';
 import { numberResolver } from '../resolvers/number.resolver';
+import { TreatmentProjectAreaComponent } from './treatment-project-area/treatment-project-area.component';
 
 const routes: Routes = [
   {
@@ -18,7 +19,7 @@ const routes: Routes = [
       {
         path: 'project-area/:projectAreaId',
         title: 'Project area overview',
-        component: ProjectAreaComponent,
+        component: TreatmentProjectAreaComponent,
         resolve: {
           projectAreaId: numberResolver('projectAreaId', ''),
         },

--- a/src/interface/src/app/treatments/treatments.state.spec.ts
+++ b/src/interface/src/app/treatments/treatments.state.spec.ts
@@ -1,0 +1,170 @@
+import { TestBed } from '@angular/core/testing';
+import { TreatmentsService } from '@services/treatments.service';
+import { TreatedStandsState } from './treatment-map/treated-stands.state';
+import { of, throwError } from 'rxjs';
+import { Summary, TreatedStand, TreatmentPlan } from '@types';
+import { TreatmentsState } from './treatments.state';
+import { MockProvider } from 'ng-mocks';
+
+describe('TreatmentsState', () => {
+  let service: TreatmentsState;
+  let treatmentsService: TreatmentsService;
+  let treatedStandsState: TreatedStandsState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TreatmentsState,
+        MockProvider(TreatmentsService),
+        MockProvider(TreatedStandsState),
+      ],
+    });
+
+    service = TestBed.inject(TreatmentsState);
+    treatmentsService = TestBed.inject(TreatmentsService);
+    treatedStandsState = TestBed.inject(TreatedStandsState);
+
+    spyOn(treatedStandsState, 'setTreatedStands').and.callThrough();
+    spyOn(treatedStandsState, 'updateTreatedStands').and.callThrough();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should throw an error if treatment plan ID is not set', () => {
+    expect(() => service.getTreatmentPlanId()).toThrowError(
+      'no treatment plan id!'
+    );
+  });
+
+  it('should return the treatment plan ID if it is set', () => {
+    service.setTreatmentPlanId(123);
+    expect(service.getTreatmentPlanId()).toBe(123);
+  });
+
+  it('should set and get the project area ID', () => {
+    service.setProjectAreaId(456);
+    expect(service.getProjectAreaId()).toBe(456);
+
+    service.setProjectAreaId(undefined);
+    expect(service.getProjectAreaId()).toBeUndefined();
+  });
+
+  it('should load summary and set treated stands', () => {
+    const mockSummary: Summary = {
+      project_areas: [
+        {
+          project_area_id: 1,
+          project_area_name: 'Area 1',
+          total_stand_count: 10,
+          prescriptions: [
+            {
+              action: 'cut',
+              area_acres: 100,
+              treated_stand_count: 3,
+              type: 'type1',
+              stand_ids: [1, 2, 3],
+            },
+            {
+              action: 'burn',
+              area_acres: 50,
+              treated_stand_count: 2,
+              type: 'type2',
+              stand_ids: [4, 5],
+            },
+          ],
+        },
+      ],
+    };
+
+    spyOn(treatmentsService, 'getTreatmentPlanSummary').and.returnValue(
+      of(mockSummary)
+    );
+
+    service.setTreatmentPlanId(123);
+    service.loadSummary();
+
+    expect(treatedStandsState.setTreatedStands).toHaveBeenCalledWith([]);
+    expect(treatedStandsState.setTreatedStands).toHaveBeenCalledWith([
+      { id: 1, action: 'cut' },
+      { id: 2, action: 'cut' },
+      { id: 3, action: 'cut' },
+      { id: 4, action: 'burn' },
+      { id: 5, action: 'burn' },
+    ]);
+    service.summary$.subscribe((summary) => {
+      expect(summary).toEqual(mockSummary);
+    });
+  });
+
+  it('should load treatment plan and update the observable', () => {
+    const mockTreatmentPlan: TreatmentPlan = {
+      id: 123,
+      name: 'Plan 1',
+      status: 'SUCCESS',
+      created_at: '2024-01-01T00:00:00Z',
+      creator_name: 'John Doe',
+    };
+
+    spyOn(treatmentsService, 'getTreatmentPlan').and.returnValue(
+      of(mockTreatmentPlan)
+    );
+
+    service.setTreatmentPlanId(123);
+    service.loadTreatmentPlan();
+
+    service.treatmentPlan$.subscribe((treatmentPlan) => {
+      expect(treatmentPlan).toEqual(mockTreatmentPlan);
+    });
+  });
+
+  it('should throw an error if project area ID is not set when updating treated stands', () => {
+    expect(() => service.updateTreatedStands('cut', [1, 2])).toThrowError(
+      'Project area Id is required to update stands'
+    );
+  });
+
+  it('should update treated stands and call the service', () => {
+    service.setTreatmentPlanId(123);
+    service.setProjectAreaId(456);
+
+    spyOn(treatmentsService, 'setTreatments').and.returnValue(of({}));
+
+    service.updateTreatedStands('cut', [1, 2]);
+
+    expect(treatedStandsState.updateTreatedStands).toHaveBeenCalledWith([
+      { id: 1, action: 'cut' },
+      { id: 2, action: 'cut' },
+    ]);
+    expect(treatmentsService.setTreatments).toHaveBeenCalledWith(
+      123,
+      456,
+      'cut',
+      [1, 2]
+    );
+  });
+
+  it('should revert treated stands on update error', () => {
+    service.setTreatmentPlanId(123);
+    service.setProjectAreaId(456);
+
+    const originalStands: TreatedStand[] = [{ id: 1, action: 'cut' }];
+    spyOn(treatedStandsState, 'getTreatedStands').and.returnValue(
+      originalStands
+    );
+    spyOn(treatmentsService, 'setTreatments').and.returnValue(
+      throwError(() => new Error('Update failed'))
+    );
+
+    service.updateTreatedStands('cut', [2, 3]).subscribe({
+      error: (err) => {
+        expect(err.message).toBe('Update failed');
+      },
+    });
+
+    expect(treatedStandsState.setTreatedStands).toHaveBeenCalledWith(
+      originalStands
+    );
+  });
+});

--- a/src/interface/src/app/treatments/treatments.state.spec.ts
+++ b/src/interface/src/app/treatments/treatments.state.spec.ts
@@ -26,6 +26,7 @@ describe('TreatmentsState', () => {
 
     spyOn(treatedStandsState, 'setTreatedStands').and.callThrough();
     spyOn(treatedStandsState, 'updateTreatedStands').and.callThrough();
+    spyOn(treatedStandsState, 'removeTreatments').and.callThrough();
   });
 
   it('should be created', () => {
@@ -160,6 +161,51 @@ describe('TreatmentsState', () => {
     service.updateTreatedStands('cut', [2, 3]).subscribe({
       error: (err) => {
         expect(err.message).toBe('Update failed');
+      },
+    });
+
+    expect(treatedStandsState.setTreatedStands).toHaveBeenCalledWith(
+      originalStands
+    );
+  });
+
+  it('should remove treated stands and call the service', () => {
+    service.setTreatmentPlanId(123);
+    service.setProjectAreaId(456);
+    const originalStands: TreatedStand[] = [
+      { id: 1, action: 'cut' },
+      { id: 2, action: 'cut' },
+      { id: 3, action: 'burn' },
+    ];
+    spyOn(treatedStandsState, 'getTreatedStands').and.returnValue(
+      originalStands
+    );
+    spyOn(treatmentsService, 'setTreatments').and.returnValue(of({}));
+    spyOn(treatmentsService, 'removeTreatments').and.returnValue(of({}));
+
+    service.removeTreatments([1, 3]);
+
+    expect(treatmentsService.removeTreatments).toHaveBeenCalledWith(
+      123,
+      [1, 3]
+    );
+  });
+
+  it('should revert treated stands on remove error', () => {
+    service.setTreatmentPlanId(123);
+    service.setProjectAreaId(456);
+
+    const originalStands: TreatedStand[] = [{ id: 1, action: 'cut' }];
+    spyOn(treatedStandsState, 'getTreatedStands').and.returnValue(
+      originalStands
+    );
+    spyOn(treatmentsService, 'removeTreatments').and.returnValue(
+      throwError(() => new Error('Remove failed'))
+    );
+
+    service.removeTreatments([2, 3]).subscribe({
+      error: (err) => {
+        expect(err.message).toBe('Remove failed');
       },
     });
 

--- a/src/interface/src/app/treatments/treatments.state.spec.ts
+++ b/src/interface/src/app/treatments/treatments.state.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { TreatmentsService } from '@services/treatments.service';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
 import { of, throwError } from 'rxjs';
-import { Summary, TreatedStand, TreatmentPlan } from '@types';
+import { TreatedStand, TreatmentPlan, TreatmentSummary } from '@types';
 import { TreatmentsState } from './treatments.state';
 import { MockProvider } from 'ng-mocks';
 
@@ -53,7 +53,7 @@ describe('TreatmentsState', () => {
   });
 
   it('should load summary and set treated stands', () => {
-    const mockSummary: Summary = {
+    const mockSummary: TreatmentSummary = {
       project_areas: [
         {
           project_area_id: 1,

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -98,4 +98,18 @@ export class TreatmentsState {
         })
       );
   }
+
+  removeTreatments(standIds: number[]) {
+    const currentTreatedStands = this.treatedStandsState.getTreatedStands();
+    this.treatedStandsState.removeTreatments(standIds);
+    return this.treatmentsService
+      .removeTreatments(this.getTreatmentPlanId(), standIds)
+      .pipe(
+        catchError((error) => {
+          // rolls back to previous treated stands
+          this.treatedStandsState.setTreatedStands(currentTreatedStands);
+          throw error;
+        })
+      );
+  }
 }

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -48,6 +48,9 @@ export class TreatmentsState {
   }
 
   loadSummary() {
+    // TODO caching
+    this._summary$.next(null);
+    this.treatedStandsState.setTreatedStands([]);
     this.treatmentsService
       .getTreatmentPlanSummary(
         this.getTreatmentPlanId(),
@@ -60,6 +63,8 @@ export class TreatmentsState {
   }
 
   loadTreatmentPlan() {
+    // TODO caching
+    this._treatmentPlan.next(null);
     return this.treatmentsService
       .getTreatmentPlan(this.getTreatmentPlanId())
       .subscribe((treatmentPlan) => {

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { TreatmentsService } from '@services/treatments.service';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
 import { BehaviorSubject, catchError } from 'rxjs';
-import { Summary, TreatedStand, TreatmentPlan } from '@types';
+import { TreatedStand, TreatmentPlan, TreatmentSummary } from '@types';
 
 /**
  * Class that holds data of the current state, and makes it available
@@ -18,7 +18,7 @@ export class TreatmentsState {
   private _treatmentPlanId: number | undefined = undefined;
   private _projectAreaId: number | undefined = undefined;
 
-  private _summary$ = new BehaviorSubject<Summary | null>(null);
+  private _summary$ = new BehaviorSubject<TreatmentSummary | null>(null);
   private _treatmentPlan = new BehaviorSubject<TreatmentPlan | null>(null);
 
   public summary$ = this._summary$.asObservable();
@@ -68,7 +68,7 @@ export class TreatmentsState {
       });
   }
 
-  private setTreatedStandsFromSummary(summary: Summary) {
+  private setTreatedStandsFromSummary(summary: TreatmentSummary) {
     const treatedStands: TreatedStand[] = summary.project_areas.flatMap((pa) =>
       pa.prescriptions.flatMap((prescription) =>
         prescription.stand_ids.map((standId) => {

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -5,6 +5,7 @@ import {
   TreatmentsService,
 } from '@services/treatments.service';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
+import { BehaviorSubject, tap } from 'rxjs';
 
 @Injectable()
 export class TreatmentsState {
@@ -13,7 +14,8 @@ export class TreatmentsState {
     private treatedStandsState: TreatedStandsState
   ) {}
 
-  summary: Summary | null = null;
+  private _summary$ = new BehaviorSubject<Summary | null>(null);
+  public summary$ = this._summary$.asObservable();
 
   loadSummary(treatmentPlanId: number, projectAreaId?: number) {
     this.treatmentsService
@@ -22,17 +24,32 @@ export class TreatmentsState {
   }
 
   processSummary(summary: Summary) {
-    this.summary = summary;
+    this._summary$.next(summary);
     // now process the treated stands
-    const treatedStands: TreatedStand[] = this.summary.project_areas.flatMap(
-      (pa) =>
-        pa.prescriptions.flatMap((prescription) =>
-          // treated stands, at least action + stand id
-          prescription.stand_ids.map((standId) => {
-            return { id: standId, action: prescription.action };
-          })
-        )
+    const treatedStands: TreatedStand[] = summary.project_areas.flatMap((pa) =>
+      pa.prescriptions.flatMap((prescription) =>
+        // treated stands, at least action + stand id
+        prescription.stand_ids.map((standId) => {
+          return { id: standId, action: prescription.action };
+        })
+      )
     );
-    this.treatedStandsState.updateTreatedStands(treatedStands);
+    this.treatedStandsState.setTreatedStands(treatedStands);
+  }
+
+  updateTreatedStands(
+    treatmentPlanId: number,
+    projectAreaId: number,
+    action: string,
+    standIds: number[]
+  ) {
+    // const currentTreatedStands = this.treatedStandsState.getTreatedStands();
+    this.treatedStandsState.updateTreatedStands(
+      standIds.map((standId) => ({ id: standId, action: action }))
+    );
+    // TODO return to currentTreatedStands on error.
+    return this.treatmentsService
+      .setTreatments(treatmentPlanId, projectAreaId, action, standIds)
+      .pipe(tap((s) => {}));
   }
 }

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import {
+  Summary,
+  TreatedStand,
+  TreatmentsService,
+} from '@services/treatments.service';
+import { TreatedStandsState } from './treatment-map/treated-stands.state';
+
+@Injectable()
+export class TreatmentsState {
+  constructor(
+    private treatmentsService: TreatmentsService,
+    private treatedStandsState: TreatedStandsState
+  ) {}
+
+  summary: Summary | null = null;
+
+  loadSummary(treatmentPlanId: number, projectAreaId?: number) {
+    this.treatmentsService
+      .getTreatmentPlanSummary(treatmentPlanId, projectAreaId)
+      .subscribe((summary) => this.processSummary(summary));
+  }
+
+  processSummary(summary: Summary) {
+    this.summary = summary;
+    // now process the treated stands
+    const treatedStands: TreatedStand[] = this.summary.project_areas.flatMap(
+      (pa) =>
+        pa.prescriptions.flatMap((prescription) =>
+          // treated stands, at least action + stand id
+          prescription.stand_ids.map((standId) => {
+            return { id: standId, action: prescription.action };
+          })
+        )
+    );
+    this.treatedStandsState.updateTreatedStands(treatedStands);
+  }
+}

--- a/src/interface/src/app/types/treatment.types.ts
+++ b/src/interface/src/app/types/treatment.types.ts
@@ -7,3 +7,27 @@ export interface TreatmentPlan {
   created_at: string;
   creator_name: string;
 }
+
+interface TreatmentProjectArea {
+  project_area_id: number;
+  project_area_name: string;
+  total_stand_count: number;
+  prescriptions: Prescription[];
+}
+
+export interface Prescription {
+  action: string;
+  area_acres: number;
+  treated_stand_count: number;
+  type: string;
+  stand_ids: number[];
+}
+
+export interface TreatedStand {
+  id: number;
+  action: string;
+}
+
+export interface Summary {
+  project_areas: TreatmentProjectArea[];
+}

--- a/src/interface/src/app/types/treatment.types.ts
+++ b/src/interface/src/app/types/treatment.types.ts
@@ -28,6 +28,6 @@ export interface TreatedStand {
   action: string;
 }
 
-export interface Summary {
+export interface TreatmentSummary {
   project_areas: TreatmentProjectArea[];
 }


### PR DESCRIPTION
- Apply treatment on selected stands
- Remove treatment on selected stands
- Load treatments and apply them on maps
- Adds a treatmentState class to handle state for loading summary, map stands, treatment plan, etc. This instance is shared between the components via the router configuration
- Adds a resolver to kick off loading the required data, also provided via router configuration

Final UI not included on this pr. There are a couple of placeholder elements for applying treatments and showing them on the map as color coded stands.
Also, not including any caching between each pages for now.