### PR TITLE
Adjust treatment-legend to match figma

### DIFF
--- a/src/interface/src/app/treatments/treatment-legend/treatment-legend.component.html
+++ b/src/interface/src/app/treatments/treatment-legend/treatment-legend.component.html
@@ -2,18 +2,19 @@
   class="treatment-legend"
   title="Treatment Legend"
   [hasFooter]="false"
-  [shortHeader]="true"
   [scrollableContent]="false"
   width="xsmall"
   (clickedClose)="handleClose()">
   <div modalBodyContent class="legend-body">
     <div class="legend-no-expander">
-      <div class="no-treatment-row legend-row">
+      <div class="no-treatment-row">
         <sg-treatment-type-icon [treatment]="null"></sg-treatment-type-icon>
-        <div class="legend-text">No Treatment</div>
+        <div>No Treatment</div>
       </div>
     </div>
-    <mat-expansion-panel class="legend-expander-panel">
+    <mat-expansion-panel
+      class="legend-expander-panel"
+      [expanded]="defaultExpanded">
       <mat-expansion-panel-header class="legend-expander-heading">
         <div class="expander-heading-content">
           <mat-icon class="material-symbols-outlined expander-heading-icon"
@@ -31,7 +32,10 @@
         </div>
       </div>
     </mat-expansion-panel>
-    <mat-expansion-panel class="legend-expander-panel">
+    <mat-divider class="tx-divider"></mat-divider>
+    <mat-expansion-panel
+      class="legend-expander-panel"
+      [expanded]="defaultExpanded">
       <mat-expansion-panel-header class="legend-expander-heading">
         <div class="expander-heading-content">
           <mat-icon class="material-symbols-outlined expander-heading-icon"

--- a/src/interface/src/app/treatments/treatment-legend/treatment-legend.component.scss
+++ b/src/interface/src/app/treatments/treatment-legend/treatment-legend.component.scss
@@ -10,9 +10,12 @@
     0px 4px 4px 0px rgba(0, 0, 0, 0.1),
     0px 2px 2px 0px rgba(0, 0, 0, 0.1);
 
-    max-height: calc(100% - 100px);
-    z-index: 1000;
+  max-height: calc(100% - 100px);
+  z-index: 1000;
 
+  ::ng-deep .header {
+    height: 24px;
+  }
 
   ::ng-deep .header-title {
     @include xs-label();
@@ -29,7 +32,12 @@
   }
 
   ::ng-deep .mat-expansion-panel-body {
-    padding: 0 24px 8px;
+    padding: 0 16px 8px;
+  }
+
+  ::ng-deep .treatment-img {
+    width: 20px;
+    height: 20px;
   }
 }
 
@@ -38,20 +46,20 @@
   background-color: $color-white;
   display: flex;
   flex-direction: column;
-  
-  padding-top: 4px;}
+  padding-top: 10px;
+}
 
 .legend-section {
   background-color: $color-white;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .legend-expander-panel {
   --mat-expansion-header-indicator-color: $color-black;
-  --mat-expansion-header-expanded-state-height: 40px;
-  --mat-expansion-header-collapsed-state-height: 40px;
+  --mat-expansion-header-expanded-state-height: 24px;
+  --mat-expansion-header-collapsed-state-height: 24px;
   --mat-expansion-header-hover-state-layer-color: $color-white;
   border-radius: 0px;
 }
@@ -68,6 +76,7 @@
   justify-content: left;
   gap: 6px;
   align-items: center;
+  padding: 10px 24px 10px 16px;
 }
 
 .expander-heading-content {
@@ -78,16 +87,24 @@
 }
 
 .legend-no-expander {
-  height: 30px;
-  flex-direction: row;
-  align-items: center;
   display: flex;
+  width: 100%;
 }
 
 .no-treatment-row {
-  height: 40px;
-  padding-left: 24px;
-  align-items: center;
+  @include xs-label();
+
+  padding: 0px 16px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  line-height: 20px;
+}
+
+.tx-divider {
+  margin-left: 16px;
+  margin-right: 16px;
 }
 
 .expander-heading-icon {
@@ -95,10 +112,10 @@
   background-repeat: no-repeat;
   display: inline-block;
   fill: currentColor;
-  height: 22px;
-  width: 22px;
+  height: 20px;
+  width: 20px;
+  font-size: 20px;
   overflow: hidden;
-  font-size: 22px;
 }
 
 .legend-row {
@@ -116,6 +133,6 @@
   font-family: Public Sans;
   font-size: 14px;
   font-weight: 500;
-  line-height: 24px;
+  line-height: 20px;
   text-align: left;
 }

--- a/src/interface/src/app/treatments/treatment-legend/treatment-legend.component.ts
+++ b/src/interface/src/app/treatments/treatment-legend/treatment-legend.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, Input, EventEmitter, Output } from '@angular/core';
 import { NgIf, NgFor, NgClass, KeyValuePipe } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -6,7 +6,7 @@ import { TreatmentTypeIconComponent } from '../../../styleguide/treatment-type-i
 import { SequenceIconComponent } from '../../../styleguide/sequence-icon/sequence-icon.component';
 import { ModalComponent } from '../../../styleguide/modal/modal.component';
 import { PRESCRIPTIONS } from '../prescriptions';
-
+import { MatDividerModule } from '@angular/material/divider';
 /**
  * Treatment Legend
  * A component that displays a set of treatments, along with an icon
@@ -16,6 +16,7 @@ import { PRESCRIPTIONS } from '../prescriptions';
   standalone: true,
   imports: [
     KeyValuePipe,
+    MatDividerModule,
     MatExpansionModule,
     MatIconModule,
     ModalComponent,
@@ -31,6 +32,7 @@ import { PRESCRIPTIONS } from '../prescriptions';
 export class TreatmentLegendComponent {
   readonly singlePrescriptions = PRESCRIPTIONS.SINGLE;
   readonly sequencePrescriptions = PRESCRIPTIONS.SEQUENCE;
+  @Input() defaultExpanded = true;
   @Output() closeRequest = new EventEmitter();
   constructor() {}
 


### PR DESCRIPTION
This mainly adjusts some CSS, but also:
- defaults sections to expanded
- cleans up a few icon sizes
- reverts some stuff that was intended to make this component a little shorter

<img width="327" alt="Screenshot 2024-11-06 at 9 11 04 AM" src="https://github.com/user-attachments/assets/4013544c-27c2-4cb8-b943-6108d5586059">
<img width="321" alt="Screenshot 2024-11-06 at 9 11 23 AM" src="https://github.com/user-attachments/assets/8082a576-42ef-46fc-bf4c-8fcd1023fceb">
