### PR TITLE
Add acreage tooltips

### DIFF
--- a/src/interface/src/app/maplibre-map/draw.service.ts
+++ b/src/interface/src/app/maplibre-map/draw.service.ts
@@ -104,12 +104,12 @@ export class DrawService {
   }
 
   registerChangeCallback(changeCallback: Function) {
-    this._terraDraw?.on('change', (changedFeatureIds) => {
-      changeCallback(changedFeatureIds);
+    this._terraDraw?.on('change', (changedFeatureIds, type, context) => {
+      changeCallback(changedFeatureIds, type, context);
     });
   }
 
-  getPolygonPointCount(featureId: string) {
+  getPolygonPointCount(featureId: FeatureId) {
     const snapshot = this._terraDraw?.getSnapshotFeature(featureId);
     if (snapshot?.geometry.type === 'Polygon') {
       return snapshot?.geometry.coordinates[0].length;

--- a/src/interface/src/app/maplibre-map/draw.service.ts
+++ b/src/interface/src/app/maplibre-map/draw.service.ts
@@ -137,10 +137,6 @@ export class DrawService {
     this._terraDraw?.selectFeature(featureId);
   }
 
-  currentSelectedFeature() {
-    this._terraDraw?.getFeatureId;
-  }
-
   hasPolygonFeatures() {
     if (!this._terraDraw) {
       return false;
@@ -174,6 +170,10 @@ export class DrawService {
     } else {
       return polygons[0].geometry;
     }
+  }
+
+  getShapeForFeature(featureId: FeatureId) {
+    return this._terraDraw?.getSnapshotFeature(featureId);
   }
 
   featuresAtMouseEvents(e: MapMouseEvent) {

--- a/src/interface/src/app/maplibre-map/draw.service.ts
+++ b/src/interface/src/app/maplibre-map/draw.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
-import { TerraDraw } from 'terra-draw';
+import { GeoJSONStoreFeatures, TerraDraw } from 'terra-draw';
 import { FeatureId } from 'terra-draw/dist/extend';
 import bbox from '@turf/bbox';
 import { Geometry } from '@turf/helpers';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { TerraDrawMapLibreGLAdapter } from 'terra-draw-maplibre-gl-adapter';
-import { Map as MapLibreMap } from 'maplibre-gl';
+import { Map as MapLibreMap, MapMouseEvent } from 'maplibre-gl';
 export type DrawMode = 'polygon' | 'select' | 'none';
 
 export const DefaultSelectConfig = {
@@ -174,5 +174,14 @@ export class DrawService {
     } else {
       return polygons[0].geometry;
     }
+  }
+
+  featuresAtMouseEvents(e: MapMouseEvent) {
+    let features: GeoJSONStoreFeatures[] = [];
+    if (this._terraDraw?.enabled && this.hasPolygonFeatures()) {
+      const mouseEvent = e.originalEvent;
+      features = this._terraDraw?.getFeaturesAtPointerEvent(mouseEvent);
+    }
+    return features;
   }
 }

--- a/src/interface/src/app/maplibre-map/explore-map/explore-map.component.scss
+++ b/src/interface/src/app/maplibre-map/explore-map/explore-map.component.scss
@@ -5,6 +5,11 @@
   display: block;
 }
 
+::ng-deep .acreage-popup .maplibregl-popup-content {
+      padding: 8px;
+      border-radius: 8px;
+  }
+
 mgl-map {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
TBD: this PR shows/hides tooltips based on hover, but we may decide to keep them static.

Forgoing a frontend calculation (at least until we find a suitable alternative), in favor of just relying on the django geos backend calculation.

https://github.com/user-attachments/assets/3b980e7e-df66-427d-98be-356549ca31a2

