### PR TITLE
PLAN-1929: Missing divider on tabs

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.scss
@@ -158,4 +158,12 @@
   .mat-mdc-tab-header{
     background-color: $color-white;
   }
+
+  .mat-mdc-tab-labels {
+    border: 0;
+  }
+
+  .mdc-tab-indicator--active {
+    border-bottom: 2px solid $color-standard-blue;
+  }
 }

--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.scss
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.scss
@@ -7,11 +7,6 @@
     flex-direction: column;
     max-width: 100%;
     height: calc(100% - 170px);
-
-
-    ::ng-deep .mat-mdc-tab-labels {
-      border-bottom: 1px $color-soft-gray solid;
-    }
   }
   
 }

--- a/src/interface/src/styles/material.scss
+++ b/src/interface/src/styles/material.scss
@@ -109,3 +109,13 @@ mat-radio-button:not([disabled]) .mdc-label {
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="white"><path d="M480-424 364-308q-11 11-28 11t-28-11q-11-11-11-28t11-28l116-116-116-115q-11-11-11-28t11-28q11-11 28-11t28 11l116 116 115-116q11-11 28-11t28 11q12 12 12 28.5T651-595L535-480l116 116q11 11 11 28t-11 28q-12 12-28.5 12T595-308L480-424Z"/></svg>');
   }
 }
+
+// Default styles for tabs
+.mat-mdc-tab-labels {
+  border-bottom: 2px solid $color-soft-gray;
+
+  .mat-mdc-tab {
+    position: relative;
+    top: 2px;
+  }
+}


### PR DESCRIPTION
Adding the missing divider on tabs and updating some styles to look same as figma.

Jira: https://sig-gis.atlassian.net/browse/PLAN-1929

![image](https://github.com/user-attachments/assets/71fae832-430e-4863-b229-10f709d8e1a0)

![image](https://github.com/user-attachments/assets/1e909182-579e-441d-afc3-f58b642b1338)

![image](https://github.com/user-attachments/assets/4061bc98-6bc1-4af7-b01a-2b97ab1091e6)
