### PR TITLE
Base layer hovers

### DIFF
--- a/src/interface/src/app/base-layers/base-layers.state.service.ts
+++ b/src/interface/src/app/base-layers/base-layers.state.service.ts
@@ -48,7 +48,7 @@ export class BaseLayersStateService {
     })
   );
 
-  private _enableBaseLayerHover$ = new BehaviorSubject<boolean>(false);
+  private _enableBaseLayerHover$ = new BehaviorSubject<boolean>(true);
   enableBaseLayerHover$ = this._enableBaseLayerHover$.asObservable();
 
   private _selectedBaseLayers$ = new BehaviorSubject<BaseLayer[] | null>(null);

--- a/src/interface/src/app/explore/explore/explore.component.ts
+++ b/src/interface/src/app/explore/explore/explore.component.ts
@@ -13,7 +13,6 @@ import { BehaviorSubject } from 'rxjs';
 import { MatTabsModule } from '@angular/material/tabs';
 import { ExploreStorageService } from '@services/local-storage.service';
 import { BaseLayersComponent } from '../../base-layers/base-layers/base-layers.component';
-import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
 import { ExploreModesToggleComponent } from '../../maplibre-map/explore-modes-toggle/explore-modes-toggle.component';
 import { MapSelectorComponent } from '../map-selector/map-selector.component';
 import { MapConfigService } from '../../maplibre-map/map-config.service';
@@ -62,7 +61,6 @@ export class ExploreComponent implements OnDestroy {
   constructor(
     private breadcrumbService: BreadcrumbService,
     private exploreStorageService: ExploreStorageService,
-    private baseLayersStateService: BaseLayersStateService,
     private multiMapConfigState: MultiMapConfigState,
     private mapConfigService: MapConfigService
   ) {
@@ -71,7 +69,6 @@ export class ExploreComponent implements OnDestroy {
       label: ' New Plan',
       backUrl: '/',
     });
-    this.baseLayersStateService.enableBaseLayerHover(true);
 
     this.mapConfigService.initialize();
   }

--- a/src/interface/src/app/maplibre-map/map-base-layers/map-base-layers.component.ts
+++ b/src/interface/src/app/maplibre-map/map-base-layers/map-base-layers.component.ts
@@ -132,6 +132,8 @@ export class MapBaseLayersComponent implements OnInit, OnDestroy {
           this.setTooltipData(tooltipInfo);
           this.paintHover(features[0]);
         }
+      } else {
+        this.hoverOutLayer();
       }
     });
   }

--- a/src/interface/src/app/maplibre-map/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/maplibre-map/map-project-areas/map-project-areas.component.ts
@@ -3,21 +3,21 @@ import {
   LayerComponent,
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
+import type { ExpressionSpecification } from 'maplibre-gl';
 import {
   LayerSpecification,
+  LngLat,
   Map as MapLibreMap,
   MapGeoJSONFeature,
   MapMouseEvent,
-  LngLat,
   Point,
 } from 'maplibre-gl';
 import { MatIconModule } from '@angular/material/icon';
 import { AsyncPipe, NgIf } from '@angular/common';
 import { MARTIN_SOURCES } from '../../treatments/map.sources';
 import { BASE_COLORS, LABEL_PAINT } from '../../treatments/map.styles';
-import { filter, map, Subject } from 'rxjs';
+import { BehaviorSubject, filter, map } from 'rxjs';
 import { getColorForProjectPosition } from 'src/app/plan/plan-helpers';
-import type { ExpressionSpecification } from 'maplibre-gl';
 import { MapConfigState } from '../map-config.state';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ScenarioState } from '../scenario.state';
@@ -58,7 +58,7 @@ export class MapProjectAreasComponent implements OnInit {
 
   private readonly martinSource = MARTIN_SOURCES.projectAreasByScenario;
 
-  hoveredProjectAreaId$ = new Subject<number | null>();
+  hoveredProjectAreaId$ = new BehaviorSubject<number | null>(null);
   hoveredProjectAreaFromFeatures: MapGeoJSONFeature | null = null;
   opacity: number = 0.5;
 

--- a/src/interface/src/app/maplibre-map/map-project-areas/map-project-areas.component.ts
+++ b/src/interface/src/app/maplibre-map/map-project-areas/map-project-areas.component.ts
@@ -16,7 +16,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { AsyncPipe, NgIf } from '@angular/common';
 import { MARTIN_SOURCES } from '../../treatments/map.sources';
 import { BASE_COLORS, LABEL_PAINT } from '../../treatments/map.styles';
-import { BehaviorSubject, filter, map } from 'rxjs';
+import { filter, map, Subject } from 'rxjs';
 import { getColorForProjectPosition } from 'src/app/plan/plan-helpers';
 import { MapConfigState } from '../map-config.state';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -58,7 +58,7 @@ export class MapProjectAreasComponent implements OnInit {
 
   private readonly martinSource = MARTIN_SOURCES.projectAreasByScenario;
 
-  hoveredProjectAreaId$ = new BehaviorSubject<number | null>(null);
+  hoveredProjectAreaId$ = new Subject<number | null>();
   hoveredProjectAreaFromFeatures: MapGeoJSONFeature | null = null;
   opacity: number = 0.5;
 

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.ts
@@ -50,6 +50,7 @@ import { RxSelectionToggleComponent } from '../../maplibre-map/rx-selection-togg
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BaseLayersComponent } from '../../base-layers/base-layers/base-layers.component';
 import { MapBaseLayersComponent } from '../../maplibre-map/map-base-layers/map-base-layers.component';
+import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
 
 @UntilDestroy()
 @Component({
@@ -187,6 +188,7 @@ export class TreatmentMapComponent {
     private treatmentsState: TreatmentsState,
     private selectedStandsState: SelectedStandsState,
     private dataLayersStateService: DataLayersStateService,
+    private baseLayersStateService: BaseLayersStateService,
     private route: ActivatedRoute,
     private router: Router,
     private planState: PlanState
@@ -287,6 +289,7 @@ export class TreatmentMapComponent {
     addRequestHeaders(url, resourceType, this.authService.getAuthCookie());
 
   setHoveredProjectAreaId(value: number | null) {
+    this.baseLayersStateService.enableBaseLayerHover(!value);
     this.hoveredProjectAreaId$.next(value);
   }
 

--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.html
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.html
@@ -2,8 +2,7 @@
   #tabGroup
   class="summary-tab-group"
   mat-align-tabs="start"
-  disablePagination="true"
-  (selectedTabChange)="handleSelectedTab($event)">
+  disablePagination="true">
   <mat-tab label="Project Areas">
     <app-project-areas-tab></app-project-areas-tab>
   </mat-tab>

--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.spec.ts
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.spec.ts
@@ -1,13 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TreatmentPlanTabsComponent } from './treatment-plan-tabs.component';
-import { TreatmentsState } from '../treatments.state';
 import { MockDeclarations, MockProvider } from 'ng-mocks';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ProjectAreasTabComponent } from '../project-areas-tab/project-areas-tab.component';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { BehaviorSubject, of } from 'rxjs';
+import { of } from 'rxjs';
 import { DataLayersStateService } from 'src/app/data-layers/data-layers.state.service';
 import { DataLayersComponent } from '../../data-layers/data-layers/data-layers.component';
 
@@ -28,9 +27,6 @@ describe('TreatmentPlanTabsComponent', () => {
         MockDeclarations(ProjectAreasTabComponent, DataLayersComponent),
       ],
       providers: [
-        MockProvider(TreatmentsState, {
-          treatmentPlan$: new BehaviorSubject(null),
-        }),
         MockProvider(DataLayersStateService, {
           paths$: of([]),
         }),

--- a/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.ts
+++ b/src/interface/src/app/treatments/treatment-plan-tabs/treatment-plan-tabs.component.ts
@@ -1,9 +1,5 @@
-import { AfterViewInit, Component, ViewChild } from '@angular/core';
-import {
-  MatTabChangeEvent,
-  MatTabGroup,
-  MatTabsModule,
-} from '@angular/material/tabs';
+import { Component, ViewChild } from '@angular/core';
+import { MatTabGroup, MatTabsModule } from '@angular/material/tabs';
 import { ProjectAreasTabComponent } from '../project-areas-tab/project-areas-tab.component';
 import { FeaturesModule } from 'src/app/features/features.module';
 import { DataLayersComponent } from '../../data-layers/data-layers/data-layers.component';
@@ -11,8 +7,6 @@ import { BaseLayersComponent } from 'src/app/base-layers/base-layers/base-layers
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { DataLayersStateService } from '../../data-layers/data-layers.state.service';
 import { skip } from 'rxjs';
-import { BaseLayersStateService } from '../../base-layers/base-layers.state.service';
-import { TreatmentsState } from '../treatments.state';
 
 @UntilDestroy()
 @Component({
@@ -28,35 +22,10 @@ import { TreatmentsState } from '../treatments.state';
   templateUrl: './treatment-plan-tabs.component.html',
   styleUrl: './treatment-plan-tabs.component.scss',
 })
-export class TreatmentPlanTabsComponent implements AfterViewInit {
-  private readonly BASE_LAYER_INDEX = 2;
-
+export class TreatmentPlanTabsComponent {
   @ViewChild('tabGroup') tabGroup!: MatTabGroup;
 
-  ngAfterViewInit() {
-    const currentIndex = this.tabGroup.selectedIndex;
-    this.setTabHoverOptions(currentIndex);
-  }
-
-  handleSelectedTab(selectedTab: MatTabChangeEvent) {
-    this.setTabHoverOptions(selectedTab.index);
-  }
-
-  setTabHoverOptions(curIndex: number | null) {
-    if (curIndex === this.BASE_LAYER_INDEX) {
-      this.baseLayersStateService.enableBaseLayerHover(true);
-      this.treatmentStateService.enableTreatmentTooltips(false);
-    } else {
-      this.baseLayersStateService.enableBaseLayerHover(false);
-      this.treatmentStateService.enableTreatmentTooltips(true);
-    }
-  }
-
-  constructor(
-    private dataLayersStateService: DataLayersStateService,
-    private baseLayersStateService: BaseLayersStateService,
-    private treatmentStateService: TreatmentsState
-  ) {
+  constructor(private dataLayersStateService: DataLayersStateService) {
     this.dataLayersStateService.paths$
       .pipe(untilDestroyed(this), skip(1))
       .subscribe((path) => {

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.html
@@ -3,8 +3,7 @@
   #tabGroup
   class="summary-tab-group"
   mat-align-tabs="start"
-  disablePagination="true"
-  (selectedTabChange)="handleSelectedTab($event)">
+  disablePagination="true">
   <mat-tab label="Treatments">
     <app-project-area-tx-tab></app-project-area-tx-tab>
   </mat-tab>

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -60,17 +60,17 @@ export class TreatmentProjectAreaComponent implements OnDestroy, AfterViewInit {
   ngAfterViewInit() {
     const currentIndex = this.tabGroup.selectedIndex;
     this.setTabHoverOptions(currentIndex);
+    this.baseLayersStateService.enableBaseLayerHover(false);
   }
+
   handleSelectedTab(selectedTab: MatTabChangeEvent) {
     this.setTabHoverOptions(selectedTab.index);
   }
 
   setTabHoverOptions(curIndex: number | null) {
     if (curIndex === this.BASE_LAYER_INDEX) {
-      this.baseLayersStateService.enableBaseLayerHover(true);
       this.treatmentsState.enableTreatmentTooltips(false);
     } else {
-      this.baseLayersStateService.enableBaseLayerHover(false);
       this.treatmentsState.enableTreatmentTooltips(true);
     }
   }

--- a/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
+++ b/src/interface/src/app/treatments/treatment-project-area/treatment-project-area.component.ts
@@ -2,11 +2,7 @@ import { AfterViewInit, Component, OnDestroy, ViewChild } from '@angular/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { SharedModule } from '@shared';
 import { MatDialogModule } from '@angular/material/dialog';
-import {
-  MatTabChangeEvent,
-  MatTabGroup,
-  MatTabsModule,
-} from '@angular/material/tabs';
+import { MatTabGroup, MatTabsModule } from '@angular/material/tabs';
 import { ProjectAreaTreatmentsTabComponent } from '../treatments-tab/treatments-tab.component';
 import { SelectedStandsState } from '../treatment-map/selected-stands.state';
 import { TreatmentsState } from '../treatments.state';
@@ -38,8 +34,6 @@ import { BaseLayersStateService } from '../../base-layers/base-layers.state.serv
   styleUrl: './treatment-project-area.component.scss',
 })
 export class TreatmentProjectAreaComponent implements OnDestroy, AfterViewInit {
-  private readonly BASE_LAYER_INDEX = 2;
-
   @ViewChild('tabGroup') tabGroup!: MatTabGroup;
 
   constructor(
@@ -58,21 +52,7 @@ export class TreatmentProjectAreaComponent implements OnDestroy, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    const currentIndex = this.tabGroup.selectedIndex;
-    this.setTabHoverOptions(currentIndex);
     this.baseLayersStateService.enableBaseLayerHover(false);
-  }
-
-  handleSelectedTab(selectedTab: MatTabChangeEvent) {
-    this.setTabHoverOptions(selectedTab.index);
-  }
-
-  setTabHoverOptions(curIndex: number | null) {
-    if (curIndex === this.BASE_LAYER_INDEX) {
-      this.treatmentsState.enableTreatmentTooltips(false);
-    } else {
-      this.treatmentsState.enableTreatmentTooltips(true);
-    }
   }
 
   projectAreaId?: number;
@@ -80,5 +60,6 @@ export class TreatmentProjectAreaComponent implements OnDestroy, AfterViewInit {
   ngOnDestroy(): void {
     this.selectedStandsState.clearStands();
     this.treatmentsState.setShowApplyTreatmentsDialog(false);
+    this.baseLayersStateService.enableBaseLayerHover(true);
   }
 }


### PR DESCRIPTION
Update base layers tooltip logic on treatments, when a base layer is shown:
- On treatment overview, regardless of the tab selected, show the tooltip and hover, unless a project area is at the top
- On treatment project area page, disable base layer tooltips and hovers