### PR TITLE
plan-2438 make datalayer info field read-only in Django Admin

### DIFF
--- a/src/planscape/datasets/admin.py
+++ b/src/planscape/datasets/admin.py
@@ -86,6 +86,7 @@ class DataLayerAdmin(admin.ModelAdmin):
         "mimetype",
         "table",
         "public_url",
+        "info",
     ]
     inlines = [DataLayerHasStyleAdmin]
 


### PR DESCRIPTION
@george-silva @roquebetioljr, Quick PR for PLAN-2438 to make the "info" field for datalayers be un-editable/read-only in Django Admin. 

I just listed "info" as one of the entries under the `readonly_field` in `DataLayerAdmin` in `src/planscape/datasets/admin.py`.