### PR TITLE
Handle uploaded shapefile edge cases

### DIFF
--- a/src/interface/src/app/plan/upload-project-areas-modal/upload-project-areas-modal.component.html
+++ b/src/interface/src/app/plan/upload-project-areas-modal/upload-project-areas-modal.component.html
@@ -54,13 +54,13 @@
         </div>
         <mat-form-field class="stand-picker-field" appearance="outline">
           <mat-select name="standSize" formControlName="standSize">
-            <mat-option class="nav-page-item" value="Small"
+            <mat-option class="nav-page-item" value="SMALL"
               >Small (10 acres)</mat-option
             >
-            <mat-option class="nav-page-item" value="Medium"
+            <mat-option class="nav-page-item" value="MEDIUM"
               >Medium (100 acres)</mat-option
             >
-            <mat-option class="nav-page-item" value="Large"
+            <mat-option class="nav-page-item" value="LARGE"
               >Large (500 acres)</mat-option
             >
           </mat-select>

--- a/src/interface/src/app/plan/upload-project-areas-modal/upload-project-areas-modal.component.ts
+++ b/src/interface/src/app/plan/upload-project-areas-modal/upload-project-areas-modal.component.ts
@@ -25,7 +25,6 @@ import { ButtonComponent, InputFieldComponent } from '@styleguide';
 import { FileUploadFieldComponent } from '../../../styleguide/file-upload-field/file-upload-field.component';
 import { SharedModule } from '../../shared/shared.module';
 import { FormMessageType } from '@types';
-import { GeoJsonObject } from 'geojson';
 import { PlanService } from '@services';
 import { take } from 'rxjs';
 
@@ -68,7 +67,7 @@ export class UploadProjectAreasModalComponent {
   standSize = 'Medium';
   uploadError?: string | null = null;
   alertMessage?: string | null = null;
-  geometries: GeoJsonObject | null = null;
+  geometries: GeoJSON.GeoJSON | null = null;
   readonly FormMessageType = FormMessageType;
   readonly dialogRef = inject(MatDialogRef<UploadProjectAreasModalComponent>);
   readonly data = inject<DialogData>(MAT_DIALOG_DATA);
@@ -118,8 +117,7 @@ export class UploadProjectAreasModalComponent {
       const geojson = (await shp.parseZip(
         fileAsArrayBuffer
       )) as GeoJSON.GeoJSON;
-      if (geojson.type == 'FeatureCollection') {
-        // Note: this has to be set to a value in order for the 'create' button to be enabled
+      if (Array.isArray(geojson) || geojson.type == 'FeatureCollection') {
         this.geometries = geojson;
       } else {
         this.uploadElementStatus = 'failed';
@@ -166,8 +164,8 @@ export class UploadProjectAreasModalComponent {
             this.dialogRef.close({ response: response });
           },
           error: (err: any) => {
-            if (err.error.error !== undefined) {
-              this.uploadError = err.error.error;
+            if (!!err.error?.global) {
+              this.uploadError = err.error.global.join(' ');
             } else {
               this.uploadError =
                 'An unknown error occured when trying to create a scenario.';


### PR DESCRIPTION
This PR addresses a few competing issues:
1. The serializer stand size options didn't allow nulls, nor did it match the format of values from the frontend
2. Some shpjs files are parsed as an array of FeatureCollection objects, which weren't being passed to the backend
3. The backend response about shapefiles not fitting within their planning areas was not being shown to the user
4. The serializer was not handling cases where a geojson was still a list or (somehow) still a string