### PR TITLE
disable font inlining at build time

### DIFF
--- a/src/interface/angular.json
+++ b/src/interface/angular.json
@@ -85,7 +85,12 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "optimization": {
+                "fonts": {
+                  "inline": false
+                }
+              }
             },
             "development": {
               "buildOptimizer": false,


### PR DESCRIPTION
https://github.com/OurPlanscape/Planscape/pull/2719 didn't fixed the issue with request to fonts.googleapis.com when building.

This pr disables font inlining so we don't request the fonts to be bundled at built time.