### PR TITLE
PLAN-1796: Moving about tab on treatment overview

### DIFF
--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.html
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.html
@@ -3,12 +3,12 @@
   mat-align-tabs="start"
   disablePagination="true">
   <mat-tab label="Project Areas"
-  ><app-project-areas-tab></app-project-areas-tab>
-</mat-tab>
-<mat-tab label="Base Maps">
-  <app-map-base-layer></app-map-base-layer>
-</mat-tab>
-<mat-tab label="About">
-  <app-treatment-plan-about-tab></app-treatment-plan-about-tab>
-</mat-tab>
+    ><app-project-areas-tab></app-project-areas-tab>
+  </mat-tab>
+  <mat-tab label="Base Maps">
+    <app-map-base-layer></app-map-base-layer>
+  </mat-tab>
+  <mat-tab label="About">
+    <app-treatment-plan-about-tab></app-treatment-plan-about-tab>
+  </mat-tab>
 </mat-tab-group>

--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.html
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.html
@@ -2,13 +2,13 @@
   class="summary-tab-group"
   mat-align-tabs="start"
   disablePagination="true">
-  <mat-tab label="About">
-    <app-treatment-plan-about-tab></app-treatment-plan-about-tab>
-  </mat-tab>
   <mat-tab label="Project Areas"
-    ><app-project-areas-tab></app-project-areas-tab>
-  </mat-tab>
-  <mat-tab label="Base Maps">
-    <app-map-base-layer></app-map-base-layer>
-  </mat-tab>
+  ><app-project-areas-tab></app-project-areas-tab>
+</mat-tab>
+<mat-tab label="Base Maps">
+  <app-map-base-layer></app-map-base-layer>
+</mat-tab>
+<mat-tab label="About">
+  <app-treatment-plan-about-tab></app-treatment-plan-about-tab>
+</mat-tab>
 </mat-tab-group>


### PR DESCRIPTION
Moving the "about" tab on treatments overview page.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1796

Result:
![image](https://github.com/user-attachments/assets/d5139303-79a1-4945-ab6c-80cd896d7cb5)
