### PR TITLE
New sql file and martin update

### DIFF
--- a/martin.yaml
+++ b/martin.yaml
@@ -65,6 +65,17 @@ postgres:
       maxzoom: 20
       bounds: [ -180.0, -90.0, 180.0, 90.0 ]
       id_column: id
+    # dynamic layer that can serve ANY table as tiles
+    # parameters:
+    # - layer: string  (full table name, e.g. public.my_table) 
+    dynamic_layer:
+      schema: public                 
+      function: martin_dynamic_layer 
+      minzoom: 0
+      maxzoom: 20
+      bounds: [ -180.0, -90.0, 180.0, 90.0 ]
+      id_column: id                  
+      query_params: [ layer ]    
   tables:
     stands:
       layer_id: stands

--- a/martin.yaml
+++ b/martin.yaml
@@ -65,10 +65,10 @@ postgres:
       maxzoom: 20
       bounds: [ -180.0, -90.0, 180.0, 90.0 ]
       id_column: id
-    # dynamic layer that can serve ANY table as tiles
+    # dynamic endpoint for any imported DataLayer by ID
     # parameters:
-    # - layer: string  (full table name, e.g. public.my_table) 
-    dynamic_layer:
+    # - layer: integer  (DataLayer id) 
+    dynamic:
       schema: public                 
       function: martin_dynamic_layer 
       minzoom: 0

--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -7,37 +7,54 @@ CREATE OR REPLACE FUNCTION martin_dynamic_layer(
 RETURNS bytea AS $$
 
 DECLARE
-    layer_name text := query_params->>'layer';
-    sql         text;
+    layer_id integer := (query_params->>'layer')::int;
+    dyn_table    text;
     tile        bytea;
 BEGIN
-    IF layer_name !~ '^[a-zA-Z0-9_\.]+$' THEN
-        RAISE EXCEPTION 'Invalid layer name %', layer_name;
+    SELECT "table"
+        INTO dyn_table
+        FROM public.datasets_datalayer
+    WHERE id = layer_id;
+    
+    IF dyn_table IS NULL THEN    
+        RAISE EXCEPTION 'Datalayer with id % not found or has no table defined', layer_id;
     END IF;
 
-    sql := format($f$
+    EXECUTE format($f$
         WITH
         bbox AS (
-          SELECT ST_TileEnvelope(%1$s, %2$s, %3$s, margin => (64.0/4096)) AS geom
+          SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
         ),
         mvtgeom AS (
           SELECT
             t.id AS id,  
             ST_AsMVTGeom(
               ST_Transform(t.geometry, 3857),
-              ST_TileEnvelope(%1$s, %2$s, %3$s),
+              ST_TileEnvelope($1, $2, $3),
               4096, 64, true
             ) AS geom
-          FROM %4$I AS t, bbox
-          WHERE
-            t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
+          FROM %I AS t, bbox
+          WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
         )
-        SELECT ST_AsMVT(mvtgeom.*, 'dynamic_layer', 4096, 'geom')
+        SELECT ST_AsMVT(mvtgeom.*, %L, 4096, 'geom')
         FROM mvtgeom;
-    $f$, z, x, y, layer_name);
-
-    EXECUTE sql INTO tile;
+    $f$, dyn_table, format('dynamic_%s', layer_id))
+    INTO tile
+    USING z, x, y;
     RETURN tile;
+
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'martin_dynamic_layer(%): %', layer_id, SQLERRM;
+
+    RETURN (
+      WITH empty AS (
+        SELECT NULL::integer AS id, NULL::geometry AS geom
+        WHERE FALSE
+      )
+      SELECT ST_AsMVT(empty, format('dynamic_%s', layer_id), 4096, 'geom')
+      FROM empty
+    );
+
 END; 
 
 $$ LANGUAGE plpgsql

--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -15,10 +15,6 @@ BEGIN
         INTO dyn_table
         FROM public.datasets_datalayer
     WHERE id = layer_id;
-    
-    IF dyn_table IS NULL THEN    
-        RAISE EXCEPTION 'Datalayer with id % not found or has no table defined', layer_id;
-    END IF;
 
     EXECUTE format($f$
         WITH
@@ -42,18 +38,6 @@ BEGIN
     INTO tile
     USING z, x, y;
     RETURN tile;
-
-EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'martin_dynamic_layer(%): %', layer_id, SQLERRM;
-
-    RETURN (
-      WITH empty AS (
-        SELECT NULL::integer AS id, NULL::geometry AS geom
-        WHERE FALSE
-      )
-      SELECT ST_AsMVT(empty, format('dynamic_%s', layer_id), 4096, 'geom')
-      FROM empty
-    );
 
 END; 
 

--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -1,0 +1,46 @@
+CREATE OR REPLACE FUNCTION martin_dynamic_layer(
+    z integer,
+    x integer,
+    y integer,
+    query_params json
+)
+RETURNS bytea AS $$
+
+DECLARE
+    layer_name text := query_params->>'layer';
+    sql         text;
+    tile        bytea;
+BEGIN
+    IF layer_name !~ '^[a-zA-Z0-9_\.]+$' THEN
+        RAISE EXCEPTION 'Invalid layer name %', layer_name;
+    END IF;
+
+    sql := format($f$
+        WITH
+        bbox AS (
+          SELECT ST_TileEnvelope(%1$s, %2$s, %3$s, margin => (64.0/4096)) AS geom
+        ),
+        mvtgeom AS (
+          SELECT
+            t.id AS id,  
+            ST_AsMVTGeom(
+              ST_Transform(t.geometry, 3857),
+              ST_TileEnvelope(%1$s, %2$s, %3$s),
+              4096, 64, true
+            ) AS geom
+          FROM %4$I AS t, bbox
+          WHERE
+            t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
+        )
+        SELECT ST_AsMVT(mvtgeom.*, 'dynamic_layer', 4096, 'geom')
+        FROM mvtgeom;
+    $f$, z, x, y, layer_name);
+
+    EXECUTE sql INTO tile;
+    RETURN tile;
+END; 
+
+$$ LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+PARALLEL SAFE;


### PR DESCRIPTION
@george-silva @roquebetioljr, Added a new `dynamic_layer` to Martin using the other SQL files as reference, so that Martin can dynamically serve Mapbox-style vector tiles from any PostGIS table, rather than just the hard-coded layers we have: 


1. `martin_dynamic_layer.sql` new file: 

A new SQL function that takes `z`, `x`, `y` and a `JSON layer`, validates the table name, builds and executes a dynamic SQL query to generate an MVT tile (PBF) for any PostGIS table.


2. `martin.yaml` update: 

Update that registers `dynamic_layer` under `postgres.functions`, so Martin can expose `/tiles/public.dynamic_layer/{z}/{x}/{y}.pbf?layer=public.my_table`.