### PR TITLE
Calculate impacts for all stands within Project Areas

### DIFF
--- a/src/planscape/impacts/models.py
+++ b/src/planscape/impacts/models.py
@@ -377,11 +377,10 @@ class ImpactVariable(models.TextChoices):
 
     @classmethod
     def get_measurable_impact_variables(cls) -> List:
-        variables = set(cls.choices)
-        for variable in variables:
-            if variable in cls.get_baseline_only_impact_variables():
-                variables.remove(variable)
-        return list(variables)
+        variables = list(cls)
+        for baseline_variable in cls.get_baseline_only_impact_variables():
+            variables.remove(baseline_variable)
+        return variables
 
     @classmethod
     def get_datalayer(

--- a/src/planscape/impacts/models.py
+++ b/src/planscape/impacts/models.py
@@ -372,8 +372,16 @@ class ImpactVariable(models.TextChoices):
         return list([x for x in AGGREGATIONS[impact_variable]])
 
     @classmethod
-    def get_baseline_only_impact_variables(cls):
+    def get_baseline_only_impact_variables(cls) -> List:
         return [cls.FLAME_LENGTH, cls.RATE_OF_SPREAD]
+
+    @classmethod
+    def get_measurable_impact_variables(cls) -> List:
+        variables = set(cls.choices)
+        for variable in variables:
+            if variable in cls.get_baseline_only_impact_variables():
+                variables.remove(variable)
+        return list(variables)
 
     @classmethod
     def get_datalayer(

--- a/src/planscape/impacts/models.py
+++ b/src/planscape/impacts/models.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Optional, Tuple, Type, Union
+from typing import List, Optional, Tuple
 
 from core.models import (
     AliveObjectsManager,

--- a/src/planscape/impacts/models.py
+++ b/src/planscape/impacts/models.py
@@ -372,6 +372,10 @@ class ImpactVariable(models.TextChoices):
         return list([x for x in AGGREGATIONS[impact_variable]])
 
     @classmethod
+    def get_baseline_only_impact_variables(cls):
+        return [cls.FLAME_LENGTH, cls.RATE_OF_SPREAD]
+
+    @classmethod
     def get_datalayer(
         cls,
         impact_variable: Self,

--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -356,14 +356,7 @@ def calculate_impacts(
     treated_stand_ids = prescriptions.values_list("stand_id", flat=True)
 
     scenario = treatment_plan.scenario
-    stand_size = scenario.get_stand_size()
-    project_areas = scenario.project_areas
-    project_areas_geometry = project_areas.all().aggregate(
-        geometry=UnionOp("geometry")
-    )["geometry"]
-    stands = Stand.objects.within_polygon(
-        project_areas_geometry, stand_size
-    ).with_webmercator()
+    stands = scenario.get_stands().with_webmercator()
 
     aws_session = AWSSession(get_aws_session())
     with rasterio.Env(aws_session):
@@ -523,12 +516,8 @@ def calculate_project_area_deltas(
     """
     # untreated stands just copy the values from baselines
     results = []
-    stand_size = project_area.scenario.get_stand_size()
     stands_in_project_area = list(
-        Stand.objects.within_polygon(project_area.geometry, stand_size).values_list(
-            "id",
-            flat=True,
-        )
+        project_area.get_stands().values_list("id", flat=True)
     )
 
     baseline_dict = {

--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -413,7 +413,7 @@ def calculate_impacts(
 
     # It iterates over all stands within the project areas
     # and creates a TreatmentResult for each stand.
-    # If the stand is not treated (no delta calculated), it 
+    # If the stand is not treated (no delta calculated), it
     # will create a TreatmentResult with delta=0.
     treatment_results = list(
         map(

--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -410,6 +410,11 @@ def calculate_impacts(
             project_area_deltas,
         )
     )
+
+    # It iterates over all stands within the project areas
+    # and creates a TreatmentResult for each stand.
+    # If the stand is not treated (no delta calculated), it 
+    # will create a TreatmentResult with delta=0.
     treatment_results = list(
         map(
             lambda x: to_treatment_result(

--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -363,10 +363,6 @@ def calculate_impacts(
             variable=variable,
             year=year,
         )
-        if variable in [ImpactVariable.FLAME_LENGTH, ImpactVariable.RATE_OF_SPREAD]:
-            # Flame length and rate of spread are special cases
-            # where action metrics cannot be calculated.
-            return ([],[])
 
         action_metrics = calculate_metrics(
             stands=stands,

--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -178,9 +178,7 @@ def generate_summary(
         geometry=UnionOp("geometry")
     )["geometry"]
     for project in project_area_queryset:
-        stand_project_count = Stand.objects.within_polygon(
-            project.geometry, stand_size
-        ).count()
+        stand_project_count = project.get_stands().count()
         project_areas.append(
             {
                 "project_area_id": project.id,

--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -363,6 +363,10 @@ def calculate_impacts(
             variable=variable,
             year=year,
         )
+        if variable in [ImpactVariable.FLAME_LENGTH, ImpactVariable.RATE_OF_SPREAD]:
+            # Flame length and rate of spread are special cases
+            # where action metrics cannot be calculated.
+            return ([],[])
 
         action_metrics = calculate_metrics(
             stands=stands,

--- a/src/planscape/impacts/tasks.py
+++ b/src/planscape/impacts/tasks.py
@@ -98,7 +98,7 @@ def async_calculate_baseline_metrics_for_variable_year(
         treatment_plan = TreatmentPlan.objects.select_related("scenario").get(
             pk=treatment_plan_pk
         )
-        stands = treatment_plan.scenario.get_stands().with_webmercator()
+        stands = treatment_plan.scenario.get_project_areas_stands().with_webmercator()
         aws_session = AWSSession(get_aws_session())
         with rasterio.Env(aws_session):
             baseline_metrics = calculate_metrics(

--- a/src/planscape/impacts/tasks.py
+++ b/src/planscape/impacts/tasks.py
@@ -2,7 +2,11 @@ import logging
 from typing import Tuple
 from urllib.parse import urljoin
 from celery import chord, chain
+
+import rasterio
 from rasterio.errors import RasterioIOError
+from rasterio.session import AWSSession
+from core.s3 import get_aws_session
 from django.conf import settings
 from django.db import transaction
 from django.core.mail import send_mail
@@ -17,6 +21,7 @@ from impacts.models import (
 )
 from impacts.services import (
     calculate_impacts,
+    calculate_metrics,
     get_calculation_matrix,
 )
 from planscape.celery import app
@@ -55,6 +60,53 @@ def async_calculate_impacts_for_variable_action_year(
         calculate_impacts(
             treatment_plan=treatment_plan, variable=variable, action=action, year=year
         )
+    except (OSError, RasterioIOError) as exc:
+        if self.request.retries >= self.max_retries:
+            log.exception("Task failed on all retries.")
+        else:
+            log.warning("Task failed. Retrying.")
+        raise exc
+    except Exception as exc:
+        log.exception(
+            "Task failed due to an unhandled exception. Not retrying execution."
+        )
+        raise exc
+
+
+@app.task(
+    bind=True, autoretry_for=(OSError, RasterioIOError), retry_kwargs={"max_retries": 5}
+)
+def async_calculate_baseline_metrics_for_variable_year(
+    self,
+    treatment_plan_pk: int,
+    variable: ImpactVariable,
+    year: int,
+):
+    """Calculates baseline metrics for the variable, action year triple.
+
+    :param treatment_plan_pk: _description_
+    :type treatment_plan_pk: int
+    :param variable: _description_
+    :type variable: ImpactVariable
+    :param year: _description_
+    :type year: int
+    :return: _description_
+    :rtype: List[int]
+    """
+    log.info(f"Calculating baseline metrics for {variable}")
+    try:
+        treatment_plan = TreatmentPlan.objects.select_related("scenario").get(
+            pk=treatment_plan_pk
+        )
+        stands = treatment_plan.scenario.get_stands().with_webmercator()
+        aws_session = AWSSession(get_aws_session())
+        with rasterio.Env(aws_session):
+            baseline_metrics = calculate_metrics(
+                stands=stands,
+                variable=variable,
+                year=year,
+            )
+        log.info(f"Calculated {baseline_metrics.count()} metrics for {variable}")
     except (OSError, RasterioIOError) as exc:
         if self.request.retries >= self.max_retries:
             log.exception("Task failed on all retries.")
@@ -126,6 +178,12 @@ def async_calculate_persist_impacts_treatment_plan(
             treatment_plan_pk=treatment_plan_pk,
             variable=variable,
             action=action,
+            year=year,
+        )
+        if variable not in [ImpactVariable.FLAME_LENGTH, ImpactVariable.RATE_OF_SPREAD]
+        else async_calculate_baseline_metrics_for_variable_year.si(
+            treatment_plan_pk=treatment_plan_pk,
+            variable=variable,
             year=year,
         )
         for variable, action, year in matrix

--- a/src/planscape/impacts/tests/test_services.py
+++ b/src/planscape/impacts/tests/test_services.py
@@ -23,6 +23,7 @@ from impacts.services import (
     generate_impact_results_data_to_plot,
     generate_summary,
     get_calculation_matrix,
+    get_baseline_matrix,
     get_treatment_results_table_data,
     upsert_treatment_prescriptions,
 )
@@ -260,7 +261,7 @@ class SummaryTest(TransactionTestCase):
 
 
 class GetCalculationMatrixTest(TransactionTestCase):
-    def test_matrix_returns_correctly(self):
+    def test_calculation_matrix_returns_correctly(self):
         years = [1, 2]
         plan = TreatmentPlanFactory.create()
         s1 = StandFactory.create()
@@ -274,7 +275,20 @@ class GetCalculationMatrixTest(TransactionTestCase):
         self.assertIsNotNone(matrix)
 
         # impact variables * years * actions
-        total_records = 17 * len(years) * 3
+        total_records = (
+            len(ImpactVariable.get_measurable_impact_variables()) * len(years) * 3
+        )
+        self.assertEqual(len(matrix), total_records)
+
+    def test_baseline_matrix_returns_correctly(self):
+        years = [1, 2]
+        matrix = get_baseline_matrix(years=years)
+        self.assertIsNotNone(matrix)
+
+        # impact variables * years
+        total_records = len(ImpactVariable.get_baseline_only_impact_variables()) * len(
+            years
+        )
         self.assertEqual(len(matrix), total_records)
 
 

--- a/src/planscape/impacts/tests/test_services.py
+++ b/src/planscape/impacts/tests/test_services.py
@@ -500,7 +500,10 @@ class AsyncGetOrCalculatePersistImpactsTestCase(TransactionTestCase):
 
             self.assertGreater(TreatmentResult.objects.count(), 0)
             self.assertGreater(ProjectAreaTreatmentResult.objects.count(), 0)
-            self.assertEquals(len(self.stands), TreatmentResult.objects.count())
+            stands_within_project_area = self.project_area.get_stands()
+            self.assertEquals(
+                stands_within_project_area.count(), TreatmentResult.objects.count()
+            )
 
 
 class ImpactResultsDataPlotTest(TransactionTestCase):

--- a/src/planscape/impacts/tests/test_tasks.py
+++ b/src/planscape/impacts/tests/test_tasks.py
@@ -1,7 +1,37 @@
+import json
+
 from unittest import mock
 from django.test import TransactionTestCase
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+from django.contrib.gis.db.models import Union
+
 from impacts.tests.factories import TreatmentPlanFactory
-from impacts.tasks import async_send_email_process_finished
+from impacts.tasks import (
+    async_send_email_process_finished,
+    async_calculate_impacts_for_variable_action_year,
+    async_calculate_baseline_metrics_for_variable_year,
+)
+from stands.models import Stand
+from impacts.services import (
+    get_calculation_matrix,
+)
+from impacts.models import (
+    AVAILABLE_YEARS,
+    ProjectAreaTreatmentResult,
+    TreatmentPrescriptionAction,
+    TreatmentResult,
+    ImpactVariable,
+)
+from stands.models import StandMetric
+from datasets.models import DataLayerType
+from datasets.tests.factories import DataLayerFactory
+from impacts.tests.factories import (
+    TreatmentPlanFactory,
+    TreatmentPrescriptionFactory,
+)
+from planning.tests.factories import (
+    ProjectAreaFactory,
+)
 
 
 class AsyncSendEmailProcessFinishedTest(TransactionTestCase):
@@ -23,3 +53,174 @@ class AsyncSendEmailProcessFinishedTest(TransactionTestCase):
             message=mock.ANY,
             html_message=mock.ANY,
         )
+
+
+class AsyncGetOrCalculatePersistImpactsTestCase(TransactionTestCase):
+    def load_stands(self):
+        with open("impacts/tests/test_data/stands.geojson") as fp:
+            geojson = json.loads(fp.read())
+
+        features = geojson.get("features")
+        return list(
+            [
+                Stand.objects.create(
+                    geometry=GEOSGeometry(json.dumps(f.get("geometry")), srid=4326),
+                    size="LARGE",
+                    area_m2=1,
+                )
+                for f in features
+            ]
+        )
+
+    def setUp(self):
+        self.stands = self.load_stands()
+        self.plan = TreatmentPlanFactory.create()
+        stand_ids = [s.id for s in self.stands]
+        self.project_area_geometry = MultiPolygon(
+            [
+                Stand.objects.filter(id__in=stand_ids).aggregate(
+                    geometry=Union("geometry")
+                )["geometry"]
+            ]
+        )
+        self.project_area = ProjectAreaFactory.create(
+            scenario=self.plan.scenario, geometry=self.project_area_geometry
+        )
+        self.prescriptions = list(
+            [
+                TreatmentPrescriptionFactory.create(
+                    treatment_plan=self.plan,
+                    stand=stand,
+                    action=TreatmentPrescriptionAction.HEAVY_MASTICATION,
+                    geometry=stand.geometry,
+                )
+                for stand in self.stands
+            ]
+        )
+
+    def test_calculate_impacts_returns_data(self):
+        """Test that this function is performing work correctly. we don't
+        really care about the returned values right now, only that it works.
+        """
+        with self.settings(
+            CELERY_ALWAYS_EAGER=True,
+            CELERY_TASK_STORE_EAGER_RESULT=True,
+            CELERY_TASK_IGNORE_RESULT=False,
+        ):
+            matrix = get_calculation_matrix(self.plan)
+            variable, action, year = matrix[0]
+            baseline_metadata = {
+                "modules": {
+                    "impacts": {
+                        "year": year,
+                        "variable": variable,
+                        "action": None,
+                        "baseline": True,
+                    }
+                }
+            }
+            action_metadata = {
+                "modules": {
+                    "impacts": {
+                        "year": year,
+                        "variable": variable,
+                        "action": TreatmentPrescriptionAction.get_file_mapping(action),
+                        "baseline": False,
+                    }
+                }
+            }
+
+            DataLayerFactory.create(
+                name="baseline",
+                url="impacts/tests/test_data/test_raster.tif",
+                metadata=baseline_metadata,
+                type=DataLayerType.RASTER,
+            )
+            DataLayerFactory.create(
+                name="action",
+                url="impacts/tests/test_data/test_raster.tif",
+                metadata=action_metadata,
+                type=DataLayerType.RASTER,
+            )
+            self.assertEquals(TreatmentResult.objects.count(), 0)
+
+            async_calculate_impacts_for_variable_action_year(
+                self.plan.id,
+                variable=variable,
+                action=action,
+                year=year,
+            )
+
+            self.assertGreater(TreatmentResult.objects.count(), 0)
+            self.assertGreater(ProjectAreaTreatmentResult.objects.count(), 0)
+            stands_within_project_area = self.project_area.get_stands()
+            self.assertEquals(
+                stands_within_project_area.count(), TreatmentResult.objects.count()
+            )
+
+
+class AsyncCalculateBaselineMetricsForVariableYearTest(TransactionTestCase):
+    def load_stands(self):
+        with open("impacts/tests/test_data/stands.geojson") as fp:
+            geojson = json.loads(fp.read())
+
+        features = geojson.get("features")
+        return list(
+            [
+                Stand.objects.create(
+                    geometry=GEOSGeometry(json.dumps(f.get("geometry")), srid=4326),
+                    size="LARGE",
+                    area_m2=1,
+                )
+                for f in features
+            ]
+        )
+
+    def setUp(self):
+        self.stands = self.load_stands()
+        self.plan = TreatmentPlanFactory.create()
+        stand_ids = [s.id for s in self.stands]
+        self.project_area_geometry = MultiPolygon(
+            [
+                Stand.objects.filter(id__in=stand_ids).aggregate(
+                    geometry=Union("geometry")
+                )["geometry"]
+            ]
+        )
+        self.project_area = ProjectAreaFactory.create(
+            scenario=self.plan.scenario, geometry=self.project_area_geometry
+        )
+
+    def test_calculate_baseline_metrics_for_variable_year(self):
+        with self.settings(
+            CELERY_ALWAYS_EAGER=True,
+            CELERY_TASK_STORE_EAGER_RESULT=True,
+            CELERY_TASK_IGNORE_RESULT=False,
+        ):
+            variable = ImpactVariable.FLAME_LENGTH
+            year = AVAILABLE_YEARS[0]
+            baseline_metadata = {
+                "modules": {
+                    "impacts": {
+                        "year": year,
+                        "variable": variable,
+                        "action": None,
+                        "baseline": True,
+                    }
+                }
+            }
+            DataLayerFactory.create(
+                name="baseline",
+                url="impacts/tests/test_data/test_raster.tif",
+                metadata=baseline_metadata,
+                type=DataLayerType.RASTER,
+            )
+            async_calculate_baseline_metrics_for_variable_year(
+                self.plan.id,
+                variable=variable,
+                year=year,
+            )
+            stands_within_project_area = self.project_area.get_stands()
+            self.assertEquals(
+                stands_within_project_area.count(), StandMetric.objects.count()
+            )

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -248,7 +248,7 @@ class Scenario(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
         ]
         return {"type": "FeatureCollection", "features": features}
 
-    def get_stands(self) -> QuerySet[Stand]:
+    def get_project_areas_stands(self) -> QuerySet[Stand]:
         project_areas = self.project_areas
         project_areas_geometry = project_areas.all().aggregate(
             geometry=UnionOp("geometry")

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from pathlib import Path
-from typing import Optional, Type
+from typing import Optional
 
 from collaboration.models import UserObjectRole
 from core.models import (
@@ -15,11 +15,12 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.db import models
+from django.contrib.gis.db.models import Union as UnionOp
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Count, Max, Q, QuerySet
 from django.db.models.functions import Coalesce
 from django_stubs_ext.db.models import TypedModelMeta
-from stands.models import StandSizeChoices
+from stands.models import StandSizeChoices, Stand
 from utils.uuid_utils import generate_short_uuid
 
 from planscape.typing import TUser
@@ -247,6 +248,15 @@ class Scenario(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
         ]
         return {"type": "FeatureCollection", "features": features}
 
+    def get_stands(self) -> QuerySet[Stand]:
+        project_areas = self.project_areas
+        project_areas_geometry = project_areas.all().aggregate(
+            geometry=UnionOp("geometry")
+        )["geometry"]
+        return Stand.objects.within_polygon(
+            project_areas_geometry, self.get_stand_size()
+        )
+
     objects = ScenarioManager()
 
     class Meta(TypedModelMeta):
@@ -356,6 +366,10 @@ class ProjectArea(
         srid=settings.CRS_INTERNAL_REPRESENTATION,
         help_text="Geometry of the Project Area.",
     )
+
+    def get_stands(self) -> QuerySet[Stand]:
+        scenario = self.scenario
+        return Stand.objects.within_polygon(self.geometry, scenario.get_stand_size())
 
     class Meta(TypedModelMeta):
         verbose_name = "Project Area"


### PR DESCRIPTION
- Calculate impacts for all stands within Project Areas, even when no action was applied to stands.
- Filtering stands with applied actions to calculate the Project Area Treatment Result in order to keep current implementation.
- Calculate baseline metrics for Flame Length and Rate of Spread metrics instead of calculating its impacts.
- Some refactoring on repetitive queries to retrieve Stands.