### PR TITLE
PLAN-1768: Reduce breadcrumb font size

### DIFF
--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
@@ -36,7 +36,7 @@
 }
 
 .breadcrumb {
-  @include h3();
+  @include h4();
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
We reduced the breadcrumb font size from h3 to h4 (same as figma)

Jira: https://sig-gis.atlassian.net/browse/PLAN-1768