### PR TITLE
stand-info endpoint slight modification and new tests

### DIFF
--- a/src/planscape/impacts/services.py
+++ b/src/planscape/impacts/services.py
@@ -674,16 +674,27 @@ def get_treatment_results_table_data(
 ) -> List[Dict[str, Any]]:
     """
     Retrieves a list of dictionaries, with each dictionary representing
-    a year and its variables.
+    a year and its variables. Returns something like:
+    [
+      {
+        "year": 2024,
+        "flame_length": { ... },
+        "rate_of_spread": { ... },
+        ...
+      },
+      ...
+    ]
     """
     # Fetch treatment results
     treated_results = TreatmentResult.objects.filter(
         treatment_plan=treatment_plan, stand_id=stand_id
     ).values("year", "variable", "value", "delta", "baseline")
 
+    if not treated_results.exists():
+        return []
+
     data_map = defaultdict(dict)
 
-    # Fetch baseline data for all years
     for year in AVAILABLE_YEARS:
         flame_length = ImpactVariable.get_datalayer(
             impact_variable=ImpactVariable.FLAME_LENGTH,
@@ -693,28 +704,23 @@ def get_treatment_results_table_data(
             impact_variable=ImpactVariable.RATE_OF_SPREAD,
             year=year,
         )
-        try:
-            fl_metric = StandMetric.objects.get(
-                stand_id=stand_id, datalayer=flame_length
-            )
-            ros_metric = StandMetric.objects.get(
-                stand_id=stand_id, datalayer=rate_of_spread
-            )
-        except StandMetric.DoesNotExist:
-            fl_metric = ros_metric = None
+        fl_metric = StandMetric.objects.get(stand_id=stand_id, datalayer=flame_length)
+        ros_metric = StandMetric.objects.get(
+            stand_id=stand_id, datalayer=rate_of_spread
+        )
 
         data_map[year][ImpactVariable.FLAME_LENGTH] = {
             "value": None,
             "delta": None,
-            "baseline": fl_metric.avg if fl_metric else None,
-            "category": classify_flame_length(fl_metric.avg) if fl_metric else None,
+            "baseline": fl_metric.avg,
+            "category": classify_flame_length(fl_metric.avg),
         }
 
         data_map[year][ImpactVariable.RATE_OF_SPREAD] = {
             "value": None,
             "delta": None,
-            "baseline": ros_metric.avg if ros_metric else None,
-            "category": classify_rate_of_spread(ros_metric.avg) if ros_metric else None,
+            "baseline": ros_metric.avg,
+            "category": classify_rate_of_spread(ros_metric.avg),
         }
 
     # Populate data_map with treatment results

--- a/src/planscape/impacts/tests/test_services.py
+++ b/src/planscape/impacts/tests/test_services.py
@@ -1,5 +1,7 @@
 import json
+import random
 from collections import defaultdict
+from pathlib import Path
 
 from datasets.models import DataLayerType
 from datasets.tests.factories import DataLayerFactory
@@ -30,7 +32,9 @@ from impacts.services import (
     generate_summary,
     get_baseline_matrix,
     get_calculation_matrix,
+    get_calculation_matrix_wo_action,
     get_treatment_results_table_data,
+    itertools,
     upsert_treatment_prescriptions,
 )
 from impacts.tests.factories import (

--- a/src/planscape/impacts/tests/test_services.py
+++ b/src/planscape/impacts/tests/test_services.py
@@ -708,7 +708,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
         Ensures that both TreatmentResult and StandMetric data are correctly included
         in the final table_data structure.
         """
-        # LARGE_TREE_BIOMASS: TREATABLE VARIABLE
         TreatmentResultFactory.create(
             treatment_plan=self.treatment_plan,
             stand=self.stand,
@@ -742,7 +741,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
                 avg=70.0,
             )
 
-        # FLAME_LENGTH: BASELINE ONLY
         for year in AVAILABLE_YEARS:
             flame_length_metadata = {
                 "modules": {
@@ -766,7 +764,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
                 avg=4.5,
             )
 
-        # RATE_OF_SPREAD: BASELINE ONLY
         for year in AVAILABLE_YEARS:
             rate_of_spread_metadata = {
                 "modules": {
@@ -790,7 +787,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
                 avg=12.0,
             )
 
-        # RUN FUNCTION: TABLE
         table_data = get_treatment_results_table_data(
             self.treatment_plan, self.stand.id
         )
@@ -798,20 +794,17 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
         self.assertEqual(len(row_2024_list), 1, "Expected exactly 1 row for 2024")
         row_2024 = row_2024_list[0]
 
-        # LARGE_TREE_BIOMASS: VALUE-CHECK
         biomass_data = row_2024[ImpactVariable.LARGE_TREE_BIOMASS]
         self.assertEqual(biomass_data["value"], 80.0)
         self.assertEqual(biomass_data["delta"], 10.0)
         self.assertEqual(biomass_data["baseline"], 70.0)
 
-        # FLAME_LENGTH: VALUE-CHECK
         fl_data = row_2024[ImpactVariable.FLAME_LENGTH]
         self.assertEqual(fl_data["value"], None)
         self.assertEqual(fl_data["delta"], None)
         self.assertEqual(fl_data["baseline"], 4.5)
         self.assertEqual(fl_data["category"], "Moderate")
 
-        # RATE_OF_SPREAD: VALUE-CHECK
         ros_data = row_2024[ImpactVariable.RATE_OF_SPREAD]
         self.assertEqual(ros_data["value"], None)
         self.assertEqual(ros_data["delta"], None)
@@ -822,7 +815,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
         """
         Ensures that only StandMetric data is returned, as long as TreatmentResult exists.
         """
-        # Dummy TreatmentResult data
         TreatmentResultFactory.create(
             treatment_plan=self.treatment_plan,
             stand=self.stand,
@@ -834,7 +826,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
             action=None,
         )
 
-        # FLAME_LENGTH: BASELINE ONLY
         for year in AVAILABLE_YEARS:
             flame_length_metadata = {
                 "modules": {
@@ -858,7 +849,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
                 avg=4.5,
             )
 
-        # RATE_OF_SPREAD: BASELINE ONLY
         for year in AVAILABLE_YEARS:
             rate_of_spread_metadata = {
                 "modules": {
@@ -882,7 +872,6 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
                 avg=12.0,
             )
 
-        # RUN FUNCTION: TABLE
         table_data = get_treatment_results_table_data(
             self.treatment_plan, self.stand.id
         )
@@ -890,12 +879,10 @@ class GetTreatmentResultsTableDataTest(TransactionTestCase):
         self.assertEqual(len(row_2024_list), 1, "Expected exactly 1 row for 2024")
         row_2024 = row_2024_list[0]
 
-        # FLAME_LENGTH: VALUE-CHECK
         fl_data = row_2024[ImpactVariable.FLAME_LENGTH]
         self.assertEqual(fl_data["baseline"], 4.5)
         self.assertEqual(fl_data["category"], "Moderate")
 
-        # RATE_OF_SPREAD: VALUE-CHECK
         ros_data = row_2024[ImpactVariable.RATE_OF_SPREAD]
         self.assertEqual(ros_data["baseline"], 12.0)
         self.assertEqual(ros_data["category"], "Moderate")

--- a/src/planscape/impacts/tests/test_views.py
+++ b/src/planscape/impacts/tests/test_views.py
@@ -627,7 +627,6 @@ class StandTreatmentResultsViewTest(APITestCase):
             aggregation=ImpactVariableAggregation.SUM,
         )
 
-        # LARGE_TREE_BIOMASS: BASELINE
         for year in AVAILABLE_YEARS:
             biomass_meta = {
                 "modules": {
@@ -651,7 +650,6 @@ class StandTreatmentResultsViewTest(APITestCase):
                 avg=70.0,
             )
 
-            # FLAME_LENGTH: BASELINE
             flame_length_meta = {
                 "modules": {
                     "impacts": {
@@ -674,7 +672,6 @@ class StandTreatmentResultsViewTest(APITestCase):
                 avg=4.5,
             )
 
-            # RATE_OF_SPREAD: BASELINE
             ros_meta = {
                 "modules": {
                     "impacts": {
@@ -697,12 +694,10 @@ class StandTreatmentResultsViewTest(APITestCase):
                 avg=12.0,
             )
 
-        # ENDPOINT: CALL
         response = self.client.get(f"{self.url}?stand_id={self.stand.pk}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        # TABLE: CHECK ROWS
         self.assertEqual(
             len(data),
             len(AVAILABLE_YEARS),
@@ -712,7 +707,6 @@ class StandTreatmentResultsViewTest(APITestCase):
         self.assertEqual(len(row_2024_list), 1, "Expected exactly one row for 2024")
         row_2024 = row_2024_list[0]
 
-        # MULTIPLE-ROW: VALUE-CHECK
         self.assertIn(ImpactVariable.FLAME_LENGTH, row_2024)
         self.assertIn(ImpactVariable.RATE_OF_SPREAD, row_2024)
 

--- a/src/planscape/impacts/tests/test_views.py
+++ b/src/planscape/impacts/tests/test_views.py
@@ -3,13 +3,15 @@ from urllib.parse import urlencode
 
 from collaboration.models import Permissions, Role, UserObjectRole
 from collaboration.services import get_content_type
+from datasets.models import DataLayerType
+from datasets.tests.factories import DataLayerFactory
 from django.contrib.auth import get_user_model
 from django.forms.models import model_to_dict
 from django.urls import reverse
 from impacts.models import (
+    AVAILABLE_YEARS,
     ImpactVariable,
     ImpactVariableAggregation,
-    AVAILABLE_YEARS,
     TreatmentPlan,
     TreatmentPlanStatus,
     TreatmentPrescriptionAction,
@@ -29,7 +31,7 @@ from planning.tests.factories import (
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase, APITransactionTestCase
 from stands.models import StandSizeChoices
-from stands.tests.factories import StandFactory
+from stands.tests.factories import StandFactory, StandMetricFactory
 
 from planscape.tests.factories import UserFactory
 
@@ -601,29 +603,123 @@ class StandTreatmentResultsViewTest(APITestCase):
         """
         Tests that the endpoint returns correct data when multiple TreatmentResult rows exist.
         """
-        TreatmentResultFactory(
+        TreatmentResultFactory.create(
             treatment_plan=self.treatment_plan,
             stand=self.stand,
-            variable=ImpactVariable.FLAME_LENGTH,
+            variable=ImpactVariable.LARGE_TREE_BIOMASS,
             year=2024,
-            value=3.5,
-        )
-        TreatmentResultFactory(
-            treatment_plan=self.treatment_plan,
-            stand=self.stand,
-            variable=ImpactVariable.RATE_OF_SPREAD,
-            year=2024,
-            value=2.5,
+            value=80.0,
+            delta=10.0,
+            baseline=70.0,
+            action=None,
+            aggregation=ImpactVariableAggregation.MEAN,
         )
 
+        TreatmentResultFactory.create(
+            treatment_plan=self.treatment_plan,
+            stand=self.stand,
+            variable=ImpactVariable.LARGE_TREE_BIOMASS,
+            year=2024,
+            value=105.0,
+            delta=12.0,
+            baseline=45.0,
+            action=None,
+            aggregation=ImpactVariableAggregation.SUM,
+        )
+
+        # LARGE_TREE_BIOMASS: BASELINE
+        for year in AVAILABLE_YEARS:
+            biomass_meta = {
+                "modules": {
+                    "impacts": {
+                        "year": year,
+                        "baseline": True,
+                        "variable": ImpactVariable.LARGE_TREE_BIOMASS,
+                        "action": None,
+                    }
+                }
+            }
+            biomass_layer = DataLayerFactory.create(
+                name=f"biomass_layer_{year}",
+                url="impacts/tests/test_data/test_raster.tif",
+                metadata=biomass_meta,
+                type=DataLayerType.RASTER,
+            )
+            StandMetricFactory.create(
+                stand=self.stand,
+                datalayer=biomass_layer,
+                avg=70.0,
+            )
+
+            # FLAME_LENGTH: BASELINE
+            flame_length_meta = {
+                "modules": {
+                    "impacts": {
+                        "year": year,
+                        "variable": ImpactVariable.FLAME_LENGTH,
+                        "action": None,
+                        "baseline": True,
+                    }
+                }
+            }
+            fl_layer = DataLayerFactory.create(
+                name=f"flame_length_{year}",
+                url="impacts/tests/test_data/test_raster.tif",
+                metadata=flame_length_meta,
+                type=DataLayerType.RASTER,
+            )
+            StandMetricFactory.create(
+                stand=self.stand,
+                datalayer=fl_layer,
+                avg=4.5,
+            )
+
+            # RATE_OF_SPREAD: BASELINE
+            ros_meta = {
+                "modules": {
+                    "impacts": {
+                        "year": year,
+                        "variable": ImpactVariable.RATE_OF_SPREAD,
+                        "action": None,
+                        "baseline": True,
+                    }
+                }
+            }
+            ros_layer = DataLayerFactory.create(
+                name=f"rate_of_spread_{year}",
+                url="impacts/tests/test_data/test_raster.tif",
+                metadata=ros_meta,
+                type=DataLayerType.RASTER,
+            )
+            StandMetricFactory.create(
+                stand=self.stand,
+                datalayer=ros_layer,
+                avg=12.0,
+            )
+
+        # ENDPOINT: CALL
         response = self.client.get(f"{self.url}?stand_id={self.stand.pk}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertEqual(len(data), 1, "Expected data for 1 year (2024)")
-        row_2024 = data[0]
-        self.assertEqual(row_2024["year"], 2024)
-        self.assertIn("fl", row_2024)
-        self.assertIn("ros", row_2024)
+
+        # TABLE: CHECK ROWS
+        self.assertEqual(
+            len(data),
+            len(AVAILABLE_YEARS),
+            f"Expected {len(AVAILABLE_YEARS)} rows (one for each year).",
+        )
+        row_2024_list = [row for row in data if row["year"] == 2024]
+        self.assertEqual(len(row_2024_list), 1, "Expected exactly one row for 2024")
+        row_2024 = row_2024_list[0]
+
+        # MULTIPLE-ROW: VALUE-CHECK
+        self.assertIn(ImpactVariable.FLAME_LENGTH, row_2024)
+        self.assertIn(ImpactVariable.RATE_OF_SPREAD, row_2024)
+
+        biomass_data = row_2024.get(ImpactVariable.LARGE_TREE_BIOMASS)
+        self.assertEqual(biomass_data["value"], 105.0)
+        self.assertEqual(biomass_data["delta"], 12.0)
+        self.assertEqual(biomass_data["baseline"], 45.0)
 
     def test_missing_stand_id(self):
         """


### PR DESCRIPTION
@george-silva, Kept having issues getting [] when testing the untreated stands, so I made a potential change to the get-stand info endpoint logic in `services.py` that caused the test to pass. The potential new logic now:

- Always fetches baseline data from StandMetric for all years, regardless of treated_results.
- Handles missing StandMetric entries by setting None for baseline and category.

Also made new tests for the stand-info endpoing in `test_services.py` and `test_views.py`. Interestingly, `test_services.py` has two tests that aren't  related to the stand-info endpoint failing (one of which is about empty URLs, and the second about a shapefile directory).