### PR TITLE
plan-2506-allow-unath-datasets-datalayers

### DIFF
--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -3,14 +3,13 @@ from urllib.parse import urlencode
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from organizations.tests.factories import OrganizationFactory
-from rest_framework.test import APITransactionTestCase, APIClient
+from rest_framework.test import APITransactionTestCase
 
 from datasets.models import DataLayerType, VisibilityOptions
 from datasets.tests.factories import DataLayerFactory, DatasetFactory, StyleFactory
 from planscape.tests.factories import UserFactory
 
 User = get_user_model()
-anon = APIClient()
 
 
 class TestDataLayerViewSet(APITransactionTestCase):
@@ -274,7 +273,7 @@ class TestPublicAccess(APITransactionTestCase):
 
     def test_datasets_list_is_public(self):
         url = reverse("api:datasets:datasets-list")
-        resp = anon.get(url)
+        resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
 
     def test_all_public_endpoints_are_readable(self):
@@ -285,10 +284,10 @@ class TestPublicAccess(APITransactionTestCase):
         ]
         for url in urls:
             with self.subTest(url=url):
-                resp = anon.get(url)
+                resp = self.client.get(url)
                 self.assertEqual(resp.status_code, 200)
 
     def test_write_still_requires_authentication(self):
         url = reverse("api:datasets:datasets-list")
-        resp = anon.post(url, {})
+        resp = self.client.post(url, {})
         self.assertIn(resp.status_code, (401, 403))

--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -12,6 +12,7 @@ from planscape.tests.factories import UserFactory
 User = get_user_model()
 anon = APIClient()
 
+
 class TestDataLayerViewSet(APITransactionTestCase):
     def setUp(self) -> None:
         self.admin = UserFactory.create(is_staff=True)

--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -3,14 +3,14 @@ from urllib.parse import urlencode
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from organizations.tests.factories import OrganizationFactory
-from rest_framework.test import APITransactionTestCase
+from rest_framework.test import APITransactionTestCase, APIClient
 
 from datasets.models import DataLayerType, VisibilityOptions
 from datasets.tests.factories import DataLayerFactory, DatasetFactory, StyleFactory
 from planscape.tests.factories import UserFactory
 
 User = get_user_model()
-
+anon = APIClient()
 
 class TestDataLayerViewSet(APITransactionTestCase):
     def setUp(self) -> None:
@@ -264,3 +264,30 @@ class TestDatasetViewSet(APITransactionTestCase):
         data = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(datalayer.pk, data[0].get("id"))
+
+
+class TestPublicAccess(APITransactionTestCase):
+    def setUp(self) -> None:
+        self.dataset = DatasetFactory.create(visibility=VisibilityOptions.PUBLIC)
+        self.datalayer = DataLayerFactory.create(dataset=self.dataset)
+
+    def test_datasets_list_is_public(self):
+        url = reverse("api:datasets:datasets-list")
+        resp = anon.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_all_public_endpoints_are_readable(self):
+        urls = [
+            reverse("api:datasets:datasets-browse", kwargs={"pk": self.dataset.pk}),
+            f"{reverse('api:datasets:datalayers-find-anything')}?term=x",
+            reverse("api:datasets:datalayers-urls", kwargs={"pk": self.datalayer.pk}),
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                resp = anon.get(url)
+                self.assertEqual(resp.status_code, 200)
+
+    def test_write_still_requires_authentication(self):
+        url = reverse("api:datasets:datasets-list")
+        resp = anon.post(url, {})
+        self.assertIn(resp.status_code, (401, 403))

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -9,7 +9,7 @@ from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
 from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -36,7 +36,7 @@ from planscape.openpanel import track_openpanel
 
 class DatasetViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
     queryset = Dataset.objects.none()
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedOrReadOnly]
     pagination_class = LimitOffsetPagination
     serializer_class = DatasetSerializer
     serializer_classes = {
@@ -104,7 +104,7 @@ class DatasetViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
 
 class DataLayerViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
     queryset = DataLayer.objects.none()
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedOrReadOnly]
     pagination_class = LimitOffsetPagination
     serializer_class = DataLayerSerializer
     serializer_classes = {


### PR DESCRIPTION
@george-silva @pflopez @roquebetioljr -- [PLAN-2506](https://sig-gis.atlassian.net/browse/PLAN-2506?focusedCommentId=18255&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&action=REPLY_TO_COMMENT#comment-18255), to allow unauthenticated requests to datasets/datalayers endpoints:

--------------------------

1. **`src/planscape/datasets/views.py`** – added `IsAuthenticatedOrReadOnly` import, and replaced `IsAuthenticated` with that new import in the `DatasetViewSet` & `DataLayerViewSet` classes, making all four GET endpoints accessible to logged-out users.

2. **`src/planscape/datasets/tests/test_views.py`** – added new unit test class `TestPublicAccess` and `anon = APIClient()`, to test if anonymous GET requests to the four URLs Pablo requested -- `/v2/datasets/`, `/v2/datasets/<id>/browse/`, `/v2/datalayers/find_anything/`, and `/v2/datalayers/<id>/urls/` -- all return **200 OK**. Tests passed.
