### PR TITLE
PLAN-1843: Wrong margin metric selector

### DIFF
--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
@@ -71,10 +71,12 @@
   grid-template-rows: repeat(12, 86px);
   gap: 16px;
   padding: 16px 0;
+  width: calc(100% - 16px);
 
   @include on-small() {
     display: flex;
     flex-direction: column;
+    width: 100%;
   }
 
 


### PR DESCRIPTION
Wrong margin corrected.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1843

Result desktop:
![image](https://github.com/user-attachments/assets/8a3eab23-9f52-4222-a77a-ffd141122946)


Result mobile: 
![image](https://github.com/user-attachments/assets/28062903-90ee-4ea6-b782-8e1dad2e1196)
