### PR TITLE
PLAN-1890: Scenario tabs styles

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -31,8 +31,9 @@
     <div class="tab-container">
       <mat-tab-group
         [selectedIndex]="selectedTab"
+        class="create-scenarios-tab-group"
         [animationDuration]="tabAnimation">
-        <mat-tab label="Configuration">
+        <mat-tab label="Configurations">
           <div class="create-scenarios-inner-wrapper">
             <app-set-priorities></app-set-priorities>
             <app-identify-project-areas
@@ -94,7 +95,9 @@
               [scenarioState]="scenarioState"></app-scenario-failure>
           </div>
         </mat-tab>
-        <mat-tab label="Treatments" *ngIf="showTreatmentsTab && scenarioId">
+        <mat-tab
+          label="Treatment Plans"
+          *ngIf="showTreatmentsTab && scenarioId">
           <app-treatments-tab
             [scenarioId]="scenarioId"
             [planningArea]="plan$ | async"></app-treatments-tab>

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -149,3 +149,7 @@
 .new-treatment {
   margin: 0 16px;
 }
+
+.create-scenarios-tab-group ::ng-deep .mat-mdc-tab-header .mat-mdc-tab-label-container .mat-mdc-tab {
+  flex-grow: 0;
+}


### PR DESCRIPTION
Updating the styles for scenario tabs to match the figma design.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1890

Before: 
![image](https://github.com/user-attachments/assets/58f59951-e41c-4858-ad3d-a858a4ac1fff)


Result:
![image](https://github.com/user-attachments/assets/4332dfb9-7b72-470a-ab86-846f9b9215b9)
