### PR TITLE
More sentry config changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,9 @@ build-storybook:
 	cd src/interface && npm run build-storybook
 
 remove-local-sourcemaps:
-	@echo "Removing Sourcemaps from build"; \
-	rm -rf ./src/interface/dist/out/**.map
+	@echo "Removing Sourcemaps from build" ; \
+	rm -rf ./src/interface/dist/out/**.map ; \
+	rm -rf ./src/interface/dist/interface/**.map
 
 # This command uploads sourcemaps to Sentry and injects a sourceId reference. 
 # if we have a tagged release, we associate it with the sourcemaps,

--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -56,12 +56,13 @@
               "maplibre-gl",
               "polylabel",
               "raf",
-              "rgbcolor"
-              "shpjs",
+              "rgbcolor",
+              "shpjs"
             ]
           },
           "configurations": {
             "production": {
+              "sourceMap": true,
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
It seems that only a portion of sourcemaps are correctly generated and injected with a Debug Id, unless we explicitly allow this in angular.json, so that's what this PR does.

Note that these are still automatically deleted after being uploaded with the `remove-local-sourcemaps` build command, but I'm frankly not sure if there are other concerns about doing this on non-development envs.