### PR TITLE
Base map tooltips

### DIFF
--- a/src/interface/src/app/base-layers/base-layers.state.service.ts
+++ b/src/interface/src/app/base-layers/base-layers.state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, map, shareReplay } from 'rxjs';
 import { DataLayersService } from '@services/data-layers.service';
-import { BaseLayer } from '@types';
+import { BaseLayer, BaseLayerTooltipData } from '@types';
 
 @Injectable({
   providedIn: 'root',
@@ -35,6 +35,14 @@ export class BaseLayersStateService {
       }));
     })
   );
+
+  private _enableBaseLayerHover$ = new BehaviorSubject<boolean>(false);
+  enableBaseLayerHover$ = this._enableBaseLayerHover$.asObservable();
+
+  private _tooltipInfo$ = new BehaviorSubject<BaseLayerTooltipData | null>(
+    null
+  );
+  tooltipInfo$ = this._tooltipInfo$.asObservable();
 
   private _selectedBaseLayers$ = new BehaviorSubject<BaseLayer[] | null>(null);
   selectedBaseLayers$ = this._selectedBaseLayers$.asObservable();
@@ -76,6 +84,14 @@ export class BaseLayersStateService {
 
   clearBaseLayer() {
     this._selectedBaseLayers$.next(null);
+  }
+
+  enableBaseLayerHover(value: boolean) {
+    this._enableBaseLayerHover$.next(value);
+  }
+
+  setTooltipData(tooltipInfo: BaseLayerTooltipData | null) {
+    this._tooltipInfo$.next(tooltipInfo);
   }
 
   private isCategoryMultiSelect(path: string) {

--- a/src/interface/src/app/base-layers/base-layers.state.service.ts
+++ b/src/interface/src/app/base-layers/base-layers.state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, map, shareReplay } from 'rxjs';
 import { DataLayersService } from '@services/data-layers.service';
-import { BaseLayer, BaseLayerTooltipData } from '@types';
+import { BaseLayer } from '@types';
 
 @Injectable({
   providedIn: 'root',
@@ -38,11 +38,6 @@ export class BaseLayersStateService {
 
   private _enableBaseLayerHover$ = new BehaviorSubject<boolean>(false);
   enableBaseLayerHover$ = this._enableBaseLayerHover$.asObservable();
-
-  private _tooltipInfo$ = new BehaviorSubject<BaseLayerTooltipData | null>(
-    null
-  );
-  tooltipInfo$ = this._tooltipInfo$.asObservable();
 
   private _selectedBaseLayers$ = new BehaviorSubject<BaseLayer[] | null>(null);
   selectedBaseLayers$ = this._selectedBaseLayers$.asObservable();
@@ -88,10 +83,6 @@ export class BaseLayersStateService {
 
   enableBaseLayerHover(value: boolean) {
     this._enableBaseLayerHover$.next(value);
-  }
-
-  setTooltipData(tooltipInfo: BaseLayerTooltipData | null) {
-    this._tooltipInfo$.next(tooltipInfo);
   }
 
   private isCategoryMultiSelect(path: string) {

--- a/src/interface/src/app/data-layers/data-layers.state.service.ts
+++ b/src/interface/src/app/data-layers/data-layers.state.service.ts
@@ -12,13 +12,7 @@ import {
   switchMap,
   tap,
 } from 'rxjs';
-import {
-  DataLayer,
-  DataSet,
-  Pagination,
-  SearchResult,
-  BaseLayerTooltipData,
-} from '@types';
+import { DataLayer, DataSet, Pagination, SearchResult } from '@types';
 import { buildPathTree } from './data-layers/tree-node';
 import { extractLegendInfo } from './utilities';
 
@@ -48,14 +42,6 @@ export class DataLayersStateService {
 
   private _selectedDataLayer$ = new BehaviorSubject<DataLayer | null>(null);
   selectedDataLayer$ = this._selectedDataLayer$.asObservable();
-
-  private _enableBaseLayerHover$ = new BehaviorSubject<boolean>(false);
-  enableBaseLayerHover$ = this._enableBaseLayerHover$.asObservable();
-
-  private _tooltipInfo$ = new BehaviorSubject<BaseLayerTooltipData | null>(
-    null
-  );
-  tooltipInfo$ = this._tooltipInfo$.asObservable();
 
   dataLayerWithUrl$ = this.selectedDataLayer$.pipe(
     switchMap((layer) => {
@@ -167,14 +153,6 @@ export class DataLayersStateService {
   reloadDataLayerUrl() {
     const currentLayer = this._selectedDataLayer$.value;
     this._selectedDataLayer$.next(currentLayer);
-  }
-
-  enableBaseLayerHover(value: boolean) {
-    this._enableBaseLayerHover$.next(value);
-  }
-
-  setTooltipData(tooltipInfo: BaseLayerTooltipData | null) {
-    this._tooltipInfo$.next(tooltipInfo);
   }
 
   search(term: string) {

--- a/src/interface/src/app/explore/explore/explore.component.ts
+++ b/src/interface/src/app/explore/explore/explore.component.ts
@@ -13,6 +13,7 @@ import { BehaviorSubject } from 'rxjs';
 import { MatTabsModule } from '@angular/material/tabs';
 import { ExploreStorageService } from '@services/local-storage.service';
 import { BaseLayersComponent } from '../../base-layers/base-layers/base-layers.component';
+import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
 
 @Component({
   selector: 'app-explore',
@@ -54,13 +55,15 @@ export class ExploreComponent implements OnDestroy {
 
   constructor(
     private breadcrumbService: BreadcrumbService,
-    private exploreStorageService: ExploreStorageService
+    private exploreStorageService: ExploreStorageService,
+    private baseLayersStateService: BaseLayersStateService
   ) {
     this.loadStateFromLocalStorage();
     this.breadcrumbService.updateBreadCrumb({
       label: ' New Plan',
       backUrl: '/',
     });
+    this.baseLayersStateService.enableBaseLayerHover(true);
   }
 
   handleOpacityChange(opacity: number) {

--- a/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.spec.ts
+++ b/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.spec.ts
@@ -7,8 +7,8 @@ import {
 } from 'ng-mocks';
 import { MapArcgisVectorLayerComponent } from './map-arcgis-vector-layer.component';
 import { MapLayerMouseEvent } from 'maplibre-gl';
-import { DataLayersStateService } from 'src/app/data-layers/data-layers.state.service';
 import { of } from 'rxjs';
+import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
 
 function createMapSpy() {
   return jasmine.createSpyObj('MapLibreMap', [
@@ -47,7 +47,7 @@ describe('MapArcgisVectorLayerComponent', () => {
     map = createMapSpy();
     TestBed.configureTestingModule({
       providers: [
-        MockProvider(DataLayersStateService, {
+        MockProvider(BaseLayersStateService, {
           enableBaseLayerHover$: of(true),
         }),
       ],

--- a/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.ts
@@ -113,18 +113,12 @@ export class MapArcgisVectorLayerComponent implements OnInit, OnDestroy {
   private onMouseLeave = () => this.clearHover();
 
   private addArcgisLayers() {
-    try {
-      this.arcGisService = new FeatureService(this.sourceId, this.mapLibreMap, {
-        url: this.layer.map_url,
-        setAttributionFromService: false,
-        // add options provided on metadata
-        ...(this.layer.metadata?.['modules']?.['map']?.['arcgis'] ?? {}),
-      });
-    } catch (e) {
-      console.log(e);
-      console.log(this.sourceId);
-      console.log(this.mapLibreMap);
-    }
+    this.arcGisService = new FeatureService(this.sourceId, this.mapLibreMap, {
+      url: this.layer.map_url,
+      setAttributionFromService: false,
+      // add options provided on metadata
+      ...(this.layer.metadata?.['modules']?.['map']?.['arcgis'] ?? {}),
+    });
 
     this.mapLibreMap.addLayer(
       {

--- a/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.ts
@@ -8,8 +8,8 @@ import {
 } from 'maplibre-gl';
 import { BaseLayer, BaseLayerTooltipData } from '@types';
 import { defaultBaseLayerFill, defaultBaseLayerLine } from '../maplibre.helper';
-import { DataLayersStateService } from 'src/app/data-layers/data-layers.state.service';
 import { take } from 'rxjs';
+import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
 
 @Component({
   selector: 'app-map-arcgis-vector-layer',
@@ -25,13 +25,13 @@ export class MapArcgisVectorLayerComponent implements OnInit, OnDestroy {
 
   private arcGisService: FeatureService | null = null;
 
-  constructor(private dataLayersStateService: DataLayersStateService) {}
+  constructor(private baseLayersStateService: BaseLayersStateService) {}
 
   ngOnInit(): void {
     this.addArcgisLayers();
   }
 
-  enableBaseLayerHover$ = this.dataLayersStateService.enableBaseLayerHover$;
+  enableBaseLayerHover$ = this.baseLayersStateService.enableBaseLayerHover$;
 
   ngOnDestroy(): void {
     this.mapLibreMap.off('mousemove', this.layerFillId, this.onMouseMove);
@@ -91,7 +91,7 @@ export class MapArcgisVectorLayerComponent implements OnInit, OnDestroy {
   };
 
   private clearTooltip() {
-    this.dataLayersStateService.setTooltipData(null);
+    this.baseLayersStateService.setTooltipData(null);
   }
 
   private setTooltipInfo(longLat: LngLat, f: MapGeoJSONFeature) {
@@ -99,7 +99,7 @@ export class MapArcgisVectorLayerComponent implements OnInit, OnDestroy {
       content: this.createTooltipContent(this.layer, f) ?? '',
       longLat: longLat,
     };
-    this.dataLayersStateService.setTooltipData(tooltipInfo);
+    this.baseLayersStateService.setTooltipData(tooltipInfo);
   }
 
   private onMouseLeave = () => this.clearHover();

--- a/src/interface/src/app/maplibre-map/map-base-layer-tooltip/map-base-layer-tooltip.component.html
+++ b/src/interface/src/app/maplibre-map/map-base-layer-tooltip/map-base-layer-tooltip.component.html
@@ -3,9 +3,8 @@
   [lngLat]="lngLat"
   [closeButton]="false"
   [closeOnClick]="false"
-  [anchor]="'left'"
   [offset]="20"
   maxWidth="none"
-  className="vector-tooltip">
+  className="vector-tooltip black-tooltip">
   <div class="tooltip-content no-select">{{ content }}</div>
 </mgl-popup>

--- a/src/interface/src/app/maplibre-map/map-base-layer-tooltip/map-base-layer-tooltip.component.scss
+++ b/src/interface/src/app/maplibre-map/map-base-layer-tooltip/map-base-layer-tooltip.component.scss
@@ -2,24 +2,6 @@
 
 ::ng-deep {
   .vector-tooltip {
-
-    .maplibregl-popup-content {
-      background-color: black;
-      color: white;
-      padding: 8px 12px;
-      border-radius: 8px;
-      @include small-paragraph();
-      font-size: 12px;
-    }
-
-    &.maplibregl-popup-anchor-right .maplibregl-popup-tip {
-      border-left-color: black;
-    }
-
-    &.maplibregl-popup-anchor-left .maplibregl-popup-tip {
-      border-right-color: black;
-    }
-
     .tooltip-content {
       display: flex;
       align-items: center;

--- a/src/interface/src/app/maplibre-map/map-base-layers/map-base-layers.component.html
+++ b/src/interface/src/app/maplibre-map/map-base-layers/map-base-layers.component.html
@@ -1,9 +1,13 @@
 <div *ngFor="let layer of selectedLayers$ | async">
   <ng-container *ngIf="layer.map_service_type === 'ESRI_GEOJSON'">
     <app-map-arcgis-vector-layer
+      *ngIf="mapLibreMap"
       [layer]="layer"
       [before]="before"
-      [mapLibreMap]="mapLibreMap"></app-map-arcgis-vector-layer>
+      [mapLibreMap]="mapLibreMap"
+      (updateTooltipData)="
+        setTooltipData($event)
+      "></app-map-arcgis-vector-layer>
   </ng-container>
   <ng-container *ngIf="layer.map_service_type === 'VECTORTILES'">
     <mgl-vector-source

--- a/src/interface/src/app/maplibre-map/map-base-layers/map-base-layers.component.ts
+++ b/src/interface/src/app/maplibre-map/map-base-layers/map-base-layers.component.ts
@@ -15,7 +15,6 @@ import { BaseLayer, BaseLayerTooltipData } from '@types';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { MapArcgisVectorLayerComponent } from '../map-arcgis-vector-layer/map-arcgis-vector-layer.component';
 import { defaultBaseLayerFill, defaultBaseLayerLine } from '../maplibre.helper';
-import { DataLayersStateService } from 'src/app/data-layers/data-layers.state.service';
 import { take } from 'rxjs';
 
 @UntilDestroy()
@@ -42,13 +41,10 @@ export class MapBaseLayersComponent {
   // only one hovered stand
   hoveredFeature: MapGeoJSONFeature | null = null;
   selectedLayers$ = this.baseLayersStateService.selectedBaseLayers$;
-  enableBaseLayerHover$ = this.dataLayersStateService.enableBaseLayerHover$;
-  currentTooltipInfo$ = this.dataLayersStateService.tooltipInfo$;
+  enableBaseLayerHover$ = this.baseLayersStateService.enableBaseLayerHover$;
+  currentTooltipInfo$ = this.baseLayersStateService.tooltipInfo$;
 
-  constructor(
-    private baseLayersStateService: BaseLayersStateService,
-    private dataLayersStateService: DataLayersStateService
-  ) {}
+  constructor(private baseLayersStateService: BaseLayersStateService) {}
 
   lineLayerPaint(layer: BaseLayer) {
     return defaultBaseLayerLine(layer.styles[0].data['fill-outline-color']);
@@ -70,7 +66,7 @@ export class MapBaseLayersComponent {
             content: this.createTooltipContent(layer, features[0]) ?? '',
             longLat: event.lngLat,
           };
-          this.dataLayersStateService.setTooltipData(tooltipInfo);
+          this.baseLayersStateService.setTooltipData(tooltipInfo);
           this.paintHover(features[0]);
         }
       }
@@ -78,7 +74,7 @@ export class MapBaseLayersComponent {
   }
 
   hoverOutLayer() {
-    this.dataLayersStateService.setTooltipData(null);
+    this.baseLayersStateService.setTooltipData(null);
     this.removeHover();
   }
 

--- a/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.html
+++ b/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.html
@@ -41,7 +41,7 @@
   [lngLat]="tooltipLongLat"
   [closeButton]="false"
   maxWidth="500px"
-  className="treatment-tooltip">
+  className="treatment-tooltip black-tooltip">
   <div class="tooltip-content">
     <div class="tooltip-title">{{ projectAreaData.name }}:</div>
     <div>{{ projectAreaData.acres | number: '1.0-0' }} Acres</div>

--- a/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.scss
+++ b/src/interface/src/app/treatments/map-stands-tx-result/map-stands-tx-result.component.scss
@@ -12,72 +12,6 @@ $tooltip-background: #000000D9;
     line-height: 22px;
 
 
-    .maplibregl-popup-content {
-      background-color: $tooltip-background;
-      color: $color-white;
-      padding: 8px 12px;
-      border-radius: 8px;
-    }
-
-    // overriding tip colors for each corner
-
-    &.maplibregl-popup-anchor-right .maplibregl-popup-tip {
-      border-left-color: $tooltip-background;
-    }
-
-    &.maplibregl-popup-anchor-left .maplibregl-popup-tip {
-      border-right-color: $tooltip-background;
-    }
-
-    &.maplibregl-popup-anchor-top .maplibregl-popup-tip {
-      border-bottom-color: $tooltip-background;
-    }
-
-    &.maplibregl-popup-anchor-bottom .maplibregl-popup-tip {
-      border-top-color: $tooltip-background;
-    }
-
-    // overriding tip color for diagonals
-    &.maplibregl-popup-anchor-bottom-right {
-      .maplibregl-popup-tip {
-        border-top-color: $tooltip-background;
-      }
-
-      .maplibregl-popup-content {
-        border-bottom-right-radius: 0;
-      }
-    }
-
-    &.maplibregl-popup-anchor-bottom-left {
-      .maplibregl-popup-tip {
-        border-top-color: $tooltip-background;
-      }
-
-      .maplibregl-popup-content {
-        border-bottom-left-radius: 0;
-      }
-    }
-
-    &.maplibregl-popup-anchor-top-left {
-      .maplibregl-popup-tip {
-        border-bottom-color: $tooltip-background;
-      }
-
-      .maplibregl-popup-content {
-        border-top-left-radius: 0;
-      }
-    }
-
-    &.maplibregl-popup-anchor-top-right {
-      .maplibregl-popup-tip {
-        border-bottom-color: $tooltip-background;
-      }
-
-      .maplibregl-popup-content {
-        border-top-right-radius: 0;
-      }
-    }
-
     .tooltip-title {
       color: $color-soft-gray;
       font-weight: 600;
@@ -90,7 +24,5 @@ $tooltip-background: #000000D9;
       grid-template-columns: 120px 1fr;
       gap: 8px 0;
     }
-
-
   }
 }

--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.ts
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
 import {
   MatTab,
   MatTabChangeEvent,
@@ -14,6 +14,7 @@ import { BaseLayersComponent } from 'src/app/base-layers/base-layers/base-layers
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { DataLayersStateService } from '../../data-layers/data-layers.state.service';
 import { skip } from 'rxjs';
+import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
 
 @UntilDestroy()
 @Component({
@@ -46,13 +47,16 @@ export class TreatmentPlanTabsComponent implements AfterViewInit {
     const currentTab: MatTab =
       this.tabGroup._tabs.toArray()[this.tabGroup.selectedIndex ?? 1];
     if (currentTab && currentTab.textLabel === 'Base Layers') {
-      this.dataLayersStateService.enableBaseLayerHover(true);
+      this.baseLayersStateService.enableBaseLayerHover(true);
     } else {
-      this.dataLayersStateService.enableBaseLayerHover(false);
+      this.baseLayersStateService.enableBaseLayerHover(false);
     }
   }
 
-  constructor(private dataLayersStateService: DataLayersStateService) {
+  constructor(
+    private dataLayersStateService: DataLayersStateService,
+    private baseLayersStateService: BaseLayersStateService
+  ) {
     this.dataLayersStateService.paths$
       .pipe(untilDestroyed(this), skip(1))
       .subscribe((path) => {

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -20,6 +20,7 @@ import { BaseLayersComponent } from 'src/app/base-layers/base-layers/base-layers
 import { DataLayersStateService } from '../../data-layers/data-layers.state.service';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { skip } from 'rxjs';
+import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
 
 @UntilDestroy()
 @Component({
@@ -49,7 +50,8 @@ export class TreatmentProjectAreaComponent implements OnDestroy {
   constructor(
     private selectedStandsState: SelectedStandsState,
     private treatmentsState: TreatmentsState,
-    private dataLayersStateService: DataLayersStateService
+    private dataLayersStateService: DataLayersStateService,
+    private baseLayersStateService: BaseLayersStateService
   ) {
     this.dataLayersStateService.paths$
       .pipe(untilDestroyed(this), skip(1))
@@ -62,9 +64,9 @@ export class TreatmentProjectAreaComponent implements OnDestroy {
 
   handleTabChange(selectedTab: MatTabChangeEvent) {
     if (selectedTab && selectedTab.tab.textLabel === 'Base Layers') {
-      this.dataLayersStateService.enableBaseLayerHover(true);
+      this.baseLayersStateService.enableBaseLayerHover(true);
     } else {
-      this.dataLayersStateService.enableBaseLayerHover(false);
+      this.baseLayersStateService.enableBaseLayerHover(false);
     }
   }
 

--- a/src/interface/src/styles/index.scss
+++ b/src/interface/src/styles/index.scss
@@ -4,3 +4,4 @@
 @import 'menu';
 @import 'material';
 @import 'links';
+@import 'maplibre';

--- a/src/interface/src/styles/maplibre.scss
+++ b/src/interface/src/styles/maplibre.scss
@@ -1,0 +1,73 @@
+@import "colors";
+@import "mixins";
+
+$tooltip-background: #000000D9;
+
+.black-tooltip {
+  .maplibregl-popup-content {
+    background-color: $tooltip-background;
+    color: white;
+    padding: 8px 12px;
+    border-radius: 8px;
+    @include small-paragraph();
+    font-size: 12px;
+  }
+
+
+  &.maplibregl-popup-anchor-right .maplibregl-popup-tip {
+    border-left-color: $tooltip-background;
+  }
+
+  &.maplibregl-popup-anchor-left .maplibregl-popup-tip {
+    border-right-color: $tooltip-background;
+  }
+
+  &.maplibregl-popup-anchor-top .maplibregl-popup-tip {
+    border-bottom-color: $tooltip-background;
+  }
+
+  &.maplibregl-popup-anchor-bottom .maplibregl-popup-tip {
+    border-top-color: $tooltip-background;
+  }
+
+  // overriding tip color for diagonals
+  &.maplibregl-popup-anchor-bottom-right {
+    .maplibregl-popup-tip {
+      border-top-color: $tooltip-background;
+    }
+
+    .maplibregl-popup-content {
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  &.maplibregl-popup-anchor-bottom-left {
+    .maplibregl-popup-tip {
+      border-top-color: $tooltip-background;
+    }
+
+    .maplibregl-popup-content {
+      border-bottom-left-radius: 0;
+    }
+  }
+
+  &.maplibregl-popup-anchor-top-left {
+    .maplibregl-popup-tip {
+      border-bottom-color: $tooltip-background;
+    }
+
+    .maplibregl-popup-content {
+      border-top-left-radius: 0;
+    }
+  }
+
+  &.maplibregl-popup-anchor-top-right {
+    .maplibregl-popup-tip {
+      border-bottom-color: $tooltip-background;
+    }
+
+    .maplibregl-popup-content {
+      border-top-right-radius: 0;
+    }
+  }
+}


### PR DESCRIPTION
- Refactors base maps tooltips moving things to BaseLayersStateService, as well as keeping tooltips on each instance instead of in global service (as we dont want the tooltip to show on all maps on `explore`)
- Refactor styles so we can have a shared `black-tooltip` class to apply to tooltips.
- Enables base maps tooltips by default on `explore`