### PR TITLE
remove padding options from explore map

### DIFF
--- a/src/interface/src/app/maplibre-map/explore-map/explore-map.component.html
+++ b/src/interface/src/app/maplibre-map/explore-map/explore-map.component.html
@@ -7,7 +7,6 @@
   [minZoom]="minZoom"
   [pitchWithRotate]="false"
   [fitBounds]="(bounds$ | async) || undefined"
-  [fitBoundsOptions]="boundOptions"
   (mapLoad)="mapCreated.emit({ map: $event, mapNumber: mapNumber })"
   [style]="(baseLayerUrl$ | async) || ''"
   [attributionControl]="false"


### PR DESCRIPTION
Notice a bug on the new explore, with fitbounds and saving bounds.
When reloading the map, the padding options where adding up and the map gets zoomed out