### PR TITLE
Use slot palettes for hover color

### DIFF
--- a/src/interface/src/app/treatments/change-over-time-chart/change-over-time-chart.component.ts
+++ b/src/interface/src/app/treatments/change-over-time-chart/change-over-time-chart.component.ts
@@ -11,7 +11,7 @@ import {
   switchMap,
   filter,
 } from 'rxjs';
-import { SLOT_COLORS, ImpactsMetricSlot, Metric } from '../metrics';
+import { SLOT_COLORS, ImpactsMetricSlot, Metric, SLOT_PALETTES } from '../metrics';
 import { TreatmentsService } from '@services/treatments.service';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TreatmentsState } from '../treatments.state';
@@ -54,7 +54,7 @@ export class ChangeOverTimeChartComponent {
     private directImpactsStateService: DirectImpactsStateService,
     private treatmentsState: TreatmentsState,
     private treatmentsService: TreatmentsService
-  ) {}
+  ) { }
 
   @Input() metrics!: Record<ImpactsMetricSlot, Metric> | null;
 
@@ -144,18 +144,22 @@ export class ChangeOverTimeChartComponent {
         {
           data: data['blue'].map((d: ChangeOverTimeChartItem) => d.avg_value),
           backgroundColor: SLOT_COLORS['blue'],
+          hoverBackgroundColor: SLOT_PALETTES['blue'][0],
         },
         {
           data: data['purple'].map((d: ChangeOverTimeChartItem) => d.avg_value),
           backgroundColor: SLOT_COLORS['purple'],
+          hoverBackgroundColor: SLOT_PALETTES['purple'][0],
         },
         {
           data: data['orange'].map((d: ChangeOverTimeChartItem) => d.avg_value),
           backgroundColor: SLOT_COLORS['orange'],
+          hoverBackgroundColor: SLOT_PALETTES['orange'][0],
         },
         {
           data: data['green'].map((d: ChangeOverTimeChartItem) => d.avg_value),
           backgroundColor: SLOT_COLORS['green'],
+          hoverBackgroundColor: SLOT_PALETTES['green'][0],
         },
       ],
     } as ChartConfiguration<'bar'>['data'];


### PR DESCRIPTION
I don't think there's a design for this, specifically, but since we have the option for hover colors on the Average Change Over Time bars, I'd like to propose we use a color from SLOT_PALETTES. Conversely, we could also just remove hover colors entirely.

https://github.com/user-attachments/assets/cd500e2f-a83a-4c0b-97f9-3220c762b2a2

