### PR TITLE
PLAN-2420: Default map zoom

### DIFF
--- a/src/interface/src/app/maplibre-map/scenario-map/scenario-map.component.html
+++ b/src/interface/src/app/maplibre-map/scenario-map/scenario-map.component.html
@@ -16,7 +16,7 @@
   [maxZoom]="maxZoom"
   [minZoom]="minZoom"
   [dragRotate]="false"
-  [fitBoundsOptions]="{ padding: 20 }"
+  [fitBoundsOptions]="{ padding: { top: 70, bottom: 40, left: 20, right: 20 } }"
   [fitBounds]="bounds"
   (mapLoad)="mapLoaded($event)">
   <app-map-zoom-control

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
@@ -16,7 +16,7 @@
   [doubleClickZoom]="true"
   [dragPan]="(standSelectionEnabled$ | async) === false"
   [dragRotate]="false"
-  [fitBoundsOptions]="{ padding: 20 }"
+  [fitBoundsOptions]="{ padding: { top: 70, bottom: 40, left: 20, right: 20 } }"
   [fitBounds]="bounds"
   [interactive]="true"
   [maxZoom]="maxZoom"

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -25,7 +25,7 @@
   [doubleClickZoom]="(standSelectionEnabled$ | async) === false"
   [dragPan]="(standSelectionEnabled$ | async) === false"
   [dragRotate]="false"
-  [fitBoundsOptions]="{ padding: 20 }"
+  [fitBoundsOptions]="{ padding: { top: 80, bottom: 60, left: 20, right: 20 } }"
   [fitBounds]="bounds"
   [interactive]="true"
   [maxZoom]="maxZoom"


### PR DESCRIPTION
Fixing a small issue where the project areas were overlapped by the top bar.

Ticket: https://sig-gis.atlassian.net/browse/PLAN-2420

Scenarios:
![image](https://github.com/user-attachments/assets/356d7335-c807-4ffe-927a-8390cca26242)


Treatments:
![image](https://github.com/user-attachments/assets/a9c3c42e-4350-4ab9-b7a6-7bbb805b845a)


Direct impacts:
![image](https://github.com/user-attachments/assets/832877a4-e3f0-4752-ba7b-bc5fc9b27d12)


Direct impacts expanded:
![image](https://github.com/user-attachments/assets/7be4a393-4392-4e79-a2c7-975201d8ce8d)
