### PR TITLE
Overlay loader component and loader in treatments page

### DIFF
--- a/src/interface/src/app/standalone/planning-areas/planning-areas.component.html
+++ b/src/interface/src/app/standalone/planning-areas/planning-areas.component.html
@@ -1,7 +1,5 @@
 <!--Overlay loader -->
-<div class="overlay-loader" *ngIf="overlayLoader$ | async">
-  <mat-spinner class="main-loader" diameter="48"></mat-spinner>
-</div>
+<sg-overlay-loader *ngIf="overlayLoader$ | async"></sg-overlay-loader>
 
 <div class="title-nav">
   <h3>Home</h3>

--- a/src/interface/src/app/standalone/planning-areas/planning-areas.component.ts
+++ b/src/interface/src/app/standalone/planning-areas/planning-areas.component.ts
@@ -37,6 +37,7 @@ import { PlanningAreaMenuComponent } from '../planning-area-menu/planning-area-m
 import { PlanningAreasSearchComponent } from '../planning-areas-search/planning-areas-search.component';
 import { FormsModule } from '@angular/forms';
 import { combineLatest, map } from 'rxjs';
+import { OverlayLoaderComponent } from '../../../styleguide/overlay-loader/overlay-loader.component';
 
 @Component({
   selector: 'app-planning-areas',
@@ -67,6 +68,7 @@ import { combineLatest, map } from 'rxjs';
     FormsModule,
     FilterDropdownComponent,
     PaginatorComponent,
+    OverlayLoaderComponent,
   ],
   templateUrl: './planning-areas.component.html',
   styleUrl: './planning-areas.component.scss',

--- a/src/interface/src/app/treatments/treatment-config/treatment-config.component.html
+++ b/src/interface/src/app/treatments/treatment-config/treatment-config.component.html
@@ -1,3 +1,4 @@
+<sg-overlay-loader *ngIf="loading" [offsetTop]="48"></sg-overlay-loader>
 <app-nav-bar [breadcrumbs]="(breadcrumbs$ | async) || []" [area]="'TREATMENTS'">
   <app-treatment-navbar-menu
     [treatmentPlanName]="(treatmentPlanName$ | async) || ''"

--- a/src/interface/src/app/treatments/treatment-config/treatment-config.component.ts
+++ b/src/interface/src/app/treatments/treatment-config/treatment-config.component.ts
@@ -29,6 +29,8 @@ import { MatLegacySlideToggleModule } from '@angular/material/legacy-slide-toggl
 import { MatDialog } from '@angular/material/dialog';
 import { ReviewTreatmentPlanDialogComponent } from '../review-treatment-plan-dialog/review-treatment-plan-dialog.component';
 import { getMergedRouteData } from '../treatments-routing-data';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { OverlayLoaderComponent } from '../../../styleguide/overlay-loader/overlay-loader.component';
 
 @UntilDestroy()
 @Component({
@@ -50,6 +52,8 @@ import { getMergedRouteData } from '../treatments-routing-data';
     ApplyTreatmentComponent,
     TreatmentLegendComponent,
     RouterLink,
+    MatProgressSpinnerModule,
+    OverlayLoaderComponent,
   ],
   providers: [
     TreatmentsState,
@@ -75,6 +79,8 @@ export class TreatmentConfigComponent {
   );
 
   breadcrumbs$ = this.treatmentsState.breadcrumbs$;
+
+  loading = true;
 
   constructor(
     private treatmentsState: TreatmentsState,
@@ -106,7 +112,7 @@ export class TreatmentConfigComponent {
               throw error;
             })
           )
-          .subscribe();
+          .subscribe((_) => (this.loading = false));
       });
   }
 

--- a/src/interface/src/styleguide/overlay-loader/overlay-loader.component.html
+++ b/src/interface/src/styleguide/overlay-loader/overlay-loader.component.html
@@ -1,0 +1,1 @@
+<mat-spinner class="main-loader" diameter="48"></mat-spinner>

--- a/src/interface/src/styleguide/overlay-loader/overlay-loader.component.scss
+++ b/src/interface/src/styleguide/overlay-loader/overlay-loader.component.scss
@@ -1,0 +1,9 @@
+:host {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(255, 255, 255, 0.50);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/interface/src/styleguide/overlay-loader/overlay-loader.component.spec.ts
+++ b/src/interface/src/styleguide/overlay-loader/overlay-loader.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OverlayLoaderComponent } from './overlay-loader.component';
+
+describe('OverlayLoaderComponent', () => {
+  let component: OverlayLoaderComponent;
+  let fixture: ComponentFixture<OverlayLoaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OverlayLoaderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OverlayLoaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/styleguide/overlay-loader/overlay-loader.component.ts
+++ b/src/interface/src/styleguide/overlay-loader/overlay-loader.component.ts
@@ -1,0 +1,17 @@
+import { Component, HostBinding, Input } from '@angular/core';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'sg-overlay-loader',
+  standalone: true,
+  imports: [MatProgressSpinnerModule],
+  templateUrl: './overlay-loader.component.html',
+  styleUrl: './overlay-loader.component.scss',
+})
+export class OverlayLoaderComponent {
+  @Input() offsetTop = 0;
+
+  @HostBinding('style.top.px') get top(): number {
+    return this.offsetTop;
+  }
+}

--- a/src/interface/src/styleguide/overlay-loader/overlay-loader.stories.ts
+++ b/src/interface/src/styleguide/overlay-loader/overlay-loader.stories.ts
@@ -1,0 +1,44 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OverlayLoaderComponent } from './overlay-loader.component';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+
+@Component({
+  selector: 'sg-demo-overlay-loader',
+  standalone: true,
+  imports: [CommonModule, OverlayLoaderComponent],
+  styles: ``,
+  template:
+    '<button (click)="openModal()">{{label}}</button><sg-overlay-loader *ngIf="open" [offsetTop]="offset"></sg-overlay-loader>',
+})
+class DemoOverlayLoaderComponent {
+  @Input() open = false;
+  @Input() offset = 0;
+  @Input() label = '';
+
+  openModal() {
+    this.open = true;
+    setTimeout(() => (this.open = false), 5000);
+  }
+}
+
+const meta: Meta<OverlayLoaderComponent> = {
+  title: 'Components/Overlay Loader',
+  component: OverlayLoaderComponent,
+  decorators: [moduleMetadata({ imports: [DemoOverlayLoaderComponent] })],
+  tags: ['autodocs'],
+  render: (args) => ({
+    props: args,
+    template: `
+<div style='height: 400px; background-color: #8e918f; padding: 20px'>This overlay uses position fixed, and in the app should cover the whole page. The demo here on storybook will only cover the story itself. </div>
+<sg-demo-overlay-loader label='Open Overlay Loader and close in 5 seconds'></sg-demo-overlay-loader>
+<sg-demo-overlay-loader label='Open Overlay with offset at top' [offset]='100'></sg-demo-overlay-loader>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<OverlayLoaderComponent>;
+
+export const Default: Story = {
+  args: {},
+};


### PR DESCRIPTION
Added a loading indicator on the treatment config page. Its not ideal in terms of ux - a skeleton loader will probably work better- but works as an MVP. 
We already had an overlay loader used on planning areas, so I created a component in storybook for this, and updated the code to use that component.