### PR TITLE
Add loading indicator for loading data layers

### DIFF
--- a/src/interface/src/app/data-layers/data-layers.state.service.ts
+++ b/src/interface/src/app/data-layers/data-layers.state.service.ts
@@ -92,7 +92,8 @@ export class DataLayersStateService {
   }
 
   selectDataLayer(dataLayer: DataLayer) {
-    this.loadingLayer.next(true);
+    // TODO: enable this when the datalayer loading function is merged
+    // this.loadingLayer.next(true);
     this._selectedDataLayer$.next(dataLayer);
   }
 

--- a/src/interface/src/app/data-layers/data-layers.state.service.ts
+++ b/src/interface/src/app/data-layers/data-layers.state.service.ts
@@ -40,6 +40,9 @@ export class DataLayersStateService {
 
   hasNoTreeData$ = this.dataTree$.pipe(map((d) => !!d && d.length === 0));
 
+  private loadingLayer = new BehaviorSubject(false);
+  loadingLayer$ = this.loadingLayer.asObservable();
+
   private loadingSubject = new BehaviorSubject(false);
   loading$ = this.loadingSubject.asObservable();
 
@@ -89,6 +92,7 @@ export class DataLayersStateService {
   }
 
   selectDataLayer(dataLayer: DataLayer) {
+    this.loadingLayer.next(true);
     this._selectedDataLayer$.next(dataLayer);
   }
 

--- a/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.html
+++ b/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.html
@@ -1,0 +1,9 @@
+<div>
+  <div class="loader-modal">
+    <mat-spinner diameter="36" class="loader"></mat-spinner>
+    <div class="headline">Loading Layer</div>
+    <div class="details">
+      This may take a few seconds, your layer will appear shortly.
+    </div>
+  </div>
+</div>

--- a/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.scss
+++ b/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.scss
@@ -1,0 +1,38 @@
+@import "mixins";
+@import "colors";
+
+:host {
+    background-color: #00000055;
+    height: 100%;
+    width: 100%;
+    z-index: 100;
+    position: absolute;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+}
+
+.loader-modal {
+    justify-content: center;
+    display: flex;
+    width: 400px;
+    padding: 32px;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    border-radius: 4px;
+    background: #FFF;
+    box-shadow: 0px 2px 6px 2px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+}
+
+.headline {
+    @include h4();
+    text-align: center;
+}
+
+.details {
+    color: $color-dark-gray;
+    text-align: center;
+    @include small-paragraph();
+}

--- a/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.spec.ts
+++ b/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoadingLayerOverlayComponent } from './loading-layer-overlay.component';
+
+describe('LoadingLayerOverlayComponent', () => {
+  let component: LoadingLayerOverlayComponent;
+  let fixture: ComponentFixture<LoadingLayerOverlayComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoadingLayerOverlayComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoadingLayerOverlayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.ts
+++ b/src/interface/src/app/maplibre-map/loading-layer-overlay/loading-layer-overlay.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-loading-layer-overlay',
+  standalone: true,
+  imports: [MatProgressSpinnerModule],
+  templateUrl: './loading-layer-overlay.component.html',
+  styleUrl: './loading-layer-overlay.component.scss',
+})
+export class LoadingLayerOverlayComponent {}

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -13,6 +13,9 @@
     (valueChange)="handleOpacityChange($event)"></sg-opacity-slider>
 </app-map-nav-bar>
 
+<app-loading-layer-overlay *ngIf="loadingLayer$ | async">
+</app-loading-layer-overlay>
+
 <mgl-map
   *ngIf="mapExtent$ | async; let bounds"
   (mapLoad)="mapLoaded($event)"

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.spec.ts
@@ -11,7 +11,7 @@ import { of } from 'rxjs';
 import { Geometry } from 'geojson';
 
 import { AuthService, PlanService } from '@services';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TreatmentsState } from '../treatments.state';
 import { DEFAULT_BASE_MAP } from '../../maplibre-map/map-base-layers';
 import { MapProjectAreasComponent } from 'src/app/maplibre-map/map-project-areas/map-project-areas.component';
@@ -36,7 +36,7 @@ describe('TreatmentMapComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [TreatmentMapComponent, CommonModule],
+      imports: [TreatmentMapComponent, CommonModule, HttpClientTestingModule],
       providers: [
         MockProviders(
           TreatedStandsState,

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -51,6 +51,8 @@ import { MapProjectAreasComponent } from '../../maplibre-map/map-project-areas/m
 import { TreatmentProjectArea } from '@types';
 import { DataLayerNameComponent } from '../../data-layers/data-layer-name/data-layer-name.component';
 import { ActivatedRoute, Router } from '@angular/router';
+import { DataLayersStateService } from '../../data-layers/data-layers.state.service';
+import { LoadingLayerOverlayComponent } from '../../maplibre-map/loading-layer-overlay/loading-layer-overlay.component';
 
 @UntilDestroy()
 @Component({
@@ -64,6 +66,7 @@ import { ActivatedRoute, Router } from '@angular/router';
     FeatureComponent,
     DraggableDirective,
     GeoJSONSourceComponent,
+    LoadingLayerOverlayComponent,
     MapActionButtonComponent,
     MapStandsComponent,
     MapRectangleComponent,
@@ -181,6 +184,8 @@ export class TreatmentMapComponent {
 
   opacity$ = this.mapConfigState.treatedStandsOpacity$;
 
+  loadingLayer$ = this.dataLayersState.loadingLayer$;
+
   get scenarioId() {
     return this.treatmentsState.getScenarioId();
   }
@@ -206,6 +211,7 @@ export class TreatmentMapComponent {
     private treatmentsState: TreatmentsState,
     private selectedStandsState: SelectedStandsState,
     private featureService: FeatureService,
+    private dataLayersState: DataLayersStateService,
     private renderer: Renderer2,
     private route: ActivatedRoute,
     private router: Router


### PR DESCRIPTION
This PR basically just adds this loading overlay component, per the [Figma design here](https://www.figma.com/design/t26t7EIshAS34JZ6UxWY6K/Explore-2.0?node-id=949-57001&m=dev).
 It will get hooked into [PR 2316](https://github.com/OurPlanscape/Planscape/pull/2316) when that's done.

![Screenshot From 2025-03-24 09-28-59](https://github.com/user-attachments/assets/a1a84483-5d87-4d71-b9d4-1ac2ee167481)
