### PR TITLE
Show uploaded plan view shapes

### DIFF
--- a/src/interface/src/app/plan/uploaded-scenario-view/uploaded-scenario-view.component.ts
+++ b/src/interface/src/app/plan/uploaded-scenario-view/uploaded-scenario-view.component.ts
@@ -29,7 +29,6 @@ export class UploadedScenarioViewComponent implements OnInit {
 
   ngOnInit() {
     if (this.scenario) {
-    
       this.planStateService.planState$
         .pipe(untilDestroyed(this), take(1))
         .subscribe((planState) => {
@@ -40,7 +39,7 @@ export class UploadedScenarioViewComponent implements OnInit {
           );
           this.planStateService.updateStateWithShapes(
             this.scenario?.scenario_result?.result.features
-        );
+          );
         });
     }
   }

--- a/src/interface/src/app/plan/uploaded-scenario-view/uploaded-scenario-view.component.ts
+++ b/src/interface/src/app/plan/uploaded-scenario-view/uploaded-scenario-view.component.ts
@@ -29,6 +29,9 @@ export class UploadedScenarioViewComponent implements OnInit {
 
   ngOnInit() {
     if (this.scenario) {
+      this.planStateService.updateStateWithShapes(
+          this.scenario?.scenario_result?.result.features
+      );
       this.planStateService.planState$
         .pipe(untilDestroyed(this), take(1))
         .subscribe((planState) => {

--- a/src/interface/src/app/plan/uploaded-scenario-view/uploaded-scenario-view.component.ts
+++ b/src/interface/src/app/plan/uploaded-scenario-view/uploaded-scenario-view.component.ts
@@ -29,9 +29,7 @@ export class UploadedScenarioViewComponent implements OnInit {
 
   ngOnInit() {
     if (this.scenario) {
-      this.planStateService.updateStateWithShapes(
-          this.scenario?.scenario_result?.result.features
-      );
+    
       this.planStateService.planState$
         .pipe(untilDestroyed(this), take(1))
         .subscribe((planState) => {
@@ -40,6 +38,9 @@ export class UploadedScenarioViewComponent implements OnInit {
             this.scenario?.id ?? null,
             this.scenario?.name ?? null
           );
+          this.planStateService.updateStateWithShapes(
+            this.scenario?.scenario_result?.result.features
+        );
         });
     }
   }


### PR DESCRIPTION
Now showing project area shapes on the uploaded scenario view.

![Screenshot From 2024-12-30 13-43-52](https://github.com/user-attachments/assets/9a10f1f5-4b67-4394-9b5d-7c581c2398f6)

This does not fix the fillColor issue on the Treatment Plan map, since this appears to be a backend issue related to the `data` field in the `planning_projectarea` table for uploaded scenarios. That will be another PR.