### PR TITLE
Treatment Goal admin page improvements

### DIFF
--- a/src/planscape/datasets/forms.py
+++ b/src/planscape/datasets/forms.py
@@ -53,6 +53,8 @@ class DataLayerAdminForm(forms.ModelForm):
         self.fields["url"].disabled = True
         self.fields["mimetype"].disabled = True
         self.fields["geometry"].disabled = True
+        self.fields["info"].required = False
+        self.fields["metadata"].required = False
 
     class Meta:
         model = DataLayer

--- a/src/planscape/planning/admin.py
+++ b/src/planscape/planning/admin.py
@@ -40,11 +40,19 @@ class TreatmentGoalUsesDataLayerAdmin(admin.ModelAdmin):
 
     list_display = ("id", "usage_type", "treatment_goal", "datalayer", "threshold")
     list_display_links = ("id", "usage_type")
-    form = TreatmentGoalUsesDataLayerAdminForm
     search_fields = ["usage_type", "treatment_goal__name", "datalayer__name"]
     list_filter = ["usage_type", "treatment_goal__name", "datalayer__name"]
     ordering = ["usage_type", "treatment_goal__name", "datalayer__name"]
     raw_id_fields = ["treatment_goal", "datalayer"]
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=...):
+        return False
 
 
 admin.site.register(TreatmentGoal, TreatmentGoalAdmin)

--- a/src/planscape/planning/admin.py
+++ b/src/planscape/planning/admin.py
@@ -6,18 +6,28 @@ from planning.models import TreatmentGoal, TreatmentGoalUsesDataLayer
 from planning.forms import TreatmentGoalAdminForm, TreatmentGoalUsesDataLayerAdminForm
 
 
+class TreatmentGoalUsesDataLayerInline(admin.TabularInline):
+    model = TreatmentGoalUsesDataLayer
+
+    form = TreatmentGoalUsesDataLayerAdminForm
+    raw_id_fields = ["datalayer"]
+
+
 class TreatmentGoalAdmin(admin.ModelAdmin):
     """
     Admin interface for TreatmentGoal model.
     """
 
-    list_display = ("id", "name", "description", "priorities", "active")
+    list_display = ("id", "name", "category", "active")
     list_display_links = ("id", "name")
     form = TreatmentGoalAdminForm
     search_fields = ["name"]
-    list_filter = ["priorities"]
+    list_filter = ["active", "category"]
     ordering = ["name"]
     raw_id_fields = ["created_by"]
+    inlines = [
+        TreatmentGoalUsesDataLayerInline,
+    ]
 
     def get_changeform_initial_data(self, request) -> Dict[str, Any]:
         return {"created_by": request.user}
@@ -28,10 +38,11 @@ class TreatmentGoalUsesDataLayerAdmin(admin.ModelAdmin):
     Admin interface for TreatmentGoalUsesDataLayer model.
     """
 
-    list_display = ("id", "usage_type", "treatment_goal", "datalayer")
+    list_display = ("id", "usage_type", "treatment_goal", "datalayer", "threshold")
     list_display_links = ("id", "usage_type")
     form = TreatmentGoalUsesDataLayerAdminForm
     search_fields = ["usage_type", "treatment_goal__name", "datalayer__name"]
+    list_filter = ["usage_type", "treatment_goal__name", "datalayer__name"]
     ordering = ["usage_type", "treatment_goal__name", "datalayer__name"]
     raw_id_fields = ["treatment_goal", "datalayer"]
 

--- a/src/planscape/planning/forms.py
+++ b/src/planscape/planning/forms.py
@@ -13,22 +13,17 @@ class TreatmentGoalAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["description"].required = False
-        self.fields["priorities"].required = False
-        self.fields["stand_thresholds"].required = False
+        self.fields["created_by"].required = False
 
     class Meta:
         model = TreatmentGoal
         widgets = {
             "description": AdminMartorWidget,
-            "priorities": JSONEditorWidget,
-            "stand_thresholds": JSONEditorWidget,
         }
         fields = (
             "name",
             "category",
             "description",
-            "priorities",
-            "stand_thresholds",
             "active",
             "created_by",
         )

--- a/src/planscape/planning/forms.py
+++ b/src/planscape/planning/forms.py
@@ -10,6 +10,12 @@ class TreatmentGoalAdminForm(forms.ModelForm):
     Admin form for TreatmentGoal model.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["description"].required = False
+        self.fields["priorities"].required = False
+        self.fields["stand_thresholds"].required = False
+
     class Meta:
         model = TreatmentGoal
         widgets = {

--- a/src/planscape/planning/forms.py
+++ b/src/planscape/planning/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django_json_widget.widgets import JSONEditorWidget
 from martor.widgets import AdminMartorWidget
 
 from planning.models import TreatmentGoal, TreatmentGoalUsesDataLayer


### PR DESCRIPTION
- Useful filters
- Create/Edit/Delete TreatmentGoalUsesDataLayer on Treatment Goal editing page
- TreatmentGoalUsesDataLayer admin page as read-only