### PR TITLE
PLAN-1920: Empty treatment types

### DIFF
--- a/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.ts
+++ b/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.ts
@@ -16,7 +16,7 @@ import {
 import { SINGLE_STAND_SELECTED, STANDS_CELL_PAINT } from '../map.styles';
 import { environment } from '../../../environments/environment';
 import { DEFAULT_SLOT, ImpactsMetricSlot, SLOT_PALETTES } from '../metrics';
-import { map, switchMap, take } from 'rxjs';
+import { combineLatest, map, switchMap, take } from 'rxjs';
 import { DirectImpactsStateService } from '../direct-impacts.state.service';
 import { TreatmentsState } from '../treatments.state';
 import { descriptionForAction } from '../prescriptions';
@@ -94,6 +94,7 @@ export class MapStandsTxResultComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.updateStandOnTreatmentChanges();
     this.paint = this.generatePaint(DEFAULT_SLOT);
     this.directImpactsStateService.standsTxSourceLoaded$
       .pipe(
@@ -112,6 +113,22 @@ export class MapStandsTxResultComponent implements OnInit {
           if (sourceFeatures[0]) {
             this.directImpactsStateService.setActiveStand(sourceFeatures[0]);
           }
+        }
+      });
+  }
+
+  updateStandOnTreatmentChanges() {
+    combineLatest([
+      this.directImpactsStateService.filteredTreatmentTypes$,
+      this.directImpactsStateService.activeStand$,
+    ])
+      .pipe(untilDestroyed(this))
+      .subscribe(([treatments, stand]) => {
+        if (
+          treatments?.length &&
+          !treatments.includes(stand?.properties?.['action'])
+        ) {
+          this.directImpactsStateService.resetActiveStand();
         }
       });
   }

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.html
@@ -49,24 +49,26 @@
         else noCategory
       ">
       <div *ngFor="let categoryGroup of displayedItems">
-        <details class="expander" open (click)="$event.stopPropagation()">
-          <summary>{{ categoryGroup.category }}</summary>
-          <div *ngFor="let item of categoryGroup.options">
-            <button
-              mat-menu-item
-              role="menuitemcheckbox"
-              (click)="toggleSelection($event, item)">
-              <div class="menu-item-content">
-                <span class="menu-item-text">{{
-                  displayField ? item[displayField] : item
-                }}</span>
-                <mat-checkbox
-                  [color]="'primary'"
-                  [checked]="isInSelection(item)"></mat-checkbox>
-              </div>
-            </button>
-          </div>
-        </details>
+        <ng-container *ngIf="categoryGroup.options?.length > 0">
+          <details class="expander" open (click)="$event.stopPropagation()">
+            <summary>{{ categoryGroup.category }}</summary>
+            <div *ngFor="let item of categoryGroup.options">
+              <button
+                mat-menu-item
+                role="menuitemcheckbox"
+                (click)="toggleSelection($event, item)">
+                <div class="menu-item-content">
+                  <span class="menu-item-text">{{
+                    displayField ? item[displayField] : item
+                  }}</span>
+                  <mat-checkbox
+                    [color]="'primary'"
+                    [checked]="isInSelection(item)"></mat-checkbox>
+                </div>
+              </button>
+            </div>
+          </details>
+        </ng-container>
       </div>
     </ng-container>
     <ng-template #noCategory>

--- a/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
+++ b/src/interface/src/styleguide/filter-dropdown/filter-dropdown.component.ts
@@ -3,8 +3,10 @@ import {
   EventEmitter,
   HostBinding,
   Input,
+  OnChanges,
   OnInit,
   Output,
+  SimpleChanges,
   ViewChild,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -34,7 +36,7 @@ import { SearchBarComponent } from '../search-bar/search-bar.component';
   templateUrl: './filter-dropdown.component.html',
   styleUrls: ['./filter-dropdown.component.scss'],
 })
-export class FilterDropdownComponent<T> implements OnInit {
+export class FilterDropdownComponent<T> implements OnInit, OnChanges {
   @ViewChild(SearchBarComponent) searchbar!: SearchBarComponent;
 
   /**
@@ -92,8 +94,13 @@ export class FilterDropdownComponent<T> implements OnInit {
   private previousSelections: T[] = [];
 
   ngOnInit(): void {
-    this.displayCategories = this.menuItems.some((e) => (e as any).category);
     this.displayedItems = this.menuItems;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['menuItems']) {
+      this.displayCategories = this.menuItems.some((e) => (e as any).category);
+    }
   }
 
   hasSelections(): boolean {


### PR DESCRIPTION
The treatment types where empty. It was because oninit menuItems where null since it's async in `metric-filters.component`. I adeed `ngOnchanges ` to update the value of `displayCategories ` when the value of `menuItems` changed.

Result:
![image](https://github.com/user-attachments/assets/43afa608-a0eb-4a2d-8332-44e6e425e6a7)
