### PR TITLE
remove dash from get_map_url url

### DIFF
--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -355,7 +355,7 @@ class DataLayer(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
             return self.get_public_url()
         if self.table and self.storage_type == StorageTypeChoices.DATABASE:
             base = get_base_url(settings.ENV) or f"https://{get_domain(settings.ENV)}"
-            return base + "/tiles/dynamic/{z}/{x}/{y}/?layer=" + str(self.id)
+            return base + "/tiles/dynamic/{z}/{x}/{y}?layer=" + str(self.id)
 
         return None
 


### PR DESCRIPTION
@pflopez @george-silva remove the final "/" after the {y} in the map_url url