### PR TITLE
Delay in Breadcrumb Display after Clicking 'View Scenario

### DIFF
--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AuthService, ScenarioService } from '@services';
+import { AuthService, PlanStateService, ScenarioService } from '@services';
 import { FeatureService } from '../../../features/feature.service';
 import { interval, take } from 'rxjs';
 import { Plan, Scenario } from '@types';
@@ -49,7 +49,8 @@ export class SavedScenariosComponent implements OnInit {
     private snackbar: MatSnackBar,
     private scenarioService: ScenarioService,
     private dialog: MatDialog,
-    private featureService: FeatureService
+    private featureService: FeatureService,
+    private planStateService: PlanStateService
   ) {}
 
   ngOnInit(): void {
@@ -138,6 +139,10 @@ export class SavedScenariosComponent implements OnInit {
   }
 
   viewScenario(): void {
+    // Updating planstate with the selected scenario name and ID
+    if(this.highlightedScenarioRow) {
+      this.planStateService.updateStateWithScenario(this.highlightedScenarioRow.id, this.highlightedScenarioRow.name)
+    }
     this.router.navigate(['config', this.highlightedScenarioRow?.id], {
       relativeTo: this.route,
     });

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -152,6 +152,10 @@ export class SavedScenariosComponent implements OnInit {
   }
 
   navigateToScenario(clickedScenario: ScenarioRow): void {
+    this.planStateService.updateStateWithScenario(
+      clickedScenario.id,
+      clickedScenario.name
+    );
     this.router.navigate(['config', clickedScenario.id], {
       relativeTo: this.route,
     });

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -140,8 +140,11 @@ export class SavedScenariosComponent implements OnInit {
 
   viewScenario(): void {
     // Updating planstate with the selected scenario name and ID
-    if(this.highlightedScenarioRow) {
-      this.planStateService.updateStateWithScenario(this.highlightedScenarioRow.id, this.highlightedScenarioRow.name)
+    if (this.highlightedScenarioRow) {
+      this.planStateService.updateStateWithScenario(
+        this.highlightedScenarioRow.id,
+        this.highlightedScenarioRow.name
+      );
     }
     this.router.navigate(['config', this.highlightedScenarioRow?.id], {
       relativeTo: this.route,


### PR DESCRIPTION
Currently, when clicking 'View Scenario,' there is a delay in displaying the scenario name in the breadcrumb until the getScenario response is received. This delay shouldn’t occur, as we already know the scenario name upon selection and should be able to display it immediately in the breadcrumb. This ticket addresses the issue by allowing the breadcrumb to update without waiting for the API response.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1776