### PR TITLE
fix import type error

### DIFF
--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -160,11 +160,9 @@ def create_style(
     action.send(created_by, verb="created", action_object=style)
 
     if datalayers:
-        datalayer_qs = DataLayer.objects.filter(id__in=datalayers)
-        if datalayer_qs.count() != len(datalayers):
-            raise ValueError("One or more provided datalayer IDs do not exist.")
-        for datalayer in datalayer_qs:
+        for datalayer in datalayers:
             assign_style(created_by=created_by, style=style, datalayer=datalayer)
+
     invalidate_model(Style)
     return {"style": style, "possibly_exists": hash_already_exists}
 


### PR DESCRIPTION
@george-silva @roquebetioljr:

Removed this line from serializers.py, as well as its associated if statements:

`datalayer_qs = DataLayer.objects.filter(id__in=datalayers)` 

This is to fix the TypeError on Sentry here:

https://sentry.sig-gis.com/organizations/sig/issues/257/?project=2&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0