### PR TITLE
fixes async bugs with stands summary and run treatment analysis button

### DIFF
--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -9,6 +9,7 @@ import {
   map,
   Observable,
   of,
+  shareReplay,
   switchMap,
   tap,
 } from 'rxjs';
@@ -72,8 +73,10 @@ export class TreatmentsState {
   );
 
   public planningArea$: Observable<Plan> = this._planningAreaId$.pipe(
+    distinctUntilChanged(),
     filter((id): id is number => !!id),
-    switchMap((id) => this.planStateService.getPlan(id.toString()))
+    switchMap((id) => this.planStateService.getPlan(id.toString())),
+    shareReplay(1)
   );
 
   breadcrumbs$ = combineLatest([this.activeProjectArea$, this.summary$]).pipe(
@@ -288,7 +291,7 @@ export class TreatmentsState {
       );
   }
 
-  private selectProjectArea(projectAreaId: number) {
+  private selectProjectArea(projectAreaId: number, setStands = false) {
     const summary = this._summary$.value;
 
     if (!summary) {
@@ -304,7 +307,9 @@ export class TreatmentsState {
     this._projectAreaId$.next(projectAreaId);
     this.mapConfigState.updateShowTreatmentStands(true);
     this.mapConfigState.updateMapCenter(projectArea?.extent);
-    this.setTreatedStandsFromSummary([projectArea]);
+    if (setStands) {
+      this.setTreatedStandsFromSummary([projectArea]);
+    }
   }
 
   getCurrentSummary() {


### PR DESCRIPTION
This pr fixes a couple of bugs:
- Delay on showing 'run treatment analysis button' when coming back from Project Areas
- Race condition between applying treatments on map and loading summary