### PR TITLE
Sidebar name input control

### DIFF
--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
@@ -1,8 +1,14 @@
 <div class="heading-line">
   <div class="title">{{ title }}</div>
-  <div class="icon"><mat-icon>info</mat-icon></div>
+  <div class="icon">
+    <mat-icon class="material-symbols-outlined" color="primary">info</mat-icon>
+  </div>
 </div>
-
-<sg-input-field [disabled]="false" size="small">
-  <input sgInput placeholder="..." value="..." />
+<sg-input-field [disabled]="false" size="regular" class="name-input">
+  <input
+    sgInput
+    placeholder="..."
+    [(ngModel)]="textValue"
+    (blur)="emitTextValue($event)"
+    (keyup.enter)="emitTextValue($event)" />
 </sg-input-field>

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
@@ -1,5 +1,5 @@
 <div class="heading-line">
-  <div class="title">{{ title }}</div>
+  <div *ngIf="title" class="title">{{ title }}</div>
   <div class="icon">
     <mat-icon *ngIf="helpText" class="material-symbols-outlined" color="primary"
       >info</mat-icon
@@ -9,7 +9,7 @@
 <sg-input-field [disabled]="false" size="regular" class="name-input">
   <input
     sgInput
-    placeholder="..."
+    [placeholder]="placeholderText"
     [(ngModel)]="textValue"
     (blur)="emitTextValue($event)"
     (keyup.enter)="emitTextValue($event)" />

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
@@ -1,7 +1,9 @@
 <div class="heading-line">
   <div class="title">{{ title }}</div>
   <div class="icon">
-    <mat-icon class="material-symbols-outlined" color="primary">info</mat-icon>
+    <mat-icon *ngIf="helpText" class="material-symbols-outlined" color="primary"
+      >info</mat-icon
+    >
   </div>
 </div>
 <sg-input-field [disabled]="false" size="regular" class="name-input">
@@ -12,3 +14,6 @@
     (blur)="emitTextValue($event)"
     (keyup.enter)="emitTextValue($event)" />
 </sg-input-field>
+<div class="error-blurb" *ngIf="errorMessage">
+  {{ errorMessage }}
+</div>

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.html
@@ -1,0 +1,8 @@
+<div class="heading-line">
+  <div class="title">{{ title }}</div>
+  <div class="icon"><mat-icon>info</mat-icon></div>
+</div>
+
+<sg-input-field [disabled]="false" size="small">
+  <input sgInput placeholder="..." value="..." />
+</sg-input-field>

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.scss
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.scss
@@ -1,0 +1,12 @@
+@import 'colors';
+@import 'mixins';
+
+.heading-line {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.title {
+  @include small-input-label();
+}

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.scss
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.scss
@@ -6,7 +6,6 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  border: 1px black solid;
   padding: 10px;
 
   .heading-line {
@@ -22,8 +21,16 @@
     line-height: 22px;
     text-align: left;
   }
+  .error-blurb {
+    @include small-input-label();
+    color: $color-dark-red;
+  }
 }
 
 ::ng-deep .input-wrapper {
   width: 100%;
+}
+
+::ng-deep .focus-within {
+  border-width: 1px;
 }

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.scss
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.scss
@@ -1,12 +1,29 @@
 @import 'colors';
 @import 'mixins';
 
-.heading-line {
+:host {
+  background-color: $color-white;
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  flex-direction: column;
+  width: 100%;
+  border: 1px black solid;
+  padding: 10px;
+
+  .heading-line {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .title {
+    @include small-input-label();
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 22px;
+    text-align: left;
+  }
 }
 
-.title {
-  @include small-input-label();
+::ng-deep .input-wrapper {
+  width: 100%;
 }

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
@@ -2,13 +2,7 @@
 // emit change event
 
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import {
-  //     DatePipe,
-  //     CurrencyPipe,
-  NgIf,
-  //     NgSwitch,
-  //     NgClass,
-} from '@angular/common';
+import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms'; // Import FormsModule
 import { InputFieldComponent } from '@styleguide';
 // import { debounceTime, distinctUntilChanged, Subject } from 'rxjs';
@@ -34,6 +28,7 @@ import { MatIconModule } from '@angular/material/icon';
 export class SidebarNameInputComponent {
   @Input() textValue = '';
   @Input() title = '';
+  @Input() helpText = '';
   @Input() errorMessage: string | null = null;
   @Output() textValueUpdated = new EventEmitter<string>();
 

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
@@ -1,0 +1,32 @@
+// handle errors
+// emit change event
+
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import {
+  //     DatePipe,
+  //     CurrencyPipe,
+  NgIf,
+  //     NgSwitch,
+  //     NgClass,
+} from '@angular/common';
+import { InputFieldComponent } from '@styleguide';
+// import { debounceTime, distinctUntilChanged, Subject } from 'rxjs';
+import { InputDirective } from '../input/input.directive';
+import { MatIconModule } from '@angular/material/icon';
+
+/**
+ * Component for setting name
+ */
+@Component({
+  selector: 'sg-sidebar-name-input',
+  standalone: true,
+  imports: [NgIf, InputFieldComponent, InputDirective, MatIconModule],
+  templateUrl: './sidebar-name-input.component.html',
+  styleUrl: './sidebar-name-input.component.scss',
+})
+export class SidebarNameInputComponent {
+  @Input() name = '';
+  @Input() title = '';
+  @Input() errorMessage: string | null = null;
+  @Output() updatedName = new EventEmitter();
+}

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
@@ -29,7 +29,9 @@ export class SidebarNameInputComponent {
   @Input() textValue = '';
   @Input() title = '';
   @Input() helpText = '';
+  @Input() placeholderText: string | null = '';
   @Input() errorMessage: string | null = null;
+
   @Output() textValueUpdated = new EventEmitter<string>();
 
   emitTextValue(e: Event) {

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.component.ts
@@ -9,6 +9,7 @@ import {
   //     NgSwitch,
   //     NgClass,
 } from '@angular/common';
+import { FormsModule } from '@angular/forms'; // Import FormsModule
 import { InputFieldComponent } from '@styleguide';
 // import { debounceTime, distinctUntilChanged, Subject } from 'rxjs';
 import { InputDirective } from '../input/input.directive';
@@ -20,13 +21,23 @@ import { MatIconModule } from '@angular/material/icon';
 @Component({
   selector: 'sg-sidebar-name-input',
   standalone: true,
-  imports: [NgIf, InputFieldComponent, InputDirective, MatIconModule],
+  imports: [
+    NgIf,
+    FormsModule,
+    InputFieldComponent,
+    InputDirective,
+    MatIconModule,
+  ],
   templateUrl: './sidebar-name-input.component.html',
   styleUrl: './sidebar-name-input.component.scss',
 })
 export class SidebarNameInputComponent {
-  @Input() name = '';
+  @Input() textValue = '';
   @Input() title = '';
   @Input() errorMessage: string | null = null;
-  @Output() updatedName = new EventEmitter();
+  @Output() textValueUpdated = new EventEmitter<string>();
+
+  emitTextValue(e: Event) {
+    this.textValueUpdated.emit(this.textValue);
+  }
 }

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
@@ -25,6 +25,22 @@ type Story = StoryObj<SidebarNameInputComponent>;
 export const Default: Story = {
   args: {
     textValue: '',
-    title: 'Treatment Plan Name',
+    title: 'Treatment plan name',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    textValue: '',
+    title: 'Treatment plan name',
+    errorMessage: 'This name already exists',
+  },
+};
+
+export const HelpText: Story = {
+  args: {
+    textValue: '',
+    title: 'Treatment plan name',
+    helpText: 'Clicking this does something',
   },
 };

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig, argsToTemplate } from '@storybook/angular';
+import { SidebarNameInputComponent } from './sidebar-name-input.component';
+import { provideAnimations } from '@angular/platform-browser/animations';
+
+const meta: Meta<SidebarNameInputComponent> = {
+  title: 'Components/Sidebar Name Component',
+  component: SidebarNameInputComponent,
+  decorators: [
+    applicationConfig({
+      providers: [provideAnimations()],
+    }),
+  ],
+  tags: ['autodocs'],
+  render: ({ ...args }) => ({
+    props: args,
+    template: `<sg-sidebar-name-input ${argsToTemplate(args)}></sg-sidebar-name-input>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<SidebarNameInputComponent>;
+
+export const Default: Story = {
+  args: {
+    name: 'hello',
+    title: 'ok',
+  },
+};

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
@@ -37,6 +37,12 @@ export const WithError: Story = {
   },
 };
 
+export const NoTitle: Story = {
+  args: {
+    textValue: '',
+  },
+};
+
 export const HelpText: Story = {
   args: {
     textValue: '',

--- a/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
+++ b/src/interface/src/styleguide/sidebar-name-input/sidebar-name-input.stories.ts
@@ -14,7 +14,8 @@ const meta: Meta<SidebarNameInputComponent> = {
   tags: ['autodocs'],
   render: ({ ...args }) => ({
     props: args,
-    template: `<sg-sidebar-name-input ${argsToTemplate(args)}></sg-sidebar-name-input>`,
+    template: `<div style="width:100%;height:200px;background-color:#aaaaaa;">
+    <div style="width:400px"><sg-sidebar-name-input ${argsToTemplate(args)}></sg-sidebar-name-input></div></div>`,
   }),
 };
 
@@ -23,7 +24,7 @@ type Story = StoryObj<SidebarNameInputComponent>;
 
 export const Default: Story = {
   args: {
-    name: 'hello',
-    title: 'ok',
+    textValue: '',
+    title: 'Treatment Plan Name',
   },
 };


### PR DESCRIPTION
Creating this as a reusable styleguide component, since I suspect we'll be reusing a name component elsewhere.
<img width="281" alt="Screenshot 2024-09-24 at 10 19 53 PM" src="https://github.com/user-attachments/assets/b10e9087-0b66-42ad-98ba-fa5bb6dcd844">
<img width="289" alt="Screenshot 2024-09-24 at 10 20 24 PM" src="https://github.com/user-attachments/assets/8efb713b-c3c1-4879-8966-25467b7ef077">

TODO / Questions:
Is this always a text field, or do we need to click it to activate it?
Should the help icon just use a standard tooltop?
When to send the change -- onblur, onenter?
Should this have underline on focus, or other behavior?
Should this display a spinner when sending an event?