### PR TITLE
PLAN 2470: URL datalayer creation -- required layer type and auto READY status

### DIFF
--- a/src/planscape/datasets/management/commands/datalayers.py
+++ b/src/planscape/datasets/management/commands/datalayers.py
@@ -391,7 +391,10 @@ class Command(PlanscapeCommand):
     ) -> Optional[Dict[str, Any]]:
         map_service_type = kwargs.pop("map_service_type", None)
         metadata = kwargs.pop("metadata", None)
-        layer_type = kwargs.pop("layer_type")
+        layer_type = kwargs.pop("layer_type", None)
+
+        if url and not layer_type:
+            raise ValueError("Missing required layer_type when using url.")
 
         try:
             if skip_existing:

--- a/src/planscape/datasets/management/commands/datalayers.py
+++ b/src/planscape/datasets/management/commands/datalayers.py
@@ -391,6 +391,7 @@ class Command(PlanscapeCommand):
     ) -> Optional[Dict[str, Any]]:
         map_service_type = kwargs.pop("map_service_type", None)
         metadata = kwargs.pop("metadata", None)
+        layer_type = kwargs.pop("layer_type")
 
         try:
             if skip_existing:
@@ -409,7 +410,7 @@ class Command(PlanscapeCommand):
                 name=name,
                 dataset=dataset,
                 org=org,
-                layer_type=kwargs["layer_type"],
+                layer_type=layer_type,
                 geometry_type="NO_GEOM",
                 layer_info={},
                 metadata=metadata,

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -309,6 +309,7 @@ def create_datalayer(
         storage_type = StorageTypeChoices.EXTERNAL_SERVICE
         original_file_name = None
         upload_to = {}
+        kwargs["status"] = DataLayerStatus.READY
 
     if original_name:
         storage_url = get_storage_url(


### PR DESCRIPTION
@george-silva @roquebetioljr, small changes to PLAN-2470, add ability to add data layer url into import cli:

1. Requires CLI user to input a `--layer-type` if using url (re: Raster, Vector, etc.), in `datalayers.py`
2. Auto-set url-datalayer status to `READY` if `--url` is used, in `services.py`
3. Fixed `metadata` and `map_service_type` handling that was causing url to not go through, in `datalayers.py`