### PR TITLE
Use base layers store to list and select base layers

### DIFF
--- a/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.html
+++ b/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.html
@@ -14,30 +14,27 @@
 </div>
 <div class="list-content" *ngIf="expanded">
   <ng-container
-    *ngIf="categorizedBaseLayer?.category.isMulti; else singleSelect">
+    *ngIf="categorizedBaseLayer.category.isMultiSelect; else singleSelect">
     <div
       *ngFor="let layer of categorizedBaseLayer.layers"
       class="checkbox-option">
-      <label class="checkbox-label">
-        <input
-          type="checkbox"
-          [value]="layer.id"
-          [checked]="isLayerSelected(layer)"
-          (change)="onCheckboxChange(layer, $event)" />
-        <span>{{ layer.name }}</span>
-      </label>
+      <mat-checkbox
+        [value]="layer.id.toString()"
+        [checked]="selectedLayersId.includes(layer.id)"
+        class="data-layer-input"
+        (change)="onLayerChange(layer, true)"
+        >{{ layer.name }}
+      </mat-checkbox>
     </div>
   </ng-container>
   <ng-template #singleSelect>
-    <div *ngFor="let layer of categorizedBaseLayer.layers" class="radio-option">
-      <label class="radio-label">
-        <input
-          type="radio"
-          name="baseLayer"
-          [value]="layer.id"
-          (change)="onLayerChange(layer)" />
-        <span>{{ layer.name }}</span>
-      </label>
-    </div>
+    <mat-radio-button
+      *ngFor="let layer of categorizedBaseLayer.layers"
+      [value]="layer.id"
+      [checked]="selectedLayersId.includes(layer.id)"
+      class="data-layer-input"
+      (change)="onLayerChange(layer, false)"
+      >{{ layer.name }}
+    </mat-radio-button>
   </ng-template>
 </div>

--- a/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.scss
+++ b/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.scss
@@ -28,24 +28,11 @@
   align-items: flex-start;
   gap: 16px;
   align-self: stretch;
-  padding: 16px;
   background: $color-soft-purple-light;
 }
 
-.radio-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-}
 
-.radio-option {
-  display: flex;
-}
 
-.checkbox-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-}
+
+
+

--- a/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.spec.ts
+++ b/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BaseLayersListComponent } from './base-layers-list.component';
+import { BaseLayer } from '@types';
 
 describe('BaseLayersListComponent', () => {
   let component: BaseLayersListComponent;
@@ -12,56 +13,35 @@ describe('BaseLayersListComponent', () => {
 
     fixture = TestBed.createComponent(BaseLayersListComponent);
     component = fixture.componentInstance;
+    component.categorizedBaseLayer = {
+      category: {
+        name: 'Demo Category',
+        isMultiSelect: false,
+      },
+      layers: [
+        {
+          id: 1,
+          name: 'Watersheds (HUC-12)',
+          path: ['DEMO multi'],
+        },
+      ] as BaseLayer[],
+    };
     fixture.detectChanges();
   });
 
   it('should emit layerSelected when a radio is selected', () => {
-    const mockLayer = component.categorizedBaseLayer.layers[0];
+    const mockLayer = {
+      id: 1,
+      name: 'Watersheds (HUC-12)',
+      path: ['DEMO multi'],
+    } as BaseLayer;
     spyOn(component.layerSelected, 'emit');
 
-    component.onLayerChange(mockLayer);
+    component.onLayerChange(mockLayer, false);
 
-    expect(component.layerSelected.emit).toHaveBeenCalledWith(mockLayer);
-  });
-
-  it('should emit layersSelected with layer added when checkbox is checked', () => {
-    const mockLayer = component.categorizedBaseLayer.layers[1];
-    spyOn(component.layersSelected, 'emit');
-
-    const mockEvent = { target: { checked: true } };
-    component.onCheckboxChange(mockLayer, mockEvent);
-
-    expect(component.selectedLayers).toContain(mockLayer);
-    expect(component.layersSelected.emit).toHaveBeenCalledWith([mockLayer]);
-  });
-
-  it('should emit layersSelected with layer removed when checkbox is unchecked', () => {
-    const mockLayer = component.categorizedBaseLayer.layers[2];
-    component.selectedLayers = [mockLayer];
-    spyOn(component.layersSelected, 'emit');
-
-    const mockEvent = { target: { checked: false } };
-    component.onCheckboxChange(mockLayer, mockEvent);
-
-    expect(component.selectedLayers).not.toContain(mockLayer);
-    expect(component.layersSelected.emit).toHaveBeenCalledWith([]);
-  });
-
-  it('isLayerSelected should return true if layer is in selectedLayers', () => {
-    const mockLayer = component.categorizedBaseLayer.layers[0];
-    component.selectedLayers = [mockLayer];
-
-    const result = component.isLayerSelected(mockLayer);
-
-    expect(result).toBeTrue();
-  });
-
-  it('isLayerSelected should return false if layer is not in selectedLayers', () => {
-    const mockLayer = component.categorizedBaseLayer.layers[1];
-    component.selectedLayers = [];
-
-    const result = component.isLayerSelected(mockLayer);
-
-    expect(result).toBeFalse();
+    expect(component.layerSelected.emit).toHaveBeenCalledWith({
+      layer: mockLayer,
+      isMulti: false,
+    });
   });
 });

--- a/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.ts
+++ b/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.ts
@@ -1,64 +1,28 @@
-import { NgFor, NgIf } from '@angular/common';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { BaseLayer, CategorizedBaseLayers } from '@types';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 @Component({
   selector: 'app-base-layers-list',
   standalone: true,
-  imports: [NgIf, NgFor],
+  imports: [NgIf, NgFor, AsyncPipe, MatRadioModule, MatCheckboxModule],
   templateUrl: './base-layers-list.component.html',
   styleUrl: './base-layers-list.component.scss',
 })
 export class BaseLayersListComponent {
-  // TODO change any for categorizedBaseLayers and remove default mocked value
-  @Input() categorizedBaseLayer: any = {
-    category: {
-      name: 'Boundaries',
-      key: 'boundaries',
-      isMulti: false,
-    },
-    layers: [
-      {
-        id: 1,
-        name: 'Watersheds (HUC-12)',
-        category: '',
-      },
-      {
-        id: 2,
-        name: 'PODs',
-        category: '',
-      },
-      {
-        id: 3,
-        name: 'Subfireshreds',
-        category: '',
-      },
-    ],
-  };
-  // TODO: change any for baseLayer
-  @Output() layerSelected = new EventEmitter<any>();
-  // TODO: change any for BaseLayer[]
-  @Output() layersSelected = new EventEmitter<any[]>();
+  @Input() categorizedBaseLayer!: CategorizedBaseLayers;
+  @Input() selectedLayersId: number[] = [];
 
-  selectedLayers: any[] = [];
+  @Output() layerSelected = new EventEmitter<{
+    layer: BaseLayer;
+    isMulti: boolean;
+  }>();
+
   expanded = false;
 
-  onLayerChange(layer: any): void {
-    this.layerSelected.emit(layer);
-  }
-
-  isLayerSelected(layer: any): boolean {
-    return this.selectedLayers.some((l) => l.id === layer.id);
-  }
-
-  onCheckboxChange(layer: any, event: any): void {
-    if (event?.target?.checked) {
-      this.selectedLayers.push(layer);
-    } else {
-      this.selectedLayers = this.selectedLayers.filter(
-        (l) => l.id !== layer.id
-      );
-    }
-
-    this.layersSelected.emit(this.selectedLayers);
+  onLayerChange(layer: any, isMulti: boolean): void {
+    this.layerSelected.emit({ layer, isMulti });
   }
 }

--- a/src/interface/src/app/base-layers/base-layers.state.service.spec.ts
+++ b/src/interface/src/app/base-layers/base-layers.state.service.spec.ts
@@ -47,7 +47,7 @@ describe('BaseLayersStateService', () => {
   });
 
   it('should start with null selection', (done) => {
-    service.selectedBaseLayer$.pipe(take(1)).subscribe((layers) => {
+    service.selectedBaseLayers$.pipe(take(1)).subscribe((layers) => {
       expect(layers).toBeNull();
       done();
     });
@@ -55,9 +55,9 @@ describe('BaseLayersStateService', () => {
 
   it('should select a single base layer if none is selected', (done) => {
     const layer = makeLayer(1, 'catA');
-    service.selectBaseLayer(layer, false);
+    service.updateBaseLayers(layer, false);
 
-    service.selectedBaseLayer$.pipe(take(1)).subscribe((layers) => {
+    service.selectedBaseLayers$.pipe(take(1)).subscribe((layers) => {
       expect(layers).toEqual([layer]);
       done();
     });
@@ -67,10 +67,10 @@ describe('BaseLayersStateService', () => {
     const layer1 = makeLayer(1, 'catA');
     const layer2 = makeLayer(2, 'catA');
 
-    service.selectBaseLayer(layer1, true);
-    service.selectBaseLayer(layer2, false);
+    service.updateBaseLayers(layer1, true);
+    service.updateBaseLayers(layer2, false);
 
-    service.selectedBaseLayer$.pipe(take(1)).subscribe((layers) => {
+    service.selectedBaseLayers$.pipe(take(1)).subscribe((layers) => {
       expect(layers).toEqual([layer2]);
       done();
     });
@@ -80,23 +80,23 @@ describe('BaseLayersStateService', () => {
     const layer1 = makeLayer(1, 'catA');
     const layer2 = makeLayer(2, 'catA');
 
-    service.selectBaseLayer(layer1, true);
-    service.selectBaseLayer(layer2, true);
+    service.updateBaseLayers(layer1, true);
+    service.updateBaseLayers(layer2, true);
 
-    service.selectedBaseLayer$.pipe(take(1)).subscribe((layers) => {
+    service.selectedBaseLayers$.pipe(take(1)).subscribe((layers) => {
       expect(layers).toEqual([layer1, layer2]);
       done();
     });
   });
 
-  it('should ignore if already selected multi layer is selected again', (done) => {
+  it('should remove if already selected multi layer is selected again', (done) => {
     const layer = makeLayer(1, 'catA');
 
-    service.selectBaseLayer(layer, true);
-    service.selectBaseLayer(layer, true); // selecting the same one again
+    service.updateBaseLayers(layer, true);
+    service.updateBaseLayers(layer, true); // selecting the same one again
 
-    service.selectedBaseLayer$.pipe(take(1)).subscribe((layers) => {
-      expect(layers).toEqual([layer]);
+    service.selectedBaseLayers$.pipe(take(1)).subscribe((layers) => {
+      expect(layers).toEqual([]);
       done();
     });
   });
@@ -105,10 +105,10 @@ describe('BaseLayersStateService', () => {
     const layer1 = makeLayer(1, 'catA');
     const layer2 = makeLayer(2, 'catB');
 
-    service.selectBaseLayer(layer1, true);
-    service.selectBaseLayer(layer2, true);
+    service.updateBaseLayers(layer1, true);
+    service.updateBaseLayers(layer2, true);
 
-    service.selectedBaseLayer$.pipe(take(1)).subscribe((layers) => {
+    service.selectedBaseLayers$.pipe(take(1)).subscribe((layers) => {
       expect(layers).toEqual([layer2]);
       done();
     });
@@ -116,11 +116,11 @@ describe('BaseLayersStateService', () => {
 
   it('should clear the selection', (done) => {
     const layer = makeLayer(1, 'catA');
-    service.selectBaseLayer(layer, true);
+    service.updateBaseLayers(layer, true);
 
     service.clearBaseLayer();
 
-    service.selectedBaseLayer$.pipe(take(1)).subscribe((layers) => {
+    service.selectedBaseLayers$.pipe(take(1)).subscribe((layers) => {
       expect(layers).toBeNull();
       done();
     });

--- a/src/interface/src/app/base-layers/base-layers.state.service.ts
+++ b/src/interface/src/app/base-layers/base-layers.state.service.ts
@@ -48,27 +48,29 @@ export class BaseLayersStateService {
   selectedBaseLayers$ = this._selectedBaseLayers$.asObservable();
 
   updateBaseLayers(bl: BaseLayer, isMulti: boolean) {
-    const current = this._selectedBaseLayers$.value ?? [];
+    const currentLayers = this._selectedBaseLayers$.value ?? [];
 
     // If no layers selected, just set the new one
-    if (current.length === 0) {
+    if (currentLayers.length === 0) {
       this._selectedBaseLayers$.next([bl]);
       return;
     }
 
-    const currentCategory = current[0].path[0];
+    const currentCategory = currentLayers[0].path[0];
 
     // if the layer allows multi select
     if (isMulti) {
       if (bl.path[0] === currentCategory) {
-        const alreadySelected = current.some((layer) => layer.id === bl.id);
+        const alreadySelected = currentLayers.some(
+          (layer) => layer.id === bl.id
+        );
         if (alreadySelected) {
           // Remove if already selected
-          const updated = current.filter((layer) => layer.id !== bl.id);
+          const updated = currentLayers.filter((layer) => layer.id !== bl.id);
           this._selectedBaseLayers$.next(updated);
         } else {
           // Add if not already selected
-          this._selectedBaseLayers$.next([...current, bl]);
+          this._selectedBaseLayers$.next([...currentLayers, bl]);
         }
       } else {
         // Different category, start new selection

--- a/src/interface/src/app/base-layers/base-layers.state.service.ts
+++ b/src/interface/src/app/base-layers/base-layers.state.service.ts
@@ -29,7 +29,7 @@ export class BaseLayersStateService {
 
       const result: CategorizedBaseLayers[] = Object.entries(grouped).map(
         ([categoryName, categoryLayers]) => {
-          const isMulti = categoryName === 'Organization';
+          const isMulti = this.isCategoryMultiSelect(categoryName);
           return {
             category: {
               name: categoryName,
@@ -44,15 +44,15 @@ export class BaseLayersStateService {
     })
   );
 
-  private _selectedBaseLayer$ = new BehaviorSubject<BaseLayer[] | null>(null);
-  selectedBaseLayer$ = this._selectedBaseLayer$.asObservable();
+  private _selectedBaseLayers$ = new BehaviorSubject<BaseLayer[] | null>(null);
+  selectedBaseLayers$ = this._selectedBaseLayers$.asObservable();
 
-  selectBaseLayer(bl: BaseLayer, isMulti: boolean) {
-    const current = this._selectedBaseLayer$.value ?? [];
+  updateBaseLayers(bl: BaseLayer, isMulti: boolean) {
+    const current = this._selectedBaseLayers$.value ?? [];
 
     // If no layers selected, just set the new one
     if (current.length === 0) {
-      this._selectedBaseLayer$.next([bl]);
+      this._selectedBaseLayers$.next([bl]);
       return;
     }
 
@@ -61,22 +61,30 @@ export class BaseLayersStateService {
     // if the layer allows multi select
     if (isMulti) {
       if (bl.path[0] === currentCategory) {
-        // Add only if not already selected
         const alreadySelected = current.some((layer) => layer.id === bl.id);
-        if (!alreadySelected) {
-          this._selectedBaseLayer$.next([...current, bl]);
+        if (alreadySelected) {
+          // Remove if already selected
+          const updated = current.filter((layer) => layer.id !== bl.id);
+          this._selectedBaseLayers$.next(updated);
+        } else {
+          // Add if not already selected
+          this._selectedBaseLayers$.next([...current, bl]);
         }
       } else {
         // Different category, start new selection
-        this._selectedBaseLayer$.next([bl]);
+        this._selectedBaseLayers$.next([bl]);
       }
     } else {
       // Replace with only this layer regardless of current state
-      this._selectedBaseLayer$.next([bl]);
+      this._selectedBaseLayers$.next([bl]);
     }
   }
 
   clearBaseLayer() {
-    this._selectedBaseLayer$.next(null);
+    this._selectedBaseLayers$.next(null);
+  }
+
+  private isCategoryMultiSelect(path: string) {
+    return path == 'DEMO multi' || path == 'Organization';
   }
 }

--- a/src/interface/src/app/base-layers/base-layers/base-layers.component.html
+++ b/src/interface/src/app/base-layers/base-layers/base-layers.component.html
@@ -1,1 +1,11 @@
-<app-base-layers-list></app-base-layers-list>
+<app-base-layers-list
+  *ngFor="let categorizedBaseLayer of categorizedBaseLayers$ | async"
+  [categorizedBaseLayer]="categorizedBaseLayer"
+  [selectedLayersId]="(selectedLayersId$ | async) || []"
+  (layerSelected)="updateSelectedLayer($event)"></app-base-layers-list>
+
+<!--DEMO remove before turning flag on-->
+<div>
+  Selected layers:
+  <span *ngFor="let layer of selectedLayers$ | async">{{ layer.name }} </span>
+</div>

--- a/src/interface/src/app/base-layers/base-layers/base-layers.component.spec.ts
+++ b/src/interface/src/app/base-layers/base-layers/base-layers.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BaseLayersComponent } from './base-layers.component';
+import { MockProvider } from 'ng-mocks';
+import { BaseLayersStateService } from '../base-layers.state.service';
+import { of } from 'rxjs';
 
 describe('BaseLayersComponent', () => {
   let component: BaseLayersComponent;
@@ -9,6 +12,12 @@ describe('BaseLayersComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [BaseLayersComponent],
+      providers: [
+        MockProvider(BaseLayersStateService, {
+          selectedBaseLayers$: of([]),
+          categorizedBaseLayers$: of([]),
+        }),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BaseLayersComponent);

--- a/src/interface/src/app/base-layers/base-layers/base-layers.component.ts
+++ b/src/interface/src/app/base-layers/base-layers/base-layers.component.ts
@@ -1,11 +1,27 @@
 import { Component } from '@angular/core';
 import { BaseLayersListComponent } from '../base-layers-list/base-layers-list.component';
+import { BaseLayersStateService } from '../base-layers.state.service';
+import { AsyncPipe, NgForOf } from '@angular/common';
+import { BaseLayer } from '@types';
+import { map } from 'rxjs';
 
 @Component({
   selector: 'app-base-layers',
   standalone: true,
-  imports: [BaseLayersListComponent],
+  imports: [BaseLayersListComponent, AsyncPipe, NgForOf],
   templateUrl: './base-layers.component.html',
   styleUrl: './base-layers.component.scss',
 })
-export class BaseLayersComponent {}
+export class BaseLayersComponent {
+  selectedLayers$ = this.baseLayersStateService.selectedBaseLayers$;
+  selectedLayersId$ = this.selectedLayers$.pipe(
+    map((layers) => (layers ? layers.map((l) => l.id) : []))
+  );
+  categorizedBaseLayers$ = this.baseLayersStateService.categorizedBaseLayers$;
+
+  constructor(private baseLayersStateService: BaseLayersStateService) {}
+
+  updateSelectedLayer(data: { layer: BaseLayer; isMulti: boolean }) {
+    this.baseLayersStateService.updateBaseLayers(data.layer, data.isMulti);
+  }
+}

--- a/src/interface/src/app/services/data-layers.service.ts
+++ b/src/interface/src/app/services/data-layers.service.ts
@@ -52,12 +52,38 @@ export class DataLayersService {
   }
 
   listBaseLayers() {
-    return this.http.get<BaseLayer[]>(
-      environment.backend_endpoint + '/v2/datasets/999/browse',
-      {
-        withCredentials: true,
-        params: { type: 'VECTOR' },
-      }
+    return (
+      this.http
+        .get<BaseLayer[]>(
+          environment.backend_endpoint + '/v2/datasets/999/browse',
+          {
+            withCredentials: true,
+            params: { type: 'VECTOR' },
+          }
+        )
+        // TODO - remove once we got more layers from API
+        .pipe(
+          map((s) => [
+            ...s,
+            ...([
+              {
+                id: 1,
+                name: 'Watersheds (HUC-12)',
+                path: ['DEMO multi'],
+              },
+              {
+                id: 2,
+                name: 'PODs',
+                path: ['DEMO multi'],
+              },
+              {
+                id: 3,
+                name: 'Subfireshreds',
+                path: ['DEMO multi'],
+              },
+            ] as BaseLayer[]),
+          ])
+        )
     );
   }
 

--- a/src/interface/src/app/services/data-layers.service.ts
+++ b/src/interface/src/app/services/data-layers.service.ts
@@ -10,6 +10,24 @@ import {
 } from '@types';
 import { map } from 'rxjs';
 
+const MOCKED_MULTI = [
+  {
+    id: 1,
+    name: 'Watersheds (HUC-12)',
+    path: ['DEMO multi'],
+  },
+  {
+    id: 2,
+    name: 'PODs',
+    path: ['DEMO multi'],
+  },
+  {
+    id: 3,
+    name: 'Subfireshreds',
+    path: ['DEMO multi'],
+  },
+] as BaseLayer[];
+
 @Injectable({
   providedIn: 'root',
 })
@@ -62,28 +80,7 @@ export class DataLayersService {
           }
         )
         // TODO - remove once we got more layers from API
-        .pipe(
-          map((s) => [
-            ...s,
-            ...([
-              {
-                id: 1,
-                name: 'Watersheds (HUC-12)',
-                path: ['DEMO multi'],
-              },
-              {
-                id: 2,
-                name: 'PODs',
-                path: ['DEMO multi'],
-              },
-              {
-                id: 3,
-                name: 'Subfireshreds',
-                path: ['DEMO multi'],
-              },
-            ] as BaseLayer[]),
-          ])
-        )
+        .pipe(map((s) => [...s, ...MOCKED_MULTI]))
     );
   }
 


### PR DESCRIPTION
- Use base layers store to list and select base layers
- Updating markup to use mat-radio and mat-checkbox

We are still using some mockup data for multi select layers, but the layer under `Disturbances` is coming from API.
This should unblock other tickets, but I'll need to revisit a couple of things (avoid requesting the list again, remove mocked data, etc) once we have more data from API.