### PR TITLE
Add treatment_rank in uploaded project areas as json

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -153,7 +153,7 @@ def feature_to_project_area(user_id: int, scenario, feature, idx: Optional[int] 
             "name": area_name,
             "created_by": user_id,
             "scenario": scenario,
-            "data": {"treatment_rank":idx},
+            "data": {"treatment_rank": idx},
         }
         proj_area_obj = ProjectArea.objects.create(**project_area)
 

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -153,7 +153,7 @@ def feature_to_project_area(user_id: int, scenario, feature, idx: Optional[int] 
             "name": area_name,
             "created_by": user_id,
             "scenario": scenario,
-            "data": idx,
+            "data": {"treatment_rank":idx},
         }
         proj_area_obj = ProjectArea.objects.create(**project_area)
 


### PR DESCRIPTION
For our maps to see the rank of project areas and therefore show a fillColor, we need the value in the `data` field to be a JSON value with an attribute name. This should fix that.