### PR TITLE
Pre-calculate stand_count on Project Areas

### DIFF
--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -178,12 +178,11 @@ def generate_summary(
         geometry=UnionOp("geometry")
     )["geometry"]
     for project in project_area_queryset:
-        stand_project_count = project.get_stands().count()
         project_areas.append(
             {
                 "project_area_id": project.id,
                 "project_area_name": project.name,
-                "total_stand_count": stand_project_count,
+                "total_stand_count": project.stand_count,
                 "extent": project.geometry.extent,
                 "centroid": json.loads(project.geometry.point_on_surface.json),
                 "prescriptions": [

--- a/src/planscape/planning/migrations/0027_alter_projectarea_data.py
+++ b/src/planscape/planning/migrations/0027_alter_projectarea_data.py
@@ -1,0 +1,20 @@
+import django.core.serializers.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("planning", "0026_alter_planningareanote_planning_area_projectareanote"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="projectarea",
+            name="data",
+            field=models.JSONField(
+                encoder=django.core.serializers.json.DjangoJSONEncoder,
+                help_text="Project Area data from Forsys.",
+                null=True,
+            ),
+        ),
+    ]

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -369,8 +369,8 @@ class ProjectArea(
 
     @property
     def stand_count(self) -> int:
-        data = json.loads(self.data) if self.data else {}
-        return data.get("stand_count", 0)
+        stored_stand_count = self.data.get("stand_count") if self.data else None
+        return stored_stand_count or self.get_stands().count()
 
     def get_stands(self) -> QuerySet[Stand]:
         scenario = self.scenario

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -367,6 +367,11 @@ class ProjectArea(
         help_text="Geometry of the Project Area.",
     )
 
+    @property
+    def stand_count(self) -> int:
+        data = json.loads(self.data) if self.data else {}
+        return data.get("stand_count", 0)
+
     def get_stands(self) -> QuerySet[Stand]:
         scenario = self.scenario
         return Stand.objects.within_polygon(self.geometry, scenario.get_stand_size())

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -142,18 +142,24 @@ def feature_to_project_area(user_id: int, scenario, feature, idx: Optional[int] 
         if idx is not None:
             area_name += f" {idx}"
 
+        geometry = MultiPolygon(
+            [
+                GEOSGeometry(feature, srid=4326).transform(
+                    settings.CRS_INTERNAL_REPRESENTATION, clone=True
+                ),
+            ]
+        )
+
+        stand_count = Stand.objects.within_polygon(
+            geometry, scenario.get_stand_size()
+        ).count()
+
         project_area = {
-            "geometry": MultiPolygon(
-                [
-                    GEOSGeometry(feature, srid=4326).transform(
-                        settings.CRS_INTERNAL_REPRESENTATION, clone=True
-                    )
-                ]
-            ),
+            "geometry": geometry,
             "name": area_name,
             "created_by": user_id,
             "scenario": scenario,
-            "data": {"treatment_rank": idx},
+            "data": {"treatment_rank": idx, "stand_count": stand_count},
         }
         proj_area_obj = ProjectArea.objects.create(**project_area)
 

--- a/src/planscape/stands/migrations/0010_alter_stand_size.py
+++ b/src/planscape/stands/migrations/0010_alter_stand_size.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("stands", "0009_remove_standmetric_unique_stand_metric_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="stand",
+            name="size",
+            field=models.CharField(
+                choices=[("SMALL", "Small"), ("MEDIUM", "Medium"), ("LARGE", "Large")],
+                db_index=True,
+                max_length=16,
+            ),
+        ),
+    ]

--- a/src/planscape/stands/models.py
+++ b/src/planscape/stands/models.py
@@ -56,9 +56,13 @@ class StandQuerySet(models.QuerySet):
         if not geometry.valid:
             raise ValueError("Invalid geometry")
 
-        return Stand.objects.annotate(centroid=Centroid("geometry")).filter(
-            centroid__within=geometry,
-            size=size,
+        return (
+            Stand.objects.filter(geometry__bboverlaps=geometry)
+            .annotate(centroid=Centroid("geometry"))
+            .filter(
+                centroid__within=geometry,
+                size=size,
+            )
         )
 
 
@@ -71,6 +75,7 @@ class Stand(CreatedAtMixin, models.Model):
     size = models.CharField(
         choices=StandSizeChoices.choices,
         max_length=16,
+        db_index=True,
     )
 
     geometry = models.PolygonField(srid=4269, spatial_index=True)


### PR DESCRIPTION
**Problem:** Calculating the number of stands within a ProjectArea cost is high to perform during request time. Which causes is currently causing problems on Impacts interfaces.

**Idea**: Calculate it during creation. It is already calculated when Project Areas are generated by Forsys.