### PR TITLE
Fixing common JS warnings

### DIFF
--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -47,7 +47,14 @@
               "geojson-rbush",
               "polylabel",
               "file-saver",
-              "canvg"
+              "canvg",
+              "core-js",
+              "raf",
+              "rgbcolor",
+              "fast-deep-equal",
+              "jspdf-autotable",
+              "maplibre-gl",
+              "@geomatico/maplibre-cog-protocol"
             ]
           },
           "configurations": {


### PR DESCRIPTION
Fixing commonJS warnings.

Before: 
![image](https://github.com/user-attachments/assets/14a8d8d2-51bf-409b-9017-8e7ac93a07b4)


Now:
![image](https://github.com/user-attachments/assets/b84c2853-ab00-47a5-ac40-397d6f886be7)
