### PR TITLE
PLAN-1829: Selected stands yellow outline

### DIFF
--- a/src/interface/src/app/treatments/map-stands/map-stands.component.html
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.html
@@ -38,7 +38,7 @@
 
   <mgl-layer
     [id]="layers.selectedStands.name"
-    type="fill"
+    type="line"
     source="stands"
     [paint]="layers.selectedStands.paint"
     [sourceLayer]="layers.selectedStands.sourceLayer"></mgl-layer>

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -38,7 +38,7 @@ import {
   generatePaintForSequencedStands,
   generatePaintForTreatedStands,
   PROJECT_AREA_OUTLINE_PAINT,
-  SELECTED_STANDS_PAINT,
+  SELECTED_STANDS_LINE_PAINT,
   STANDS_CELL_PAINT,
 } from '../map.styles';
 import { PATTERN_NAMES, PatternName, SEQUENCE_ACTIONS } from '../prescriptions';
@@ -172,7 +172,7 @@ export class MapStandsComponent implements OnChanges, OnInit {
     selectedStands: {
       name: 'stands-layer-selected',
       sourceLayer: 'stands_by_tx_plan',
-      paint: SELECTED_STANDS_PAINT as any,
+      paint: SELECTED_STANDS_LINE_PAINT as any,
     },
   };
 

--- a/src/interface/src/app/treatments/map.styles.ts
+++ b/src/interface/src/app/treatments/map.styles.ts
@@ -9,7 +9,7 @@ import {
 } from './prescriptions';
 
 export const BASE_COLORS: Record<
-  'white' | 'black' | 'blue' | 'dark' | 'light',
+  'white' | 'black' | 'blue' | 'dark' | 'light' | 'yellow',
   string
 > = {
   white: '#FFF',
@@ -17,22 +17,23 @@ export const BASE_COLORS: Record<
   dark: '#4A4A4A',
   light: '#F6F6F650',
   blue: '#007dff',
+  yellow: '#FFD54F',
 };
 
-export const SELECTED_STANDS_PAINT = {
-  'fill-color': [
+export const SELECTED_STANDS_LINE_PAINT = {
+  'line-color': [
     'case',
     ['boolean', ['feature-state', 'selected'], false],
-    BASE_COLORS.blue,
-    'transparent',
+    BASE_COLORS.yellow, // Selected
+    'transparent', // Non selected
   ],
-  'fill-outline-color': [
+  'line-width': [
     'case',
     ['boolean', ['feature-state', 'selected'], false],
-    BASE_COLORS.black,
-    'transparent',
+    8, // Selected
+    1, // Non selected
   ],
-  'fill-opacity': 0.7,
+  'line-opacity': 1,
 };
 
 export const PROJECT_AREA_OUTLINE_PAINT = {


### PR DESCRIPTION
We’ve changed the way we highlight the selected stand. Instead of filling it, we now change the outline color.

We’re using the same color specified in Figma, and I confirmed with Jordan that the highlighted line width is correct.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1829

Figma: https://www.figma.com/design/njHEIn6MWPYJ5hw4we0lFY/Impacts?node-id=921-18337&node-type=frame&t=uGvA5LUwOtcoCRW9-0

Result: 
![image](https://github.com/user-attachments/assets/40842bf3-b624-45d7-9029-92c525847af8)
