### PR TITLE
PLAN-1911: Navigation issues

### DIFF
--- a/src/interface/src/app/plan/plan-map/plan-map.component.ts
+++ b/src/interface/src/app/plan/plan-map/plan-map.component.ts
@@ -243,7 +243,7 @@ export class PlanMapComponent implements OnInit, AfterViewInit, OnDestroy {
       layerTiles = satelliteTiles();
     }
     this.currentBaseLayer = selectedLayer;
-    this.map.addLayer(layerTiles);
+    this.map?.addLayer(layerTiles);
     // redraw the condition layer
     this.setCondition(this.layer);
   }
@@ -274,7 +274,7 @@ export class PlanMapComponent implements OnInit, AfterViewInit, OnDestroy {
         opacity: 0.7,
       }
     );
-    this.map.addLayer(this.tileLayer);
+    this.map?.addLayer(this.tileLayer);
 
     // Map legend request
     var dataUnit = '';
@@ -420,6 +420,9 @@ function addTooltipAtCenter(
     .setLatLng([center[1], center[0]])
     .setContent(content);
 
-  tooltip.addTo(map);
+  if (map) {
+    tooltip.addTo(map);
+  }
+
   return tooltip;
 }


### PR DESCRIPTION
Looks like there is a navigation issue when navigating back and forward between planning page and scenario page .

Jira: https://sig-gis.atlassian.net/browse/PLAN-1911

Investigation results:
I was able to reproduce once (I don't know how to be honestt) and I got this error:
![image](https://github.com/user-attachments/assets/f9f84724-b170-4c35-9bca-aef372fc0f96)

Investigating the code looks like we are initializing the map on `ngAfterViewInit `but we are trying to add some stuff to the map onInit `setCondition` so I'm pretty sure that is the issue.

In order to prevent the error to happen I added some conditionals to the code.
Hopefully that will solve the issue.

If you see the issue again please let me know.