### PR TITLE
remove close button from delete planning area modal

### DIFF
--- a/src/interface/src/app/standalone/delete-planning-area/delete-planning-area.component.html
+++ b/src/interface/src/app/standalone/delete-planning-area/delete-planning-area.component.html
@@ -3,6 +3,7 @@
   primaryButtonVariant="negative"
   primaryButtonText="Delete"
   [showBorders]="false"
+  [showClose]="false"
   (clickedClose)="clickedClose($event)"
   (clickedPrimary)="clickedPrimary($event)"
   (clickedSecondary)="clickedClose($event)">

--- a/src/interface/src/styleguide/modal/modal.component.html
+++ b/src/interface/src/styleguide/modal/modal.component.html
@@ -18,7 +18,11 @@
         </ng-content>
       </mat-menu>
     </button>
-    <button mat-icon-button (click)="handleCloseButton()" aria-label="close">
+    <button
+      mat-icon-button
+      (click)="handleCloseButton()"
+      aria-label="close"
+      *ngIf="showClose">
       <mat-icon class="close-btn">close</mat-icon>
     </button>
   </div>

--- a/src/interface/src/styleguide/modal/modal.component.ts
+++ b/src/interface/src/styleguide/modal/modal.component.ts
@@ -80,15 +80,15 @@ export class ModalComponent {
    */
   @Input() secondaryButtonVariant: ButtonVariant = 'ghost';
   /**
-   * Whether or not to show the close button in the header
+   *  If the body has scrollable content
    */
   @Input() scrollableContent? = false;
   /**
-   * Whether or not to show the tooltip button in the header
+   * Whether or not to show the close button in the header
    */
   @Input() showClose? = true;
   /**
-   * Whether or not to show the header at all
+   * Whether or not to show the tooltip button in the header
    */
   @Input() showToolTip? = false;
   /**


### PR DESCRIPTION
This PR: hides the close button on the dialog. Fixes docs on sg-modal.