### PR TITLE
PLAN-1798: Add hover state to project areas 

### DIFF
--- a/src/interface/src/app/color.service.ts
+++ b/src/interface/src/app/color.service.ts
@@ -1,48 +1,43 @@
 import { Injectable } from '@angular/core';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ColorService {
-    /**
+  /**
    * Darkens a specified color by a given percentage.
    * @param hexColor The color in hexadecimal format (#RRGGBB).
    * @param percent The percentage by which to darken the color (0-100).
    * @returns The darkened color in hexadecimal format.
    */
-    darkenColor(hexColor: string, percent: number): string {
-      // Remove the '#' character if present
-      hexColor = hexColor.replace('#', '');
-  
-      // Convert HEX to RGB
-      const r = parseInt(hexColor.substring(0, 2), 16);
-      const g = parseInt(hexColor.substring(2, 4), 16);
-      const b = parseInt(hexColor.substring(4, 6), 16);
-  
-      // Calculate the darkness factor
-      const factor = (100 - percent) / 100;
-  
-      // Apply the darkness factor to each color channel
-      const newR = Math.floor(r * factor);
-      const newG = Math.floor(g * factor);
-      const newB = Math.floor(b * factor);
-  
-      // Convert back to HEX
-      return (
-        '#' +
-        this.toHex(newR) +
-        this.toHex(newG) +
-        this.toHex(newB)
-      );
-    }
+  darkenColor(hexColor: string, percent: number): string {
+    // Remove the '#' character if present
+    hexColor = hexColor.replace('#', '');
 
-    /**
+    // Convert HEX to RGB
+    const r = parseInt(hexColor.substring(0, 2), 16);
+    const g = parseInt(hexColor.substring(2, 4), 16);
+    const b = parseInt(hexColor.substring(4, 6), 16);
+
+    // Calculate the darkness factor
+    const factor = (100 - percent) / 100;
+
+    // Apply the darkness factor to each color channel
+    const newR = Math.floor(r * factor);
+    const newG = Math.floor(g * factor);
+    const newB = Math.floor(b * factor);
+
+    // Convert back to HEX
+    return '#' + this.toHex(newR) + this.toHex(newG) + this.toHex(newB);
+  }
+
+  /**
    * Converts a number to a 2-digit HEX format.
    * @param value A number between 0 and 255.
    * @returns A 2-character HEX string.
    */
-    private toHex(value: number): string {
-      const hex = value.toString(16);
-      return hex.length === 1 ? '0' + hex : hex;
-    }
+  private toHex(value: number): string {
+    const hex = value.toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  }
 }

--- a/src/interface/src/app/color.service.ts
+++ b/src/interface/src/app/color.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ColorService {
+    /**
+   * Darkens a specified color by a given percentage.
+   * @param hexColor The color in hexadecimal format (#RRGGBB).
+   * @param percent The percentage by which to darken the color (0-100).
+   * @returns The darkened color in hexadecimal format.
+   */
+    darkenColor(hexColor: string, percent: number): string {
+      // Remove the '#' character if present
+      hexColor = hexColor.replace('#', '');
+  
+      // Convert HEX to RGB
+      const r = parseInt(hexColor.substring(0, 2), 16);
+      const g = parseInt(hexColor.substring(2, 4), 16);
+      const b = parseInt(hexColor.substring(4, 6), 16);
+  
+      // Calculate the darkness factor
+      const factor = (100 - percent) / 100;
+  
+      // Apply the darkness factor to each color channel
+      const newR = Math.floor(r * factor);
+      const newG = Math.floor(g * factor);
+      const newB = Math.floor(b * factor);
+  
+      // Convert back to HEX
+      return (
+        '#' +
+        this.toHex(newR) +
+        this.toHex(newG) +
+        this.toHex(newB)
+      );
+    }
+
+    /**
+   * Converts a number to a 2-digit HEX format.
+   * @param value A number between 0 and 255.
+   * @returns A 2-character HEX string.
+   */
+    private toHex(value: number): string {
+      const hex = value.toString(16);
+      return hex.length === 1 ? '0' + hex : hex;
+    }
+}

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
@@ -18,7 +18,7 @@
   [paint]="{
     'fill-color': [
       'case',
-      ['==', ['get', 'id'], hoveredProjectAreaId$.value],
+      ['==', ['get', 'id'], hoveredProjectAreaFromFeatures?.properties?.['id']],
       hoveredFillColor,
       fillColor
     ],

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
@@ -2,7 +2,7 @@
   id="scenarioProjectAreas"
   [tiles]="[vectorLayerUrl]"></mgl-vector-source>
 
-  <mgl-layer
+<mgl-layer
   [id]="layers.projectAreasFill.name"
   type="fill"
   source="scenarioProjectAreas"

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.html
@@ -2,7 +2,7 @@
   id="scenarioProjectAreas"
   [tiles]="[vectorLayerUrl]"></mgl-vector-source>
 
-<mgl-layer
+  <mgl-layer
   [id]="layers.projectAreasFill.name"
   type="fill"
   source="scenarioProjectAreas"
@@ -16,7 +16,12 @@
   "
   [sourceLayer]="layers.projectAreasFill.sourceLayer"
   [paint]="{
-    'fill-color': fillColor,
+    'fill-color': [
+      'case',
+      ['==', ['get', 'id'], hoveredProjectAreaId$.value],
+      hoveredFillColor,
+      fillColor
+    ],
     'fill-opacity': visible && withFill ? 0.5 : 0
   }"></mgl-layer>
 

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
@@ -163,7 +163,9 @@ export class MapProjectAreasComponent implements OnInit {
       e.point
     );
     if (this.hoveredProjectAreaFromFeatures?.properties?.['id']) {
-      this.hoveredProjectAreaId$.next(this.hoveredProjectAreaFromFeatures.properties['id']);
+      this.hoveredProjectAreaId$.next(
+        this.hoveredProjectAreaFromFeatures.properties['id']
+      );
     }
     this.updateHoveredFillColor(
       this.hoveredProjectAreaFromFeatures.properties['rank']

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
@@ -155,7 +155,7 @@ export class MapProjectAreasComponent implements OnInit {
       e.point
     );
     this.updateHoveredFillColor(
-      this.hoveredProjectAreaFromFeatures.properties['id']
+      this.hoveredProjectAreaFromFeatures.properties['rank']
     );
     this.mouseLngLat = e.lngLat;
   }
@@ -175,9 +175,9 @@ export class MapProjectAreasComponent implements OnInit {
     return features[0];
   }
 
-  updateHoveredFillColor(projectAreaId: number | null) {
-    if (projectAreaId) {
-      const baseColor = getColorForProjectPosition(projectAreaId + 6);
+  updateHoveredFillColor(projectAreaRank: number | null) {
+    if (projectAreaRank) {
+      const baseColor = getColorForProjectPosition(projectAreaRank);
       this.hoveredFillColor = this.colorService.darkenColor(baseColor, 20);
     } else {
       this.hoveredFillColor = BASE_COLORS['dark'];

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
@@ -7,6 +7,7 @@ import { getColorForProjectPosition } from '../../plan/plan-helpers';
 import {
   LayerSpecification,
   LngLat,
+  MapGeoJSONFeature,
   Map as MapLibreMap,
   MapMouseEvent,
   Point,
@@ -21,13 +22,11 @@ import { BASE_COLORS, LABEL_PAINT } from '../map.styles';
 import { getTreatedStandsTotal } from '../prescriptions';
 import { TreatmentProjectArea } from '@types';
 import {
-  combineLatest,
   Observable,
-  distinctUntilChanged,
   map,
-  BehaviorSubject,
 } from 'rxjs';
 import { MapConfigState } from '../treatment-map/map-config.state';
+import { ColorService } from 'src/app/color.service';
 
 type MapLayerData = {
   readonly name: string;
@@ -62,15 +61,12 @@ export class MapProjectAreasComponent implements OnInit {
   fillColor!: any;
   getTreatedStandsTotal = getTreatedStandsTotal;
 
-  hoveredProjectAreaId$ = new BehaviorSubject<any>(null);
+  hoveredProjectAreaFromFeatures: MapGeoJSONFeature | null = null;
   hoveredProjectArea$: Observable<TreatmentProjectArea | undefined> =
-    combineLatest([
-      this.summary$,
-      this.hoveredProjectAreaId$.pipe(distinctUntilChanged()),
-    ]).pipe(
-      map(([summary, projectAreaId]) => {
+      this.summary$.pipe(
+      map((summary) => {
         return summary?.project_areas.find(
-          (p: TreatmentProjectArea) => p.project_area_id === projectAreaId
+          (p: TreatmentProjectArea) => p.project_area_id === this.hoveredProjectAreaFromFeatures?.properties['id']
         );
       })
     );
@@ -107,7 +103,8 @@ export class MapProjectAreasComponent implements OnInit {
     private treatmentsState: TreatmentsState,
     private router: Router,
     private route: ActivatedRoute,
-    private mapConfigState: MapConfigState
+    private mapConfigState: MapConfigState,
+    private colorService: ColorService
   ) {}
 
   get vectorLayerUrl() {
@@ -132,7 +129,7 @@ export class MapProjectAreasComponent implements OnInit {
   }
 
   goToProjectArea(event: MapMouseEvent) {
-    const projectAreaId = this.getProjectAreaIdFromFeatures(event.point);
+    const projectAreaId = this.getProjectAreaFromFeatures(event.point).properties['id'];
     this.mouseLngLat = null;
 
     this.router
@@ -154,75 +151,32 @@ export class MapProjectAreasComponent implements OnInit {
     if (this.treatmentsState.getProjectAreaId()) {
       return;
     }
-    const hoveredProjectAreaId = this.getProjectAreaIdFromFeatures(e.point);
-    this.hoveredProjectAreaId$.next(hoveredProjectAreaId);
-    this.updateHoveredFillColor(hoveredProjectAreaId);
+    this.hoveredProjectAreaFromFeatures = this.getProjectAreaFromFeatures(e.point);
+    this.updateHoveredFillColor(this.hoveredProjectAreaFromFeatures.properties['id']);
     this.mouseLngLat = e.lngLat;
   }
 
   resetCursorAndTooltip(e: MapMouseEvent) {
     this.mapLibreMap.getCanvas().style.cursor = '';
-    this.hoveredProjectAreaId$.next(null);
+    this.hoveredProjectAreaFromFeatures = null;
     this.updateHoveredFillColor(null);
     this.mouseLngLat = null;
   }
 
-  private getProjectAreaIdFromFeatures(point: Point): number | null {
+  private getProjectAreaFromFeatures(point: Point): MapGeoJSONFeature {
     const features = this.mapLibreMap.queryRenderedFeatures(point, {
       layers: ['map-project-areas-fill'],
     });
 
-    return features[0].properties['id'];
+    return features[0];
   }
 
   updateHoveredFillColor(projectAreaId: number | null) {
     if (projectAreaId) {
       const baseColor = getColorForProjectPosition(projectAreaId + 6);
-      this.hoveredFillColor = this.darkenColor(baseColor, 20);
+      this.hoveredFillColor = this.colorService.darkenColor(baseColor, 20);
     } else {
       this.hoveredFillColor = BASE_COLORS['dark'];
     }
-  }
-
-  /**
-   * Darkens a specified color by a given percentage.
-   * @param hexColor The color in hexadecimal format (#RRGGBB).
-   * @param percent The percentage by which to darken the color (0-100).
-   * @returns The darkened color in hexadecimal format.
-   */
-  darkenColor(hexColor: string, percent: number): string {
-    // Remove the '#' character if present
-    hexColor = hexColor.replace('#', '');
-
-    // Convert HEX to RGB
-    const r = parseInt(hexColor.substring(0, 2), 16);
-    const g = parseInt(hexColor.substring(2, 4), 16);
-    const b = parseInt(hexColor.substring(4, 6), 16);
-
-    // Calculate the darkness factor
-    const factor = (100 - percent) / 100;
-
-    // Apply the darkness factor to each color channel
-    const newR = Math.floor(r * factor);
-    const newG = Math.floor(g * factor);
-    const newB = Math.floor(b * factor);
-
-    // Convert back to HEX
-    return (
-      '#' +
-      this.toHex(newR) +
-      this.toHex(newG) +
-      this.toHex(newB)
-    );
-  }
-
-  /**
-   * Converts a number to a 2-digit HEX format.
-   * @param value A number between 0 and 255.
-   * @returns A 2-character HEX string.
-   */
-  private toHex(value: number): string {
-    const hex = value.toString(16);
-    return hex.length === 1 ? '0' + hex : hex;
   }
 }

--- a/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/treatments/map-project-areas/map-project-areas.component.ts
@@ -21,10 +21,7 @@ import { MapTooltipComponent } from '../map-tooltip/map-tooltip.component';
 import { BASE_COLORS, LABEL_PAINT } from '../map.styles';
 import { getTreatedStandsTotal } from '../prescriptions';
 import { TreatmentProjectArea } from '@types';
-import {
-  Observable,
-  map,
-} from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { MapConfigState } from '../treatment-map/map-config.state';
 import { ColorService } from 'src/app/color.service';
 
@@ -63,14 +60,16 @@ export class MapProjectAreasComponent implements OnInit {
 
   hoveredProjectAreaFromFeatures: MapGeoJSONFeature | null = null;
   hoveredProjectArea$: Observable<TreatmentProjectArea | undefined> =
-      this.summary$.pipe(
+    this.summary$.pipe(
       map((summary) => {
         return summary?.project_areas.find(
-          (p: TreatmentProjectArea) => p.project_area_id === this.hoveredProjectAreaFromFeatures?.properties['id']
+          (p: TreatmentProjectArea) =>
+            p.project_area_id ===
+            this.hoveredProjectAreaFromFeatures?.properties['id']
         );
       })
     );
-    hoveredFillColor = BASE_COLORS['dark'];
+  hoveredFillColor = BASE_COLORS['dark'];
 
   readonly tilesUrl =
     environment.martin_server + 'project_areas_by_scenario/{z}/{x}/{y}';
@@ -79,21 +78,21 @@ export class MapProjectAreasComponent implements OnInit {
     'projectAreasOutline' | 'projectAreasFill' | 'projectAreaLabels',
     MapLayerData
   > = {
-      projectAreasOutline: {
-        name: 'map-project-areas-line',
-        sourceLayer: 'project_areas_by_scenario',
-        color: BASE_COLORS['dark'],
-      },
-      projectAreasFill: {
-        name: 'map-project-areas-fill',
-        sourceLayer: 'project_areas_by_scenario',
-      },
-      projectAreaLabels: {
-        name: 'map-project-areas-labels',
-        sourceLayer: 'project_areas_by_scenario_label',
-        paint: LABEL_PAINT,
-      },
-    };
+    projectAreasOutline: {
+      name: 'map-project-areas-line',
+      sourceLayer: 'project_areas_by_scenario',
+      color: BASE_COLORS['dark'],
+    },
+    projectAreasFill: {
+      name: 'map-project-areas-fill',
+      sourceLayer: 'project_areas_by_scenario',
+    },
+    projectAreaLabels: {
+      name: 'map-project-areas-labels',
+      sourceLayer: 'project_areas_by_scenario_label',
+      paint: LABEL_PAINT,
+    },
+  };
 
   textSize$ = this.mapConfigState.zoomLevel$.pipe(
     map((zoomLevel) => (zoomLevel > 9 ? 14 : 0))
@@ -129,7 +128,8 @@ export class MapProjectAreasComponent implements OnInit {
   }
 
   goToProjectArea(event: MapMouseEvent) {
-    const projectAreaId = this.getProjectAreaFromFeatures(event.point).properties['id'];
+    const projectAreaId = this.getProjectAreaFromFeatures(event.point)
+      .properties['id'];
     this.mouseLngLat = null;
 
     this.router
@@ -151,8 +151,12 @@ export class MapProjectAreasComponent implements OnInit {
     if (this.treatmentsState.getProjectAreaId()) {
       return;
     }
-    this.hoveredProjectAreaFromFeatures = this.getProjectAreaFromFeatures(e.point);
-    this.updateHoveredFillColor(this.hoveredProjectAreaFromFeatures.properties['id']);
+    this.hoveredProjectAreaFromFeatures = this.getProjectAreaFromFeatures(
+      e.point
+    );
+    this.updateHoveredFillColor(
+      this.hoveredProjectAreaFromFeatures.properties['id']
+    );
     this.mouseLngLat = e.lngLat;
   }
 


### PR DESCRIPTION
Add hover state to project areas on treatment overview page to deepen color when hovering
As discussed with the team, we will apply a 20% darker color to the project area when hovering over it.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1798
