### PR TITLE
json-import-filterset-fix-icontains

### DIFF
--- a/src/planscape/datasets/filters.py
+++ b/src/planscape/datasets/filters.py
@@ -41,6 +41,7 @@ class DataLayerFilterSet(filters.FilterSet):
             "category": ["exact"],
             "type": ["exact"],
             "status": ["exact"],
+            "original_name": ["exact", "icontains"],
         }
 
 

--- a/src/planscape/datasets/management/commands/styles.py
+++ b/src/planscape/datasets/management/commands/styles.py
@@ -122,7 +122,7 @@ class Command(PlanscapeCommand):
 
             datalayers_url = f"{base_url}/v2/admin/datalayers"
             query_params = {
-                "original_name": base_name,
+                "original_name__icontains": base_name,
                 "dataset": fixed_dataset_id,
             }
             dl_response = requests.get(

--- a/src/planscape/datasets/serializers.py
+++ b/src/planscape/datasets/serializers.py
@@ -96,6 +96,7 @@ class DataLayerSerializer(serializers.ModelSerializer[DataLayer]):
         source="get_assigned_style",
         read_only=True,
     )  # type: ignore
+    original_name = serializers.CharField(read_only=True)
 
     class Meta:
         model = DataLayer
@@ -117,6 +118,7 @@ class DataLayerSerializer(serializers.ModelSerializer[DataLayer]):
             "info",
             "metadata",
             "style",
+            "original_name",
         )
 
 


### PR DESCRIPTION
@george-silva @roquebetioljr, **Goal:** to get the JSON style names to find original_name and match the raster names in the DB:

1. Added `"original_name": ["exact", "icontains"]` to `DataLayerFilterSet` in `filters.py`
2. Modified `styles.py` import match logic to `"original_name__icontains": base_name,`
3. Added `original_name = serializers.CharField(read_only=True)` & `"original_name"` to `serializers.py`

----------------------

Django Admin lists the raster files as, for example:

`PotentialTotalSmoke_202209_202312_T1_v5.tif`

![image](https://github.com/user-attachments/assets/115aa420-399e-4a25-a481-bacc3941f024)

-----------

& my re-named JSON files are re-named like this:

`PotentialTotalSmoke_202209_202312_T1_v5`

![image](https://github.com/user-attachments/assets/8f8403d0-27e8-4cb0-9d65-7f2ddae1632f)

-----------

I used `icontains` to resolve this issue quickly, but I doubt that's best long-term (e.g., matcher could find more than one raster file, for example), so may need to add a function to remove the ends from files I'm trying to exactly match.


