### PR TITLE
Update martin_dynamic_layer.sql with latest version

### DIFF
--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -19,31 +19,27 @@ BEGIN
     EXECUTE format($f$
         WITH
         bbox AS (
-        SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
+          SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
         ),
         mvtgeom AS (
-        SELECT
-            t.id AS id,
+          SELECT
+            t.id AS id,  
             ST_AsMVTGeom(
-            ST_Transform(t.geometry, 3857),
-            ST_TileEnvelope($1, $2, $3),
-            4096, 64, true
+              ST_Transform(t.geometry, 3857),
+              ST_TileEnvelope($1, $2, $3),
+              4096, 64, true
             ) AS geom
-        FROM %I.%I AS t, bbox
-        WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
+          FROM %1$s AS t, bbox
+          WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
         )
-        SELECT ST_AsMVT(mvtgeom.*, %L, 4096, 'geom')
+        SELECT ST_AsMVT(mvtgeom.*, %2$s, 4096, 'geom')
         FROM mvtgeom;
-    $f$,
-        split_part(dyn_table, '.', 1),
-        split_part(dyn_table, '.', 2),
-        format('dynamic_%s', layer_id)
-    )
+    $f$, dyn_table, quote_literal(format('dynamic_%s', layer_id)))
     INTO tile
     USING z, x, y;
 
     RETURN tile;
-END; 
+END;
 
 $$ LANGUAGE plpgsql
 IMMUTABLE

--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -19,26 +19,30 @@ BEGIN
     EXECUTE format($f$
         WITH
         bbox AS (
-          SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
+        SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
         ),
         mvtgeom AS (
-          SELECT
-            t.id AS id,  
+        SELECT
+            t.id AS id,
             ST_AsMVTGeom(
-              ST_Transform(t.geometry, 3857),
-              ST_TileEnvelope($1, $2, $3),
-              4096, 64, true
+            ST_Transform(t.geometry, 3857),
+            ST_TileEnvelope($1, $2, $3),
+            4096, 64, true
             ) AS geom
-          FROM %I AS t, bbox
-          WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
+        FROM %I.%I AS t, bbox
+        WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
         )
         SELECT ST_AsMVT(mvtgeom.*, %L, 4096, 'geom')
         FROM mvtgeom;
-    $f$, dyn_table, format('dynamic_%s', layer_id))
+    $f$,
+        split_part(dyn_table, '.', 1),
+        split_part(dyn_table, '.', 2),
+        format('dynamic_%s', layer_id)
+    )
     INTO tile
     USING z, x, y;
-    RETURN tile;
 
+    RETURN tile;
 END; 
 
 $$ LANGUAGE plpgsql


### PR DESCRIPTION
@george-silva @roquebetioljr Latest version of martin_dynamic_layer.sql. I was able to get 200 on QGIS with 9999 vector layer I created via CLI. I think the tiles do not show in QGIS because the 9999 vector layer isn't correct, so I'd like to see if the martin_dynamic_layer.sql works on dev, where the vector files were produced correctly.