### PR TITLE
Nest the project area notes URLs under project-areas

### DIFF
--- a/src/planscape/planning/permissions.py
+++ b/src/planscape/planning/permissions.py
@@ -50,9 +50,10 @@ class ProjectAreaNoteViewPermission(PlanscapePermission):
         if not self.is_authenticated(request):
             return False
 
+        project_area_id = view.kwargs.get("project_area_id")
+
         match view.action:
             case "create":
-                project_area_id = request.data.get("project_area") or None
                 if not project_area_id:
                     return False
                 try:
@@ -62,7 +63,6 @@ class ProjectAreaNoteViewPermission(PlanscapePermission):
                 return ProjectAreaNotePermission.can_add(request.user, project_area)
 
             case "list":
-                project_area_id = request.query_params.get("project_area_pk") or None
                 if not project_area_id:
                     raise ValidationError(f"Missing required project_area_pk")
                 try:

--- a/src/planscape/planning/routers.py
+++ b/src/planscape/planning/routers.py
@@ -25,7 +25,7 @@ router.register(
 )
 router.register("project-areas", ProjectAreaViewSet, basename="project-areas")
 router.register(
-    r"projectarea-notes",
+    "project-areas/(?P<project_area_id>\d+)/note",
     ProjectAreaNoteViewSet,
-    basename="projectarea-notes",
+    basename="project-areas-notes",
 )

--- a/src/planscape/planning/tests/test_planningarea_views.py
+++ b/src/planscape/planning/tests/test_planningarea_views.py
@@ -1282,6 +1282,23 @@ class GetPlanningAreaNotes(APITestCase):
             self.owner_user.pk,
         )
 
+    def test_get_note_delete_permissions(self):
+        self.client.force_authenticate(self.collab_user)
+        response = self.client.get(
+            reverse(
+                "planning:get_planningareanote",
+                kwargs={"planningarea_pk": self.planningarea.pk},
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        planning_area_notes = response.json()
+        self.assertEqual(len(planning_area_notes), 3)
+        self.assertEqual(planning_area_notes[0]["can_delete"], False)
+        # note owned by collab_user, so can delete
+        self.assertEqual(planning_area_notes[1]["can_delete"], True)
+        self.assertEqual(planning_area_notes[2]["can_delete"], False)
+
     def test_get_notes_unauthenticated(self):
         response = self.client.post(
             reverse(

--- a/src/planscape/planning/views.py
+++ b/src/planscape/planning/views.py
@@ -33,6 +33,7 @@ from planning.serializers import (
     ScenarioSerializer,
     SharedLinkSerializer,
     PlanningAreaNoteSerializer,
+    PlanningAreaNoteListSerializer,
     ValidatePlanningAreaOutputSerializer,
     ValidatePlanningAreaSerializer,
 )
@@ -982,8 +983,10 @@ class PlanningAreaNotes(APIView):
                 )
                 if not PlanningAreaNotePermission.can_view(user, planningareanote):
                     return Response(status=status.HTTP_403_FORBIDDEN)
-                serializer = PlanningAreaNoteSerializer(
-                    instance=planningareanote, many=False
+                serializer = PlanningAreaNoteListSerializer(
+                    instance=planningareanote,
+                    many=False,
+                    context={"request": request, "user": user},
                 )
                 return Response(serializer.data)
 
@@ -997,7 +1000,11 @@ class PlanningAreaNotes(APIView):
                 notes = PlanningAreaNote.objects.filter(
                     planning_area=planningarea_pk
                 ).order_by("-created_at")
-                serializer = PlanningAreaNoteSerializer(instance=notes, many=True)
+                serializer = PlanningAreaNoteListSerializer(
+                    instance=notes,
+                    many=True,
+                    context={"request": request, "user": user},
+                )
                 return Response(serializer.data)
 
         except PlanningArea.DoesNotExist as pa_dne:

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -30,6 +30,7 @@ from planning.serializers import (
     PlanningAreaSerializer,
     ProjectAreaNoteSerializer,
     ProjectAreaNoteListSerializer,
+    ProjectAreaNoteCreateSerializer,
     ProjectAreaSerializer,
     ScenarioSerializer,
     ScenarioAndProjectAreasSerializer,
@@ -272,37 +273,19 @@ class ProjectAreaViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     }
 
 
-class ProjectAreaNoteViewSet(
-    mixins.ListModelMixin,
-    mixins.CreateModelMixin,
-    mixins.DestroyModelMixin,
-    mixins.RetrieveModelMixin,
-    viewsets.GenericViewSet,
-):
+class ProjectAreaNoteViewSet(viewsets.ModelViewSet):
     queryset = ProjectAreaNote.objects.all()
-    permission_classes = [ProjectAreaNoteViewPermission]
     serializer_class = ProjectAreaNoteSerializer
+    permission_classes = [ProjectAreaNoteViewPermission]
     serializer_classes = {
         "list": ProjectAreaNoteListSerializer,
+        "create": ProjectAreaNoteCreateSerializer,
     }
     filterset_class = ProjectAreaNoteFilterSet
     filter_backends = [DjangoFilterBackend]
 
-    def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-
-        note = create_projectarea_note(
-            self.request.user,
-            **serializer.validated_data,
-        )
-        out_serializer = ProjectAreaNoteSerializer(instance=note)
-        headers = self.get_success_headers(out_serializer.data)
-        return Response(
-            out_serializer.data,
-            status=status.HTTP_201_CREATED,
-            headers=headers,
-        )
+    # def get_serializer_class(self):
+    #     return self.serializer_classes.get(self.action, ProjectAreaNoteSerializer)
 
     def get_serializer_class(self):
         return (
@@ -310,12 +293,11 @@ class ProjectAreaNoteViewSet(
             or self.serializer_class
         )
 
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
     def get_queryset(self):
-        user = self.request.user
-        queryset = ProjectAreaNote.objects.select_related("project_area")
-
-        project_area_pk = self.request.query_params.get("project_area_pk")
-        if project_area_pk:
-            queryset = queryset.filter(project_area__pk=project_area_pk)
-
-        return queryset
+        project_area_id = self.kwargs.get("project_area_id")
+        if project_area_id is None:
+            raise ValueError("project_area_id is required")
+        return self.queryset.filter(project_area_id=project_area_id)

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -284,9 +284,6 @@ class ProjectAreaNoteViewSet(viewsets.ModelViewSet):
     filterset_class = ProjectAreaNoteFilterSet
     filter_backends = [DjangoFilterBackend]
 
-    # def get_serializer_class(self):
-    #     return self.serializer_classes.get(self.action, ProjectAreaNoteSerializer)
-
     def get_serializer_class(self):
         return (
             self.serializer_classes.get(self.action, self.serializer_class)


### PR DESCRIPTION
I think, for now, in order to push the notes components for project-areas, we should stay consistent with the url formats that exist for the planning-area notes.

If we ultimately decide to change our approach later to resources that don't depend on related objects, I think it will be less work to change them all together, rather than have FE interfaces that operate differently.

This PR:  
-changes the format of ProjectArea Notes urls  
-updates some serializers to accomodate this change  
-ensures we include 'can_delete' as backend attributes in the List serializers for planningarea notes and projectarea notes  
-adds some tests