### PR TITLE
PLAN-1697: Expander sections for filter dropdown

### DIFF
--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
@@ -38,7 +38,7 @@
   <div
     class="search-section"
     *ngIf="hasSearch"
-    (click)="$event.stopPropagation()">
+    >
     <sg-search-bar
       [debounceInterval]="0"
       searchPlaceholder="Search for {{ menuLabel }}"
@@ -53,8 +53,8 @@
       ">
       <div
         *ngFor="let categoryGroup of displayedItems"
-        (click)="$event.stopPropagation()">
-        <details class="expander" open>
+        >
+        <details class="expander" open (click)="$event.stopPropagation()">
           <summary>{{ categoryGroup.category }}</summary>
           <div *ngFor="let item of categoryGroup.options">
             <button

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
@@ -46,20 +46,50 @@
       (searchString)="filterSearch($event)"></sg-search-bar>
   </div>
   <div class="options-section">
-    <button
-      *ngFor="let item of displayedItems"
-      mat-menu-item
-      role="menuitemcheckbox"
-      (click)="toggleSelection($event, item)">
-      <div class="menu-item-content">
-        <span class="menu-item-text">{{
-          displayField ? item[displayField] : item
-        }}</span>
-        <mat-checkbox
-          [color]="'primary'"
-          [checked]="isInSelection(item)"></mat-checkbox>
+    <ng-container
+      *ngIf="
+        displayCategories && displayedItems && displayedItems.length > 0;
+        else noCategory
+      ">
+      <div
+        *ngFor="let categoryGroup of displayedItems"
+        (click)="$event.stopPropagation()">
+        <details class="expander" open>
+          <summary>{{ categoryGroup.category }}</summary>
+          <div *ngFor="let item of categoryGroup.options">
+            <button
+              mat-menu-item
+              role="menuitemcheckbox"
+              (click)="toggleSelection($event, item)">
+              <div class="menu-item-content">
+                <span class="menu-item-text">{{
+                  displayField ? item[displayField] : item
+                }}</span>
+                <mat-checkbox
+                  [color]="'primary'"
+                  [checked]="isInSelection(item)"></mat-checkbox>
+              </div>
+            </button>
+          </div>
+        </details>
       </div>
-    </button>
+    </ng-container>
+    <ng-template #noCategory>
+      <button
+        *ngFor="let item of displayedItems"
+        mat-menu-item
+        role="menuitemcheckbox"
+        (click)="toggleSelection($event, item)">
+        <div class="menu-item-content">
+          <span class="menu-item-text">{{
+            displayField ? item[displayField] : item
+          }}</span>
+          <mat-checkbox
+            [color]="'primary'"
+            [checked]="isInSelection(item)"></mat-checkbox>
+        </div>
+      </button>
+    </ng-template>
   </div>
   <div class="bottom-section">
     <div class="bottom-content">

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
@@ -35,10 +35,7 @@
   #multiSelectMenu="matMenu"
   class="filtermenu"
   (closed)="handleClosedMenu($event)">
-  <div
-    class="search-section"
-    *ngIf="hasSearch"
-    >
+  <div class="search-section" *ngIf="hasSearch">
     <sg-search-bar
       [debounceInterval]="0"
       searchPlaceholder="Search for {{ menuLabel }}"
@@ -51,9 +48,7 @@
         displayCategories && displayedItems && displayedItems.length > 0;
         else noCategory
       ">
-      <div
-        *ngFor="let categoryGroup of displayedItems"
-        >
+      <div *ngFor="let categoryGroup of displayedItems">
         <details class="expander" open (click)="$event.stopPropagation()">
           <summary>{{ categoryGroup.category }}</summary>
           <div *ngFor="let item of categoryGroup.options">

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.scss
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.scss
@@ -263,3 +263,11 @@
 .clear-all-text:hover:not(:disabled) {
   color: $color-standard-blue;
 }
+
+.expander {
+  summary {
+    padding: 8px 12px 8px 12px;
+    border-bottom: 1px solid $color-dark-gray;
+    cursor: pointer;
+  }
+}

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
@@ -75,7 +75,10 @@ export class FilterDropdownComponent<T> implements OnInit {
    */
   @Output() confirmedSelection = new EventEmitter<T[]>();
 
-  displayedItems: T[] = [];
+  displayedItems: any[] = [];
+
+  displayCategories: boolean = false;
+
   /**
    * the items already selected
    */
@@ -89,6 +92,7 @@ export class FilterDropdownComponent<T> implements OnInit {
   private previousSelections: T[] = [];
 
   ngOnInit(): void {
+    this.displayCategories = this.menuItems.some((e) => (e as any).category);
     this.displayedItems = this.menuItems;
   }
 
@@ -154,21 +158,44 @@ export class FilterDropdownComponent<T> implements OnInit {
   }
 
   filterSearch(searchTerm: string): void {
-    if (searchTerm !== '') {
+    if (searchTerm === '') {
       this.displayedItems = this.menuItems.slice();
+      return;
     }
 
-    this.displayedItems = this.menuItems.filter((item) => {
-      let value = '';
-      if (typeof item === 'string') {
-        value = item;
-      }
-      if (this.displayField && typeof item !== 'string') {
-        value = item[this.displayField] as string;
-      }
+    this.displayedItems = this.menuItems
+      .map((item) => {
+        let matches = false;
+        let value = '';
 
-      return value.toLowerCase().includes(searchTerm.toLowerCase());
-    });
+        if (typeof item === 'string') {
+          value = item;
+        }
+
+        if (this.displayField && typeof item !== 'string') {
+          value = item[this.displayField] as string;
+        }
+
+        if (this.displayCategories && (item as any).options) {
+          const filteredOptions = (item as any).options.filter(
+            (subItem: any) => {
+              return subItem.toLowerCase().includes(searchTerm.toLowerCase());
+            }
+          );
+
+          if (filteredOptions.length > 0) {
+            matches = true;
+            return { ...item, options: filteredOptions };
+          }
+        }
+
+        if (value.toLowerCase().includes(searchTerm.toLowerCase())) {
+          matches = true;
+        }
+
+        return matches ? item : null;
+      })
+      .filter((item) => item !== null);
   }
 
   applyChanges(e: Event) {

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.stories.ts
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.stories.ts
@@ -20,7 +20,7 @@ const meta: Meta<FilterDropdownComponent<string>> = {
 };
 
 export default meta;
-type Story = StoryObj<FilterDropdownComponent<string>>;
+type Story = StoryObj<FilterDropdownComponent<any>>;
 
 export const Default: Story = {
   args: {
@@ -269,6 +269,16 @@ export const WithSearchTerm: Story = {
       'Olivia Turner',
       'Owen King',
       'Penelope Johnson',
+    ],
+  },
+};
+
+export const WithExpansionCategories: Story = {
+  args: {
+    menuLabel: 'With categories',
+    menuItems: [
+      { category: 'Primary', options: ['hello', 'is'] },
+      { category: 'Secondary', options: ['this', 'selectable'] },
     ],
   },
 };


### PR DESCRIPTION
The idea is to keep the component as it is and when a category and its options array is provided we are displaying the expander sections for each category.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1697

Design: https://www.figma.com/design/njHEIn6MWPYJ5hw4we0lFY/Impacts?node-id=1760-51648&node-type=instance&m=dev

Result:
![image](https://github.com/user-attachments/assets/1954395e-a137-4e26-b97e-2f963e3ec083)
