### PR TITLE
Hide close button instead of disabling it

### DIFF
--- a/src/interface/src/styleguide/search-bar/search-bar.component.html
+++ b/src/interface/src/styleguide/search-bar/search-bar.component.html
@@ -31,8 +31,7 @@
       }
     </mat-autocomplete>
     <button
-      *ngIf="showCloseButton"
-      [disabled]="!searchValue.length"
+      *ngIf="showCloseButton && searchValue.length"
       class="close-button"
       sg-button
       variant="icon-only"


### PR DESCRIPTION
per discussion with design, we should just hide this X when no text is in the searchbar