### PR TITLE
expose-map-service-type-DA

### DIFF
--- a/src/planscape/datasets/admin.py
+++ b/src/planscape/datasets/admin.py
@@ -81,6 +81,7 @@ class DataLayerAdmin(admin.ModelAdmin):
         "geometry_type",
         "type",
         "storage_type",
+        "map_service_type",
         "original_name",
         "mimetype",
         "table",


### PR DESCRIPTION
@roquebetioljr @george-silva, Hey Roque, want to expose `map_service_type` as a read only field in Django Admin, so it's easy to confirm that the field is working/where the datalayers are sourced from.