### PR TITLE
remove shouldReuseRoute hack

### DIFF
--- a/src/interface/src/app/plan/plan-routing.module.ts
+++ b/src/interface/src/app/plan/plan-routing.module.ts
@@ -11,6 +11,7 @@ const routes: Routes = [
     title: 'Plan Details',
     component: PlanComponent,
     canActivate: [AuthGuard],
+
     children: [
       {
         path: 'config',

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -13,6 +13,7 @@ import { SNACK_BOTTOM_NOTICE_CONFIG, SNACK_ERROR_CONFIG } from '@shared';
 import { MatTab } from '@angular/material/tabs';
 import { UploadProjectAreasModalComponent } from '../../upload-project-areas-modal/upload-project-areas-modal.component';
 import { ScenarioCreateConfirmationComponent } from '../../scenario-create-confirmation/scenario-create-confirmation.component';
+
 export interface ScenarioRow extends Scenario {
   selected?: boolean;
   created_at?: string;

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -36,7 +36,6 @@ export class PlanComponent implements OnInit, OnDestroy {
   planOwner$ = new Observable<User | null>();
 
   showOverview$ = new BehaviorSubject<boolean>(false);
-
   area$ = this.showOverview$.pipe(
     map((show) => (show ? 'SCENARIOS' : 'SCENARIO'))
   );
@@ -58,6 +57,8 @@ export class PlanComponent implements OnInit, OnDestroy {
   ]).pipe(
     map(([plan, scenario]) => {
       const path = this.getPathFromSnapshot();
+      const scenarioId = this.route.children[0]?.snapshot.params['id'];
+
       const crumbs: Breadcrumb[] = [
         {
           name: plan.name,
@@ -67,7 +68,7 @@ export class PlanComponent implements OnInit, OnDestroy {
       if (scenario === undefined) {
         return crumbs;
       }
-      if (path === 'config' && !scenario) {
+      if (path === 'config' && !scenarioId) {
         crumbs.push({ name: 'New Scenario' });
       }
       if (scenario) {
@@ -115,10 +116,10 @@ export class PlanComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    const path = this.getPathFromSnapshot();
     this.planStateService.planState$
       .pipe(takeUntil(this.destroy$))
       .subscribe((state) => {
+        const path = this.getPathFromSnapshot();
         if (state.currentScenarioId || path === 'config') {
           this.showOverview$.next(false);
         } else {

--- a/src/interface/src/app/shared/top-bar/top-bar.component.ts
+++ b/src/interface/src/app/shared/top-bar/top-bar.component.ts
@@ -40,8 +40,6 @@ export class TopBarComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-
     this.router.events.subscribe((event) => {
       this.sidebarOpen = false;
       this.removeBodyClass();


### PR DESCRIPTION
Removes a the usage of `this.router.routeReuseStrategy.shouldReuseRoute = () => false;` and fixes some issues, mainly on scenarios (new vs view scenario), and breadcrumbs.