### PR TITLE
New Explore placeholder and routing

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -7,7 +7,6 @@ import {
   TitleStrategy,
 } from '@angular/router';
 import { HomeComponent } from './home/home.component';
-import { MapComponent } from './map/map.component';
 import {
   AuthGuard,
   DevelopmentRouteGuard,
@@ -15,10 +14,14 @@ import {
   RedirectGuard,
   redirectResolver,
 } from '@services';
-import { ExploreComponent } from './plan/explore/explore/explore.component';
+import { ExploreLegacyComponent } from './plan/explore/explore/explore-legacy.component';
 import { numberResolver } from './resolvers/number.resolver';
 import { planLoaderResolver } from './resolvers/plan-loader.resolver';
 import { scenarioLoaderResolver } from './resolvers/scenario-loader.resolver';
+
+import { ExploreComponent } from './explore/explore/explore.component';
+import { MapComponent } from './map/map.component';
+import { createFeatureGuard } from './features/feature.guard';
 
 const routes: Routes = [
   {
@@ -90,20 +93,47 @@ const routes: Routes = [
             './standalone/account-validation/account-validation.component'
           ).then((m) => m.AccountValidationComponent),
       },
+      // old map
       {
         path: 'map',
         title: 'Explore',
         component: MapComponent,
+        data: {
+          inverted: true,
+          fallback: '/explore',
+        },
+        canActivate: [
+          createFeatureGuard({
+            featureName: 'maplibre_on_explore',
+            fallback: '/explore',
+            inverted: true,
+          }),
+        ],
+      },
+      // new map
+      {
+        path: 'explore',
+        title: 'Explore',
+        data: {
+          fallback: '/map',
+        },
+        component: ExploreComponent,
+        canActivate: [
+          createFeatureGuard({
+            featureName: 'maplibre_on_explore',
+            fallback: '/map',
+          }),
+        ],
       },
       {
         path: 'explore/:id',
-        title: 'Explore Plan',
-        component: ExploreComponent,
-        canActivate: [AuthGuard],
-        resolve: {
-          planInit: planLoaderResolver,
+        title: 'Explore',
+        data: {
+          fallback: '/map',
         },
+        component: ExploreLegacyComponent,
       },
+
       {
         path: 'feedback',
         canActivate: [RedirectGuard],

--- a/src/interface/src/app/explore/explore/explore.component.html
+++ b/src/interface/src/app/explore/explore/explore.component.html
@@ -1,0 +1,17 @@
+<app-nav-bar area="EXPLORE"></app-nav-bar>
+<section>
+  <div class="side-panel">Side menu</div>
+  <div class="main">
+    <app-map-nav-bar></app-map-nav-bar>
+    <mgl-map
+      [boxZoom]="false"
+      [dragRotate]="false"
+      [interactive]="true"
+      [maxZoom]="maxZoom"
+      [minZoom]="minZoom"
+      [pitchWithRotate]="false"
+      [style]="(baseLayerUrl$ | async) || ''"
+      [transformRequest]="transformRequest">
+    </mgl-map>
+  </div>
+</section>

--- a/src/interface/src/app/explore/explore/explore.component.scss
+++ b/src/interface/src/app/explore/explore/explore.component.scss
@@ -1,0 +1,24 @@
+:host {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+section {
+  display: flex;
+  height: 100%;
+}
+
+.side-panel {
+  width: 200px; // placeholder
+}
+
+.main {
+  flex: 1;
+  position: relative;
+}
+
+mgl-map {
+  width: 100%;
+  height: 100%;
+}

--- a/src/interface/src/app/explore/explore/explore.component.spec.ts
+++ b/src/interface/src/app/explore/explore/explore.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExploreComponent } from './explore.component';
+import { BreadcrumbService } from '@services/breadcrumb.service';
+import { MapConfigState } from '../../maplibre-map/map-config.state';
+import { AuthService } from '@services';
+import { MockDeclarations, MockProviders } from 'ng-mocks';
+import { MapComponent } from '@maplibre/ngx-maplibre-gl';
+import { NavBarComponent, SharedModule } from '@shared';
+
+describe('ExploreComponent', () => {
+  let component: ExploreComponent;
+  let fixture: ComponentFixture<ExploreComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExploreComponent, SharedModule],
+      providers: [
+        MockProviders(BreadcrumbService, MapConfigState, AuthService),
+      ],
+      declarations: [MockDeclarations(MapComponent, NavBarComponent)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExploreComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/explore/explore/explore.component.ts
+++ b/src/interface/src/app/explore/explore/explore.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { FrontendConstants } from '../../map/map.constants';
+import { MapNavbarComponent } from '../../maplibre-map/map-nav-bar/map-nav-bar.component';
+import { MapComponent } from '@maplibre/ngx-maplibre-gl';
+import { MapConfigState } from '../../maplibre-map/map-config.state';
+import { RequestTransformFunction } from 'maplibre-gl';
+import { addRequestHeaders } from '../../maplibre-map/maplibre.helper';
+import { AuthService } from '@services';
+import { SharedModule } from '@shared';
+import { BreadcrumbService } from '@services/breadcrumb.service';
+
+@Component({
+  selector: 'app-explore',
+  standalone: true,
+  imports: [AsyncPipe, MapNavbarComponent, MapComponent, SharedModule],
+  templateUrl: './explore.component.html',
+  styleUrl: './explore.component.scss',
+  providers: [MapConfigState],
+})
+export class ExploreComponent {
+  /**
+   * Maplibre defaults
+   */
+  minZoom = FrontendConstants.MAPLIBRE_MAP_MIN_ZOOM;
+  maxZoom = FrontendConstants.MAPLIBRE_MAP_MAX_ZOOM;
+
+  /**
+   * Observable that provides the url to load the selected map base layer
+   */
+  baseLayerUrl$ = this.mapConfigState.baseLayerUrl$;
+
+  constructor(
+    private mapConfigState: MapConfigState,
+    private authService: AuthService,
+    private breadcrumbService: BreadcrumbService
+  ) {
+    this.breadcrumbService.updateBreadCrumb({
+      label: ' New Plan',
+      backUrl: '/',
+    });
+  }
+
+  transformRequest: RequestTransformFunction = (url, resourceType) =>
+    addRequestHeaders(url, resourceType, this.authService.getAuthCookie());
+}

--- a/src/interface/src/app/features/feature.guard.ts
+++ b/src/interface/src/app/features/feature.guard.ts
@@ -3,15 +3,23 @@ import { CanActivateFn, CanMatchFn, Router } from '@angular/router';
 
 import { FeatureService } from './feature.service';
 
+interface FeatureGuardOptions {
+  featureName: string;
+  fallback?: string;
+  inverted?: boolean;
+}
+
 /** Guard for a route based on whether a feature flag is enabled. */
 export const createFeatureGuard: (
-  featureName: string
-) => CanMatchFn | CanActivateFn = (featureName: string) => () => {
+  options: FeatureGuardOptions
+) => CanMatchFn | CanActivateFn = (options) => () => {
   const featureService = inject(FeatureService);
   const router = inject(Router);
 
-  if (featureService.isFeatureEnabled(featureName)) return true;
+  const enabled = featureService.isFeatureEnabled(options.featureName);
 
-  // Redirect to the default page.
-  return router.parseUrl('');
+  // if inverted, flip the flag; otherwise, leave it as‐is
+  const shouldActivate = options.inverted ? !enabled : enabled;
+
+  return shouldActivate ? true : router.parseUrl(options.fallback || '');
 };

--- a/src/interface/src/app/plan/explore/explore/explore-legacy.component.html
+++ b/src/interface/src/app/plan/explore/explore/explore-legacy.component.html
@@ -1,0 +1,4 @@
+<app-map
+  [planId]="planId"
+  *appFeatureFlag="'maplibre_on_explore'; hide: true"></app-map>
+<app-explore></app-explore>

--- a/src/interface/src/app/plan/explore/explore/explore-legacy.component.spec.ts
+++ b/src/interface/src/app/plan/explore/explore/explore-legacy.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ExploreComponent } from './explore.component';
+import { ExploreLegacyComponent } from './explore-legacy.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Component, Input } from '@angular/core';
 
@@ -9,16 +9,16 @@ class MapMockComponent {
 }
 
 describe('ExploreComponent', () => {
-  let component: ExploreComponent;
-  let fixture: ComponentFixture<ExploreComponent>;
+  let component: ExploreLegacyComponent;
+  let fixture: ComponentFixture<ExploreLegacyComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ExploreComponent, MapMockComponent],
+      declarations: [ExploreLegacyComponent, MapMockComponent],
       imports: [RouterTestingModule],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(ExploreComponent);
+    fixture = TestBed.createComponent(ExploreLegacyComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/interface/src/app/plan/explore/explore/explore-legacy.component.ts
+++ b/src/interface/src/app/plan/explore/explore/explore-legacy.component.ts
@@ -2,11 +2,11 @@ import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 @Component({
-  selector: 'app-explore',
-  templateUrl: './explore.component.html',
-  styleUrls: ['./explore.component.scss'],
+  selector: 'app-explore-legacy',
+  templateUrl: './explore-legacy.component.html',
+  styleUrls: ['./explore-legacy.component.scss'],
 })
-export class ExploreComponent {
+export class ExploreLegacyComponent {
   planId = this.route.snapshot.paramMap.get('id');
 
   constructor(private route: ActivatedRoute) {}

--- a/src/interface/src/app/plan/explore/explore/explore.component.html
+++ b/src/interface/src/app/plan/explore/explore/explore.component.html
@@ -1,1 +1,0 @@
-<app-map [planId]="planId"></app-map>

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -2,7 +2,7 @@ import { AreaNotesComponent } from './area-notes/area-notes.component';
 import { CommonModule } from '@angular/common';
 import { ConstraintsPanelComponent } from './create-scenarios/constraints-panel/constraints-panel.component';
 import { CreateScenariosComponent } from './create-scenarios/create-scenarios.component';
-import { ExploreComponent } from './explore/explore/explore.component';
+import { ExploreLegacyComponent } from './explore/explore/explore-legacy.component';
 import { FeaturesModule } from '../features/features.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientXsrfModule } from '@angular/common/http';
@@ -49,6 +49,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MapConfigState } from '../maplibre-map/map-config.state';
 import { ScenarioMapComponent } from '../maplibre-map/scenario-map/scenario-map.component';
 import { PlanTabsFooterComponent } from './plan-tabs-footer/plan-tabs-footer.component';
+import { ExploreComponent } from '../explore/explore/explore.component';
 
 /** Components used in the plan flow. */
 @NgModule({
@@ -57,7 +58,7 @@ import { PlanTabsFooterComponent } from './plan-tabs-footer/plan-tabs-footer.com
     ConstraintsPanelComponent,
     CreateScenariosComponent,
     DeleteNoteDialogComponent,
-    ExploreComponent,
+    ExploreLegacyComponent,
     GoalOverlayComponent,
     IdentifyProjectAreasComponent,
     PlanComponent,
@@ -108,6 +109,7 @@ import { PlanTabsFooterComponent } from './plan-tabs-footer/plan-tabs-footer.com
     MatTabsModule,
     ScenarioMapComponent,
     PlanTabsFooterComponent,
+    ExploreComponent,
   ],
 })
 export class PlanModule {}


### PR DESCRIPTION
This pr adds a placeholder and map for the new explore view
<img width="1496" alt="Screenshot 2025-05-15 at 7 18 04 PM" src="https://github.com/user-attachments/assets/47fe7d89-e68c-4b1b-86ff-08a85d832f3e" />

- Added new explore component and feature flagged routes for new explore view
- Added maplibre map and basic map header component with base map selection as well as navbar element.
- Modified feature guard to allow more configurations

So this PR introduces some changes in routing. 
These is the expected behavior that I tested:

### With flag ON

- `/explore` -> Shows new explore page with maplibre map.
- `/map` -> Redirects to `/explore`
- `/explore/id` -> shows new explore plan with maplibre map.


### With flag OFF
- `/map` -> Shows old explore page with leaflet
- `/explore` -> redirects to `/map`
- `/explore/id` -> Shows old explore page with leaflet (and plan geometry)

