### PR TITLE
update css to fix tab height

### DIFF
--- a/src/interface/src/app/treatments/project-areas-tab/project-areas-tab.component.scss
+++ b/src/interface/src/app/treatments/project-areas-tab/project-areas-tab.component.scss
@@ -37,7 +37,7 @@
   }
 
   .project-areas-list {
-    overflow: scroll;
+    overflow-y: scroll;
     height: 100%;
   }
 

--- a/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.scss
+++ b/src/interface/src/app/treatments/treatment-overview/treatment-overview.component.scss
@@ -3,7 +3,8 @@
 
 :host {
   height: 100%;
-  display: block;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 

--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.scss
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.scss
@@ -2,11 +2,13 @@
 @import "colors";
 
 :host {
+  height: 100%;
+  overflow: hidden;
+
   .summary-tab-group {
     display: flex;
     flex-direction: column;
     max-width: 100%;
-    height: calc(100% - 180px);
   }
 
   ::ng-deep .mat-mdc-tab-group {


### PR DESCRIPTION
The height on  the treatments  tabs where not dynamically calculated, so when we had more content (like the help message regarding no permissions to edit) the content didn't fit. 