### PR TITLE
fix: Command to initialize gunicorn on web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - db
       - redis
     working_dir: /usr/src/app/src/planscape
+    command: bin/run_gunicorn.sh
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - .:/usr/src/app


### PR DESCRIPTION
Command to initialize `gunicorn` on web container configured on `docker-compose.yml` file.