### PR TITLE
Remove Project Area Notes UI

### DIFF
--- a/src/interface/src/app/services/notes.service.ts
+++ b/src/interface/src/app/services/notes.service.ts
@@ -71,7 +71,3 @@ export abstract class BaseNotesService {
 export class PlanningAreaNotesService extends BaseNotesService {
   protected baseUrl = '/planning/planning_area/';
 }
-@Injectable()
-export class ProjectAreaNotesService extends BaseNotesService {
-  protected baseUrl = '/v2/project-areas/';
-}

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
@@ -14,14 +14,4 @@
   <mat-tab label="Base Maps">
     <app-map-base-layer></app-map-base-layer>
   </mat-tab>
-  <mat-tab label="Notes">
-    <sg-notes-sidebar
-      [notes]="notes"
-      [notesState]="notesSidebarState"
-      (createNote)="addNote($event)"
-      (deleteNote)="handleNoteDelete($event)"
-      noNotesTitleText="No Project Area Notes Yet"
-      noNotesDetailText="Start adding notes to help your team learn more about this project area.">
-    </sg-notes-sidebar>
-  </mat-tab>
 </mat-tab-group>

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.spec.ts
@@ -7,11 +7,8 @@ import { MapConfigState } from '../treatment-map/map-config.state';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { TreatmentsState } from '../treatments.state';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { TreatmentsService } from '@services/treatments.service';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
-import { NotesSidebarComponent } from '@styleguide';
 import { of } from 'rxjs';
 import { Geometry } from 'geojson';
 
@@ -34,24 +31,16 @@ describe('TreatmentProjectAreaComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [
-        NotesSidebarComponent,
         TreatmentProjectAreaComponent,
         RouterTestingModule,
         HttpClientTestingModule,
-        MatSnackBar,
         BrowserAnimationsModule,
       ],
       providers: [
-        MockProviders(
-          MapConfigState,
-          SelectedStandsState,
-          TreatmentsState,
-          TreatmentsService
-        ),
+        MockProviders(MapConfigState, SelectedStandsState, TreatmentsState),
         {
           provide: TreatmentsState,
           useValue: {
-            getTreatmentPlanId: jasmine.createSpy('getTreatmentPlanId'),
             setShowApplyTreatmentsDialog: jasmine.createSpy(
               'setShowApplyTreatmentsDialog'
             ),

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -1,19 +1,9 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { AsyncPipe, NgIf } from '@angular/common';
-import { Note, ProjectAreaNotesService } from '../../services/notes.service';
 import { MatDividerModule } from '@angular/material/divider';
-import {
-  NotesSidebarComponent,
-  NotesSidebarState,
-  TreatmentStandsProgressBarComponent,
-} from '@styleguide';
-import { TreatmentsService } from '@services/treatments.service';
-import { TreatmentPlan } from '@types';
-import { DeleteNoteDialogComponent } from '../../plan/delete-note-dialog/delete-note-dialog.component';
-import { distinctUntilChanged, take } from 'rxjs';
-import { SharedModule, SNACK_ERROR_CONFIG, SNACK_NOTICE_CONFIG } from '@shared';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { TreatmentStandsProgressBarComponent } from '@styleguide';
+import { SharedModule } from '@shared';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatTabsModule } from '@angular/material/tabs';
 import { ProjectAreaTreatmentsTabComponent } from '../treatments-tab/treatments-tab.component';
 import { MapConfigState } from '../treatment-map/map-config.state';
@@ -21,13 +11,10 @@ import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { TreatmentsState } from '../treatments.state';
 import { getTreatedStandsTotal } from '../prescriptions';
 import { MapBaseLayerComponent } from '../map-base-layer/map-base-layer.component';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
-@UntilDestroy()
 @Component({
   selector: 'app-project-area',
   standalone: true,
-  providers: [ProjectAreaNotesService],
   imports: [
     AsyncPipe,
     MapBaseLayerComponent,
@@ -35,7 +22,6 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
     MatDividerModule,
     MatTabsModule,
     NgIf,
-    NotesSidebarComponent,
     ProjectAreaTreatmentsTabComponent,
     SharedModule,
     TreatmentStandsProgressBarComponent,
@@ -43,27 +29,16 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
   templateUrl: './treatment-project-area.component.html',
   styleUrl: './treatment-project-area.component.scss',
 })
-export class TreatmentProjectAreaComponent implements OnDestroy, OnInit {
+export class TreatmentProjectAreaComponent implements OnDestroy {
   constructor(
     private mapConfigState: MapConfigState,
     private selectedStandsState: SelectedStandsState,
-    private treatmentsState: TreatmentsState,
-    private treatmentsService: TreatmentsService,
-    private notesService: ProjectAreaNotesService,
-    private dialog: MatDialog,
-    private snackbar: MatSnackBar
+    private treatmentsState: TreatmentsState
   ) {}
 
   opacity = this.mapConfigState.treatedStandsOpacity$;
   activeProjectArea$ = this.treatmentsState.activeProjectArea$;
   projectAreaId?: number;
-  treatmentPlan: TreatmentPlan | null = null;
-  treatmentPlanId: number = this.treatmentsState.getTreatmentPlanId();
-
-  // notes data
-  notesModel = 'project_area';
-  notes: Note[] = [];
-  notesSidebarState: NotesSidebarState = 'READY';
 
   getTreatedStandsTotal = getTreatedStandsTotal;
 
@@ -74,82 +49,5 @@ export class TreatmentProjectAreaComponent implements OnDestroy, OnInit {
   ngOnDestroy(): void {
     this.selectedStandsState.clearStands();
     this.treatmentsState.setShowApplyTreatmentsDialog(false);
-  }
-
-  ngOnInit(): void {
-    if (this.treatmentPlanId) {
-      this.treatmentsService
-        .getTreatmentPlan(Number(this.treatmentPlanId))
-        .subscribe((r) => (this.treatmentPlan = r));
-    }
-
-    this.activeProjectArea$
-      .pipe(untilDestroyed(this), distinctUntilChanged())
-      .subscribe((projectArea) => {
-        this.projectAreaId = projectArea?.project_area_id;
-        this.loadNotes();
-      });
-  }
-
-  //notes handling functions
-  addNote(comment: string) {
-    if (this.projectAreaId) {
-      this.notesSidebarState = 'SAVING';
-      this.notesService.addNote(this.projectAreaId, comment).subscribe({
-        next: () => {
-          this.loadNotes();
-        },
-        error: () => {
-          this.snackbar.open(
-            `Error: Could not add note.`,
-            'Dismiss',
-            SNACK_ERROR_CONFIG
-          );
-        },
-        complete: () => {
-          this.notesSidebarState = 'READY';
-        },
-      });
-    }
-  }
-
-  handleNoteDelete(note: Note) {
-    const dialogRef = this.dialog.open(DeleteNoteDialogComponent, {});
-    dialogRef
-      .afterClosed()
-      .pipe(take(1))
-      .subscribe((confirmed) => {
-        if (confirmed && this.projectAreaId) {
-          this.notesService.deleteNote(this.projectAreaId, note.id).subscribe({
-            next: () => {
-              this.snackbar.open(
-                `Deleted note`,
-                'Dismiss',
-                SNACK_NOTICE_CONFIG
-              );
-            },
-            error: () => {
-              this.snackbar.open(
-                `Error: Could not delete note.`,
-                'Dismiss',
-                SNACK_ERROR_CONFIG
-              );
-            },
-            complete: () => {
-              this.loadNotes();
-            },
-          });
-        }
-      });
-  }
-
-  loadNotes() {
-    if (this.projectAreaId) {
-      this.notesService
-        .getNotes(this.projectAreaId)
-        .subscribe((notes: Note[]) => {
-          this.notes = [...notes];
-        });
-    }
   }
 }


### PR DESCRIPTION
I'm splitting the notes migration ticket into a few PRs, so it's not massive, and can be reviewed independently by FE and BE folks.

This is the first of those PRs: removing the UI for project area notes. I figure if the backend PR ends up changing a lot of things, we at least won't end up with a UI that can't talk to removed/nonexistent endpoints.