### PR TITLE
Avoid requests to fonts.googleapis.com when building

### DIFF
--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -75,7 +75,7 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
+                  "maximumWarning": "4kb",
                   "maximumError": "110kb"
                 }
               ],

--- a/src/interface/src/index.html
+++ b/src/interface/src/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css?family=Public+Sans:300,400,500,600,700|Roboto:300,400,500,600,700&display=swap"
       rel="stylesheet" />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Symbols+Outlined"
       rel="stylesheet" />
   </head>
   <body class="mat-typography">

--- a/src/interface/src/styles.scss
+++ b/src/interface/src/styles.scss
@@ -28,8 +28,7 @@
 // that you are using.
 @include mat.all-legacy-component-themes($planscape-frontend-theme);
 @include mat.all-component-themes($planscape-frontend-theme);
-/* You can add global styles to this file, and also import other style files */
-@import url('https://fonts.googleapis.com/icon?family=Material+Icons|Material+Symbols+Outlined');
+
 
 html,
 body {
@@ -59,7 +58,7 @@ body.no-scroll-bounce {
   button {
     color: $color-white;
   }
-  
+
 }
 
 .snackbar-debug-error {


### PR DESCRIPTION
Also increases the budget to avoid most of the warnings 