### PR TITLE
Lucho plan 1975 analysis header update

### DIFF
--- a/src/interface/src/app/plan/plan-helpers.ts
+++ b/src/interface/src/app/plan/plan-helpers.ts
@@ -20,6 +20,12 @@ export const STAND_SIZES: Record<string, number> = {
   LARGE: 500,
 };
 
+export const STAND_SIZES_LABELS: Record<string, string> = {
+  SMALL: 'Small',
+  MEDIUM: 'Medium',
+  LARGE: 'Large',
+};
+
 export function parseResultsToProjectAreas(
   results: ScenarioResult
 ): ProjectAreaReport[] {

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
@@ -38,7 +38,7 @@
           >check_box_outline_blank</mat-icon
         >
         <span class="item-label">Total Planning Area Acres:</span>
-        {{ (projectArea$ | async)?.total_area_acres }}
+        {{ (summary$ | async)?.total_area_acres }}
       </div>
 
       <div class="item">

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
@@ -7,7 +7,7 @@
 <div class="direct-impacts">
   <sg-panel>
     <div class="title-row">
-      <h4 class="title">Direct Treatment Impacts</h4>
+      <h4 class="title">Direct Treatment Effects Analysis</h4>
       <button
         sg-button
         variant="ghost"
@@ -24,12 +24,26 @@
       class="treatment-plan">
       <div class="item">
         <mat-icon class="material-symbols-outlined">person</mat-icon>
-        {{ treatmentPlan.creator_name }}
+        <span class="item-label">Run By:</span> {{ treatmentPlan.creator_name }}
       </div>
 
       <div class="item">
         <mat-icon class="material-symbols-outlined">calendar_month</mat-icon>
+        <span class="item-label">Run Date:</span>
         {{ treatmentPlan.updated_at | date }}
+      </div>
+
+      <div class="item">
+        <mat-icon class="material-symbols-outlined"
+          >check_box_outline_blank</mat-icon
+        >
+        <span class="item-label">Total Planning Area Acres:</span>
+        {{ (projectArea$ | async)?.total_area_acres }}
+      </div>
+
+      <div class="item">
+        <mat-icon class="material-symbols-outlined">hexagon</mat-icon>
+        <span class="item-label">Stand Size:</span> {{ getStandSizeValue() }}
       </div>
     </div>
   </sg-panel>

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
@@ -17,6 +17,16 @@
     display: flex;
     gap: 8px;
     align-items: center;
+    color: $color-dark-gray;
+    font-weight: 500;
+
+    .material-symbols-outlined {
+      color: $color-standard-blue;
+    }
+
+    &-label {
+      font-weight: 600;
+    }
   }
 }
 

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
@@ -106,7 +106,7 @@
   display: flex;
   gap: 16px;
   align-items: center;
-  padding: 16px 0 0 0;
+  padding: 0;
 
   @include on-small() {
     flex-direction: column;

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
@@ -8,9 +8,10 @@
 
 .treatment-plan {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 16px;
-  padding: 16px;
-  align-items: center;
+  padding: 16px 0 0 0;
 
   .item {
     @include xs-label();
@@ -26,6 +27,24 @@
 
     &-label {
       font-weight: 600;
+    }
+  }
+
+  @include on-medium() {
+    display: block;
+    .item {
+      width: 50%;
+      display: inline-flex;
+    }
+  }
+
+  @include on-extra-large() {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    .item {
+      width: auto;
+      display: flex;
     }
   }
 }
@@ -72,8 +91,8 @@
 }
 
 ::ng-deep
-.mat-mdc-text-field-wrapper.mdc-text-field--outlined
-.mat-mdc-form-field-infix {
+  .mat-mdc-text-field-wrapper.mdc-text-field--outlined
+  .mat-mdc-form-field-infix {
   padding: 0px;
   line-height: 38px;
   height: 38px;
@@ -87,12 +106,7 @@
   display: flex;
   gap: 16px;
   align-items: center;
-  padding: 5px 0;
-
-  padding-top: 11px;
-  padding-bottom: 11px;
-  padding-left: 14px;
-  padding-right: 14px;
+  padding: 16px 0 0 0;
 
   @include on-small() {
     flex-direction: column;
@@ -101,10 +115,10 @@
 }
 
 .title {
-  @include h4();
+  @include h5();
+  font-size: 18px;
   margin: 0 auto 0 0;
 }
-
 
 .metric-selection {
   //placeholder styles
@@ -116,7 +130,7 @@
 .direct-impacts-metrics {
   display: grid;
   grid-template-columns: 50% 50%;
-  grid-template-rows:  600px; // todo what about this size?
+  grid-template-rows: 600px; // todo what about this size?
   gap: 16px;
   width: calc(100% - 16px);
 
@@ -125,8 +139,6 @@
     flex-direction: column;
     width: 100%;
   }
-
-
 }
 
 .empty-state {
@@ -145,7 +157,6 @@
     top: 6px;
   }
 }
-
 
 .map-panel-content {
   height: 100%;

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
@@ -42,7 +42,7 @@ import { ExpandedStandDataChartComponent } from '../expanded-stand-data-chart/ex
 import { ExpandedChangeOverTimeChartComponent } from '../expanded-change-over-time-chart/expanded-change-over-time-chart.component';
 import { MatDialog } from '@angular/material/dialog';
 import { ExpandedDirectImpactMapComponent } from '../expanded-direct-impact-map/expanded-direct-impact-map.component';
-import { Scenario, TreatmentPlan, TreatmentProjectArea } from '@types';
+import { Scenario, TreatmentProjectArea } from '@types';
 import { OverlayLoaderComponent } from 'src/styleguide/overlay-loader/overlay-loader.component';
 import { TreatmentsService } from '@services/treatments.service';
 import { FileSaverService, ScenarioService } from '@services';
@@ -93,7 +93,6 @@ import { STAND_SIZES, STAND_SIZES_LABELS } from 'src/app/plan/plan-helpers';
 export class DirectImpactsComponent implements OnInit, OnDestroy {
   loading = false;
   downloadingShapefile = false;
-  scenarioId: string | null = null;
   scenario: Scenario | null = null;
 
   constructor(
@@ -122,7 +121,6 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
           this.mapConfigState.setShowFillProjectAreas(false);
           this.mapConfigState.updateShowTreatmentStands(true);
           this.mapConfigState.updateShowProjectAreas(true);
-          return plan as TreatmentPlan;
         }),
         catchError((error) => {
           this.loading = false;
@@ -130,9 +128,10 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
           throw error;
         })
       )
-      .subscribe((plan) => {
-        if (plan?.scenario) {
-          this.scenarioService.getScenario(String(plan.scenario)).subscribe({
+      .subscribe(() => {
+        const scenarioId = this.treatmentsState.getScenarioId();
+        if (scenarioId) {
+          this.scenarioService.getScenario(scenarioId.toString()).subscribe({
             next: (scenario: Scenario) => {
               this.scenario = scenario;
               this.loading = false;
@@ -156,7 +155,7 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
   selectedChartProjectArea$ =
     this.directImpactsStateService.selectedProjectArea$;
 
-  projectArea$ = this.treatmentsState.summary$;
+  summary$ = this.treatmentsState.summary$;
 
   availableProjectAreas$ = this.treatmentsState.summary$.pipe(
     map((summary) => {

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
@@ -251,9 +251,10 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
   }
 
   getStandSizeValue(): string {
-    if (!this.scenario?.configuration?.stand_size) {
+    const stand_size = this.scenario?.configuration?.stand_size;
+    if (!stand_size) {
       return '';
     }
-    return `${STAND_SIZES_LABELS[this.scenario.configuration.stand_size]} (${STAND_SIZES[this.scenario.configuration.stand_size]} acres)`;
+    return `${STAND_SIZES_LABELS[stand_size]} (${STAND_SIZES[stand_size]} acres)`;
   }
 }

--- a/src/interface/src/app/treatments/mocks.ts
+++ b/src/interface/src/app/treatments/mocks.ts
@@ -52,4 +52,5 @@ export const MOCK_TREATMENT_PLAN: TreatmentPlan = {
   created_at: '2024-01-01T00:00:00Z',
   updated_at: '2024-01-01T00:00:00Z',
   creator_name: 'John Doe',
+  scenario: 2,
 };

--- a/src/interface/src/app/types/treatment.types.ts
+++ b/src/interface/src/app/types/treatment.types.ts
@@ -17,6 +17,7 @@ export interface TreatmentPlan {
   created_at: string;
   creator_name: string;
   updated_at: string;
+  scenario: number;
 }
 
 interface Totals {

--- a/src/interface/src/styleguide/panel/panel.component.scss
+++ b/src/interface/src/styleguide/panel/panel.component.scss
@@ -30,7 +30,7 @@ $panel-title-height: 60px;
   display: flex;
   align-items: center;
 
-  padding: 14px 16px 14px 24px;
+  padding: 16px;
   border-bottom: 1px solid $color-soft-gray;
 
   mat-icon {
@@ -53,7 +53,7 @@ $panel-title-height: 60px;
 
 
 .padded {
-  padding: 14px 16px 14px 24px;
+  padding: 0px 16px 16px 16px;
 
   &.content {
     height: calc(100% - $panel-title-height - 28px);

--- a/src/interface/src/styleguide/panel/panel.component.scss
+++ b/src/interface/src/styleguide/panel/panel.component.scss
@@ -1,5 +1,5 @@
-@import "colors";
-@import "mixins";
+@import 'colors';
+@import 'mixins';
 
 $panel-title-height: 60px;
 
@@ -8,7 +8,7 @@ $panel-title-height: 60px;
   border-radius: 4px;
   border: 1px solid $color-soft-gray;
   background: $color-white;
-  box-shadow: 0 6px 6px 0 rgba(0, 0, 0, 0.20);
+  box-shadow: 0 6px 6px 0 rgba(0, 0, 0, 0.2);
   box-sizing: border-box;
 
   ::ng-deep *[panelTitle] {
@@ -38,7 +38,6 @@ $panel-title-height: 60px;
   }
 }
 
-
 .content {
   height: calc(100% - $panel-title-height);
   position: relative;
@@ -51,12 +50,10 @@ $panel-title-height: 60px;
   gap: 16px;
 }
 
-
 .padded {
-  padding: 0px 16px 16px 16px;
+  padding: 16px;
 
   &.content {
     height: calc(100% - $panel-title-height - 28px);
   }
 }
-


### PR DESCRIPTION
Title: Direct Treatment Effect Analysis

Planning Areas Details:
- Acres
- Stand Size
- Ability to export GeoPackage

Jira: https://sig-gis.atlassian.net/browse/PLAN-1975

Design:
![image](https://github.com/user-attachments/assets/8b0e4e22-9b06-4f6b-8557-595bc36df156)


Result:
![image](https://github.com/user-attachments/assets/e3ca67bb-a449-42dc-aa3c-f0e8baf3f3e1)


![image](https://github.com/user-attachments/assets/cb49947b-52bc-4b7d-ae5e-5ffd50042e6f)

![image](https://github.com/user-attachments/assets/60812592-4471-4942-b6fe-735d914fa633)


