### PR TITLE
PLAN-2026: Moving styles to material overrides

### DIFF
--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
@@ -72,7 +72,7 @@
       <div class="filter-label">Project Area:</div>
       <mat-form-field
         appearance="outline"
-        class="changes-chart-select project-area-selector">
+        class="changes-chart-select project-area-selector dropdown-selector">
         <mat-select
           class="project-area-selector"
           [ngModel]="selectedChartProjectArea$ | async"

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.scss
@@ -222,15 +222,7 @@ $panel-height: 600px;
 }
 
 .project-area-selector {
-  --mdc-outlined-text-field-outline-color: #{$color-fields-gray};
-
-  ::ng-deep .mat-mdc-form-field-infix {
-    height: 38px;
-    padding: 8px 0;
-  }
-
   ::ng-deep .mat-mdc-select-trigger {
-    top: -2px;
     color: $color-black;
     font-size: 14px;
     font-weight: 400;

--- a/src/interface/src/app/treatments/metric-selector/metric-selector.component.html
+++ b/src/interface/src/app/treatments/metric-selector/metric-selector.component.html
@@ -8,7 +8,7 @@
 <mat-form-field
   appearance="outline"
   subscriptSizing="dynamic"
-  class="metric-selector">
+  class="dropdown-selector">
   <mat-select
     [ngModel]="selectedOption"
     (ngModelChange)="onSelect($event)"

--- a/src/interface/src/app/treatments/metric-selector/metric-selector.component.scss
+++ b/src/interface/src/app/treatments/metric-selector/metric-selector.component.scss
@@ -13,7 +13,6 @@
   flex-shrink: 0;
 }
 
-
 .selector {
   width: 200px;
   background-color: $color-white;
@@ -21,7 +20,6 @@
   border: 1px solid $color-soft-gray;
   padding: 8px 14px 8px 14px;
 }
-
 
 .metric-color {
   display: inline-block;
@@ -37,14 +35,4 @@
   color: $color-dark-gray;
   margin-right: 8px;
   vertical-align: middle;
-}
-
-.metric-selector {
-  --mdc-outlined-text-field-outline-color: #{$color-fields-gray};
-
-  ::ng-deep .mat-mdc-form-field-infix {
-
-    min-height: 38px;
-    padding: 8px 0;
-  }
 }

--- a/src/interface/src/styles/material.scss
+++ b/src/interface/src/styles/material.scss
@@ -1,5 +1,5 @@
 // material overrides
-@import "colors";
+@import 'colors';
 
 .mat-tooltip {
   font-size: 12px;
@@ -14,7 +14,6 @@
   padding: 0;
 }
 
-
 .mat-card mat-card-title.mat-card-title {
   font-size: 24px;
   line-height: 20px;
@@ -27,12 +26,11 @@
 
 // default styles for menu
 body {
-  --mat-menu-item-label-text-font: "Public Sans", sans-serif;
+  --mat-menu-item-label-text-font: 'Public Sans', sans-serif;
   --mat-menu-item-label-text-size: 14px;
   --mat-menu-item-label-text-tracking: 0;
   --mat-menu-item-label-text-line-height: 22px;
   --mat-menu-item-label-text-weight: 400;
-
 
   --mat-table-header-headline-size: 14px;
 }
@@ -49,7 +47,7 @@ body {
     padding: 0;
 
     &::before {
-      display: none
+      display: none;
     }
   }
 }
@@ -81,7 +79,6 @@ mat-radio-button:not([disabled]) .mdc-label {
     color: $color-error;
   }
 }
-
 
 .mat-mdc-radio-button.mat-warn {
   --mdc-radio-unselected-icon-color: #{$color-error};
@@ -117,5 +114,14 @@ mat-radio-button:not([disabled]) .mdc-label {
   .mat-mdc-tab {
     position: relative;
     top: 2px;
+  }
+}
+
+// material dropdown styles
+.dropdown-selector .mdc-text-field {
+  .mat-mdc-form-field-infix {
+    min-height: 38px;
+    padding: 0;
+    align-content: center;
   }
 }


### PR DESCRIPTION
Moving styles for the material dropdown to a common place since it was repeated:

Jira: https://sig-gis.atlassian.net/browse/PLAN-2026

![image](https://github.com/user-attachments/assets/223003de-7d10-4750-b4b8-4970544cfed0)
