### PR TITLE
handle failure to load rasterimage

### DIFF
--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.spec.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MapDataLayerComponent } from './map-data-layer.component';
 import { Map as MapLibreMap } from 'maplibre-gl';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 describe('MapDataLayerComponent', () => {
   let component: MapDataLayerComponent;
@@ -16,7 +17,7 @@ describe('MapDataLayerComponent', () => {
     });
 
     await TestBed.configureTestingModule({
-      imports: [MapDataLayerComponent, HttpClientTestingModule],
+      imports: [MapDataLayerComponent, HttpClientTestingModule, MatSnackBarModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MapDataLayerComponent);

--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.spec.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.spec.ts
@@ -17,7 +17,11 @@ describe('MapDataLayerComponent', () => {
     });
 
     await TestBed.configureTestingModule({
-      imports: [MapDataLayerComponent, HttpClientTestingModule, MatSnackBarModule],
+      imports: [
+        MapDataLayerComponent,
+        HttpClientTestingModule,
+        MatSnackBarModule,
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MapDataLayerComponent);

--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
@@ -71,7 +71,6 @@ export class MapDataLayerComponent implements OnInit {
         event.sourceId === 'rasterImage' &&
         !event.isSourceLoaded
       ) {
-        //TODO: show message to user -- MatSnackBar? 
         this.dataLayersStateService.setDataLayerLoading(false);
       }
     });

--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
@@ -78,7 +78,7 @@ export class MapDataLayerComponent implements OnInit {
       ) {
         this.dataLayersStateService.setDataLayerLoading(false);
         this.matSnackBar.open(
-          '[Error] Unable to load data layer due to a backend error.',
+          '[Error] Unable to load data layer.',
           'Dismiss',
           SNACK_ERROR_CONFIG
         );

--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { DataLayersStateService } from 'src/app/data-layers/data-layers.state.service';
-import { DataLayer } from '@types';
+import { DataLayer, FrontendConstants } from '@types';
 import { makeColorFunction } from '../../data-layers/utilities';
 import { setColorFunction } from '@geomatico/maplibre-cog-protocol';
 import {
@@ -9,7 +9,6 @@ import {
   RasterLayerSpecification,
   RasterSourceSpecification,
 } from 'maplibre-gl';
-import { FrontendConstants } from '@types';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SNACK_ERROR_CONFIG } from '@shared';
 

--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
@@ -10,6 +10,8 @@ import {
   RasterSourceSpecification,
 } from 'maplibre-gl';
 import { FrontendConstants } from '@types';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SNACK_ERROR_CONFIG } from '@shared';
 
 @UntilDestroy()
 @Component({
@@ -24,7 +26,9 @@ export class MapDataLayerComponent implements OnInit {
   tileSize: number = FrontendConstants.MAPLIBRE_MAP_DATA_LAYER_TILESIZE;
   cogUrl: string | null = null;
 
-  constructor(private dataLayersStateService: DataLayersStateService) {
+  constructor(private dataLayersStateService: DataLayersStateService,
+    private matSnackBar: MatSnackBar
+  ) {
     dataLayersStateService.selectedDataLayer$
       .pipe(untilDestroyed(this))
       .subscribe((dataLayer: DataLayer | null) => {
@@ -72,6 +76,11 @@ export class MapDataLayerComponent implements OnInit {
         !event.isSourceLoaded
       ) {
         this.dataLayersStateService.setDataLayerLoading(false);
+        this.matSnackBar.open(
+          '[Error] Unable to load data layer due to a backend error.',
+          'Dismiss',
+          SNACK_ERROR_CONFIG
+        );
       }
     });
   }

--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
@@ -26,7 +26,8 @@ export class MapDataLayerComponent implements OnInit {
   tileSize: number = FrontendConstants.MAPLIBRE_MAP_DATA_LAYER_TILESIZE;
   cogUrl: string | null = null;
 
-  constructor(private dataLayersStateService: DataLayersStateService,
+  constructor(
+    private dataLayersStateService: DataLayersStateService,
     private matSnackBar: MatSnackBar
   ) {
     dataLayersStateService.selectedDataLayer$

--- a/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-data-layer/map-data-layer.component.ts
@@ -64,6 +64,17 @@ export class MapDataLayerComponent implements OnInit {
         this.dataLayersStateService.setDataLayerLoading(false);
       }
     });
+
+    this.mapLibreMap.on('error', (event: any) => {
+      if (
+        this.mapLibreMap.getSource('rasterImage') &&
+        event.sourceId === 'rasterImage' &&
+        !event.isSourceLoaded
+      ) {
+        //TODO: show message to user -- MatSnackBar? 
+        this.dataLayersStateService.setDataLayerLoading(false);
+      }
+    });
   }
 
   addRasterLayer(): void {


### PR DESCRIPTION
This PR handles the error state when the frontend can't load a datalayer from the backend. Since we're using snackbars for this sort of error in other places, I took the liberty of adding a snackbar directly in the component here.