### PR TITLE
Returning all fields of each feature on dynamic martin function

### DIFF
--- a/src/planscape/martin/sql/martin_dynamic_layer.sql
+++ b/src/planscape/martin/sql/martin_dynamic_layer.sql
@@ -23,7 +23,7 @@ BEGIN
         ),
         mvtgeom AS (
             SELECT
-                t.id AS id,
+                t.*,
                 ST_AsMVTGeom(
                     ST_Transform(t.geometry, 3857),
                     ST_TileEnvelope($1, $2, $3),


### PR DESCRIPTION
Returning all feature's properties in order to provide info for the tooltip on the map.