### PR TITLE
PLAN-2433: FIX ESRI plugin adds extra attributions

### DIFF
--- a/src/interface/patches/mapbox-gl-arcgis-featureserver+0.0.8.patch
+++ b/src/interface/patches/mapbox-gl-arcgis-featureserver+0.0.8.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/mapbox-gl-arcgis-featureserver/dist/mapbox-gl-arcgis-featureserver.js b/node_modules/mapbox-gl-arcgis-featureserver/dist/mapbox-gl-arcgis-featureserver.js
+index 7a1f922..655d850 100644
+--- a/node_modules/mapbox-gl-arcgis-featureserver/dist/mapbox-gl-arcgis-featureserver.js
++++ b/node_modules/mapbox-gl-arcgis-featureserver/dist/mapbox-gl-arcgis-featureserver.js
+@@ -445,11 +445,11 @@
+ 
+       const attributionController = this._map._controls.find(c => '_attribHTML' in c);
+ 
+-      if (!attributionController) return
++      if (!attributionController || !this._esriServiceOptions.setAttributionFromService) return
+ 
+       const customAttribution = attributionController.options.customAttribution;
+ 
+-      if (typeof customAttribution === 'string') {
++      if (typeof customAttribution === 'string' && !customAttribution.includes(POWERED_BY_ESRI_ATTRIBUTION_STRING)) {
+         attributionController.options.customAttribution = `${customAttribution} | ${POWERED_BY_ESRI_ATTRIBUTION_STRING}`;
+       } else if (customAttribution === undefined) {
+         attributionController.options.customAttribution = POWERED_BY_ESRI_ATTRIBUTION_STRING;

--- a/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/map-arcgis-vector-layer/map-arcgis-vector-layer.component.ts
@@ -164,7 +164,7 @@ export class MapArcgisVectorLayerComponent implements OnInit, OnDestroy {
   private addArcgisLayers() {
     this.arcGisService = new FeatureService(this.sourceId, this.mapLibreMap, {
       url: this.layer.map_url,
-      setAttributionFromService: false,
+      setAttributionFromService: true,
       // add options provided on metadata
       ...(this.layer.metadata?.['modules']?.['map']?.['arcgis'] ?? {}),
     });


### PR DESCRIPTION
Fix for the extra attribution ESRI plugin is adding.

Jira: https://sig-gis.atlassian.net/browse/PLAN-2433

Pablo already created a PR on the plugin repo, but we are still waiting for approval: https://github.com/rowanwins/mapbox-gl-arcgis-featureserver/pull/11 