### PR TITLE
Silence log.

### DIFF
--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -1,13 +1,16 @@
 import multiprocessing
 import os
-from pathlib import Path
-from datetime import timedelta
 import sys
+import logging
+from datetime import timedelta
+from pathlib import Path
+
+import boto3
 import sentry_sdk
 from corsheaders.defaults import default_headers
 from decouple import config
-from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
 from utils.logging import NotInTestingFilter
 
 TESTING_MODE = "test" in sys.argv
@@ -432,3 +435,5 @@ AWS_DEFAULT_REGION = config("AWS_DEFAULT_REGION", "us-west-2")
 os.environ["AWS_ACCESS_KEY_ID"] = AWS_ACCESS_KEY_ID
 os.environ["AWS_SECRET_ACCESS_KEY"] = AWS_SECRET_ACCESS_KEY
 os.environ["AWS_DEFAULT_REGION"] = AWS_DEFAULT_REGION
+
+boto3.set_stream_logger(name="botocore.credentials", level=logging.ERROR)


### PR DESCRIPTION
silence this useless boto3 log.

```
Sep 18 19:19:37 dev-planscape-service python3[4074891]: [2024-09-18 19:19:37,276: INFO/ForkPoolWorker-3] Found credentials in environment variables.
Sep 18 19:19:37 dev-planscape-service python3[4074891]: [2024-09-18 19:19:37,401: INFO/ForkPoolWorker-3] Found credentials in environment variables.
Sep 18 19:19:37 dev-planscape-service python3[4074891]: [2024-09-18 19:19:37,409: INFO/ForkPoolWorker-3] Found credentials in environment variables.
Sep 18 19:19:37 dev-planscape-service python3[4074891]: [2024-09-18 19:19:37,503: INFO/ForkPoolWorker-3] Found credentials in environment variables.
Sep 18 19:19:37 dev-planscape-service python3[4074891]: [2024-09-18 19:19:37,511: INFO/ForkPoolWorker-3] Found credentials in environment variables.
Sep 18 19:19:37 dev-planscape-service python3[4074891]: [2024-09-18 19:19:37,624: INFO/ForkPoolWorker-3] Found credentials in environment variables.
```
https://github.com/boto/botocore/issues/1841