### PR TITLE
GCS files hash calculation

### DIFF
--- a/src/planscape/core/gcs.py
+++ b/src/planscape/core/gcs.py
@@ -1,9 +1,13 @@
+import logging
+
 from typing import Optional, Collection
 
 from django.conf import settings
 from rasterio.session import GSSession
 
 from google.cloud import storage
+
+log = logging.getLogger(__name__)
 
 
 def get_gcs_session() -> GSSession:
@@ -30,10 +34,33 @@ def get_bucket_and_key(gs_url: str) -> Collection[str]:
     return gs_url.replace("gs://", "").split("/", 1)
 
 
+def get_gcs_hash(gs_url: str) -> Optional[str]:
+    """
+    Retrieves the crc32c hash of a Google Cloud Storage file.
+
+    Args:
+        gs_url (str): The GCS URL of the file.
+
+    Returns:
+        Optional[str]: The crc32c hash of the file, or None if not found.
+    """
+    if not is_gcs_file(gs_url):
+        return None
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(settings.GCS_BUCKET)
+    blob_name = gs_url.replace(f"gs://{settings.GCS_BUCKET}/", "")
+    blob = bucket.get_blob(blob_name)
+    if not blob:
+        return None
+
+    return blob.crc32c
+
+
 def create_download_url(
     gs_url: str,
     expiration: int = int(settings.GCS_PUBLIC_URL_TTL),
-) -> str:
+) -> Optional[str]:
     """
     Creates a download URL for a Google Cloud Storage file.
 
@@ -50,7 +77,10 @@ def create_download_url(
     bucket = storage_client.bucket(settings.GCS_BUCKET)
 
     blob_name = gs_url.replace(f"gs://{settings.GCS_BUCKET}/", "")
-    blob = bucket.blob(blob_name)
+    blob = bucket.get_blob(blob_name)
+    if not blob:
+        log.error(f"Blob not found: {blob_name} in bucket {settings.GCS_BUCKET}")
+        return None
 
     url = blob.generate_signed_url(
         version="v4",

--- a/src/planscape/datasets/management/commands/s3_to_gs.py
+++ b/src/planscape/datasets/management/commands/s3_to_gs.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
 
+from core.gcs import get_gcs_hash
+
 
 class Command(BaseCommand):
     help = "Transform S3 URLs to Google Cloud Storage (GCS) URLs in dataset files."
@@ -32,6 +34,7 @@ class Command(BaseCommand):
             if layer.url.startswith(s3_prefix):
                 new_url = layer.url.replace(s3_prefix, gs_prefix)
                 layer.url = new_url
+                layer.hash = get_gcs_hash(new_url)
                 layer.save()
 
             self.stdout.write(f"{count} DataLayers updated successfully.")


### PR DESCRIPTION
- Method to get CRC32C hash from a file stored on GCS
- Datalayer's hash persist update
- S3 to GCS command updating Datalayer's hash