### PR TITLE
plan-2469: add map_service_type to admin & serializer, SERVER-SIDE

### DIFF
--- a/src/planscape/datasets/admin.py
+++ b/src/planscape/datasets/admin.py
@@ -63,6 +63,7 @@ class DataLayerAdmin(admin.ModelAdmin):
         "name",
         "status",
         "type",
+        "map_service_type",
         "geometry_type",
         "dataset",
         "category",

--- a/src/planscape/datasets/serializers.py
+++ b/src/planscape/datasets/serializers.py
@@ -9,6 +9,7 @@ from datasets.models import (
     DataLayerType,
     Dataset,
     Style,
+    MapServiceChoices,
 )
 from datasets.styles import (
     get_default_raster_style,
@@ -181,6 +182,12 @@ class CreateDataLayerSerializer(serializers.ModelSerializer[DataLayer]):
         allow_null=True,
     )  # type: ignore
 
+    map_service_type = serializers.ChoiceField(
+        choices=MapServiceChoices.choices,
+        required=False,
+        allow_null=True,
+    )
+
     class Meta:
         model = DataLayer
         fields = (
@@ -198,6 +205,7 @@ class CreateDataLayerSerializer(serializers.ModelSerializer[DataLayer]):
             "geometry",
             "geometry_type",
             "style",
+            "map_service_type",
         )
 
 


### PR DESCRIPTION
@george-silva @roquebetioljr, server-side changes to map-service-type:

1. Changes to CreateDataLayerSerializer in serializers.py
2. Small change to admin.py to list map-service-type in the table in Django Admin for quick reference.