### PR TITLE
Fix tooltip in Treatment overview

### DIFF
--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
@@ -47,10 +47,10 @@
 <ng-container *ngIf="mouseLngLat">
   <app-map-tooltip
     [lngLat]="mouseLngLat"
-    *ngIf="activeProjectArea$ | async; let activeProjectArea">
+    *ngIf="hoveredProjectArea$ | async; let curProjectArea">
     <mat-icon class="material-symbols-outlined">medication</mat-icon>
-    {{ getTreatedStandsTotal(activeProjectArea.prescriptions) }}
+    {{ getTreatedStandsTotal(curProjectArea.prescriptions) }}
     /
-    {{ activeProjectArea.total_stand_count }}
+    {{ curProjectArea.total_stand_count }}
   </app-map-tooltip>
 </ng-container>

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
@@ -61,11 +61,11 @@ export class MapProjectAreasComponent implements OnInit {
   fillColor: any;
   getTreatedStandsTotal = getTreatedStandsTotal;
 
-  hoverProjectAreaId$ = new Subject<number>();
+  hoveredProjectAreaId$ = new Subject<number>();
   hoveredProjectArea$: Observable<TreatmentProjectArea | undefined> =
     combineLatest([
       this.summary$,
-      this.hoverProjectAreaId$.pipe(distinctUntilChanged()),
+      this.hoveredProjectAreaId$.pipe(distinctUntilChanged()),
     ]).pipe(
       map(([summary, projectAreaId]) => {
         return summary?.project_areas.find(
@@ -147,9 +147,9 @@ export class MapProjectAreasComponent implements OnInit {
     if (this.treatmentsState.getProjectAreaId()) {
       return;
     }
-    const hoverProjectAreaId = this.getProjectAreaIdFromFeatures(e.point);
-    if (hoverProjectAreaId) {
-      this.hoverProjectAreaId$.next(hoverProjectAreaId);
+    const hoveredProjectAreaId = this.getProjectAreaIdFromFeatures(e.point);
+    if (hoveredProjectAreaId) {
+      this.hoveredProjectAreaId$.next(hoveredProjectAreaId);
     }
     this.mouseLngLat = e.lngLat;
   }


### PR DESCRIPTION
I don't think this was a windows issue---instead, it looks like a bug from trying to simplify the activeProjectArea$ across our codebase. For this tooltip, it seems we just want to read the summary for the project area we're hovering over, we don't want to change or use the activeProjectArea on TreatmentState.

![Screenshot from 2024-11-14 11-47-00](https://github.com/user-attachments/assets/0b7a1df6-f190-477e-afcb-e30b13384ed5)
