### PR TITLE
Lucho plan 1829 select stands yellow outline

### DIFF
--- a/src/interface/src/app/treatments/map-stands/map-stands.component.html
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.html
@@ -38,7 +38,7 @@
 
   <mgl-layer
     [id]="layers.selectedStands.name"
-    type="line"
+    type="fill"
     source="stands"
     [paint]="layers.selectedStands.paint"
     [sourceLayer]="layers.selectedStands.sourceLayer"></mgl-layer>

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.html
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.html
@@ -38,7 +38,7 @@
 
   <mgl-layer
     [id]="layers.selectedStands.name"
-    type="fill"
+    type="line"
     source="stands"
     [paint]="layers.selectedStands.paint"
     [sourceLayer]="layers.selectedStands.sourceLayer"></mgl-layer>

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -38,7 +38,7 @@ import {
   generatePaintForSequencedStands,
   generatePaintForTreatedStands,
   PROJECT_AREA_OUTLINE_PAINT,
-  SELECTED_STANDS_LINE_PAINT,
+  SELECTED_STANDS_PAINT,
   STANDS_CELL_PAINT,
 } from '../map.styles';
 import { PATTERN_NAMES, PatternName, SEQUENCE_ACTIONS } from '../prescriptions';
@@ -177,7 +177,7 @@ export class MapStandsComponent implements OnChanges, OnInit {
     selectedStands: {
       name: 'stands-layer-selected',
       sourceLayer: 'stands_by_tx_plan',
-      paint: SELECTED_STANDS_LINE_PAINT as any,
+      paint: SELECTED_STANDS_PAINT as any,
     },
   };
 

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -38,7 +38,7 @@ import {
   generatePaintForSequencedStands,
   generatePaintForTreatedStands,
   PROJECT_AREA_OUTLINE_PAINT,
-  SELECTED_STANDS_LINE_PAINT,
+  SELECTED_STANDS_PAINT,
   STANDS_CELL_PAINT,
 } from '../map.styles';
 import { PATTERN_NAMES, PatternName, SEQUENCE_ACTIONS } from '../prescriptions';
@@ -172,7 +172,7 @@ export class MapStandsComponent implements OnChanges, OnInit {
     selectedStands: {
       name: 'stands-layer-selected',
       sourceLayer: 'stands_by_tx_plan',
-      paint: SELECTED_STANDS_LINE_PAINT as any,
+      paint: SELECTED_STANDS_PAINT as any,
     },
   };
 

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -38,7 +38,7 @@ import {
   generatePaintForSequencedStands,
   generatePaintForTreatedStands,
   PROJECT_AREA_OUTLINE_PAINT,
-  SELECTED_STANDS_PAINT,
+  SELECTED_STANDS_LINE_PAINT,
   STANDS_CELL_PAINT,
 } from '../map.styles';
 import { PATTERN_NAMES, PatternName, SEQUENCE_ACTIONS } from '../prescriptions';
@@ -172,7 +172,7 @@ export class MapStandsComponent implements OnChanges, OnInit {
     selectedStands: {
       name: 'stands-layer-selected',
       sourceLayer: 'stands_by_tx_plan',
-      paint: SELECTED_STANDS_PAINT as any,
+      paint: SELECTED_STANDS_LINE_PAINT as any,
     },
   };
 

--- a/src/interface/src/app/treatments/map.styles.ts
+++ b/src/interface/src/app/treatments/map.styles.ts
@@ -32,7 +32,7 @@ export const SELECTED_STANDS_PAINT = {
     ['boolean', ['feature-state', 'selected'], false],
     BASE_COLORS.black,
     'transparent',
-  ]
+  ],
 };
 
 export const PROJECT_AREA_OUTLINE_PAINT = {

--- a/src/interface/src/app/treatments/map.styles.ts
+++ b/src/interface/src/app/treatments/map.styles.ts
@@ -20,20 +20,19 @@ export const BASE_COLORS: Record<
   yellow: '#FFD54F',
 };
 
-export const SELECTED_STANDS_LINE_PAINT = {
-  'line-color': [
+export const SELECTED_STANDS_PAINT = {
+  'fill-color': [
     'case',
     ['boolean', ['feature-state', 'selected'], false],
-    BASE_COLORS.yellow, // Selected
-    'transparent', // Non selected
+    BASE_COLORS.yellow,
+    'transparent',
   ],
-  'line-width': [
+  'fill-outline-color': [
     'case',
     ['boolean', ['feature-state', 'selected'], false],
-    8, // Selected
-    1, // Non selected
-  ],
-  'line-opacity': 1,
+    BASE_COLORS.black,
+    'transparent',
+  ]
 };
 
 export const PROJECT_AREA_OUTLINE_PAINT = {

--- a/src/interface/src/app/treatments/map.styles.ts
+++ b/src/interface/src/app/treatments/map.styles.ts
@@ -9,7 +9,7 @@ import {
 } from './prescriptions';
 
 export const BASE_COLORS: Record<
-  'white' | 'black' | 'blue' | 'dark' | 'light',
+  'white' | 'black' | 'blue' | 'dark' | 'light' | 'yellow',
   string
 > = {
   white: '#FFF',
@@ -17,22 +17,23 @@ export const BASE_COLORS: Record<
   dark: '#4A4A4A',
   light: '#F6F6F650',
   blue: '#007dff',
+  yellow: '#FFD54F',
 };
 
-export const SELECTED_STANDS_PAINT = {
-  'fill-color': [
+export const SELECTED_STANDS_LINE_PAINT = {
+  'line-color': [
     'case',
     ['boolean', ['feature-state', 'selected'], false],
-    BASE_COLORS.blue,
-    'transparent',
+    BASE_COLORS.yellow, // Selected
+    'transparent', // Non selected
   ],
-  'fill-outline-color': [
+  'line-width': [
     'case',
     ['boolean', ['feature-state', 'selected'], false],
-    BASE_COLORS.black,
-    'transparent',
+    8, // Selected
+    1, // Non selected
   ],
-  'fill-opacity': 0.7,
+  'line-opacity': 1,
 };
 
 export const PROJECT_AREA_OUTLINE_PAINT = {


### PR DESCRIPTION
When we select a stand we should fill it with yellow color.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1829

Result:

![image](https://github.com/user-attachments/assets/2e78a65e-3464-4ca6-8bd1-60f2ceb20764)
