### PR TITLE
fix: breadcrumbs on map and angular ngAfterViewChecked error

### DIFF
--- a/src/interface/src/app/map/map.component.ts
+++ b/src/interface/src/app/map/map.component.ts
@@ -232,6 +232,13 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
           this.maps.map((map: Map) => map.config)
         );
       });
+
+    if (!this.planId) {
+      this.breadcrumbService.updateBreadCrumb({
+        label: 'Explore: New Plan',
+        backUrl: '/',
+      });
+    }
   }
 
   ngDoCheck(): void {
@@ -290,7 +297,8 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
           }
 
           this.drawPlanningArea(plan);
-          this.breadcrumbService.updateBreadCrumb({
+
+          this.breadcrumbService.updateBreadcrumbIfChanged({
             label: 'Explore: ' + plan.name,
             backUrl: getPlanPath(plan.id),
           });
@@ -300,10 +308,6 @@ export class MapComponent implements AfterViewInit, OnDestroy, OnInit, DoCheck {
         },
       });
     } else {
-      this.breadcrumbService.updateBreadCrumb({
-        label: 'Explore: New Plan',
-        backUrl: '/',
-      });
     }
   }
 

--- a/src/interface/src/app/services/breadcrumb.service.ts
+++ b/src/interface/src/app/services/breadcrumb.service.ts
@@ -19,4 +19,12 @@ export class BreadcrumbService {
   updateBreadCrumb(breadcrumb: BreadCrumb) {
     this._breadcrumb$.next(breadcrumb);
   }
+
+  updateBreadcrumbIfChanged(breadcrumb: BreadCrumb) {
+    const current = this._breadcrumb$.value;
+    if (current?.label === breadcrumb.label) {
+      return;
+    }
+    this._breadcrumb$.next(breadcrumb);
+  }
 }

--- a/src/interface/src/app/standalone/planning-area-menu/planning-area-menu.component.html
+++ b/src/interface/src/app/standalone/planning-area-menu/planning-area-menu.component.html
@@ -11,7 +11,10 @@
     <mat-icon class="material-symbols-outlined">folder_open</mat-icon>
     <span>Open</span>
   </a>
-  <a mat-menu-item [routerLink]="['/explore', plan.id]">
+  <a
+    mat-menu-item
+    [routerLink]="['/explore', plan.id]"
+    (click)="saveBreadcrumbs()">
     <mat-icon class="material-symbols-outlined">map</mat-icon>
     <span>View Map</span>
   </a>

--- a/src/interface/src/app/standalone/planning-area-menu/planning-area-menu.component.ts
+++ b/src/interface/src/app/standalone/planning-area-menu/planning-area-menu.component.ts
@@ -19,6 +19,7 @@ import {
 } from '@angular/material/dialog';
 import { DeletePlanningAreaComponent } from '../delete-planning-area/delete-planning-area.component';
 import { MatLegacyButtonModule } from '@angular/material/legacy-button';
+import { BreadcrumbService } from '@services/breadcrumb.service';
 
 @Component({
   selector: 'app-planning-area-menu',
@@ -41,7 +42,8 @@ export class PlanningAreaMenuComponent {
     private authService: AuthService,
     private dialog: MatDialog,
     private snackbar: MatSnackBar,
-    private planService: PlanService
+    private planService: PlanService,
+    private breadcrumbService: BreadcrumbService
   ) {}
 
   get shareEnabled() {
@@ -93,5 +95,12 @@ export class PlanningAreaMenuComponent {
           });
         }
       });
+  }
+
+  saveBreadcrumbs() {
+    this.breadcrumbService.updateBreadCrumb({
+      label: 'Explore: ' + this.plan.name,
+      backUrl: '/',
+    });
   }
 }


### PR DESCRIPTION
We where getting an `ExpressionChangedAfterItHasBeenCheckedError` error when reloading `/map`.
Additionally, when coming from `/home` (via each plan contextual menu) the back arrow link was wrong.
