### PR TITLE
PLAN-1481: Learn more from WUI layer gets a 404 page

### DIFF
--- a/src/planscape/config/conditions.json
+++ b/src/planscape/config/conditions.json
@@ -4799,7 +4799,7 @@
                   "min_value": 0,
                   "raw_data_download_path": "sierra-nevada/forsys/wui.tif",
                   "raw_layer": "",
-                  "reference_link": "",
+                  "reference_link": "https://wildfiretaskforce.org/wp-content/uploads/2023/06/SN_RRK_Metric-Dictionary_v20230414.pdf#page=84",
                   "source": "SIG-GIS",
                   "source_link": ""
                 },


### PR DESCRIPTION
"Learn more" from WUI layer gets a 404 page

Should take you to https://wildfiretaskforce.org/wp-content/uploads/2023/06/SN_RRK_Metric-Dictionary_v20230414.pdf#page=84

Jira: https://sig-gis.atlassian.net/browse/PLAN-1481