### PR TITLE
Update details of project-area-expander

### DIFF
--- a/src/interface/src/styleguide/project-area-expander/project-area-expander.component.html
+++ b/src/interface/src/styleguide/project-area-expander/project-area-expander.component.html
@@ -60,12 +60,10 @@
 
       <div class="rx-details">
         <div>
-          <span class="rx-detail-name">Stands: </span
-          ><span class="rx-detail-value">{{ rx.treated_stand_count }}</span>
-        </div>
-        <div>
           <span class="rx-detail-name">Total: </span
-          ><span class="rx-detail-value">{{ rx.stand_ids.length }}</span>
+          ><span class="rx-detail-value"
+            >{{ rx.area_acres | number: '1.0-2' }} acres</span
+          >
         </div>
       </div>
     </mat-expansion-panel>

--- a/src/interface/src/styleguide/project-area-expander/project-area-expander.component.scss
+++ b/src/interface/src/styleguide/project-area-expander/project-area-expander.component.scss
@@ -173,7 +173,7 @@
 
 .rx-detail-value {
   @include small-paragraph();
-  color: $color-md-gray;
+  color: $color-black;
 }
 
 .rx-section {


### PR DESCRIPTION
Makes changes to the project-area-expander component, as described in [PLAN-2024](https://sig-gis.atlassian.net/browse/PLAN-2024).

Before (I think **Total** was probably wrong this whole time):
<img width="399" alt="Screenshot 2025-01-23 at 4 28 49 PM" src="https://github.com/user-attachments/assets/6bc565d2-3059-4506-87c2-267150ef072f" />

After:
<img width="399" alt="Screenshot 2025-01-23 at 4 27 11 PM" src="https://github.com/user-attachments/assets/e1193186-b2f9-497d-8312-77d3575554e3" />

