### PR TITLE
Fixes usage of `_list` when doing it from another command

### DIFF
--- a/src/planscape/datasets/management/commands/datalayers.py
+++ b/src/planscape/datasets/management/commands/datalayers.py
@@ -72,6 +72,7 @@ def get_create_call(name, input_file, dataset, metadata) -> List[str]:
         str(dataset),
         "--metadata",
         metadata,
+        "--skip-existing",
     ]
 
 
@@ -273,6 +274,7 @@ class Command(PlanscapeCommand):
             if skip_existing:
                 check_existing_args = {
                     "token": kwargs.get("token"),
+                    "env": kwargs.get("env"),
                     "dataset": dataset,
                     "name": name,
                 }
@@ -342,7 +344,6 @@ class Command(PlanscapeCommand):
                 files,
             )
         )
-
         if dry_run:
             for f in s3_files:
                 pprint(f)


### PR DESCRIPTION
When a particular command would call `_list`, it was missing the `env` key.
That makes the CLI think it needs to hit production.
