### PR TITLE
project areas label need to sit at the top 

### DIFF
--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
@@ -100,6 +100,7 @@ export class DirectImpactsMapComponent {
     this.mapLibreMap.moveLayer('map-project-areas-line');
     this.mapLibreMap.moveLayer('standHover');
     this.mapLibreMap.moveLayer('standSelected');
+    this.mapLibreMap.moveLayer('map-project-areas-labels');
   }
 
   openTreatmentLegend() {


### PR DESCRIPTION
Project Area labels get cut off by project area outline on direct impact map