### PR TITLE
fix link on treatment email

### DIFF
--- a/src/planscape/impacts/tasks.py
+++ b/src/planscape/impacts/tasks.py
@@ -122,7 +122,7 @@ def async_send_email_process_finished(treatment_plan_pk, *args, **kwargs):
         link = urljoin(
             settings.PLANSCAPE_BASE_URL,
             f"plan/{treatment_plan.scenario.planning_area_id}/"
-            f"config/{treatment_plan.scenario.pk}/treatment/{treatment_plan_pk}",
+            f"config/{treatment_plan.scenario.pk}/treatment/{treatment_plan_pk}/impacts",
         )
 
         context = {


### PR DESCRIPTION
Link was for  {....}//treatment/{id}/ but the report/analysis url is actually {....}/treatment/{id}/impacts.

It works either way bc the FE is doing a redirect, but we should link directly to the right place