### PR TITLE
fix for bug when switching base maps

### DIFF
--- a/src/interface/src/app/treatments/map-base-layer/map-base-layer.component.spec.ts
+++ b/src/interface/src/app/treatments/map-base-layer/map-base-layer.component.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { MapBaseLayerComponent } from './map-base-layer.component';
-import { MockProvider } from 'ng-mocks';
+import { MockProviders } from 'ng-mocks';
 import { MapConfigState } from '../treatment-map/map-config.state';
+import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 
 describe('MapBaseLayerComponent', () => {
   let component: MapBaseLayerComponent;
@@ -11,7 +11,7 @@ describe('MapBaseLayerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MapBaseLayerComponent],
-      providers: [MockProvider(MapConfigState)],
+      providers: [MockProviders(MapConfigState, SelectedStandsState)],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MapBaseLayerComponent);

--- a/src/interface/src/app/treatments/map-base-layer/map-base-layer.component.ts
+++ b/src/interface/src/app/treatments/map-base-layer/map-base-layer.component.ts
@@ -5,6 +5,7 @@ import {
   BaseLayerType,
 } from '../treatment-map/map-base-layers';
 import { MapConfigState } from '../treatment-map/map-config.state';
+import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 
 @Component({
   selector: 'app-map-base-layer',
@@ -15,11 +16,22 @@ import { MapConfigState } from '../treatment-map/map-config.state';
 })
 export class MapBaseLayerComponent {
   baseLayers = Object.keys(baseLayerStyles) as BaseLayerType[];
+
   readonly baseLayer$ = this.mapConfigState.baseLayer$;
 
-  constructor(private mapConfigState: MapConfigState) {}
+  constructor(
+    private mapConfigState: MapConfigState,
+    private selectedStandsState: SelectedStandsState
+  ) {}
 
   updateBaseLayer(layer: BaseLayerType) {
+    const stands = this.selectedStandsState.getSelectedStands();
+    this.selectedStandsState.clearStands();
     this.mapConfigState.updateBaseLayer(layer);
+    // not great, but updating the baseLayer re-renders all the layers, and gets the
+    // selected stands completely out of sync.
+    setTimeout(() => {
+      this.selectedStandsState.updateSelectedStands(stands);
+    }, 10);
   }
 }

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -245,12 +245,6 @@ export class MapStandsComponent implements OnChanges, OnInit {
     }
     const standId = this.getStandIdFromStandsLayer(event.point)[0];
     this.selectedStandsState.toggleStand(standId);
-
-    const features = this.mapLibreMap.queryRenderedFeatures(event.point, {
-      layers: [this.layers.stands.name],
-    });
-
-    this.mapLibreMap.setFeatureState(features[0], { selected: true });
     this.treatmentsState.setShowApplyTreatmentsDialog(true);
   }
 

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.spec.ts
@@ -9,6 +9,7 @@ import { ProjectAreasTabComponent } from '../project-areas-tab/project-areas-tab
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MapConfigState } from '../treatment-map/map-config.state';
+import { TreatmentPlanTabsComponent } from '../treatment-plan-tabs/treatment-plan-tabs.component';
 
 describe('TreatmentOverviewComponent', () => {
   let component: TreatmentOverviewComponent;
@@ -23,7 +24,11 @@ describe('TreatmentOverviewComponent', () => {
         BrowserAnimationsModule,
       ],
       declarations: [
-        MockDeclarations(ProjectAreasTabComponent, MapBaseLayerComponent),
+        MockDeclarations(
+          ProjectAreasTabComponent,
+          MapBaseLayerComponent,
+          TreatmentPlanTabsComponent
+        ),
       ],
       providers: [
         MockProviders(TreatmentsState, MapConfigState, TreatedStandsState),


### PR DESCRIPTION
Found a couple of bugs:
1- On the map, you couldn't deselect a stand by clicking on it. There was some duplicated code that was causing this, removed it.
2- When switching map layers, while having stands selected, the map gets completely out of sync. I believe this is because all the layers get re-rendered, and references get messed up. Got it working with a timeout, which is far from ideal. 
I tried to leverage the `MapSourceDataEvent` over the map component,  but couldn't figure out the right sequence of events to save and restore selected stands, without breaking anything.

Open to suggestions on another way of fixing this but wanted to time box it, and the initial _crappy_ timeout solution seems like the lesser evil