### PR TITLE
PLAN-1836: Missing storybook icons

### DIFF
--- a/src/interface/.storybook/main.ts
+++ b/src/interface/.storybook/main.ts
@@ -8,7 +8,7 @@ const config: StorybookConfig = {
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
   ],
-  staticDirs: ['../src/assets'], 
+  staticDirs: ['../src/assets', '../src/assets/svg/icons/'], 
   framework: {
     name: '@storybook/angular',
     options: {},


### PR DESCRIPTION
The icones for the Project area Expander were not displayed correctly in storybook.
The issue was related to the way we import the assets in storybook.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1836

Before:
![image](https://github.com/user-attachments/assets/9a5cc301-e335-497a-9dbf-16c7066ed17e)


Now:
![image](https://github.com/user-attachments/assets/5c7af300-239e-41a6-9946-3157d33e282f)
