### PR TITLE
Django Admin, created_by bug fix - ensuring field is saved

### DIFF
--- a/src/planscape/datasets/admin.py
+++ b/src/planscape/datasets/admin.py
@@ -10,8 +10,18 @@ class CategoryAdmin(TreeAdmin):
     search_fields = ["name"]
     list_display = ("id", "name", "order", "dataset")
 
-    def get_changeform_initial_data(self, request) -> Dict[str, Any]:
-        return {"created_by": request.user}
+    # Attach the current user to the form
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        # Attach the current user so the form can access it if needed
+        form.current_user = request.user
+        return form
+
+    # On save, explicitly set created_by if it's not already set
+    def save_model(self, request, obj, form, change):
+        if not obj.created_by_id:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
 
 
 class DatasetAdmin(admin.ModelAdmin):
@@ -25,8 +35,15 @@ class DatasetAdmin(admin.ModelAdmin):
         "name",
     )
 
-    def get_changeform_initial_data(self, request) -> Dict[str, Any]:
-        return {"created_by": request.user}
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form.current_user = request.user
+        return form
+
+    def save_model(self, request, obj, form, change):
+        if not obj.created_by_id:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
 
 
 class DataLayerAdmin(admin.ModelAdmin):
@@ -64,6 +81,15 @@ class DataLayerAdmin(admin.ModelAdmin):
         "public_url",
     ]
 
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form.current_user = request.user
+        return form
+
+    def save_model(self, request, obj, form, change):
+        if not obj.created_by_id:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
 
 admin.site.register(Dataset, DatasetAdmin)
 admin.site.register(DataLayer, DataLayerAdmin)


### PR DESCRIPTION
Bug: Django Admin categories, datalayers, and datasets form auto-populates 'created_by' field -- so it looks filled -- but the field's content does not persist when form saved, citing "created_by field is required."

Fix: in 'datasets/admin.py', changed the method that auto-populates the 'created_by' field, so that the 'created_by' field is actually set before saving, rather than just displaying as filled.