### PR TITLE
PLAN-2421: Failed scenarios cannot be archived

### DIFF
--- a/src/interface/src/styleguide/scenario-card/scenario-card.component.html
+++ b/src/interface/src/styleguide/scenario-card/scenario-card.component.html
@@ -8,14 +8,14 @@
     <mat-icon class="error-icon">error</mat-icon>
     Create a new scenario to proceed to treatment plan
   </div>
-  <div class="controls-section" *ngIf="!hasFailed()">
+  <div class="controls-section">
     <button
       sg-button
       icon="add"
       class="new-treatment-btn"
       [disabled]="!isDone()"
       type="button"
-      *ngIf="userCanCreateTreatmentPlans"
+      *ngIf="!hasFailed() && userCanCreateTreatmentPlans"
       (click)="openNewTreatment.emit($event)">
       New Treatment Plan
     </button>
@@ -30,6 +30,7 @@
     </button>
     <mat-menu class="scenario-more-menu" #menu="matMenu">
       <button
+        *ngIf="!hasFailed()"
         class="more-menu-item"
         mat-menu-item
         (click)="openScenario.emit()">


### PR DESCRIPTION
There was an issue were failed scenarios cannot be archived since the three dots were hidden.

Jira: https://sig-gis.atlassian.net/browse/PLAN-2421

**Jordan just confirmed: _Hi Lucho, I do not have a problem with the user archiving their failed scenarios. Your solution looks good.  Thank you!_**
That means we are good to go.

The issue: 
![image](https://github.com/user-attachments/assets/3fff8fcf-5421-432a-9afd-fcfb510cd599)

The fix:
![image](https://github.com/user-attachments/assets/bc268c03-6049-442e-9f35-d5c4b939c77f)
