### PR TITLE
datalayer matching error fix, and sub-folder .json search

### DIFF
--- a/src/planscape/datasets/management/commands/styles.py
+++ b/src/planscape/datasets/management/commands/styles.py
@@ -110,7 +110,7 @@ class Command(PlanscapeCommand):
         skipped = []
 
         dir_path = Path(directory)
-        for file_path in dir_path.glob("*.json"):
+        for file_path in dir_path.rglob("*.json"):
             try:
                 with file_path.open("r", encoding="utf-8") as f:
                     style_data = json.load(f)
@@ -134,8 +134,10 @@ class Command(PlanscapeCommand):
                 datalayer_ids.append(dl_data["results"][0]["id"])
             else:
                 self.stderr.write(
-                    f"WARNING: No matching datalayer found for style '{base_name}'. Continuing..."
+                    f"ERROR: No matching datalayer found for style '{base_name}'. Placing this file in failures and continuing..."
                 )
+                failures.append(str(file_path))
+                continue
 
             map_type = style_data.get("map_type", None)
             RASTER_TYPES = ("RAMP", "INTERVALS", "VALUES")


### PR DESCRIPTION
@george-silva @roquebetioljr 

This PR:

1. Changes `glob` to `rglob` when searching for `.json` files to import in a directory, so the import script can search for `.json` files that are in sub-folders. IOW, we can now import `.json` files by selecting the `json_styles` parent folder, rather than having to import each sub-folder one at a time (`rglob` allows to search for files in sub-folders)

2. Adds `.json` files WITHOUT a matching datalayer to the `failures` bucket, printing out an error saying that no mattching datalayer was found, and continuing the import .json file loop (skipping the rest of the import logic for the offending .json files with no matching datalayer)