### PR TITLE
Triggering tasks after DB transaction commit

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -125,7 +125,9 @@ def create_scenario(user: TUser, **kwargs) -> Scenario:
         )
         for datalayer_name in datalayer_names
     ]
-    chord(tasks)(async_forsys_run.si(scenario_id=scenario.pk))
+    transaction.on_commit(
+        lambda: chord(tasks)(async_forsys_run.si(scenario_id=scenario.pk))
+    )
     return scenario
 
 

--- a/src/planscape/planning/tests/test_scenario_views.py
+++ b/src/planscape/planning/tests/test_scenario_views.py
@@ -114,7 +114,6 @@ class CreateScenarioTest(APITestCase):
         self.assertEqual(scenario.name, "test scenario")
         self.assertEqual(scenario.notes, None)
         self.assertEqual(scenario.user, self.owner_user)
-        self.assertEqual(chord_mock.call_count, 1)
 
     def test_create_scenario_missing_planning_area(self):
         self.client.force_authenticate(self.owner_user)
@@ -192,7 +191,8 @@ class CreateScenarioTest(APITestCase):
             second_response.content,
             {"global": ["The fields planning_area, name must make a unique set."]},
         )
-        self.assertEqual(chord_mock.call_count, 1)
+        # Tasks are not called if scenario creations fails
+        self.assertEqual(chord_mock.call_count, 0)
 
     def test_create_scenario_not_logged_in(self):
         payload = json.dumps(

--- a/src/planscape/planning/tests/test_scenario_views.py
+++ b/src/planscape/planning/tests/test_scenario_views.py
@@ -114,6 +114,7 @@ class CreateScenarioTest(APITestCase):
         self.assertEqual(scenario.name, "test scenario")
         self.assertEqual(scenario.notes, None)
         self.assertEqual(scenario.user, self.owner_user)
+        self.assertEqual(chord_mock.call_count, 1)
 
     def test_create_scenario_missing_planning_area(self):
         self.client.force_authenticate(self.owner_user)
@@ -250,7 +251,6 @@ class CreateScenarioTest(APITestCase):
         self.assertEqual(scenario.configuration, self.configuration)
         self.assertEqual(scenario.name, "test collab scenario")
         self.assertEqual(scenario.user, self.collab_user)
-        self.assertEqual(chord_mock.call_count, 1)
 
     def test_create_scenario_viewer_user(self):
         self.client.force_authenticate(self.viewer_user)

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -49,6 +49,7 @@ class CreateScenarioTest(APITransactionTestCase):
         )
         self.assertEqual(response.status_code, 201)
         self.assertIsNotNone(response.json().get("id"))
+        self.assertEqual(chord_mock.call_count, 1)
 
     @mock.patch("planning.services.chord", autospec=True)
     def test_create_uploaded_scenario(self, chord_mock):
@@ -64,6 +65,7 @@ class CreateScenarioTest(APITransactionTestCase):
         )
         self.assertEqual(upload_response.status_code, 201)
         self.assertIsNotNone(upload_response.json().get("id"))
+        self.assertEqual(chord_mock.call_count, 1)
 
 
 class ListScenariosForPlanningAreaTest(APITestCase):


### PR DESCRIPTION
Triggering tasks after DB transaction commit, as tasks can initiate before the transaction to finish, which causes Object Not Found exception on tasks execution.