### PR TITLE
PLAN-1656: Updating metrics/selected stand when project area change

### DIFF
--- a/src/interface/src/app/treatments/direct-impacts.state.service.ts
+++ b/src/interface/src/app/treatments/direct-impacts.state.service.ts
@@ -82,6 +82,7 @@ export class DirectImpactsStateService {
 
   setProjectAreaForChanges(projectArea: TreatmentProjectArea | 'All') {
     this._selectedProjectArea$.next(projectArea);
+    this.resetActiveStand();
   }
 
   setActiveStand(standData: MapGeoJSONFeature) {

--- a/src/interface/src/app/treatments/direct-impacts.state.service.ts
+++ b/src/interface/src/app/treatments/direct-impacts.state.service.ts
@@ -115,4 +115,8 @@ export class DirectImpactsStateService {
   setStandsTxSourceLoaded(val: boolean) {
     this._standsTxSourceLoaded$.next(val);
   }
+
+  resetActiveStand() {
+    this._activeStand$.next(null);
+  }
 }

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
@@ -195,10 +195,12 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
       this.directImpactsStateService.setProjectAreaForChanges('All');
       const s = this.treatmentsState.getCurrentSummary();
       this.mapConfigState.updateMapCenter(s.extent);
+      this.directImpactsStateService.setActiveStand(null as any);
       return;
     }
     this.directImpactsStateService.setProjectAreaForChanges(pa);
     this.mapConfigState.updateMapCenter(pa.extent);
+    this.directImpactsStateService.setActiveStand(null as any);
   }
 
   expandChangeChart() {

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
@@ -195,12 +195,10 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
       this.directImpactsStateService.setProjectAreaForChanges('All');
       const s = this.treatmentsState.getCurrentSummary();
       this.mapConfigState.updateMapCenter(s.extent);
-      this.directImpactsStateService.resetActiveStand();
       return;
     }
     this.directImpactsStateService.setProjectAreaForChanges(pa);
     this.mapConfigState.updateMapCenter(pa.extent);
-    this.directImpactsStateService.resetActiveStand();
   }
 
   expandChangeChart() {

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
@@ -195,12 +195,12 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
       this.directImpactsStateService.setProjectAreaForChanges('All');
       const s = this.treatmentsState.getCurrentSummary();
       this.mapConfigState.updateMapCenter(s.extent);
-      this.directImpactsStateService.setActiveStand(null as any);
+      this.directImpactsStateService.resetActiveStand();
       return;
     }
     this.directImpactsStateService.setProjectAreaForChanges(pa);
     this.mapConfigState.updateMapCenter(pa.extent);
-    this.directImpactsStateService.setActiveStand(null as any);
+    this.directImpactsStateService.resetActiveStand();
   }
 
   expandChangeChart() {

--- a/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.ts
+++ b/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.ts
@@ -10,7 +10,6 @@ import {
   DataDrivenPropertyValueSpecification,
   LngLat,
   Map as MapLibreMap,
-  MapGeoJSONFeature,
   MapMouseEvent,
   Point,
 } from 'maplibre-gl';
@@ -20,7 +19,6 @@ import { DEFAULT_SLOT, ImpactsMetricSlot, SLOT_PALETTES } from '../metrics';
 import { map, switchMap, take } from 'rxjs';
 import { DirectImpactsStateService } from '../direct-impacts.state.service';
 import { TreatmentsState } from '../treatments.state';
-import { filter } from 'rxjs/operators';
 import { descriptionForAction } from '../prescriptions';
 import { FilterByActionPipe } from './filter-by-action.pipe';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -80,10 +78,8 @@ export class MapStandsTxResultComponent implements OnInit {
 
   activeMetric$ = this.directImpactsStateService.activeMetric$;
 
-  activeStandId$ = this.activeStand$.pipe(
-    filter((s): s is MapGeoJSONFeature => s !== null),
-    map((stand) => stand.id)
-  );
+  // If we get a null active stand we clear the stand selection
+  activeStandId$ = this.activeStand$.pipe(map((stand) => stand?.id));
 
   setActiveStand(event: MapMouseEvent) {
     this.setActiveStandFromPoint(event.point);


### PR DESCRIPTION
If we change the prroject area from the dropdown we should clear the selected satand on the map and clear the selected stand metric.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1656

Result:
![unselecting_stand](https://github.com/user-attachments/assets/077b0407-17fb-43c2-bafa-b44627bbe63b)
