### PR TITLE
Repl breadcrumbs w navstate

### DIFF
--- a/src/interface/src/app/map/map.component.html
+++ b/src/interface/src/app/map/map.component.html
@@ -1,5 +1,5 @@
 <app-nav-bar
-  [breadcrumbs]="(breadcrumbs$ | async) || []"
+  [navState]="(navState$ | async) || null"
   area="EXPLORE"></app-nav-bar>
 <div class="root-container">
   <!-- Map control panel -->

--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -56,7 +56,7 @@ import { PlanCreateDialogComponent } from './plan-create-dialog/plan-create-dial
 import { ProjectCardComponent } from './project-card/project-card.component';
 import { SignInDialogComponent } from './sign-in-dialog/sign-in-dialog.component';
 import { AreaCreationAction, LEGEND } from './map.constants';
-import { Breadcrumb, SNACK_ERROR_CONFIG } from '@shared';
+import { NavState, SNACK_ERROR_CONFIG } from '@shared';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
   addGeoJSONToMap,
@@ -141,7 +141,11 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
   ]).pipe(map(([selectedMap]) => !!selectedMap?.config.dataLayerConfig.layer));
 
   showConfirmAreaButton$ = new BehaviorSubject(false);
-  breadcrumbs$ = new BehaviorSubject<Breadcrumb[]>([{ name: 'New Plan' }]);
+  navState$ = new BehaviorSubject<NavState>({
+    currentRecordName: 'New Plan',
+    currentView: 'Explore',
+    backLink: '/',
+  });
 
   totalArea$ = this.showConfirmAreaButton$.asObservable().pipe(
     switchMap((show) => {
@@ -292,9 +296,11 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
           }
 
           this.drawPlanningArea(plan);
-          this.breadcrumbs$.next([
-            { name: plan.name, path: getPlanPath(plan.id) },
-          ]);
+          this.navState$.next({
+            currentRecordName: plan.name,
+            backLink: getPlanPath(plan.id),
+            currentView: '',
+          });
         },
         error: (error) => {
           // this.planNotFound = true;

--- a/src/interface/src/app/plan/plan.component.html
+++ b/src/interface/src/app/plan/plan.component.html
@@ -1,5 +1,5 @@
 <app-nav-bar
-  [breadcrumbs]="(breadcrumbs$ | async) || []"
+  [navState]="(navState$ | async) || undefined"
   [area]="(area$ | async) || 'SCENARIOS'">
   <ng-container *appFeatureFlag="'new_planning_area'">
     <ng-container *ngIf="(area$ | async) === 'SCENARIOS'">

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.html
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.html
@@ -1,20 +1,4 @@
 <div class="nav-bar mat-elevation-z2">
-  <section class="breadcrumb" *ngIf="breadcrumbs?.length && !navState">
-    <a
-      [routerLink]="['/home']"
-      [queryParams]="params"
-      queryParamsHandling="merge"
-      >{{ firstBreadcrumb$ | async }}</a
-    >
-    <ng-container *ngFor="let breadcrumb of breadcrumbs">
-      /
-      <a [routerLink]="breadcrumb.path" *ngIf="breadcrumb.path">
-        {{ breadcrumb.name }}</a
-      >
-      <span *ngIf="!breadcrumb.path">{{ breadcrumb.name }}</span>
-    </ng-container>
-  </section>
-
   <section class="nav-heading" *ngIf="navState">
     <button mat-icon-button aria-label="back">
       <mat-icon

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.html
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.html
@@ -1,12 +1,11 @@
 <div class="nav-bar mat-elevation-z2">
-  <section class="breadcrumb">
+  <section class="breadcrumb" *ngIf="breadcrumbs?.length && !navState">
     <a
       [routerLink]="['/home']"
       [queryParams]="params"
       queryParamsHandling="merge"
       >{{ firstBreadcrumb$ | async }}</a
     >
-
     <ng-container *ngFor="let breadcrumb of breadcrumbs">
       /
       <a [routerLink]="breadcrumb.path" *ngIf="breadcrumb.path">
@@ -15,6 +14,22 @@
       <span *ngIf="!breadcrumb.path">{{ breadcrumb.name }}</span>
     </ng-container>
   </section>
+
+  <section class="nav-heading" *ngIf="navState">
+    <button mat-icon-button aria-label="back">
+      <mat-icon
+        class="back-btn"
+        [routerLink]="navState.backLink"
+        [queryParams]="params"
+        queryParamsHandling="merge"
+        >arrow_back
+      </mat-icon>
+    </button>
+    <div class="current-page">
+      {{ navState.currentView + ': ' + navState.currentRecordName }}
+    </div>
+  </section>
+
   <div class="actions">
     <button mat-icon-button class="help" [matMenuTriggerFor]="popoverMenu">
       <mat-icon class="material-symbols-outlined" color="primary">

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.html
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.html
@@ -18,6 +18,7 @@
   <section class="nav-heading" *ngIf="navState">
     <button mat-icon-button aria-label="back">
       <mat-icon
+        *ngIf="navState.backLink !== ''"
         class="back-btn"
         [routerLink]="navState.backLink"
         [queryParams]="params"
@@ -25,7 +26,9 @@
         >arrow_back
       </mat-icon>
     </button>
-    <div class="current-page">
+    <div
+      class="current-page"
+      *ngIf="navState.currentView && navState.currentRecordName">
       {{ navState.currentView + ': ' + navState.currentRecordName }}
     </div>
   </section>

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
@@ -49,3 +49,14 @@
     }
   }
 }
+
+.nav-heading {
+  @include h4();
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+}

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.scss
@@ -9,7 +9,7 @@
   height: $navbar-height;
   position: relative;
   z-index: 200;
-  padding-left: 18px;
+  padding-left: 10px;
   gap: 10px;
 
   .mat-icon-button .mat-icon {

--- a/src/interface/src/app/shared/nav-bar/nav-bar.component.ts
+++ b/src/interface/src/app/shared/nav-bar/nav-bar.component.ts
@@ -14,6 +14,12 @@ export interface Breadcrumb {
   path?: string;
 }
 
+export interface NavState {
+  currentView: string;
+  currentRecordName: string;
+  backLink?: string;
+}
+
 @Component({
   selector: 'app-nav-bar',
   templateUrl: './nav-bar.component.html',
@@ -23,6 +29,8 @@ export class NavBarComponent implements OnInit {
   @Input() breadcrumbs: Breadcrumb[] = [];
   @Input() area: 'SCENARIOS' | 'EXPLORE' | 'SCENARIO' | 'TREATMENTS' =
     'EXPLORE';
+
+  @Input() navState?: NavState | null = null;
 
   params: Params | null = null;
 

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
@@ -1,5 +1,5 @@
 <app-nav-bar
-  [breadcrumbs]="(breadcrumbs$ | async) || []"
+  [navState]="(navState$ | async) || null"
   [area]="'TREATMENTS'"></app-nav-bar>
 
 <div *ngIf="treatmentPlan$ | async; let treatmentPlan" class="treatment-plan">

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
@@ -123,7 +123,7 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
       .subscribe();
   }
 
-  breadcrumbs$ = this.treatmentsState.breadcrumbs$;
+  navState$ = this.treatmentsState.navState$;
   treatmentPlan$ = this.treatmentsState.treatmentPlan$;
   activeStand$ = this.directImpactsStateService.activeStand$;
 

--- a/src/interface/src/app/treatments/treatment-config/treatment-config.component.html
+++ b/src/interface/src/app/treatments/treatment-config/treatment-config.component.html
@@ -1,5 +1,6 @@
 <sg-overlay-loader *ngIf="loading" [offsetTop]="48"></sg-overlay-loader>
-<app-nav-bar [breadcrumbs]="(breadcrumbs$ | async) || []" [area]="'TREATMENTS'">
+
+<app-nav-bar [navState]="(navState$ | async) || null">
   <app-treatment-navbar-menu
     [treatmentPlanName]="(treatmentPlanName$ | async) || ''"
     (treatmentPlanDeleted)="redirectToScenario()"

--- a/src/interface/src/app/treatments/treatment-config/treatment-config.component.ts
+++ b/src/interface/src/app/treatments/treatment-config/treatment-config.component.ts
@@ -94,7 +94,7 @@ export class TreatmentConfigComponent {
     )
   );
   @ViewChild(TreatmentMapComponent) mapElement: any;
-  breadcrumbs$ = this.treatmentsState.breadcrumbs$;
+  navState$ = this.treatmentsState.navState$;
 
   loading = true;
 

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -78,6 +78,7 @@ export class TreatmentsState {
     shareReplay(1)
   );
 
+  // determine navstate values based on various state conditions
   navState$ = combineLatest([
     this.activeProjectArea$,
     this.summary$,
@@ -86,12 +87,11 @@ export class TreatmentsState {
     map(([projectArea, summary, treatmentPlan]) => {
       if (!summary) {
         return {
-          currentView: 'Treatment Plan',
-          currentRecordName: treatmentPlan?.name ?? '',
+          currentView: '',
+          currentRecordName: '',
           backLink: '',
         };
       }
-      // determine navstate based on various conditions
       if (projectArea) {
         // if we are currently viewing a Project Area
         return {
@@ -99,19 +99,34 @@ export class TreatmentsState {
           currentRecordName: projectArea.project_area_name,
           backLink: `/plan/${summary.planning_area_id}/config/${summary.scenario_id}/treatment/${summary.treatment_plan_id}`,
         };
-      } // if we are currently viewing a Treatment Plan
-      else if (!!treatmentPlan && !!treatmentPlan.name) {
+      } else if (
+        //  Impacts Planning - TODO: is there a cleaner/definitive way to determine this state? by route?
+        !!treatmentPlan &&
+        !!treatmentPlan.name &&
+        treatmentPlan.status === 'SUCCESS'
+      ) {
+        return {
+          currentView: 'Direct Treatment Impacts',
+          currentRecordName: treatmentPlan.name,
+          backLink: `/plan/${summary.planning_area_id}/config/${summary.scenario_id}`,
+        };
+      } else if (
+        // if we are currently viewing a Treatment Plan
+        !!treatmentPlan &&
+        !!treatmentPlan.name &&
+        treatmentPlan.status !== 'SUCCESS'
+      ) {
         return {
           currentView: 'Treatment Plan',
           currentRecordName: treatmentPlan.name,
           backLink: `/plan/${summary.planning_area_id}/config/${summary.scenario_id}`,
         };
       }
-      // TODO: determine states for Impacts Planning
+      // TODO: can we have a default?
       return {
-        currentView: 'Treatment',
-        currentRecordName: 'ok',
-        backLink: `/plan/${summary.planning_area_id}/config/${summary.scenario_id}`,
+        currentView: '',
+        currentRecordName: '',
+        backLink: '',
       };
     })
   );


### PR DESCRIPTION
This essentially replaces the breadcrumbs sequence with a simpler object that just reflects the current view, the name of the record currently being viewed, and the link destination for the back arrow.

remaining TODOs:
- decide if we should set a default NavState in app-nav-bar, if no navstate exists
- handle pending/delayed refresh when we navigate (e.g., we go to a scenario detail, but that scenario hasn't loaded yet)
 -- or maybe rely on ActivatedRoute in these cases, rather than state details
