### PR TITLE
plan 2286 martin as datalayers w tests

### DIFF
--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -14,7 +14,7 @@ from django.core.validators import RegexValidator, URLValidator
 from django_stubs_ext.db.models import TypedModelMeta
 from organizations.models import Organization
 from treebeard.mp_tree import MP_Node
-from utils.frontend import get_domain
+from utils.frontend import get_base_url, get_domain
 
 User = get_user_model()
 
@@ -349,6 +349,14 @@ class DataLayer(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
             )
             download_url = str(new_url.geturl())
         return download_url
+
+    def get_map_url(self) -> Optional[str]:
+        if self.type == DataLayerType.RASTER:
+            return self.get_public_url()
+        if self.table and self.storage_type == StorageTypeChoices.DATABASE:
+            base = get_base_url(settings.ENV) or f"https://{get_domain(settings.ENV)}"
+            return f"{base}/tiles/dynamic?layer={self.id}"
+        return self.get_public_url()
 
     def get_assigned_style(self) -> Optional[Style]:
         return self.styles.all().first()

--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -356,7 +356,7 @@ class DataLayer(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
         if self.table and self.storage_type == StorageTypeChoices.DATABASE:
             base = get_base_url(settings.ENV) or f"https://{get_domain(settings.ENV)}"
             return f"{base}/tiles/dynamic?layer={self.id}"
-        return self.get_public_url()
+        return None
 
     def get_assigned_style(self) -> Optional[Style]:
         return self.styles.all().first()

--- a/src/planscape/datasets/serializers.py
+++ b/src/planscape/datasets/serializers.py
@@ -94,6 +94,10 @@ class DataLayerSerializer(serializers.ModelSerializer[DataLayer]):
         source="get_public_url",
         read_only=True,
     )
+    map_url = serializers.CharField(
+        source="get_map_url",
+        read_only=True,
+    )
     styles = serializers.SerializerMethodField()
     original_name = serializers.CharField(read_only=True)
 
@@ -137,6 +141,7 @@ class DataLayerSerializer(serializers.ModelSerializer[DataLayer]):
             "styles",
             "url",
             "public_url",
+            "map_url",
             "info",
             "metadata",
             "original_name",
@@ -457,6 +462,10 @@ class BrowseDataLayerSerializer(serializers.ModelSerializer["DataLayer"]):
         source="get_public_url",
         read_only=True,
     )
+    map_url = serializers.CharField(
+        source="get_map_url",
+        read_only=True,
+    )
     styles = serializers.SerializerMethodField()
 
     def _default_raster_style(self, instance):
@@ -495,6 +504,7 @@ class BrowseDataLayerSerializer(serializers.ModelSerializer["DataLayer"]):
             "dataset",
             "path",
             "public_url",
+            "map_url",
             "name",
             "type",
             "geometry_type",

--- a/src/planscape/datasets/tests/test_serializers.py
+++ b/src/planscape/datasets/tests/test_serializers.py
@@ -233,3 +233,7 @@ class MapURLTests(TestCase):
         )
         for Serializer in (DataLayerSerializer, BrowseDataLayerSerializer):
             self.assertIn("map_url", Serializer(vector).data)
+
+    def test_map_url_none_when_no_table(self):
+        layer = DataLayerFactory(type=DataLayerType.VECTOR, table=None)
+        self.assertIsNone(layer.get_map_url())

--- a/src/planscape/datasets/tests/test_serializers.py
+++ b/src/planscape/datasets/tests/test_serializers.py
@@ -1,10 +1,6 @@
-from django.contrib.auth.models import User
-from django.test import TestCase
-from impacts.models import ImpactVariable, TreatmentPrescriptionAction
-from rest_framework.test import APIRequestFactory
-
-from datasets.models import Category, DataLayerType
+from datasets.models import Category, DataLayerType, StorageTypeChoices
 from datasets.serializers import (
+    BrowseDataLayerSerializer,
     CategoryEmbbedSerializer,
     CategorySerializer,
     CreateDataLayerSerializer,
@@ -18,6 +14,12 @@ from datasets.tests.factories import (
     DatasetFactory,
     OrganizationFactory,
 )
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase
+from impacts.models import ImpactVariable, TreatmentPrescriptionAction
+from rest_framework.test import APIRequestFactory
+from utils.frontend import get_base_url, get_domain
 
 
 class CategorySerializerTest(TestCase):
@@ -82,6 +84,8 @@ class DataLayerSerializerTest(TestCase):
         self.assertEqual(data["geometry_type"], data_layer.geometry_type)
         self.assertEqual(data["type"], data_layer.type)
         self.assertIn("category", data)
+        self.assertIn("public_url", data)
+        self.assertIn("map_url", data)
 
     def test_create_data_layer_serializer(self):
         data_layer = DataLayerFactory()
@@ -203,3 +207,29 @@ class TestCreateStyleSerializer(TestCase):
         )
         self.assertFalse(serializer.is_valid())
         self.assertEqual(set(serializer.errors.keys()), set(["global"]))
+
+
+class MapURLTests(TestCase):
+    def _expected_dynamic_url(self, layer):
+        base = get_base_url(settings.ENV) or f"https://{get_domain(settings.ENV)}"
+        return f"{base}/tiles/dynamic?layer={layer.id}"
+
+    def test_get_map_url_logic(self):
+        raster = DataLayerFactory(type=DataLayerType.RASTER)
+        self.assertEqual(raster.get_map_url(), raster.get_public_url())
+
+        vector = DataLayerFactory(
+            type=DataLayerType.VECTOR,
+            storage_type=StorageTypeChoices.DATABASE,
+            table="datastore.foo_bar",
+        )
+        self.assertEqual(vector.get_map_url(), self._expected_dynamic_url(vector))
+
+    def test_map_url_present_in_serializers(self):
+        vector = DataLayerFactory(
+            type=DataLayerType.VECTOR,
+            storage_type=StorageTypeChoices.DATABASE,
+            table="datastore.foo_bar",
+        )
+        for Serializer in (DataLayerSerializer, BrowseDataLayerSerializer):
+            self.assertIn("map_url", Serializer(vector).data)

--- a/src/planscape/datasets/tests/test_services.py
+++ b/src/planscape/datasets/tests/test_services.py
@@ -101,7 +101,9 @@ class TestSearch(TransactionTestCase):
     def test_end_to_end(self):
         organization = OrganizationFactory.create(name="my cool fire org")
         dataset = DatasetFactory(
-            organization=organization, name="my awesome fire dataset"
+            organization=organization,
+            name="my awesome fire dataset",
+            visibility="PUBLIC",
         )
         category1 = Category.add_root(
             created_by=organization.created_by,


### PR DESCRIPTION
@george-silva @roquebetioljr 

1. Added `get_map_url()` to `DataLayer` model in `src/planscape/datasets/models.py`
2. Added `map_url` to both `DataLayerSerializer` and `BrowseDataLayerSerializer` in `src/planscape/datasets/serializers.py` 
3. Added new `MapURLTests` unit test class to test the new `map_url` in `src/planscape/datasets/tests/test_serializers.py`
4. Updated `test_end_to_end` to pass  in `src/planscape/datasets/tests/test_services.py`
5. Formatted imports & linted the 4 changed files.