### PR TITLE
PLAN-2136: Adding a variant for link button

### DIFF
--- a/src/interface/src/app/map/map-base-dropdown/map-base-dropdown.component.scss
+++ b/src/interface/src/app/map/map-base-dropdown/map-base-dropdown.component.scss
@@ -7,8 +7,8 @@
 
 .base-layer {
   &-icon {
-    height: 40px;
-    width: 40px;
+    height: 38px;
+    width: 38px;
     border: 1px solid $color-soft-gray;
     border-radius: 4px;
     cursor: pointer;

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.html
@@ -63,7 +63,7 @@
       <a
         sg-button
         icon="help"
-        variant="text"
+        variant="link"
         [outlined]="true"
         href="https://github.com/OurPlanscape/Planscape/wiki/Planscape-Treatment-Effects-User-Guide"
         target="_blank"

--- a/src/interface/src/app/treatments/expanded-change-over-time-chart/expanded-change-over-time-chart.component.html
+++ b/src/interface/src/app/treatments/expanded-change-over-time-chart/expanded-change-over-time-chart.component.html
@@ -10,7 +10,7 @@
     <a
       sg-button
       icon="help"
-      variant="text"
+      variant="link"
       [outlined]="true"
       href="https://github.com/OurPlanscape/Planscape/wiki/Planscape-Treatment-Effects-User-Guide"
       target="_blank"

--- a/src/interface/src/styleguide/button/button.component.scss
+++ b/src/interface/src/styleguide/button/button.component.scss
@@ -1,6 +1,5 @@
-@import "colors";
-@import "mixins";
-
+@import 'colors';
+@import 'mixins';
 
 :host {
   font-family: inherit;
@@ -25,7 +24,8 @@
     background-color: $color-standard-blue;
     border-color: $color-standard-blue;
 
-    &:active, &:hover {
+    &:active,
+    &:hover {
       background-color: $color-main-blue;
       border-color: $color-main-blue;
     }
@@ -42,13 +42,12 @@
     border-color: $color-standard-blue;
     background-color: $color-white;
 
-
-    &:active, &:hover {
+    &:active,
+    &:hover {
       color: $color-white;
       background-color: $color-main-blue;
       border-color: $color-main-blue;
     }
-
 
     &:disabled {
       color: $color-text-gray;
@@ -62,8 +61,9 @@
     background-color: $color-error;
     color: $color-white;
 
-    &:active, &:hover {
-      background: #B40000;
+    &:active,
+    &:hover {
+      background: #b40000;
     }
 
     &:disabled {
@@ -78,7 +78,8 @@
     border: none;
     color: $color-standard-blue;
 
-    &:active, &:hover {
+    &:active,
+    &:hover {
       background-color: $color-soft-gray;
     }
 
@@ -92,7 +93,8 @@
     background-color: $color-brand-teal;
     color: $color-white;
 
-    &:active, &:hover {
+    &:active,
+    &:hover {
       background: $color-brand-green;
     }
 
@@ -127,6 +129,23 @@
     }
   }
 
+  &.link-button {
+    background-color: transparent;
+    color: $color-standard-blue;
+
+    .mat-icon {
+      width: 20px;
+      height: 20px;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:disabled {
+      color: $color-md-gray;
+    }
+  }
 
   &.has-error:not(:disabled) {
     background-color: white;
@@ -140,5 +159,3 @@
     font-size: 20px;
   }
 }
-
-

--- a/src/interface/src/styleguide/button/button.component.ts
+++ b/src/interface/src/styleguide/button/button.component.ts
@@ -9,7 +9,8 @@ export type ButtonVariant =
   | 'text'
   | 'negative'
   | 'positive'
-  | 'icon-only';
+  | 'icon-only'
+  | 'link';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -68,6 +69,11 @@ export class ButtonComponent {
   @HostBinding('class.icon-button')
   get isVariantIconOnly() {
     return this.variant === 'icon-only';
+  }
+
+  @HostBinding('class.link-button')
+  get isVariantLinkOnly() {
+    return this.variant === 'link';
   }
 
   @HostBinding('class.has-error')

--- a/src/interface/src/styleguide/button/button.stories.ts
+++ b/src/interface/src/styleguide/button/button.stories.ts
@@ -81,6 +81,15 @@ export const Outline: Story = {
   },
 };
 
+export const Link: Story = {
+  args: {
+    variant: 'link',
+    icon: 'help',
+    outlined: true,
+    content: 'A link with outline icon',
+  },
+};
+
 export const Icon: Story = {
   args: {
     variant: 'icon-only',


### PR DESCRIPTION
Adding a variant for link button

After discussing with Julie we are going to add a variant for link buttons.

Jira: https://sig-gis.atlassian.net/browse/PLAN-2136
Figma: https://www.figma.com/design/5hdeZ9G9zC6aDMOmW29wEh/Planscape-Design-System?node-id=1245-5573&m=dev
Screen exaple: https://www.figma.com/proto/njHEIn6MWPYJ5hw4we0lFY/Treatment-Effects?node-id=4940-54776&t=ihU7I8dH208CCvp6-0&scaling=min-zoom&content-scaling=fixed&page-id=921%3A17034

Result:
![image](https://github.com/user-attachments/assets/7475966d-e07f-4fd8-a1a1-d1f703ce23e2)


Storybook:
![image](https://github.com/user-attachments/assets/77811d0e-8f70-47e4-ad70-d52975363a01)
