### PR TITLE
Explore plan create dialog

### DIFF
--- a/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.html
+++ b/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.html
@@ -1,0 +1,51 @@
+<p>explore-plan-create-dialog works!</p>
+<sg-modal
+  title="Name your plan"
+  [shortHeader]="false"
+  [showBorders]="false"
+  [centerFooter]="false"
+  primaryButtonText="Create"
+  secondaryButtonText="Cancel"
+  (clickedSecondary)="cancel()"
+  (clickedClose)="cancel()"
+  (clickedPrimary)="submitPlan()"
+  [hasPrimarySpinner]="true">
+  <div modalBodyContent>
+    <sg-modal-info
+      infoType="info"
+      leadingIcon="info_filled"
+      message="Boundaries cannot be modified after the plan is saved.">
+    </sg-modal-info>
+    <sg-modal-info
+      *ngIf="!isValidTotalArea"
+      infoType="warning"
+      data-id="totalAreaError"
+      leadingIcon="warning_filled"
+      message="Your planning area is less than 100 acres. You will not be able to run
+        treatment scenarios in Plan.">
+    </sg-modal-info>
+    <form [formGroup]="planForm" (ngSubmit)="submitPlan()" class="upload-form">
+      <div class="field-row">
+        <div class="field-label-required">
+          Planning Area Name
+          <div class="required-star">*</div>
+        </div>
+        <sg-input-field
+          [disabled]="false"
+          class="scenario-input"
+          showSupportMessage="on-error">
+          <input
+            sgInput
+            placeholder="Plan Name"
+            name="planName"
+            formControlName="planName"
+            class="name-field" />
+        </sg-input-field>
+      </div>
+
+      <mat-error *ngIf="planForm.hasError('planNameExists')">
+        There is already a planning area with that name.
+      </mat-error>
+    </form>
+  </div>
+</sg-modal>

--- a/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.scss
+++ b/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.scss
@@ -1,0 +1,42 @@
+@import 'colors';
+@import 'mixins';
+
+:host {
+    .upload-form {
+        padding: 12px;
+
+        ::ng-deep .input-wrapper {
+    width: 100%;
+  }
+
+    }
+
+  .field-label-row {
+    padding: 24px;
+    height: 24px;
+    font-weight: 500;
+    font-size: 16px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    line-height: 24px;
+  }
+
+  .field-label-required {
+    @include standard-input-label();
+    height: 24px;
+    font-weight: 500;
+    font-size: 16px;
+    letter-spacing: normal;
+    color: $color-black;
+    flex-direction: row;
+    display: flex;
+    justify-content: flex-start;
+    line-height: 22px;
+  }
+
+  .required-star {
+    color: $color-error;
+    padding-left: 2px;
+  }
+}

--- a/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.spec.ts
+++ b/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.spec.ts
@@ -1,14 +1,43 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ExplorePlanCreateDialogComponent } from './explore-plan-create-dialog.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { DrawService } from '../draw.service';
 
 describe('ExplorePlanCreateDialogComponent', () => {
   let component: ExplorePlanCreateDialogComponent;
   let fixture: ComponentFixture<ExplorePlanCreateDialogComponent>;
 
   beforeEach(async () => {
+
+    const fakeDrawService = {
+      getCurrentAcreageValue: jasmine.createSpy('getCurrentAcreageValue').and.returnValue(101)
+    };
+    const fakeDialogRef = jasmine.createSpyObj(
+      'MatDialogRef',
+      {
+        close: undefined,
+      },
+      {}
+    );
+
     await TestBed.configureTestingModule({
-      imports: [ExplorePlanCreateDialogComponent],
+      imports: [HttpClientTestingModule, MatDialogModule, MatSnackBarModule, ExplorePlanCreateDialogComponent],
+      providers: [
+        {
+          provide: DrawService,
+          useValue: fakeDrawService,
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { drawService: fakeDrawService }
+        },
+        {
+          provide: MatDialogRef<ExplorePlanCreateDialogComponent>,
+          useValue: fakeDialogRef
+        },
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExplorePlanCreateDialogComponent);

--- a/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.spec.ts
+++ b/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExplorePlanCreateDialogComponent } from './explore-plan-create-dialog.component';
+
+describe('ExplorePlanCreateDialogComponent', () => {
+  let component: ExplorePlanCreateDialogComponent;
+  let fixture: ComponentFixture<ExplorePlanCreateDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExplorePlanCreateDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExplorePlanCreateDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.ts
+++ b/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.ts
@@ -1,0 +1,116 @@
+import { Component, inject, Inject } from '@angular/core';
+import {
+  ModalComponent,
+  InputDirective,
+  InputFieldComponent,
+} from '@styleguide';
+import { ModalInfoComponent } from 'src/styleguide/modal-info-box/modal-info.component';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DrawService } from '../draw.service';
+import { PlanService } from '@services';
+import {
+  ReactiveFormsModule,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+import { isValidTotalArea } from '../../plan/plan-helpers';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SNACK_ERROR_CONFIG } from '@shared';
+import { firstValueFrom } from 'rxjs';
+import { AnalyticsService } from '@services/analytics.service';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-confirm-exit-drawing-modal',
+  standalone: true,
+  imports: [
+    NgIf,
+    MatFormFieldModule,
+    ReactiveFormsModule,
+    ModalComponent,
+    MatIconModule,
+    InputDirective,
+    InputFieldComponent,
+    ModalInfoComponent,
+  ],
+  templateUrl: './explore-plan-create-dialog.component.html',
+  styleUrl: './explore-plan-create-dialog.component.scss',
+})
+export class ExplorePlanCreateDialogComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any, // Access the passed data
+    private planService: PlanService,
+    private matSnackBar: MatSnackBar,
+    private analyticsService: AnalyticsService
+  ) {
+    this.drawServiceInstance = data.drawService;
+  }
+
+  planForm = new FormGroup({
+    planName: new FormControl('', Validators.required),
+  });
+  drawServiceInstance: DrawService;
+  readonly dialogRef = inject(MatDialogRef<ExplorePlanCreateDialogComponent>);
+  submitting = false;
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  get isValidTotalArea() {
+    const area = this.drawServiceInstance.getCurrentAcreageValue();
+    return isValidTotalArea(area);
+  }
+
+  async submitPlan() {
+    if (this.planForm.valid) {
+      this.submitting = true;
+      const planExists = await firstValueFrom(
+        this.planService.planNameExists(
+          this.planForm.get('planName')?.value ?? ''
+        )
+      );
+      if (planExists) {
+        this.planForm.setErrors({ planNameExists: planExists });
+        this.submitting = false;
+        return;
+      }
+
+      const planName = this.planForm.get('planName')?.value || '';
+      this.createPlan(planName);
+    } else {
+    }
+  }
+
+  private createPlan(name: string) {
+    const shape = this.drawServiceInstance.getDrawingGeoJSON();
+    this.planService
+      .createPlan({
+        name: name,
+        geometry: shape.geometry,
+      })
+      .subscribe({
+        next: (result) => {
+          this.dialogRef.close(result!.id);
+          this.submitting = false;
+          this.analyticsService.emitEvent(
+            'polygons_draw_explore',
+            undefined,
+            undefined,
+            (result as any).geometry?.coordinates?.length
+          );
+        },
+        error: (e) => {
+          this.matSnackBar.open(
+            '[Error] Unable to create plan due to backend error.',
+            'Dismiss',
+            SNACK_ERROR_CONFIG
+          );
+          this.submitting = false;
+        },
+      });
+  }
+}

--- a/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.ts
+++ b/src/interface/src/app/maplibre-map/explore-plan-create-dialog/explore-plan-create-dialog.component.ts
@@ -46,13 +46,13 @@ export class ExplorePlanCreateDialogComponent {
     private matSnackBar: MatSnackBar,
     private analyticsService: AnalyticsService
   ) {
-    this.drawServiceInstance = data.drawService;
+    this.drawService = data.drawService;
   }
 
   planForm = new FormGroup({
     planName: new FormControl('', Validators.required),
   });
-  drawServiceInstance: DrawService;
+  drawService: DrawService;
   readonly dialogRef = inject(MatDialogRef<ExplorePlanCreateDialogComponent>);
   submitting = false;
 
@@ -61,7 +61,7 @@ export class ExplorePlanCreateDialogComponent {
   }
 
   get isValidTotalArea() {
-    const area = this.drawServiceInstance.getCurrentAcreageValue();
+    const area = this.drawService.getCurrentAcreageValue();
     return isValidTotalArea(area);
   }
 
@@ -86,7 +86,7 @@ export class ExplorePlanCreateDialogComponent {
   }
 
   private createPlan(name: string) {
-    const shape = this.drawServiceInstance.getDrawingGeoJSON();
+    const shape = this.drawService.getDrawingGeoJSON();
     this.planService
       .createPlan({
         name: name,

--- a/src/interface/src/app/types/plan.types.ts
+++ b/src/interface/src/app/types/plan.types.ts
@@ -23,7 +23,7 @@ export type PreviewPlan = Omit<Plan, 'geometry' | 'area_m2'>;
 export interface CreatePlanPayload {
   geometry: Geometry;
   name: string;
-  region_name: string;
+  region_name?: string;
 }
 
 export interface BackendProjectArea {

--- a/src/interface/src/styleguide/modal-info-box/modal-info.component.html
+++ b/src/interface/src/styleguide/modal-info-box/modal-info.component.html
@@ -1,5 +1,7 @@
-<mat-icon *ngIf="leadingIcon">{{ leadingIcon }}</mat-icon>
-{{ message }}
+<div class="leading-icon-box" *ngIf="leadingIcon">
+  <mat-icon class="leading-icon">{{ leadingIcon }}</mat-icon>
+</div>
+<div class="message-content">{{ message }}</div>
 <div class="right-icon">
   <mat-icon *ngIf="infoType === 'complete'">check</mat-icon>
   <mat-spinner

--- a/src/interface/src/styleguide/modal-info-box/modal-info.component.scss
+++ b/src/interface/src/styleguide/modal-info-box/modal-info.component.scss
@@ -4,15 +4,17 @@
 :host {
     @include xs-label();
     width: 100%;
-    height: 48px;
+    min-height: 48px;
+    padding: 12px;
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 1em;
-    padding-left: 1em;
+    gap: 8px;
+    padding-left: 16px;
     border-bottom: 1px;
     box-sizing: border-box;
     justify-content: flex-start;
+    
     &.info {
         color: $color-main-blue;
         background-color: $color-soft-light-blue;
@@ -27,7 +29,8 @@
       background-color: $color-light-red;
     }
     &.warning {
-    color: $color-dark-red;
+      color: $color-dark-yellow;
+      background-color: $color-brand-soft-yellow;
     }
     &.in-progress {
     color: $color-black;
@@ -43,5 +46,17 @@
   }
 
 .progress-icon {
-    colord: $color-standard-blue;
+    color: $color-standard-blue;
+}
+
+.leading-icon-box {
+  width: 30px;
+}
+
+.leading-icon {
+  width: 30px;
+}
+
+.message-content {
+  line-height: 20px;
 }

--- a/src/interface/src/styleguide/modal-info-box/modal-info.stories.ts
+++ b/src/interface/src/styleguide/modal-info-box/modal-info.stories.ts
@@ -65,6 +65,15 @@ export const InfoBox: Story = {
   },
 };
 
+export const WarningBox: Story = {
+  args: {
+    leadingIcon: 'warning',
+    message:
+      'This is a warning, and the text being displayed is going to be a few lines long. The line-height for our font should accomodate this long warning.',
+    infoType: 'warning',
+  },
+};
+
 export const ErrorBox: Story = {
   args: {
     leadingIcon: 'error',


### PR DESCRIPTION
This PR:
- adds a new dialog for Plan creation based on the old dialog, but adds more current styles, uses non-legacy Angular components, and it removes the region related code that we no longer need in Explore 2.0.
- also updates the modal-info component to handle a warning type, to ensure that multiline text is displayed correctly, and removes a the use of em units :)
- sets `region_name` as optional in the CreatePlanPayload but allows it for backwards compatibility