### PR TITLE
Martin table search change

### DIFF
--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -19,31 +19,27 @@ BEGIN
     EXECUTE format($f$
         WITH
         bbox AS (
-        SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
+          SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
         ),
         mvtgeom AS (
-        SELECT
-            t.id AS id,
+          SELECT
+            t.id AS id,  
             ST_AsMVTGeom(
-            ST_Transform(t.geometry, 3857),
-            ST_TileEnvelope($1, $2, $3),
-            4096, 64, true
+              ST_Transform(t.geometry, 3857),
+              ST_TileEnvelope($1, $2, $3),
+              4096, 64, true
             ) AS geom
-        FROM %I.%I AS t, bbox
-        WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
+          FROM %1$s AS t, bbox
+          WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
         )
-        SELECT ST_AsMVT(mvtgeom.*, %L, 4096, 'geom')
+        SELECT ST_AsMVT(mvtgeom.*, %2$s, 4096, 'geom')
         FROM mvtgeom;
-    $f$,
-        split_part(dyn_table, '.', 1),
-        split_part(dyn_table, '.', 2),
-        format('dynamic_%s', layer_id)
-    )
+    $f$, dyn_table, quote_literal(format('dynamic_%s', layer_id)))
     INTO tile
     USING z, x, y;
 
     RETURN tile;
-END; 
+END;
 
 $$ LANGUAGE plpgsql
 IMMUTABLE

--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -19,26 +19,30 @@ BEGIN
     EXECUTE format($f$
         WITH
         bbox AS (
-          SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
+        SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
         ),
         mvtgeom AS (
-          SELECT
-            t.id AS id,  
+        SELECT
+            t.id AS id,
             ST_AsMVTGeom(
-              ST_Transform(t.geometry, 3857),
-              ST_TileEnvelope($1, $2, $3),
-              4096, 64, true
+            ST_Transform(t.geometry, 3857),
+            ST_TileEnvelope($1, $2, $3),
+            4096, 64, true
             ) AS geom
-          FROM %I AS t, bbox
-          WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
+        FROM %I.%I AS t, bbox
+        WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
         )
         SELECT ST_AsMVT(mvtgeom.*, %L, 4096, 'geom')
         FROM mvtgeom;
-    $f$, dyn_table, format('dynamic_%s', layer_id))
+    $f$,
+        split_part(dyn_table, '.', 1),
+        split_part(dyn_table, '.', 2),
+        format('dynamic_%s', layer_id)
+    )
     INTO tile
     USING z, x, y;
-    RETURN tile;
 
+    RETURN tile;
 END; 
 
 $$ LANGUAGE plpgsql

--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION martin_dynamic_layer(
+CREATE OR REPLACE FUNCTION martin_dynamic_layer( 
     z integer,
     x integer,
     y integer,
@@ -8,8 +8,8 @@ RETURNS bytea AS $$
 
 DECLARE
     layer_id integer := (query_params->>'layer')::int;
-    dyn_table    text;
-    tile        bytea;
+    dyn_table text;
+    tile bytea;
 BEGIN
     SELECT "table"
         INTO dyn_table
@@ -19,22 +19,26 @@ BEGIN
     EXECUTE format($f$
         WITH
         bbox AS (
-          SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
+            SELECT ST_TileEnvelope($1, $2, $3, margin => (64.0/4096)) AS geom
         ),
         mvtgeom AS (
-          SELECT
-            t.id AS id,  
-            ST_AsMVTGeom(
-              ST_Transform(t.geometry, 3857),
-              ST_TileEnvelope($1, $2, $3),
-              4096, 64, true
-            ) AS geom
-          FROM %1$s AS t, bbox
-          WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
+            SELECT
+                t.id AS id,
+                ST_AsMVTGeom(
+                    ST_Transform(t.geometry, 3857),
+                    ST_TileEnvelope($1, $2, $3),
+                    4096, 64, true
+                ) AS geom
+            FROM %I.%I AS t, bbox
+            WHERE t.geometry && ST_Transform(bbox.geom, ST_SRID(t.geometry))
         )
-        SELECT ST_AsMVT(mvtgeom.*, %2$s, 4096, 'geom')
+        SELECT ST_AsMVT(mvtgeom.*, %I, 4096, 'geom')
         FROM mvtgeom;
-    $f$, dyn_table, quote_literal(format('dynamic_%s', layer_id)))
+    $f$,
+        split_part(dyn_table, '.', 1),
+        split_part(dyn_table, '.', 2),
+        format('dynamic_%s', layer_id)
+    )
     INTO tile
     USING z, x, y;
 


### PR DESCRIPTION
@george-silva @pflopez, one of the Martin layers mentioned `Unable to get tile 8/42/98 with Json({"layer": Number(2942)}) params from dynamic: db error: ERROR: trailing junk after numeric literal at or near ".9e23d"`, so I think adding this split format in this version of the sql query may fix the layers' that aren't working. The original 9999 layer still produced a polygon.