### PR TITLE
Layer ordering

### DIFF
--- a/src/interface/src/app/maplibre-map/map-config.state.ts
+++ b/src/interface/src/app/maplibre-map/map-config.state.ts
@@ -22,10 +22,6 @@ export class MapConfigState {
   private _showProjectAreasLayer$ = new BehaviorSubject(true);
   public showProjectAreasLayer$ = this._showProjectAreasLayer$.asObservable();
 
-  private _showTreatmentStandsLayer$ = new BehaviorSubject(false);
-  public showTreatmentStandsLayer$ =
-    this._showTreatmentStandsLayer$.asObservable();
-
   private _showFillProjectAreas$ = new BehaviorSubject(true);
   public showFillProjectAreas$ = this._showFillProjectAreas$.asObservable();
 
@@ -72,26 +68,8 @@ export class MapConfigState {
     this._showProjectAreasLayer$.next(value);
   }
 
-  updateShowTreatmentStands(value: boolean) {
-    this.setTreatedStandsOpacity(this.defaultStandsOpacity);
-    this._showTreatmentStandsLayer$.next(value);
-  }
-
   setShowFillProjectAreas(value: boolean) {
     this._showFillProjectAreas$.next(value);
-  }
-
-  toggleShowTreatmentStands() {
-    const treatmentsVisible = this.isTreatmentStandsVisible();
-
-    this.setShowFillProjectAreas(treatmentsVisible);
-    this.setTreatedStandsOpacity(treatmentsVisible ? 0 : 1);
-    this._showTreatmentStandsLayer$.next(!treatmentsVisible);
-    this._showTreatmentLegend$.next(!treatmentsVisible);
-  }
-
-  isTreatmentStandsVisible() {
-    return this._showTreatmentStandsLayer$.value;
   }
 
   setStandSelectionEnabled(value: boolean) {

--- a/src/interface/src/app/maplibre-map/map-project-areas/map-project-areas.component.spec.ts
+++ b/src/interface/src/app/maplibre-map/map-project-areas/map-project-areas.component.spec.ts
@@ -7,7 +7,7 @@ import {
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MapConfigState } from '../../maplibre-map/map-config.state';
+import { MapConfigState } from '../map-config.state';
 import { BehaviorSubject, of } from 'rxjs';
 import { TreatmentsState } from 'src/app/treatments/treatments.state';
 import { ScenarioState } from '../scenario.state';
@@ -22,7 +22,6 @@ describe('MapProjectAreasComponent', () => {
       providers: [
         MockProvider(TreatmentsState),
         MockProvider(MapConfigState, {
-          showTreatmentStandsLayer$: of(false),
           projectAreasOpacity$: of(0.5),
           zoomLevel$: new BehaviorSubject<number>(7),
         }),

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
@@ -1,7 +1,5 @@
-<ng-container *ngIf="vectorLayerUrl$ | async as vectorLayerUrl">
-  <mgl-vector-source
-    [id]="sourceName"
-    [tiles]="[vectorLayerUrl]"></mgl-vector-source>
+<ng-container *ngIf="tilesUrl$ | async as tilesUrl">
+  <mgl-vector-source [id]="sourceName" [tiles]="[tilesUrl]"></mgl-vector-source>
   <mgl-layer
     id="planning-area-polygon"
     type="line"

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
@@ -3,23 +3,25 @@
     [id]="sourceName"
     [tiles]="[vectorLayerUrl]"></mgl-vector-source>
   <mgl-layer
-    id="treatment-area-polygon"
+    id="planning-area-polygon"
     type="line"
     [source]="sourceName"
     [sourceLayer]="sourceName"
     [paint]="{
       'line-color': COLORS.md_gray,
       'line-width': 2
-    }">
+    }"
+    before="middle-layer">
   </mgl-layer>
   <mgl-layer
-    id="treatment-area-fill"
+    id="planning-area-fill"
     type="fill"
     [source]="sourceName"
     [sourceLayer]="sourceName"
     [paint]="{
       'fill-color': COLORS.white_light_blue,
       'fill-opacity': 0.4
-    }">
+    }"
+    before="planning-area-polygon">
   </mgl-layer>
 </ng-container>

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
@@ -1,11 +1,12 @@
-<ng-container *ngIf="polygonGeometry$ | async as polygonGeometry">
-  <mgl-geojson-source [id]="sourceName">
-    <mgl-feature [geometry]="polygonGeometry"></mgl-feature>
-  </mgl-geojson-source>
+<ng-container *ngIf="vectorLayerUrl$ | async as vectorLayerUrl">
+  <mgl-vector-source
+    [id]="sourceName"
+    [tiles]="[vectorLayerUrl]"></mgl-vector-source>
   <mgl-layer
     id="treatment-area-polygon"
     type="line"
     [source]="sourceName"
+    [sourceLayer]="sourceName"
     [paint]="{
       'line-color': COLORS.md_gray,
       'line-width': 2
@@ -15,6 +16,7 @@
     id="treatment-area-fill"
     type="fill"
     [source]="sourceName"
+    [sourceLayer]="sourceName"
     [paint]="{
       'fill-color': COLORS.white_light_blue,
       'fill-opacity': 0.4

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.html
@@ -11,7 +11,7 @@
       'line-color': COLORS.md_gray,
       'line-width': 2
     }"
-    before="middle-layer">
+    [before]="before">
   </mgl-layer>
   <mgl-layer
     id="planning-area-fill"

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
@@ -3,10 +3,13 @@ import {
   FeatureComponent,
   GeoJSONSourceComponent,
   LayerComponent,
+  VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
 import { BASE_COLORS } from '../../treatments/map.styles';
 import { AsyncPipe, NgIf } from '@angular/common';
 import { PlanState } from '../../plan/plan.state';
+import { map } from 'rxjs';
+import { MARTIN_SOURCES } from '../../treatments/map.sources';
 
 @Component({
   selector: 'app-planning-area-layer',
@@ -17,14 +20,19 @@ import { PlanState } from '../../plan/plan.state';
     FeatureComponent,
     GeoJSONSourceComponent,
     LayerComponent,
+    VectorSourceComponent,
   ],
   templateUrl: './planning-area-layer.component.html',
 })
 export class PlanningAreaLayerComponent {
   constructor(private planState: PlanState) {}
 
-  polygonGeometry$ = this.planState.planningAreaGeometry$;
+  vectorLayerUrl$ = this.planState.currentPlanId$.pipe(
+    map((id) => {
+      return MARTIN_SOURCES.planningArea.tilesUrl + `?id=${id}`;
+    })
+  );
 
-  readonly sourceName = 'treatment-planing-area';
+  readonly sourceName = MARTIN_SOURCES.planningArea.sources.planningArea;
   readonly COLORS = BASE_COLORS;
 }

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import {
   FeatureComponent,
   GeoJSONSourceComponent,
@@ -25,6 +25,8 @@ import { MARTIN_SOURCES } from '../../treatments/map.sources';
   templateUrl: './planning-area-layer.component.html',
 })
 export class PlanningAreaLayerComponent {
+  @Input() before = '';
+
   constructor(private planState: PlanState) {}
 
   vectorLayerUrl$ = this.planState.currentPlanId$.pipe(

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
@@ -29,7 +29,7 @@ export class PlanningAreaLayerComponent {
 
   constructor(private planState: PlanState) {}
 
-  vectorLayerUrl$ = this.planState.currentPlanId$.pipe(
+  tilesUrl$ = this.planState.currentPlanId$.pipe(
     map((id) => {
       return MARTIN_SOURCES.planningArea.tilesUrl + `?id=${id}`;
     })

--- a/src/interface/src/app/plan/plan.state.ts
+++ b/src/interface/src/app/plan/plan.state.ts
@@ -23,6 +23,7 @@ export class PlanState {
 
   // The ID of the current plan
   private _currentPlanId$ = new BehaviorSubject<number | null>(null);
+  public currentPlanId$ = this._currentPlanId$.asObservable();
 
   // Listen to ID changes and trigger network calls, returning typed results.
   private currentPlanResource$: Observable<Resource<Plan>> =

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
@@ -38,16 +38,19 @@
     [mapLibreMap]="mapLibreMap"
     [selectStart]="null"
     [selectEnd]="null"
-    (standsLoaded)="standsLoaded = true"></app-map-stands>
+    before="middle-layer"></app-map-stands>
+
+  <mgl-layer
+    type="background"
+    id="middle-layer"
+    [layout]="{ visibility: 'none' }">
+  </mgl-layer>
 
   <app-map-stands-tx-result
-    *ngIf="standsLoaded"
     [mapLibreMap]="mapLibreMap"
     [propertyName]="variables[year]"></app-map-stands-tx-result>
 
-  <app-map-project-areas
-    *ngIf="standsLoaded"
-    [mapLibreMap]="mapLibreMap"></app-map-project-areas>
+  <app-map-project-areas [mapLibreMap]="mapLibreMap"></app-map-project-areas>
 
   <app-action-button
     *ngIf="(showLegend$ | async) === false"

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
@@ -37,13 +37,17 @@
     sourceId="stands"
     [mapLibreMap]="mapLibreMap"
     [selectStart]="null"
-    [selectEnd]="null"></app-map-stands>
-
-  <app-map-project-areas [mapLibreMap]="mapLibreMap"></app-map-project-areas>
+    [selectEnd]="null"
+    (patternsLoaded)="setStandsReady()"></app-map-stands>
 
   <app-map-stands-tx-result
+    *ngIf="standsReady$ | async"
     [mapLibreMap]="mapLibreMap"
     [propertyName]="variables[year]"></app-map-stands-tx-result>
+
+  <app-map-project-areas
+    *ngIf="standsReady$ | async"
+    [mapLibreMap]="mapLibreMap"></app-map-project-areas>
 
   <app-action-button
     *ngIf="(showLegend$ | async) === false"

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
@@ -33,20 +33,20 @@
   </app-map-zoom-control>
 
   <app-map-stands
+    *ngIf="mapLibreMap"
     [userCanEditStands]="false"
-    sourceId="stands"
     [mapLibreMap]="mapLibreMap"
     [selectStart]="null"
     [selectEnd]="null"
-    (patternsLoaded)="setStandsReady()"></app-map-stands>
+    (standsLoaded)="standsLoaded = true"></app-map-stands>
 
   <app-map-stands-tx-result
-    *ngIf="standsReady$ | async"
+    *ngIf="standsLoaded"
     [mapLibreMap]="mapLibreMap"
     [propertyName]="variables[year]"></app-map-stands-tx-result>
 
   <app-map-project-areas
-    *ngIf="standsReady$ | async"
+    *ngIf="standsLoaded"
     [mapLibreMap]="mapLibreMap"></app-map-project-areas>
 
   <app-action-button

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
@@ -1,6 +1,10 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { AsyncPipe, NgIf } from '@angular/common';
-import { ControlComponent, MapComponent } from '@maplibre/ngx-maplibre-gl';
+import {
+  ControlComponent,
+  LayerComponent,
+  MapComponent,
+} from '@maplibre/ngx-maplibre-gl';
 import { MapRectangleComponent } from '../map-rectangle/map-rectangle.component';
 import { MapStandsComponent } from '../map-stands/map-stands.component';
 import { MapTooltipComponent } from '../map-tooltip/map-tooltip.component';
@@ -49,6 +53,7 @@ import { MapZoomControlComponent } from '../../maplibre-map/map-zoom-control/map
     OpacitySliderComponent,
     RxSelectionToggleComponent,
     MapZoomControlComponent,
+    LayerComponent,
   ],
   templateUrl: './direct-impacts-map.component.html',
   styleUrl: './direct-impacts-map.component.scss',
@@ -93,8 +98,6 @@ export class DirectImpactsMapComponent {
 
   opacity$ = this.mapConfigState.treatedStandsOpacity$;
 
-  standsLoaded = false;
-
   mapLoaded(event: MapLibreMap) {
     this.mapLibreMap = event;
     this.mapCreated.emit(this.mapLibreMap);
@@ -118,19 +121,7 @@ export class DirectImpactsMapComponent {
       !event.sourceDataType
     ) {
       this.directImpactsStateService.setStandsTxSourceLoaded(true);
-      this.moveLayers();
     }
-  }
-
-  // Move layers so the hover and selected stand layer sit at the top
-  private moveLayers() {
-    // this.mapLibreMap.moveLayer('map-project-areas-line');
-    // this.mapLibreMap.moveLayer('standHover');
-    // this.mapLibreMap.moveLayer('standSelected');
-    //
-    // if (this.mapLibreMap.getLayer('map-project-areas-labels')) {
-    //   this.mapLibreMap.moveLayer('map-project-areas-labels');
-    // }
   }
 
   openTreatmentLegend() {

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
@@ -28,6 +28,7 @@ import { OpacitySliderComponent } from '@styleguide';
 import { RxSelectionToggleComponent } from '../../maplibre-map/rx-selection-toggle/rx-selection-toggle.component';
 import { FrontendConstants } from '@types';
 import { MapZoomControlComponent } from '../../maplibre-map/map-zoom-control/map-zoom-control.component';
+import { BehaviorSubject } from 'rxjs';
 
 @UntilDestroy()
 @Component({
@@ -93,6 +94,14 @@ export class DirectImpactsMapComponent {
 
   opacity$ = this.mapConfigState.treatedStandsOpacity$;
 
+  standsReady$ = new BehaviorSubject(false);
+
+  setStandsReady() {
+    setTimeout(() => {
+      this.standsReady$.next(true);
+    }, 10);
+  }
+
   mapLoaded(event: MapLibreMap) {
     this.mapLibreMap = event;
     this.mapCreated.emit(this.mapLibreMap);
@@ -122,13 +131,13 @@ export class DirectImpactsMapComponent {
 
   // Move layers so the hover and selected stand layer sit at the top
   private moveLayers() {
-    this.mapLibreMap.moveLayer('map-project-areas-line');
-    this.mapLibreMap.moveLayer('standHover');
-    this.mapLibreMap.moveLayer('standSelected');
-
-    if (this.mapLibreMap.getLayer('map-project-areas-labels')) {
-      this.mapLibreMap.moveLayer('map-project-areas-labels');
-    }
+    // this.mapLibreMap.moveLayer('map-project-areas-line');
+    // this.mapLibreMap.moveLayer('standHover');
+    // this.mapLibreMap.moveLayer('standSelected');
+    //
+    // if (this.mapLibreMap.getLayer('map-project-areas-labels')) {
+    //   this.mapLibreMap.moveLayer('map-project-areas-labels');
+    // }
   }
 
   openTreatmentLegend() {

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.ts
@@ -28,7 +28,6 @@ import { OpacitySliderComponent } from '@styleguide';
 import { RxSelectionToggleComponent } from '../../maplibre-map/rx-selection-toggle/rx-selection-toggle.component';
 import { FrontendConstants } from '@types';
 import { MapZoomControlComponent } from '../../maplibre-map/map-zoom-control/map-zoom-control.component';
-import { BehaviorSubject } from 'rxjs';
 
 @UntilDestroy()
 @Component({
@@ -94,13 +93,7 @@ export class DirectImpactsMapComponent {
 
   opacity$ = this.mapConfigState.treatedStandsOpacity$;
 
-  standsReady$ = new BehaviorSubject(false);
-
-  setStandsReady() {
-    setTimeout(() => {
-      this.standsReady$.next(true);
-    }, 10);
-  }
+  standsLoaded = false;
 
   mapLoaded(event: MapLibreMap) {
     this.mapLibreMap = event;

--- a/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
+++ b/src/interface/src/app/treatments/direct-impacts/direct-impacts.component.ts
@@ -144,7 +144,6 @@ export class DirectImpactsComponent implements OnInit, OnDestroy {
             this.router.navigate(['../'], { relativeTo: this.route });
           }
           this.mapConfigState.setShowFillProjectAreas(false);
-          this.mapConfigState.updateShowTreatmentStands(true);
           this.mapConfigState.updateShowProjectAreas(true);
         }),
         catchError((error) => {

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.html
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.html
@@ -3,7 +3,7 @@
   *ngFor="let patternName of patternNames"
   [id]="patternName"
   [url]="'/assets/png/patterns/' + patternName + '.png'"
-  (imageLoaded)="setPatternLoaded(patternName)"></mgl-image>
+  (imageLoaded)="patternLoaded[patternName] = true"></mgl-image>
 
 <mgl-vector-source
   [id]="sourceId"
@@ -27,7 +27,8 @@
     (layerMouseEnter)="setCursor()"
     (layerMouseLeave)="resetCursor()"
     [filter]="projectAreaFilter$ | async"
-    [sourceLayer]="layers.stands.sourceLayer"></mgl-layer>
+    [sourceLayer]="layers.stands.sourceLayer"
+    [before]="layers.sequenceStands.name"></mgl-layer>
 
   <mgl-layer
     [id]="layers.sequenceStands.name"
@@ -35,7 +36,8 @@
     source="stands"
     [paint]="layers.sequenceStands.paint"
     [filter]="combinedFilter$ | async"
-    [sourceLayer]="layers.sequenceStands.sourceLayer"></mgl-layer>
+    [sourceLayer]="layers.sequenceStands.sourceLayer"
+    [before]="layers.standsOutline.name"></mgl-layer>
 
   <mgl-layer
     [id]="layers.standsOutline.name"
@@ -43,7 +45,8 @@
     source="stands"
     [filter]="projectAreaFilter$ | async"
     [paint]="layers.standsOutline.paint"
-    [sourceLayer]="layers.standsOutline.sourceLayer"></mgl-layer>
+    [sourceLayer]="layers.standsOutline.sourceLayer"
+    [before]="before"></mgl-layer>
 
   <mgl-layer
     [id]="layers.selectedStands.name"

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.html
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.html
@@ -18,17 +18,13 @@
 
 <ng-container *ngIf="allPatternsLoaded()">
   <mgl-layer
-    [id]="layers.stands.name"
-    type="fill"
+    [id]="layers.standsOutline.name"
+    type="line"
     source="stands"
-    [paint]="layers.stands.paint"
-    (layerMouseDown)="clickOnStand($event)"
-    (layerClick)="layerClick()"
-    (layerMouseEnter)="setCursor()"
-    (layerMouseLeave)="resetCursor()"
     [filter]="projectAreaFilter$ | async"
-    [sourceLayer]="layers.stands.sourceLayer"
-    [before]="layers.sequenceStands.name"></mgl-layer>
+    [paint]="layers.standsOutline.paint"
+    [sourceLayer]="layers.standsOutline.sourceLayer"
+    [before]="before"></mgl-layer>
 
   <mgl-layer
     [id]="layers.sequenceStands.name"
@@ -40,13 +36,17 @@
     [before]="layers.standsOutline.name"></mgl-layer>
 
   <mgl-layer
-    [id]="layers.standsOutline.name"
-    type="line"
+    [id]="layers.stands.name"
+    type="fill"
     source="stands"
+    [paint]="layers.stands.paint"
+    (layerMouseDown)="clickOnStand($event)"
+    (layerClick)="layerClick()"
+    (layerMouseEnter)="setCursor()"
+    (layerMouseLeave)="resetCursor()"
     [filter]="projectAreaFilter$ | async"
-    [paint]="layers.standsOutline.paint"
-    [sourceLayer]="layers.standsOutline.sourceLayer"
-    [before]="before"></mgl-layer>
+    [sourceLayer]="layers.stands.sourceLayer"
+    [before]="layers.sequenceStands.name"></mgl-layer>
 
   <mgl-layer
     [id]="layers.selectedStands.name"

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.html
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.html
@@ -3,7 +3,7 @@
   *ngFor="let patternName of patternNames"
   [id]="patternName"
   [url]="'/assets/png/patterns/' + patternName + '.png'"
-  (imageLoaded)="patternLoaded[patternName] = true"></mgl-image>
+  (imageLoaded)="setPatternLoaded(patternName)"></mgl-image>
 
 <mgl-vector-source
   [id]="sourceId"

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.spec.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.spec.ts
@@ -6,6 +6,7 @@ import { MockDeclarations, MockProvider } from 'ng-mocks';
 import {
   ImageComponent,
   LayerComponent,
+  MapComponent,
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
 import { TreatmentsState } from '../treatments.state';
@@ -31,19 +32,23 @@ describe('MapStandsComponent', () => {
           treatedStands$: of([]),
         }),
         MockProvider(MapConfigState, {
-          showTreatmentStandsLayer$: of(false),
           treatedStandsOpacity$: of(1),
         }),
       ],
       declarations: MockDeclarations(
         VectorSourceComponent,
         LayerComponent,
-        ImageComponent
+        ImageComponent,
+        MapComponent
       ),
     }).compileComponents();
 
     fixture = TestBed.createComponent(MapStandsComponent);
     component = fixture.componentInstance;
+    component.mapLibreMap = {
+      on: () => {},
+      off: () => {},
+    } as any;
     fixture.detectChanges();
   });
 

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -76,15 +76,14 @@ export class MapStandsComponent implements OnChanges, OnInit {
    */
   @Input() selectEnd!: Point | null;
 
-  /**
-   * The id to be applied on the source vector layer
-   */
-  @Input() sourceId = 'stands';
+  sourceId = 'stands';
 
   /**
    * Whether or not the user can edit stands on the map
    */
   @Input() userCanEditStands = false;
+
+  @Input() before = '';
 
   treatedStands$ = this.treatedStandsState.treatedStands$;
   sequenceStandsIds$ = this.treatedStandsState.sequenceStandsIds$;
@@ -106,14 +105,7 @@ export class MapStandsComponent implements OnChanges, OnInit {
     );
   }
 
-  setPatternLoaded(patternName: PatternName) {
-    this.patternLoaded[patternName] = true;
-    if (this.allPatternsLoaded()) {
-      this.patternsLoaded.emit();
-    }
-  }
-
-  @Output() patternsLoaded = new EventEmitter();
+  @Output() standsLoaded = new EventEmitter();
 
   /**
    * Reference to the selected stands before the user starts dragging for stand selection
@@ -232,11 +224,18 @@ export class MapStandsComponent implements OnChanges, OnInit {
 
   ngOnInit(): void {
     this.selectedStandsState.reset();
+    this.mapLibreMap.on('data', (event: any) => {
+      if (
+        event.sourceId === 'stands' &&
+        event.isSourceLoaded &&
+        !event.sourceDataType
+      ) {
+        this.standsLoaded.emit();
+      }
+    });
   }
 
   get vectorLayerUrl() {
-    // TODO bring back  projectAreaId ? `&project_area_id=${projectAreaId}` : ''
-    //  const projectAreaId = this.treatmentsState.getProjectAreaId();
     return (
       MARTIN_SOURCES.standsByTxPlan.tilesUrl +
       `?treatment_plan_id=${this.treatmentsState.getTreatmentPlanId()}`

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -3,6 +3,7 @@ import {
   EventEmitter,
   Input,
   OnChanges,
+  OnDestroy,
   OnInit,
   Output,
   SimpleChange,
@@ -59,7 +60,7 @@ type MapLayerData = {
   ],
   templateUrl: './map-stands.component.html',
 })
-export class MapStandsComponent implements OnChanges, OnInit {
+export class MapStandsComponent implements OnChanges, OnInit, OnDestroy {
   /**
    * The instance of mapLibreMap used with this component.
    * Must be provided while using this component.
@@ -224,16 +225,18 @@ export class MapStandsComponent implements OnChanges, OnInit {
 
   ngOnInit(): void {
     this.selectedStandsState.reset();
-    this.mapLibreMap.on('data', (event: any) => {
-      if (
-        event.sourceId === 'stands' &&
-        event.isSourceLoaded &&
-        !event.sourceDataType
-      ) {
-        this.standsLoaded.emit();
-      }
-    });
+    this.mapLibreMap.on('data', this.onDataListener);
   }
+
+  private onDataListener = (event: any) => {
+    if (
+      event.sourceId === 'stands' &&
+      event.isSourceLoaded &&
+      !event.sourceDataType
+    ) {
+      this.standsLoaded.emit();
+    }
+  };
 
   get vectorLayerUrl() {
     return (
@@ -322,8 +325,6 @@ export class MapStandsComponent implements OnChanges, OnInit {
     return features.map((feature) => feature.properties['id']);
   }
 
-  stands: number[] = [];
-
   private selectStandsWithinRectangle(): void {
     if (!this.selectStart || !this.selectEnd) {
       return;
@@ -369,5 +370,9 @@ export class MapStandsComponent implements OnChanges, OnInit {
       },
       { selected: true }
     );
+  }
+
+  ngOnDestroy(): void {
+    this.mapLibreMap.off('data', this.onDataListener);
   }
 }

--- a/src/interface/src/app/treatments/map-stands/map-stands.component.ts
+++ b/src/interface/src/app/treatments/map-stands/map-stands.component.ts
@@ -1,8 +1,10 @@
 import {
   Component,
+  EventEmitter,
   Input,
   OnChanges,
   OnInit,
+  Output,
   SimpleChange,
   SimpleChanges,
 } from '@angular/core';
@@ -103,6 +105,15 @@ export class MapStandsComponent implements OnChanges, OnInit {
       this.patternLoaded['stripes-red']
     );
   }
+
+  setPatternLoaded(patternName: PatternName) {
+    this.patternLoaded[patternName] = true;
+    if (this.allPatternsLoaded()) {
+      this.patternsLoaded.emit();
+    }
+  }
+
+  @Output() patternsLoaded = new EventEmitter();
 
   /**
    * Reference to the selected stands before the user starts dragging for stand selection

--- a/src/interface/src/app/treatments/map.sources.ts
+++ b/src/interface/src/app/treatments/map.sources.ts
@@ -27,4 +27,10 @@ export const MARTIN_SOURCES = {
       standsByTxResult: 'stands_by_tx_result',
     },
   },
+  planningArea: {
+    tilesUrl: environment.martin_server + 'planning_area_by_id/{z}/{x}/{y}',
+    sources: {
+      planningArea: 'planning_area',
+    },
+  },
 } as const;

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -1,11 +1,6 @@
 <app-map-nav-bar>
   <sg-opacity-slider
     class="navbar-slider"
-    *ngIf="
-      (standSelectionEnabled$ | async) === true ||
-      (showTreatmentStands$ | async) === true ||
-      (showLegend$ | async) === true
-    "
     [minValue]="0"
     [maxValue]="1"
     [step]="0.01"
@@ -26,7 +21,6 @@
   (mapMouseMove)="onMapMouseMove($event)"
   (mapMouseOut)="onMapMouseOut()"
   (mapMouseUp)="onMapMouseUp()"
-  (sourceData)="onSourceData($event)"
   [boxZoom]="false"
   [doubleClickZoom]="(standSelectionEnabled$ | async) === false"
   [dragPan]="(standSelectionEnabled$ | async) === false"
@@ -63,7 +57,22 @@
     [layout]="{ visibility: 'none' }">
   </mgl-layer>
 
-  <app-planning-area-layer></app-planning-area-layer>
+  <app-planning-area-layer before="middle-layer"></app-planning-area-layer>
+
+  <app-map-stands
+    *ngIf="mapLibreMap"
+    [userCanEditStands]="userCanEditStands"
+    [mapLibreMap]="mapLibreMap"
+    [selectStart]="mouseStart ? mouseStart.point : null"
+    [selectEnd]="mouseEnd ? mouseEnd.point : null"
+    (standsLoaded)="afterStandsLoaded()"
+    before="middle-layer"></app-map-stands>
+
+  <mgl-layer
+    type="background"
+    id="middle-layer"
+    [layout]="{ visibility: 'none' }">
+  </mgl-layer>
 
   <app-map-project-areas
     [mapLibreMap]="mapLibreMap"
@@ -85,14 +94,6 @@
       Treated
     </app-map-tooltip>
   </ng-container>
-
-  <app-map-stands
-    *ngIf="showTreatmentStands$ | async"
-    [userCanEditStands]="userCanEditStands"
-    [sourceId]="standsSourceLayerId"
-    [mapLibreMap]="mapLibreMap"
-    [selectStart]="mouseStart ? mouseStart.point : null"
-    [selectEnd]="mouseEnd ? mouseEnd.point : null"></app-map-stands>
 
   <app-map-rectangle
     [mapLibreMap]="mapLibreMap"

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -212,7 +212,6 @@ export class TreatmentMapComponent {
   standsLoaded = false;
 
   afterStandsLoaded() {
-    console.log('after stands are loaded');
     this.selectedStandsState.restoreSelectedStands();
     this.standsLoaded = true;
   }

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -259,11 +259,11 @@ export class TreatmentMapComponent {
     this.standsSourceLoaded$.pipe(untilDestroyed(this)).subscribe((s) => {
       this.selectedStandsState.restoreSelectedStands();
       // move the layer up
-      this.mapLibreMap.moveLayer('map-project-areas-line');
-      this.mapLibreMap.moveLayer('map-project-areas-highlight');
-      if (this.mapLibreMap.getLayer('map-project-areas-labels')) {
-        this.mapLibreMap.moveLayer('map-project-areas-labels');
-      }
+      // this.mapLibreMap.moveLayer('map-project-areas-line');
+      // this.mapLibreMap.moveLayer('map-project-areas-highlight');
+      // if (this.mapLibreMap.getLayer('map-project-areas-labels')) {
+      //   this.mapLibreMap.moveLayer('map-project-areas-labels');
+      // }
     });
   }
 

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -209,11 +209,8 @@ export class TreatmentMapComponent {
     });
   }
 
-  standsLoaded = false;
-
   afterStandsLoaded() {
     this.selectedStandsState.restoreSelectedStands();
-    this.standsLoaded = true;
   }
 
   onMapMouseDown(event: MapMouseEvent): void {

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -15,7 +15,6 @@ import {
   LngLat,
   Map as MapLibreMap,
   MapMouseEvent,
-  MapSourceDataEvent,
   RequestTransformFunction,
 } from 'maplibre-gl';
 import { MapStandsComponent } from '../map-stands/map-stands.component';
@@ -29,15 +28,8 @@ import { AuthService } from '@services';
 import { TreatmentsState } from '../treatments.state';
 import { addRequestHeaders } from '../../maplibre-map/maplibre.helper';
 import { PlanningAreaLayerComponent } from '../../maplibre-map/planning-area-layer/planning-area-layer.component';
-import {
-  combineLatest,
-  map,
-  Observable,
-  startWith,
-  Subject,
-  withLatestFrom,
-} from 'rxjs';
-import { distinctUntilChanged, filter } from 'rxjs/operators';
+import { combineLatest, map, Observable, Subject } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 import { SelectedStandsState } from './selected-stands.state';
 import { canEditTreatmentPlan } from 'src/app/plan/permissions';
 import { MatLegacySlideToggleModule } from '@angular/material/legacy-slide-toggle';
@@ -147,40 +139,8 @@ export class TreatmentMapComponent {
 
   selectedDataLayer$ = this.dataLayersStateService.selectedDataLayer$;
 
-  /**
-   * The name of the source layer used to load stands, and later check if loaded
-   */
-  standsSourceLayerId = 'stands';
+  showMapProjectAreas$ = this.mapConfigState.showProjectAreasLayer$;
 
-  private sourceLoaded$ = new Subject<MapSourceDataEvent>();
-
-  private standsSourceLoaded$ = this.sourceLoaded$.pipe(
-    filter(
-      (source) =>
-        source.sourceId === this.standsSourceLayerId && !source.sourceDataType
-    )
-  );
-
-  /**
-   * Observable to determine if we show the map project area layer.
-   * It uses the `standsSourceLoaded$` as the trigger to re-check the value provided on
-   * `mapConfigState`.
-   * We could be using mapConfigState.showProjectAreasLayer$ directly, but we want to animate
-   * properly when we show and hide this layer, when the user moves between treatment overview and
-   * project area.
-   */
-  showMapProjectAreas$ = combineLatest([
-    this.standsSourceLoaded$.pipe(startWith(null)),
-    this.mapConfigState.showProjectAreasLayer$,
-  ]).pipe(
-    map(([bounds, showAreas]) => {
-      return showAreas;
-    })
-  );
-  /**
-   * Observable to determine if we show the treatment stands layer
-   */
-  showTreatmentStands$ = this.mapConfigState.showTreatmentStandsLayer$;
   /**
    * Observable to determine if we show the map controls
    */
@@ -197,8 +157,6 @@ export class TreatmentMapComponent {
    */
   userCanEditStands: boolean = false;
   opacity$ = this.mapConfigState.treatedStandsOpacity$;
-
-  loadingLayer$ = this.dataLayersStateService.loadingLayer$;
 
   mouseLngLat: LngLat | null = null;
   hoveredProjectAreaId$ = new Subject<number | null>();
@@ -246,25 +204,17 @@ export class TreatmentMapComponent {
         }
       });
 
-    this.mapConfigState.baseLayer$
-      .pipe(
-        untilDestroyed(this),
-        withLatestFrom(this.showTreatmentStands$),
-        filter(([_, showTreatmentStands]) => showTreatmentStands) // Only pass through if showTreatmentStands is true
-      )
-      .subscribe(() => {
-        this.selectedStandsState.backUpAndClearSelectedStands();
-      });
-
-    this.standsSourceLoaded$.pipe(untilDestroyed(this)).subscribe((s) => {
-      this.selectedStandsState.restoreSelectedStands();
-      // move the layer up
-      // this.mapLibreMap.moveLayer('map-project-areas-line');
-      // this.mapLibreMap.moveLayer('map-project-areas-highlight');
-      // if (this.mapLibreMap.getLayer('map-project-areas-labels')) {
-      //   this.mapLibreMap.moveLayer('map-project-areas-labels');
-      // }
+    this.mapConfigState.baseLayer$.pipe(untilDestroyed(this)).subscribe(() => {
+      this.selectedStandsState.backUpAndClearSelectedStands();
     });
+  }
+
+  standsLoaded = false;
+
+  afterStandsLoaded() {
+    console.log('after stands are loaded');
+    this.selectedStandsState.restoreSelectedStands();
+    this.standsLoaded = true;
   }
 
   onMapMouseDown(event: MapMouseEvent): void {
@@ -319,12 +269,6 @@ export class TreatmentMapComponent {
 
   onMapMouseOut() {
     this.treatmentTooltipLngLat = null;
-  }
-
-  onSourceData(event: MapSourceDataEvent) {
-    if (event.isSourceLoaded) {
-      this.sourceLoaded$.next(event);
-    }
   }
 
   openTreatmentLegend() {

--- a/src/interface/src/app/treatments/treatment-to-pdf.service.ts
+++ b/src/interface/src/app/treatments/treatment-to-pdf.service.ts
@@ -2,16 +2,15 @@ import { Injectable } from '@angular/core';
 import jsPDF from 'jspdf';
 import {
   descriptionsForAction,
+  PATTERN_NAMES,
   PrescriptionAction,
+  PRESCRIPTIONS,
   PrescriptionSequenceAction,
   PrescriptionSingleAction,
-  PRESCRIPTIONS,
-  PATTERN_NAMES,
 } from './prescriptions';
 import { Map as MapLibreMap } from 'maplibre-gl';
 import { logoImg } from '../../assets/base64/icons';
 import { Prescription, TreatmentProjectArea, TreatmentSummary } from '@types';
-import { MapConfigState } from '../maplibre-map/map-config.state';
 
 import { TreatmentsState } from './treatments.state';
 import { TreatedStandsState } from './treatment-map/treated-stands.state';
@@ -44,7 +43,6 @@ export class TreatmentToPDFService {
   constructor(
     private treatmentsState: TreatmentsState,
     private treatedStandsState: TreatedStandsState,
-    private mapConfigState: MapConfigState,
     private authService: AuthService
   ) {}
 
@@ -103,26 +101,14 @@ export class TreatmentToPDFService {
 
     this.addAttributions(attributions, mapX + mapWidth, mapHeight + mapY - 2);
 
-    // If we are showing the treatment stands, we change what's being rendered
-    if (this.mapConfigState.isTreatmentStandsVisible()) {
-      const nextY = 132;
-      await this.drawTreatmentLegend(130, nextY, treatmentsUsedSet);
-      await this.addProjectAreaTable(
-        this.tableRowsFromSummary(curSummary),
-        this.leftMargin + 10,
-        nextY,
-        80
-      );
-    } else {
-      const projectAreasX = this.leftMargin + 10;
-      const projectAreasY = 132;
-      await this.addProjectAreaTable(
-        this.tableRowsFromSummary(curSummary),
-        projectAreasX,
-        projectAreasY,
-        140
-      );
-    }
+    const nextY = 132;
+    await this.drawTreatmentLegend(130, nextY, treatmentsUsedSet);
+    await this.addProjectAreaTable(
+      this.tableRowsFromSummary(curSummary),
+      this.leftMargin + 10,
+      nextY,
+      80
+    );
 
     document.body.removeChild(mapContainer);
     const pdfName = `planscape-${encodeURI(treatmentPlanName.split(' ').join('_'))}.pdf`;

--- a/src/interface/src/app/treatments/treatments-routing-data.ts
+++ b/src/interface/src/app/treatments/treatments-routing-data.ts
@@ -7,7 +7,6 @@ export interface TreatmentRoutingData extends Data {
   projectAreaId?: number;
   planId: number;
   showMapProjectAreas?: boolean;
-  showTreatmentStands?: boolean;
   showMapControls?: boolean;
   standSelectionEnabled?: boolean;
 }

--- a/src/interface/src/app/treatments/treatments-routing.module.ts
+++ b/src/interface/src/app/treatments/treatments-routing.module.ts
@@ -19,7 +19,6 @@ const routes: Routes = [
         component: TreatmentOverviewComponent,
         data: {
           showMapProjectAreas: true,
-          showTreatmentStands: true,
         },
       },
       { path: 'project-area', redirectTo: '', pathMatch: 'full' },
@@ -32,7 +31,6 @@ const routes: Routes = [
         },
         data: {
           showMapProjectAreas: false,
-          showTreatmentStands: true,
           showMapControls: true,
           standSelectionEnabled: true,
         },

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -165,9 +165,7 @@ export class TreatmentsState {
     this.mapConfigState.updateShowProjectAreas(
       data.showMapProjectAreas || false
     );
-    this.mapConfigState.updateShowTreatmentStands(
-      data.showTreatmentStands || false
-    );
+
     this.mapConfigState.setStandSelectionEnabled(
       data.standSelectionEnabled || false
     );
@@ -323,7 +321,6 @@ export class TreatmentsState {
     }
 
     this._projectAreaId$.next(projectAreaId);
-    this.mapConfigState.updateShowTreatmentStands(true);
     this.mapConfigState.updateMapCenter(projectArea?.extent);
     if (setStands) {
       this.setTreatedStandsFromSummary([projectArea]);


### PR DESCRIPTION
This PR removes calls to manually re-ordering layers, and instead uses `before` to set the right orders:


- On each component, use `before` to set order of layers within the component itself
- Added an auxiliary fake layer to help ordering. This is added so we don't need to remember ids from other components or couple components with each other
- Added inputs to provide `before` to set the order

Fixes several bugs/details as well:

- Updates planning area to use martin vector layer instead of geometry (in preparation to eventually removing `geometry` from the planning area payload)
- Fixes issue with slider opacity not being persisted between states 
- Fixes Layer order on pdf 
- Removes unused code from previous versions of the treatment page
- Moves listener for "stands loaded" to the stands component, removing coupling with `treatment-map` component


