### PR TITLE
Center map

### DIFF
--- a/src/interface/src/app/treatments/map-controls/map-controls.component.html
+++ b/src/interface/src/app/treatments/map-controls/map-controls.component.html
@@ -1,5 +1,5 @@
 <button (click)="toggleMapDrag()">
-  {{ mapDragging ? 'select stands' : 'drag map' }}
+  {{ (boxSelectionEnabled$ | async) ? 'drag map' : 'select stands' }}
 </button>
 <button (click)="clearTreatments()">clear selection</button>
 <button (click)="toggleShowStands()">Show/hide stands</button>

--- a/src/interface/src/app/treatments/map-controls/map-controls.component.html
+++ b/src/interface/src/app/treatments/map-controls/map-controls.component.html
@@ -2,3 +2,4 @@
   {{ mapDragging ? 'select stands' : 'drag map' }}
 </button>
 <button (click)="clearTreatments()">clear selection</button>
+<button (click)="toggleShowStands()">Show/hide stands</button>

--- a/src/interface/src/app/treatments/map-controls/map-controls.component.spec.ts
+++ b/src/interface/src/app/treatments/map-controls/map-controls.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapControlsComponent } from './map-controls.component';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
+import { MockProviders } from 'ng-mocks';
+import { MapConfigState } from '../treatment-map/map-config.state';
 
 describe('MapControlsComponent', () => {
   let component: MapControlsComponent;
@@ -10,7 +12,7 @@ describe('MapControlsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MapControlsComponent],
-      providers: [SelectedStandsState],
+      providers: [MockProviders(MapConfigState, SelectedStandsState)],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MapControlsComponent);

--- a/src/interface/src/app/treatments/map-controls/map-controls.component.ts
+++ b/src/interface/src/app/treatments/map-controls/map-controls.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { NgForOf } from '@angular/common';
+import { MapConfigState } from '../treatment-map/map-config.state';
 
 @Component({
   selector: 'app-map-controls',
@@ -15,7 +16,10 @@ export class MapControlsComponent {
   @Input() mapDragging = false;
   @Output() toggleDrag = new EventEmitter<boolean>();
 
-  constructor(private selectedStandsState: SelectedStandsState) {}
+  constructor(
+    private selectedStandsState: SelectedStandsState,
+    private mapConfigState: MapConfigState
+  ) {}
 
   clearTreatments() {
     this.selectedStandsState.clearStands();
@@ -24,5 +28,9 @@ export class MapControlsComponent {
   toggleMapDrag() {
     this.mapDragging = !this.mapDragging;
     this.toggleDrag.emit(this.mapDragging);
+  }
+
+  toggleShowStands() {
+    this.mapConfigState.toggleShowTreatmentStands();
   }
 }

--- a/src/interface/src/app/treatments/map-controls/map-controls.component.ts
+++ b/src/interface/src/app/treatments/map-controls/map-controls.component.ts
@@ -1,20 +1,17 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component } from '@angular/core';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
-import { NgForOf } from '@angular/common';
+import { AsyncPipe, NgForOf } from '@angular/common';
 import { MapConfigState } from '../treatment-map/map-config.state';
 
 @Component({
   selector: 'app-map-controls',
   standalone: true,
-  imports: [NgForOf],
+  imports: [NgForOf, AsyncPipe],
   templateUrl: './map-controls.component.html',
   styleUrl: './map-controls.component.scss',
 })
 export class MapControlsComponent {
-  // placeholder for map controls
-
-  @Input() mapDragging = false;
-  @Output() toggleDrag = new EventEmitter<boolean>();
+  boxSelectionEnabled$ = this.mapConfigState.boxSelectionEnabled$;
 
   constructor(
     private selectedStandsState: SelectedStandsState,
@@ -26,8 +23,7 @@ export class MapControlsComponent {
   }
 
   toggleMapDrag() {
-    this.mapDragging = !this.mapDragging;
-    this.toggleDrag.emit(this.mapDragging);
+    this.mapConfigState.toggleBoxSelectionEnabled();
   }
 
   toggleShowStands() {

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
@@ -16,6 +16,9 @@
   id="map-project-areas-fill"
   type="fill"
   source="scenarioProjectAreas"
+  (layerClick)="goToProjectArea($event)"
+  (layerMouseEnter)="setCursor()"
+  (layerMouseLeave)="resetCursor()"
   [sourceLayer]="layerName"
   [paint]="paint"></mgl-layer>
 

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.spec.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.spec.ts
@@ -1,11 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapProjectAreasComponent } from './map-project-areas.component';
-import { MockDeclarations } from 'ng-mocks';
+import { MockDeclarations, MockProvider } from 'ng-mocks';
 import {
   LayerComponent,
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
+import { TreatmentsState } from '../treatments.state';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('MapProjectAreasComponent', () => {
   let component: MapProjectAreasComponent;
@@ -13,7 +15,8 @@ describe('MapProjectAreasComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MapProjectAreasComponent],
+      imports: [MapProjectAreasComponent, RouterTestingModule],
+      providers: [MockProvider(TreatmentsState)],
       declarations: MockDeclarations(VectorSourceComponent, LayerComponent),
     }).compileComponents();
 

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
@@ -8,6 +8,7 @@ import {
 import { getColorForProjectPosition } from '../../plan/plan-helpers';
 import { LayerSpecification, Map as MapLibreMap } from 'maplibre-gl';
 import { environment } from '../../../environments/environment';
+import { TreatmentsState } from '../treatments.state';
 
 @Component({
   selector: 'app-map-project-areas',
@@ -22,14 +23,14 @@ import { environment } from '../../../environments/environment';
   styleUrl: './map-project-areas.component.scss',
 })
 export class MapProjectAreasComponent {
-  @Input() scenarioId!: number;
+  scenarioId = this.treatmentsState.getScenarioId();
   @Input() mapLibreMap!: MapLibreMap;
 
   readonly layerName = 'project_areas_by_scenario';
   readonly tilesUrl =
     environment.martin_server + 'project_areas_by_scenario/{z}/{x}/{y}';
 
-  constructor() {}
+  constructor(private treatmentsState: TreatmentsState) {}
 
   get vectorLayerUrl() {
     return this.tilesUrl + `?scenario_id=${this.scenarioId}`;

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
@@ -6,9 +6,14 @@ import {
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
 import { getColorForProjectPosition } from '../../plan/plan-helpers';
-import { LayerSpecification, Map as MapLibreMap } from 'maplibre-gl';
+import {
+  LayerSpecification,
+  Map as MapLibreMap,
+  MapMouseEvent,
+} from 'maplibre-gl';
 import { environment } from '../../../environments/environment';
 import { TreatmentsState } from '../treatments.state';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-map-project-areas',
@@ -30,7 +35,11 @@ export class MapProjectAreasComponent {
   readonly tilesUrl =
     environment.martin_server + 'project_areas_by_scenario/{z}/{x}/{y}';
 
-  constructor(private treatmentsState: TreatmentsState) {}
+  constructor(
+    private treatmentsState: TreatmentsState,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
 
   get vectorLayerUrl() {
     return this.tilesUrl + `?scenario_id=${this.scenarioId}`;
@@ -53,5 +62,28 @@ export class MapProjectAreasComponent {
     }
     matchExpression.push(defaultColor);
     return matchExpression;
+  }
+
+  goToProjectArea(event: MapMouseEvent) {
+    const features = this.mapLibreMap.queryRenderedFeatures(event.point, {
+      layers: ['map-project-areas-fill'],
+    });
+
+    const projectAreaId = features[0].properties['id'];
+    this.router
+      .navigate(['project-area', projectAreaId], {
+        relativeTo: this.route,
+      })
+      .then(() => {
+        this.mapLibreMap.getCanvas().style.cursor = '';
+      });
+  }
+
+  setCursor() {
+    this.mapLibreMap.getCanvas().style.cursor = 'pointer';
+  }
+
+  resetCursor() {
+    this.mapLibreMap.getCanvas().style.cursor = '';
   }
 }

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.html
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.html
@@ -16,6 +16,8 @@
   source="stands"
   [paint]="paint"
   (layerMouseDown)="clickOnLayer($event)"
+  (layerMouseEnter)="setCursor()"
+  (layerMouseLeave)="resetCursor()"
   sourceLayer="stands_by_tx_plan"></mgl-layer>
 
 <mgl-layer

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.spec.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.spec.ts
@@ -8,6 +8,7 @@ import {
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
 import { TreatmentsState } from '../treatments.state';
+import { MapConfigState } from '../treatment-map/map-config.state';
 
 describe('MapStandsComponent', () => {
   let component: MapStandsComponent;
@@ -16,7 +17,9 @@ describe('MapStandsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MapStandsComponent],
-      providers: [MockProviders(SelectedStandsState, TreatmentsState)],
+      providers: [
+        MockProviders(SelectedStandsState, TreatmentsState, MapConfigState),
+      ],
       declarations: MockDeclarations(VectorSourceComponent, LayerComponent),
     }).compileComponents();
 

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -17,6 +17,7 @@ import { environment } from '../../../environments/environment';
 import { PrescriptionSingleAction, SEQUENCE_COLORS } from '../prescriptions';
 import { TreatmentsState } from '../treatments.state';
 import { TreatedStand } from '@types';
+import { MapConfigState } from '../treatment-map/map-config.state';
 
 @Component({
   selector: 'app-map-stands',
@@ -46,7 +47,8 @@ export class MapStandsComponent implements OnChanges {
 
   constructor(
     private selectedStandsState: SelectedStandsState,
-    private treatmentsState: TreatmentsState
+    private treatmentsState: TreatmentsState,
+    private mapConfigState: MapConfigState
   ) {}
 
   get vectorLayerUrl() {
@@ -150,5 +152,13 @@ export class MapStandsComponent implements OnChanges {
       //select stands
       this.selectStandsWithinRectangle();
     }
+  }
+
+  setCursor() {
+    this.mapConfigState.setCursor('pointer');
+  }
+
+  resetCursor() {
+    this.mapConfigState.resetCursor();
   }
 }

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -30,9 +30,6 @@ export class MapStandsComponent implements OnChanges {
   @Input() selectEnd!: Point | null;
   @Input() treatedStands: TreatedStand[] = [];
 
-  treatmentPlanId = this.treatmentsState.getTreatmentPlanId();
-  projectAreaId = this.treatmentsState.getProjectAreaId();
-
   selectedStands$ = this.selectedStandsState.selectedStands$;
   private initialSelectedStands: number[] = [];
 
@@ -53,10 +50,11 @@ export class MapStandsComponent implements OnChanges {
   ) {}
 
   get vectorLayerUrl() {
+    const projectAreaId = this.treatmentsState.getProjectAreaId();
     return (
       this.tilesUrl +
-      `?treatment_plan_id=${this.treatmentPlanId}${
-        this.projectAreaId ? `&project_area_id=${this.projectAreaId}` : ''
+      `?treatment_plan_id=${this.treatmentsState.getTreatmentPlanId()}${
+        projectAreaId ? `&project_area_id=${projectAreaId}` : ''
       }`
     );
   }

--- a/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.html
+++ b/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.html
@@ -1,0 +1,4 @@
+<div class="left-side">
+  <router-outlet></router-outlet>
+</div>
+<app-treatment-map></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.scss
+++ b/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: flex;
+  height: 100%;
+}
+
+.left-side {
+  width: 200px;
+}

--- a/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TreatmentLayoutComponent } from './treatment-layout.component';
+import { MockDeclarations } from 'ng-mocks';
+import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 
 describe('TreatmentLayoutComponent', () => {
   let component: TreatmentLayoutComponent;
@@ -8,10 +10,10 @@ describe('TreatmentLayoutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TreatmentLayoutComponent]
-    })
-    .compileComponents();
-    
+      imports: [TreatmentLayoutComponent],
+      declarations: [MockDeclarations(TreatmentMapComponent)],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(TreatmentLayoutComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreatmentLayoutComponent } from './treatment-layout.component';
+
+describe('TreatmentLayoutComponent', () => {
+  let component: TreatmentLayoutComponent;
+  let fixture: ComponentFixture<TreatmentLayoutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TreatmentLayoutComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TreatmentLayoutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.ts
+++ b/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.ts
@@ -1,0 +1,28 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
+
+@Component({
+  selector: 'app-treatment-layout',
+  standalone: true,
+  imports: [RouterOutlet, TreatmentMapComponent],
+  templateUrl: './treatment-layout.component.html',
+  styleUrl: './treatment-layout.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TreatmentLayoutComponent implements OnInit, OnDestroy {
+  constructor() {}
+
+  ngOnInit(): void {
+    console.log('treatment layout my guy');
+  }
+
+  ngOnDestroy() {
+    console.log('TreatmentsLayoutComponent Destroyed');
+  }
+}

--- a/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.ts
+++ b/src/interface/src/app/treatments/treatment-layout/treatment-layout.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 
@@ -15,14 +10,6 @@ import { TreatmentMapComponent } from '../treatment-map/treatment-map.component'
   styleUrl: './treatment-layout.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TreatmentLayoutComponent implements OnInit, OnDestroy {
+export class TreatmentLayoutComponent {
   constructor() {}
-
-  ngOnInit(): void {
-    console.log('treatment layout my guy');
-  }
-
-  ngOnDestroy() {
-    console.log('TreatmentsLayoutComponent Destroyed');
-  }
 }

--- a/src/interface/src/app/treatments/treatment-map/map-config.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/map-config.state.ts
@@ -5,6 +5,8 @@ import {
   BaseLayerType,
   DEFAULT_BASE_MAP,
 } from './map-base-layers';
+import { Extent } from '@types';
+import { filter } from 'rxjs/operators';
 
 @Injectable()
 export class MapConfigState {
@@ -12,7 +14,16 @@ export class MapConfigState {
   baseLayer$ = this._baseLayer$.asObservable();
   baseLayerUrl$ = this.baseLayer$.pipe(map((b) => baseLayerStyles[b]));
 
+  private _mapCenter$ = new BehaviorSubject<Extent | null>(null);
+  mapCenter$ = this._mapCenter$
+    .asObservable()
+    .pipe(filter((m): m is Extent => !!m));
+
   updateBaseLayer(layer: BaseLayerType) {
     this._baseLayer$.next(layer);
+  }
+
+  updateMapCenter(pos: any) {
+    this._mapCenter$.next(pos);
   }
 }

--- a/src/interface/src/app/treatments/treatment-map/map-config.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/map-config.state.ts
@@ -19,11 +19,18 @@ export class MapConfigState {
     .asObservable()
     .pipe(filter((m): m is Extent => !!m));
 
-  private _showProjectAreas$ = new BehaviorSubject(true);
-  public showProjectAreas$ = this._showProjectAreas$.asObservable();
+  private _showProjectAreasLayer$ = new BehaviorSubject(true);
+  public showProjectAreasLayer$ = this._showProjectAreasLayer$.asObservable();
 
-  private _showTreatmentStands$ = new BehaviorSubject(true);
-  public showTreatmentStands$ = this._showTreatmentStands$.asObservable();
+  private _showTreatmentStandsLayer$ = new BehaviorSubject(true);
+  public showTreatmentStandsLayer$ =
+    this._showTreatmentStandsLayer$.asObservable();
+
+  private _boxSelectionEnabled$ = new BehaviorSubject(false);
+  public boxSelectionEnabled$ = this._boxSelectionEnabled$.asObservable();
+
+  private _cursor$ = new BehaviorSubject('');
+  public cursor$ = this._cursor$.asObservable();
 
   updateBaseLayer(layer: BaseLayerType) {
     this._baseLayer$.next(layer);
@@ -34,15 +41,33 @@ export class MapConfigState {
   }
 
   updateShowProjectAreas(value: boolean) {
-    this._showProjectAreas$.next(value);
+    this._showProjectAreasLayer$.next(value);
   }
 
   updateShowTreatmentStands(value: boolean) {
-    this._showTreatmentStands$.next(value);
+    this._showTreatmentStandsLayer$.next(value);
   }
 
   toggleShowTreatmentStands() {
-    const value = this._showTreatmentStands$.value;
-    this._showTreatmentStands$.next(!value);
+    const value = this._showTreatmentStandsLayer$.value;
+    this._showTreatmentStandsLayer$.next(!value);
+  }
+
+  toggleBoxSelectionEnabled() {
+    const value = this._boxSelectionEnabled$.value;
+    this._boxSelectionEnabled$.next(!value);
+    this.resetCursor();
+  }
+
+  getBoxSelectionEnabled() {
+    return this._boxSelectionEnabled$.value;
+  }
+
+  setCursor(value: string) {
+    this._cursor$.next(value);
+  }
+
+  resetCursor() {
+    this._cursor$.next(this._boxSelectionEnabled$.value ? 'crosshair' : '');
   }
 }

--- a/src/interface/src/app/treatments/treatment-map/map-config.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/map-config.state.ts
@@ -22,6 +22,9 @@ export class MapConfigState {
   private _showProjectAreas$ = new BehaviorSubject(true);
   public showProjectAreas$ = this._showProjectAreas$.asObservable();
 
+  private _showTreatmentStands$ = new BehaviorSubject(true);
+  public showTreatmentStands$ = this._showTreatmentStands$.asObservable();
+
   updateBaseLayer(layer: BaseLayerType) {
     this._baseLayer$.next(layer);
   }
@@ -32,5 +35,14 @@ export class MapConfigState {
 
   updateShowProjectAreas(value: boolean) {
     this._showProjectAreas$.next(value);
+  }
+
+  updateShowTreatmentStands(value: boolean) {
+    this._showTreatmentStands$.next(value);
+  }
+
+  toggleShowTreatmentStands() {
+    const value = this._showTreatmentStands$.value;
+    this._showTreatmentStands$.next(!value);
   }
 }

--- a/src/interface/src/app/treatments/treatment-map/map-config.state.ts
+++ b/src/interface/src/app/treatments/treatment-map/map-config.state.ts
@@ -19,11 +19,18 @@ export class MapConfigState {
     .asObservable()
     .pipe(filter((m): m is Extent => !!m));
 
+  private _showProjectAreas$ = new BehaviorSubject(true);
+  public showProjectAreas$ = this._showProjectAreas$.asObservable();
+
   updateBaseLayer(layer: BaseLayerType) {
     this._baseLayer$.next(layer);
   }
 
   updateMapCenter(pos: any) {
     this._mapCenter$.next(pos);
+  }
+
+  updateShowProjectAreas(value: boolean) {
+    this._showProjectAreas$.next(value);
   }
 }

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -2,10 +2,11 @@
   [mapDragging]="mapDragging"
   (toggleDrag)="mapDragging = $event"></app-map-controls>
 <mgl-map
+  *ngIf="bounds$ | async"
   (mapLoad)="mapLibreMap = $event"
   [style]="(styleUrl$ | async) || ''"
-  [zoom]="[10]"
-  [center]="[-120, 37]"
+  [fitBounds]="(bounds$ | async) || undefined"
+  [fitBoundsOptions]="{ padding: 20 }"
   [dragPan]="mapDragging"
   [minZoom]="7"
   [maxZoom]="17"

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -5,7 +5,7 @@
   [style]="(baseLayerUrl$ | async) || ''"
   [fitBounds]="bounds"
   [fitBoundsOptions]="{ padding: 20 }"
-  [dragPan]="!(boxSelectionEnabled$ | async)"
+  [dragPan]="(boxSelectionEnabled$ | async) === false"
   [minZoom]="7"
   [maxZoom]="17"
   [boxZoom]="false"

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -28,7 +28,6 @@
     [end]="end ? end.lngLat : null"></app-map-rectangle>
 
   <app-map-project-areas
-    *ngIf="scenarioId"
     [mapLibreMap]="mapLibreMap"
-    [scenarioId]="scenarioId"></app-map-project-areas>
+    *ngIf="showMapProjectAreas$ | async"></app-map-project-areas>
 </mgl-map>

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -1,13 +1,11 @@
-<app-map-controls
-  [mapDragging]="mapDragging"
-  (toggleDrag)="mapDragging = $event"></app-map-controls>
+<app-map-controls></app-map-controls>
 <mgl-map
   *ngIf="bounds$ | async; let bounds"
   (mapLoad)="mapLibreMap = $event"
-  [style]="(styleUrl$ | async) || ''"
+  [style]="(baseLayerUrl$ | async) || ''"
   [fitBounds]="bounds"
   [fitBoundsOptions]="{ padding: 20 }"
-  [dragPan]="mapDragging"
+  [dragPan]="!(boxSelectionEnabled$ | async)"
   [minZoom]="7"
   [maxZoom]="17"
   [boxZoom]="false"
@@ -20,13 +18,13 @@
     *ngIf="showTreatmentStands$ | async"
     [mapLibreMap]="mapLibreMap"
     [treatedStands]="(treatedStands$ | async) || []"
-    [selectStart]="start ? start.point : null"
-    [selectEnd]="end ? end.point : null"></app-map-stands>
+    [selectStart]="mouseStart ? mouseStart.point : null"
+    [selectEnd]="mouseEnd ? mouseEnd.point : null"></app-map-stands>
 
   <app-map-rectangle
     [mapLibreMap]="mapLibreMap"
-    [start]="start ? start.lngLat : null"
-    [end]="end ? end.lngLat : null"></app-map-rectangle>
+    [start]="mouseStart ? mouseStart.lngLat : null"
+    [end]="mouseEnd ? mouseEnd.lngLat : null"></app-map-rectangle>
 
   <app-map-project-areas
     [mapLibreMap]="mapLibreMap"

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -2,10 +2,10 @@
   [mapDragging]="mapDragging"
   (toggleDrag)="mapDragging = $event"></app-map-controls>
 <mgl-map
-  *ngIf="bounds$ | async"
+  *ngIf="bounds$ | async; let bounds"
   (mapLoad)="mapLibreMap = $event"
   [style]="(styleUrl$ | async) || ''"
-  [fitBounds]="(bounds$ | async) || undefined"
+  [fitBounds]="bounds"
   [fitBoundsOptions]="{ padding: 20 }"
   [dragPan]="mapDragging"
   [minZoom]="7"
@@ -17,6 +17,7 @@
   (mapMouseMove)="onMapMouseMove($event)"
   (mapMouseUp)="onMapMouseUp($event)">
   <app-map-stands
+    *ngIf="showTreatmentStands$ | async"
     [mapLibreMap]="mapLibreMap"
     [treatedStands]="(treatedStands$ | async) || []"
     [selectStart]="start ? start.point : null"

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TreatmentMapComponent } from './treatment-map.component';
-import { MockDeclarations, MockProviders } from 'ng-mocks';
+import { MockDeclarations, MockProvider, MockProviders } from 'ng-mocks';
 import { MapConfigState } from './map-config.state';
 import { TreatedStandsState } from './treated-stands.state';
 import { MapStandsComponent } from '../map-stands/map-stands.component';
@@ -8,6 +8,7 @@ import { MapRectangleComponent } from '../map-rectangle/map-rectangle.component'
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
 import { SelectedStandsState } from './selected-stands.state';
 import { CommonModule } from '@angular/common';
+import { of } from 'rxjs';
 
 describe('TreatmentMapComponent', () => {
   let component: TreatmentMapComponent;
@@ -17,7 +18,8 @@ describe('TreatmentMapComponent', () => {
     await TestBed.configureTestingModule({
       imports: [TreatmentMapComponent, CommonModule],
       providers: [
-        MockProviders(MapConfigState, TreatedStandsState, SelectedStandsState),
+        MockProviders(TreatedStandsState, SelectedStandsState),
+        MockProvider(MapConfigState, { cursor$: of('') }),
       ],
       declarations: [
         MockDeclarations(

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -17,6 +17,7 @@ import { environment } from '../../../environments/environment';
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
 import { MapConfigState } from './map-config.state';
 import { TreatedStandsState } from './treated-stands.state';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-treatment-map',
@@ -55,6 +56,9 @@ export class TreatmentMapComponent {
   styleUrl$ = this.mapConfigState.baseLayerUrl$;
 
   treatedStands$ = this.treatedStandsState.treatedStands$;
+
+  // this is not great, as I need to clean up the previous bounds$ value...hmmmm
+  bounds$ = this.mapConfigState.mapCenter$.pipe(filter((c) => !!c));
 
   constructor(
     private mapConfigState: MapConfigState,

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -17,7 +17,6 @@ import { environment } from '../../../environments/environment';
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
 import { MapConfigState } from './map-config.state';
 import { TreatedStandsState } from './treated-stands.state';
-import { distinctUntilChanged, map, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-treatment-map',
@@ -58,12 +57,13 @@ export class TreatmentMapComponent {
   // this is not great, as I need to clean up the previous bounds$ value...sometimes.
   bounds$ = this.mapConfigState.mapCenter$;
 
-  showMapProjectAreas$ = this.bounds$.pipe(
-    distinctUntilChanged(),
-    withLatestFrom(this.mapConfigState.showProjectAreas$),
-    map(([bounds, showAreas]) => showAreas) // Pass only the showProjectAreas$ value forward
-  );
+  // showMapProjectAreas$ = this.bounds$.pipe(
+  //   distinctUntilChanged(),
+  //   withLatestFrom(this.mapConfigState.showProjectAreas$),
+  //   map(([bounds, showAreas]) => showAreas) // Pass only the showProjectAreas$ value forward
+  // );
 
+  showMapProjectAreas$ = this.mapConfigState.showProjectAreas$;
   showTreatmentStands$ = this.mapConfigState.showTreatmentStands$;
 
   constructor(

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { AsyncPipe, JsonPipe, NgForOf, NgIf } from '@angular/common';
 import {
   DraggableDirective,
@@ -45,8 +45,6 @@ export class TreatmentMapComponent {
   mapLibreMap!: MapLibreMap;
   readonly key = environment.stadiamaps_key;
 
-  @Input() scenarioId: number | null = null;
-
   mapDragging = true;
 
   private isDragging = false;
@@ -59,6 +57,8 @@ export class TreatmentMapComponent {
 
   // this is not great, as I need to clean up the previous bounds$ value...hmmmm
   bounds$ = this.mapConfigState.mapCenter$.pipe(filter((c) => !!c));
+
+  showMapProjectAreas$ = this.mapConfigState.showProjectAreas$;
 
   constructor(
     private mapConfigState: MapConfigState,

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -17,7 +17,7 @@ import { environment } from '../../../environments/environment';
 import { MapProjectAreasComponent } from '../map-project-areas/map-project-areas.component';
 import { MapConfigState } from './map-config.state';
 import { TreatedStandsState } from './treated-stands.state';
-import { filter } from 'rxjs/operators';
+import { distinctUntilChanged, map, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-treatment-map',
@@ -55,10 +55,16 @@ export class TreatmentMapComponent {
 
   treatedStands$ = this.treatedStandsState.treatedStands$;
 
-  // this is not great, as I need to clean up the previous bounds$ value...hmmmm
-  bounds$ = this.mapConfigState.mapCenter$.pipe(filter((c) => !!c));
+  // this is not great, as I need to clean up the previous bounds$ value...sometimes.
+  bounds$ = this.mapConfigState.mapCenter$;
 
-  showMapProjectAreas$ = this.mapConfigState.showProjectAreas$;
+  showMapProjectAreas$ = this.bounds$.pipe(
+    distinctUntilChanged(),
+    withLatestFrom(this.mapConfigState.showProjectAreas$),
+    map(([bounds, showAreas]) => showAreas) // Pass only the showProjectAreas$ value forward
+  );
+
+  showTreatmentStands$ = this.mapConfigState.showTreatmentStands$;
 
   constructor(
     private mapConfigState: MapConfigState,

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
@@ -1,11 +1,7 @@
-<div class="left-side">
-  <div *ngIf="treatmentPlan$ | async; let treatmentPlan">
-    {{ treatmentPlan.id }}. {{ treatmentPlan.name }}
-    <div>{{ treatmentPlan.status }}</div>
-  </div>
-
-  <app-treatment-summary></app-treatment-summary>
-  <app-map-base-layer></app-map-base-layer>
+<div *ngIf="treatmentPlan$ | async; let treatmentPlan">
+  {{ treatmentPlan.id }}. {{ treatmentPlan.name }}
+  <div>{{ treatmentPlan.status }}</div>
 </div>
 
-<app-treatment-map></app-treatment-map>
+<app-treatment-summary></app-treatment-summary>
+<app-map-base-layer></app-map-base-layer>

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.html
@@ -8,4 +8,4 @@
   <app-map-base-layer></app-map-base-layer>
 </div>
 
-<app-treatment-map [scenarioId]="scenarioId"></app-treatment-map>
+<app-treatment-map></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.scss
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.scss
@@ -1,8 +1,0 @@
-:host {
-  display: flex;
-  height: 100%;
-}
-
-.left-side {
-  width: 200px;
-}

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
@@ -4,9 +4,7 @@ import { TreatmentOverviewComponent } from './treatment-overview.component';
 import { MockDeclarations, MockProviders } from 'ng-mocks';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TreatmentsState } from '../treatments.state';
-
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
-import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
 
 describe('TreatmentOverviewComponent', () => {
@@ -17,11 +15,7 @@ describe('TreatmentOverviewComponent', () => {
     await TestBed.configureTestingModule({
       imports: [TreatmentOverviewComponent, RouterTestingModule],
       declarations: [
-        MockDeclarations(
-          TreatmentSummaryComponent,
-          TreatmentMapComponent,
-          MapBaseLayerComponent
-        ),
+        MockDeclarations(TreatmentSummaryComponent, MapBaseLayerComponent),
       ],
       providers: [MockProviders(TreatmentsState)],
     }).compileComponents();

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { AsyncPipe, NgIf } from '@angular/common';
 import { TreatmentMapComponent } from '../treatment-map/treatment-map.component';
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
@@ -20,12 +19,7 @@ import { TreatmentsState } from '../treatments.state';
   styleUrl: './treatment-overview.component.scss',
 })
 export class TreatmentOverviewComponent {
-  scenarioId: number = this.route.snapshot.data['scenarioId'];
-
   treatmentPlan$ = this.treatmentsState.treatmentPlan$;
 
-  constructor(
-    private route: ActivatedRoute,
-    private treatmentsState: TreatmentsState
-  ) {}
+  constructor(private treatmentsState: TreatmentsState) {}
 }

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
@@ -1,3 +1,2 @@
 <p>Project Area</p>
 <app-prescription-actions></app-prescription-actions>
-<app-treatment-map></app-treatment-map>

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
@@ -1,2 +1,3 @@
 <p>Project Area</p>
+<a routerLink="../..">Back</a>
 <app-prescription-actions></app-prescription-actions>

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -3,6 +3,7 @@ import { TreatmentMapComponent } from '../treatment-map/treatment-map.component'
 import { TreatmentSummaryComponent } from '../treatment-summary/treatment-summary.component';
 import { AsyncPipe, JsonPipe } from '@angular/common';
 import { PrescriptionActionsComponent } from '../prescription-actions/prescription-actions.component';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-treatment-project-area',
@@ -13,6 +14,7 @@ import { PrescriptionActionsComponent } from '../prescription-actions/prescripti
     JsonPipe,
     AsyncPipe,
     PrescriptionActionsComponent,
+    RouterLink,
   ],
   templateUrl: './treatment-project-area.component.html',
   styleUrl: './treatment-project-area.component.scss',

--- a/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.spec.ts
@@ -2,14 +2,22 @@ import { TestBed } from '@angular/core/testing';
 import { treatmentStateResolver } from './treatment-state.resolver';
 import { TreatmentsState } from './treatments.state';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { MapConfigState } from './treatment-map/map-config.state';
 import { MockProvider } from 'ng-mocks';
+import { of } from 'rxjs';
 
 describe('treatmentStateResolver', () => {
   let treatmentsState: TreatmentsState;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [MockProvider(TreatmentsState)],
+      providers: [
+        MockProvider(MapConfigState),
+        MockProvider(TreatmentsState, {
+          loadSummary: () => of(true),
+          loadTreatmentPlan: () => of(true),
+        }),
+      ],
     });
 
     treatmentsState = TestBed.inject(TreatmentsState);

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -9,9 +9,14 @@ import { MapConfigState } from './treatment-map/map-config.state';
 export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
   const treatmentsState = inject(TreatmentsState);
   const mapConfig = inject(MapConfigState);
-  const treatmentPlanId = Number(route.paramMap.get('treatmentId'));
+
+  const paramMap = route.parent?.paramMap;
+  if (!paramMap) {
+    return false;
+  }
+  const treatmentPlanId = Number(paramMap.get('treatmentId'));
   const projectAreaId = route.paramMap.get('projectAreaId');
-  const scenarioId = Number(route.paramMap.get('scenarioId'));
+  const scenarioId = Number(paramMap.get('scenarioId'));
 
   // update config on map, based on route data
   mapConfig.updateShowProjectAreas(route.data['showMapProjectAreas']);

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -12,7 +12,8 @@ export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
   const mapConfig = inject(MapConfigState);
   const router = inject(Router);
 
-  const paramMap = route.parent?.paramMap;
+  const paramMap = route.parent?.paramMap || route.paramMap;
+
   if (!paramMap) {
     return false;
   }
@@ -21,8 +22,12 @@ export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
   const scenarioId = Number(paramMap.get('scenarioId'));
 
   // update config on map, based on route data
-  mapConfig.updateShowProjectAreas(route.data['showMapProjectAreas']);
-  mapConfig.updateShowTreatmentStands(route.data['showTreatmentStands']);
+  mapConfig.updateShowProjectAreas(
+    route.data?.['showMapProjectAreas'] || false
+  );
+  mapConfig.updateShowTreatmentStands(
+    route.data?.['showTreatmentStands'] || false
+  );
 
   treatmentsState.setTreatmentPlanId(treatmentPlanId);
   treatmentsState.setScenarioId(scenarioId);

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -1,7 +1,8 @@
-import { ResolveFn } from '@angular/router';
+import { ResolveFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
 import { TreatmentsState } from './treatments.state';
 import { MapConfigState } from './treatment-map/map-config.state';
+import { catchError } from 'rxjs';
 
 /**
  * Resolver that kickoff loading data via TreatmentsState.
@@ -9,6 +10,7 @@ import { MapConfigState } from './treatment-map/map-config.state';
 export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
   const treatmentsState = inject(TreatmentsState);
   const mapConfig = inject(MapConfigState);
+  const router = inject(Router);
 
   const paramMap = route.parent?.paramMap;
   if (!paramMap) {
@@ -28,7 +30,24 @@ export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
     projectAreaId ? Number(projectAreaId) : undefined
   );
 
-  treatmentsState.loadSummary();
-  treatmentsState.loadTreatmentPlan();
+  treatmentsState
+    .loadSummary()
+    .pipe(
+      catchError((error) => {
+        router.navigate(['/']);
+        throw error;
+      })
+    )
+    .subscribe();
+
+  treatmentsState
+    .loadTreatmentPlan()
+    .pipe(
+      catchError((error) => {
+        router.navigate(['/']);
+        throw error;
+      })
+    )
+    .subscribe();
   return true;
 };

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -1,16 +1,23 @@
 import { ResolveFn } from '@angular/router';
 import { inject } from '@angular/core';
 import { TreatmentsState } from './treatments.state';
+import { MapConfigState } from './treatment-map/map-config.state';
 
 /**
  * Resolver that kickoff loading data via TreatmentsState.
  */
 export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
   const treatmentsState = inject(TreatmentsState);
+  const mapConfig = inject(MapConfigState);
   const treatmentPlanId = Number(route.paramMap.get('treatmentId'));
   const projectAreaId = route.paramMap.get('projectAreaId');
+  const scenarioId = Number(route.paramMap.get('scenarioId'));
+
+  // update config on map, based on route data
+  mapConfig.updateShowProjectAreas(route.data['showMapProjectAreas']);
 
   treatmentsState.setTreatmentPlanId(treatmentPlanId);
+  treatmentsState.setScenarioId(scenarioId);
   treatmentsState.setProjectAreaId(
     projectAreaId ? Number(projectAreaId) : undefined
   );

--- a/src/interface/src/app/treatments/treatment-state.resolver.ts
+++ b/src/interface/src/app/treatments/treatment-state.resolver.ts
@@ -20,6 +20,7 @@ export const treatmentStateResolver: ResolveFn<boolean> = (route, state) => {
 
   // update config on map, based on route data
   mapConfig.updateShowProjectAreas(route.data['showMapProjectAreas']);
+  mapConfig.updateShowTreatmentStands(route.data['showTreatmentStands']);
 
   treatmentsState.setTreatmentPlanId(treatmentPlanId);
   treatmentsState.setScenarioId(scenarioId);

--- a/src/interface/src/app/treatments/treatments-routing.module.ts
+++ b/src/interface/src/app/treatments/treatments-routing.module.ts
@@ -28,6 +28,9 @@ const routes: Routes = [
         resolve: {
           initializeStates: treatmentStateResolver,
         },
+        data: {
+          showMapProjectAreas: true,
+        },
       },
       { path: 'project-area', redirectTo: '', pathMatch: 'full' },
       {
@@ -37,6 +40,9 @@ const routes: Routes = [
         resolve: {
           projectAreaId: numberResolver('projectAreaId', ''),
           initializeStates: treatmentStateResolver,
+        },
+        data: {
+          showMapProjectAreas: false,
         },
       },
     ],

--- a/src/interface/src/app/treatments/treatments-routing.module.ts
+++ b/src/interface/src/app/treatments/treatments-routing.module.ts
@@ -32,6 +32,7 @@ const routes: Routes = [
         },
         data: {
           showMapProjectAreas: true,
+          showTreatmentStands: false,
         },
       },
       { path: 'project-area', redirectTo: '', pathMatch: 'full' },
@@ -45,6 +46,7 @@ const routes: Routes = [
         },
         data: {
           showMapProjectAreas: false,
+          showTreatmentStands: true,
         },
       },
     ],

--- a/src/interface/src/app/treatments/treatments-routing.module.ts
+++ b/src/interface/src/app/treatments/treatments-routing.module.ts
@@ -9,6 +9,7 @@ import { SelectedStandsState } from './treatment-map/selected-stands.state';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
 import { treatmentStateResolver } from './treatment-state.resolver';
 import { MapConfigState } from './treatment-map/map-config.state';
+import { TreatmentLayoutComponent } from './treatment-layout/treatment-layout.component';
 
 const routes: Routes = [
   {
@@ -20,6 +21,7 @@ const routes: Routes = [
       TreatedStandsState,
       MapConfigState,
     ],
+    component: TreatmentLayoutComponent,
     children: [
       {
         path: '',

--- a/src/interface/src/app/treatments/treatments.state.spec.ts
+++ b/src/interface/src/app/treatments/treatments.state.spec.ts
@@ -4,7 +4,8 @@ import { TreatedStandsState } from './treatment-map/treated-stands.state';
 import { of, throwError } from 'rxjs';
 import { TreatedStand, TreatmentPlan, TreatmentSummary } from '@types';
 import { TreatmentsState } from './treatments.state';
-import { MockProvider } from 'ng-mocks';
+import { MockProviders } from 'ng-mocks';
+import { MapConfigState } from './treatment-map/map-config.state';
 
 describe('TreatmentsState', () => {
   let service: TreatmentsState;
@@ -15,8 +16,7 @@ describe('TreatmentsState', () => {
     TestBed.configureTestingModule({
       providers: [
         TreatmentsState,
-        MockProvider(TreatmentsService),
-        MockProvider(TreatedStandsState),
+        MockProviders(MapConfigState, TreatedStandsState, TreatmentsService),
       ],
     });
 
@@ -77,6 +77,7 @@ describe('TreatmentsState', () => {
           ],
         },
       ],
+      extent: [1, 2, 3, 4],
     };
 
     spyOn(treatmentsService, 'getTreatmentPlanSummary').and.returnValue(
@@ -84,7 +85,7 @@ describe('TreatmentsState', () => {
     );
 
     service.setTreatmentPlanId(123);
-    service.loadSummary();
+    service.loadSummary().subscribe();
 
     expect(treatedStandsState.setTreatedStands).toHaveBeenCalledWith([]);
     expect(treatedStandsState.setTreatedStands).toHaveBeenCalledWith([
@@ -113,7 +114,7 @@ describe('TreatmentsState', () => {
     );
 
     service.setTreatmentPlanId(123);
-    service.loadTreatmentPlan();
+    service.loadTreatmentPlan().subscribe();
 
     service.treatmentPlan$.subscribe((treatmentPlan) => {
       expect(treatmentPlan).toEqual(mockTreatmentPlan);

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { TreatmentsService } from '@services/treatments.service';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
-import { BehaviorSubject, catchError } from 'rxjs';
+import { BehaviorSubject, catchError, map } from 'rxjs';
 import { TreatedStand, TreatmentPlan, TreatmentSummary } from '@types';
 import { MapConfigState } from './treatment-map/map-config.state';
 
@@ -66,11 +66,14 @@ export class TreatmentsState {
         this.getTreatmentPlanId(),
         this.getProjectAreaId()
       )
-      .subscribe((summary) => {
-        this._summary$.next(summary);
-        this.setTreatedStandsFromSummary(summary);
-        this.mapConfigState.updateMapCenter(summary.extent);
-      });
+      .pipe(
+        map((summary) => {
+          this._summary$.next(summary);
+          this.setTreatedStandsFromSummary(summary);
+          this.mapConfigState.updateMapCenter(summary.extent);
+          return true;
+        })
+      );
   }
 
   loadTreatmentPlan() {
@@ -78,9 +81,12 @@ export class TreatmentsState {
     this._treatmentPlan.next(null);
     return this.treatmentsService
       .getTreatmentPlan(this.getTreatmentPlanId())
-      .subscribe((treatmentPlan) => {
-        this._treatmentPlan.next(treatmentPlan);
-      });
+      .pipe(
+        map((treatmentPlan) => {
+          this._treatmentPlan.next(treatmentPlan);
+          return true;
+        })
+      );
   }
 
   private setTreatedStandsFromSummary(summary: TreatmentSummary) {

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -3,6 +3,7 @@ import { TreatmentsService } from '@services/treatments.service';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
 import { BehaviorSubject, catchError } from 'rxjs';
 import { TreatedStand, TreatmentPlan, TreatmentSummary } from '@types';
+import { MapConfigState } from './treatment-map/map-config.state';
 
 /**
  * Class that holds data of the current state, and makes it available
@@ -12,7 +13,8 @@ import { TreatedStand, TreatmentPlan, TreatmentSummary } from '@types';
 export class TreatmentsState {
   constructor(
     private treatmentsService: TreatmentsService,
-    private treatedStandsState: TreatedStandsState
+    private treatedStandsState: TreatedStandsState,
+    private mapConfigState: MapConfigState
   ) {}
 
   private _treatmentPlanId: number | undefined = undefined;
@@ -47,7 +49,7 @@ export class TreatmentsState {
     // TODO caching
     this._summary$.next(null);
     this.treatedStandsState.setTreatedStands([]);
-    this.treatmentsService
+    return this.treatmentsService
       .getTreatmentPlanSummary(
         this.getTreatmentPlanId(),
         this.getProjectAreaId()
@@ -55,6 +57,7 @@ export class TreatmentsState {
       .subscribe((summary) => {
         this._summary$.next(summary);
         this.setTreatedStandsFromSummary(summary);
+        this.mapConfigState.updateMapCenter(summary.extent);
       });
   }
 

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -19,6 +19,7 @@ export class TreatmentsState {
 
   private _treatmentPlanId: number | undefined = undefined;
   private _projectAreaId: number | undefined = undefined;
+  private _scenarioId: number | undefined = undefined;
 
   private _summary$ = new BehaviorSubject<TreatmentSummary | null>(null);
   private _treatmentPlan = new BehaviorSubject<TreatmentPlan | null>(null);
@@ -26,7 +27,7 @@ export class TreatmentsState {
   public summary$ = this._summary$.asObservable();
   public treatmentPlan$ = this._treatmentPlan.asObservable();
 
-  getTreatmentPlanId(): number {
+  getTreatmentPlanId() {
     if (this._treatmentPlanId === undefined) {
       throw new Error('no treatment plan id!');
     }
@@ -37,12 +38,23 @@ export class TreatmentsState {
     this._treatmentPlanId = value;
   }
 
-  getProjectAreaId(): number | undefined {
+  getProjectAreaId() {
     return this._projectAreaId;
   }
 
   setProjectAreaId(value: number | undefined) {
     this._projectAreaId = value;
+  }
+
+  getScenarioId(): number {
+    if (this._scenarioId === undefined) {
+      throw new Error('no _scenario id!');
+    }
+    return this._scenarioId;
+  }
+
+  setScenarioId(value: number) {
+    this._scenarioId = value;
   }
 
   loadSummary() {

--- a/src/interface/src/app/types/treatment.types.ts
+++ b/src/interface/src/app/types/treatment.types.ts
@@ -30,4 +30,7 @@ export interface TreatedStand {
 
 export interface TreatmentSummary {
   project_areas: TreatmentProjectArea[];
+  extent: Extent;
 }
+
+export type Extent = [number, number, number, number];


### PR DESCRIPTION
- Moves most prop binding to use state service
- Adds layout component to handle common layout and shared map
- Sets centering the map when bounds change
- Moved other map config variables to mapConfigState and added observables 

Moving between treatment overview to project areas is still a bit wonky, ideally we'll have a smoother transition between the two pages, but will follow up on this separately

