### PR TITLE
restoring breadcrumbs ellipsis

### DIFF
--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
@@ -56,6 +56,9 @@
 
 .breadcrumb {
   @include h3();
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 
   a {
     color: $color-standard-blue;


### PR DESCRIPTION
seems like this got lost on merges. This adds an ellipsis to the breadcrumbs so they don't overflow.