### PR TITLE
Fix home reset

### DIFF
--- a/src/interface/src/app/home/home.component.html
+++ b/src/interface/src/app/home/home.component.html
@@ -3,5 +3,7 @@
 <ng-container *ngIf="loggedIn$ | async">
   <app-legacy-planning-areas
     *appFeatureFlag="'new_home'; hide: true"></app-legacy-planning-areas>
-  <app-planning-areas *appFeatureFlag="'new_home'"></app-planning-areas>
+  <ng-container *appFeatureFlag="'new_home'">
+    <app-planning-areas *ngIf="showPlanningAreas"></app-planning-areas>
+  </ng-container>
 </ng-container>

--- a/src/interface/src/app/home/home.component.ts
+++ b/src/interface/src/app/home/home.component.ts
@@ -1,7 +1,11 @@
 import { Component, HostBinding } from '@angular/core';
 import { AuthService } from '@services';
 import { FeatureService } from '../features/feature.service';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { filter } from 'rxjs/operators';
+import { NavigationStart, Router } from '@angular/router';
 
+@UntilDestroy()
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
@@ -9,11 +13,30 @@ import { FeatureService } from '../features/feature.service';
 })
 export class HomeComponent {
   loggedIn$ = this.authService.loggedInStatus$;
+  showPlanningAreas = true;
 
   constructor(
     private authService: AuthService,
-    private featureService: FeatureService
-  ) {}
+    private featureService: FeatureService,
+    private router: Router
+  ) {
+    this.router.events
+      .pipe(
+        untilDestroyed(this),
+        filter(
+          (event): event is NavigationStart => event instanceof NavigationStart
+        )
+      )
+      .subscribe((event: NavigationStart) => {
+        if (event.url === '/home') {
+          //reset parameters
+          this.showPlanningAreas = false;
+          setTimeout(() => {
+            this.showPlanningAreas = true;
+          }, 0);
+        }
+      });
+  }
 
   get hasNewHome() {
     return this.featureService.isFeatureEnabled('new_home');

--- a/src/interface/src/app/standalone/planning-areas/query-params.service.ts
+++ b/src/interface/src/app/standalone/planning-areas/query-params.service.ts
@@ -35,11 +35,21 @@ export class QueryParamsService {
     router.events
       .pipe(
         untilDestroyed(this),
-        filter((event) => event instanceof NavigationStart)
+        filter(
+          (event): event is NavigationStart => event instanceof NavigationStart
+        )
       )
-      .subscribe((s) => {
-        const currentParams = this.getCurrentParams();
-        this.homeParametersStorageService.setItem(currentParams);
+      .subscribe((event: NavigationStart) => {
+        console.log(event.url);
+        if (event.url === '/home') {
+          //reset parameters
+          console.log('reset');
+          this.homeParametersStorageService.setItem({});
+        } else {
+          // save parameters when leaving
+          const currentParams = this.getCurrentParams();
+          this.homeParametersStorageService.setItem(currentParams);
+        }
       });
   }
 

--- a/src/interface/src/app/standalone/planning-areas/query-params.service.ts
+++ b/src/interface/src/app/standalone/planning-areas/query-params.service.ts
@@ -40,10 +40,8 @@ export class QueryParamsService {
         )
       )
       .subscribe((event: NavigationStart) => {
-        console.log(event.url);
         if (event.url === '/home') {
           //reset parameters
-          console.log('reset');
           this.homeParametersStorageService.setItem({});
         } else {
           // save parameters when leaving


### PR DESCRIPTION
Another issue brought up by removing the hack we had for route reuse strategy, the home page was not reseting view when clicking the logo (navigating to `/home`)
Easiest solution is to re-render the component in this case. 
An alternative solution would be to add some reset() methods on the component, but given all the bindings and state with PlanningAreasDataSource, that would involve a lot of manual resetting, which seems..bad.