### PR TITLE
fix-admin-url-validation

### DIFF
--- a/src/planscape/datasets/forms.py
+++ b/src/planscape/datasets/forms.py
@@ -55,6 +55,7 @@ class DataLayerAdminForm(forms.ModelForm):
         self.fields["geometry"].disabled = True
         self.fields["info"].required = False
         self.fields["metadata"].required = False
+        self.fields["url"].required = False
 
     class Meta:
         model = DataLayer


### PR DESCRIPTION
@george-silva, @roquebetioljr, Bug fix, get this `Enter valid URL` error when trying to change the category of a datalayer in staging, even though the URL is disabled for editing and the exact same.

Added this line to `datasets/forms.py/DataLayerAdminForm`: `self.fields["url"].required = False`, so that the URL is not required, and the form will go through with its updated category.

![image](https://github.com/user-attachments/assets/686518e1-ea7a-488b-a45b-8c80fdfdb644)
