### PR TITLE
style import duplicate json behavior

### DIFF
--- a/src/planscape/datasets/management/commands/styles.py
+++ b/src/planscape/datasets/management/commands/styles.py
@@ -5,6 +5,7 @@ import requests
 from core.base_commands import PlanscapeCommand
 from core.pprint import pprint
 from django.core.management.base import CommandParser
+from django.db import IntegrityError
 from pathlib import Path
 
 
@@ -106,6 +107,7 @@ class Command(PlanscapeCommand):
 
         successes = []
         failures = []
+        skipped = []
 
         dir_path = Path(directory)
         for file_path in dir_path.glob("*.json"):
@@ -157,20 +159,47 @@ class Command(PlanscapeCommand):
             style_url = f"{base_url}/v2/admin/styles/"
             self.stdout.write(f"Sending payload:\n{json.dumps(payload, indent=2)}")
             response = requests.post(style_url, headers=headers, json=payload)
-            result = response.json()
+
             if response.status_code == 201:
+                result = response.json()
                 self.stdout.write(
                     f"Created style from {file_path}: {json.dumps(result, indent=2)}"
                 )
                 successes.append(str(file_path))
+            elif response.status_code == 400:
+                try:
+                    result = response.json()
+                    error_detail = str(result)
+                    if (
+                        "style_unique_constraint" in error_detail
+                        or "already exists" in error_detail
+                    ):
+                        self.stderr.write(
+                            f"SKIPPED (duplicate name): '{base_name}' from {file_path}"
+                        )
+                        skipped.append(str(file_path))
+                    else:
+                        self.stderr.write(
+                            f"ERROR creating style from {file_path}: {json.dumps(result, indent=2)}"
+                        )
+                        failures.append(str(file_path))
+                except Exception as e:
+                    self.stderr.write(
+                        f"ERROR (non-JSON response) from {file_path}: {e}"
+                    )
+                    failures.append(str(file_path))
             else:
-                self.stderr.write(
-                    f"ERROR creating style from {file_path}: {json.dumps(result, indent=2)}"
-                )
+                try:
+                    result = response.json()
+                except Exception:
+                    result = response.text
+                self.stderr.write(f"ERROR creating style from {file_path}: {result}")
                 failures.append(str(file_path))
 
         self.stdout.write(
-            f"Import complete: {len(successes)} successes, {len(failures)} failures."
+            f"Import complete: {len(successes)} successes, {len(skipped)} skipped (duplicates), {len(failures)} failures."
         )
+        if skipped:
+            self.stdout.write(f"Skipped files (duplicates): {', '.join(skipped)}")
         if failures:
             self.stderr.write(f"Failed files: {', '.join(failures)}")


### PR DESCRIPTION
@george-silva @roquebetioljr - The new import logic:

1. Imports styles if it receives a `201`, logging it to the `Successes` list
2. Skips styles if it receives a `400` with a "style_unique_constraint" or "already exists" error, logging it to a `Skipped` list, OR to the `Failures` list if it's a `400` without those two error messages.
3. If it receives anything else besides `201` or `400`, throws the offending files in the `Failures` list.

------------------------

P.S. There is django.db "Integrity Error" import I need to remove -- didn't end up using it, but used HTTP response codes instead.