### PR TITLE
fix project area fill on view treatment layers

### DIFF
--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -143,6 +143,10 @@ export class TreatmentsState {
     this.mapConfigState.setStandSelectionEnabled(
       data.showTreatmentStands || false
     );
+
+    this.mapConfigState.setShowFillProjectAreas(
+      data.showMapProjectAreas || false
+    );
     this.mapConfigState.setShowMapControls(data.showTreatmentStands || false);
   }
 


### PR DESCRIPTION
Fixes a bug when "view treatment layers" is on, an user clicks on project area. When user navigates back and forward the fill of the project areas was not properly reset.