### PR TITLE
change title to headline on section component

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
+++ b/src/interface/src/app/plan/create-scenarios/constraints-panel/constraints-panel.component.html
@@ -3,7 +3,7 @@
   *ngIf="constraintsForm"
   [formGroup]="constraintsForm!">
   <sg-section
-    title="Constraints"
+    headline="Constraints"
     tooltipContent="Constraints are variables that you can apply to your planning
           scenario. You can choose either the maximum area to be treated OR cost
           per acre. You can also put in your maximum total cost/budget. The
@@ -143,7 +143,7 @@
   </sg-section>
 
   <sg-section
-    title="Excluded Areas"
+    headline="Excluded Areas"
     tooltipContent="Exclude areas are types of land that you can choose to exclude from
           your planning scenarios. If you choose to exclude these areas, project
           areas will not be assigned on these lands.">

--- a/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
+++ b/src/interface/src/app/plan/create-scenarios/set-priorities/set-priorities.component.html
@@ -1,6 +1,6 @@
 <!--TODO tooltips-->
 <sg-section
-  title="Treatment Goals"
+  headline="Treatment Goals"
   tooltipContent="Treatment goals allow you to select one goal that will generate a
           scenario based on your landscape. Each of the goals uses a different
           set of input variables, thresholds and primary metrics to generate

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.html
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.html
@@ -1,6 +1,6 @@
 <sg-section
   [isCollapsible]="isScenarioImprovementsEnabled()"
-  title="Project Areas"
+  headline="Project Areas"
   tooltipContent="Project areas are the land areas defined by your treatment goals and
           constraints. You can have up to 10 project areas per scenario, and
           Planscape will rank those project areas according to how well they
@@ -14,7 +14,7 @@
 
 <sg-section
   [isCollapsible]="true"
-  title="Scenario Analytics"
+  headline="Scenario Analytics"
   tooltipContent="This section helps you interpret how well projects perform in your selected scenario based on priority metrics and co-benefits.
 Treatment Opportunity x Project Areas compares each project's potential to deliver treatment benefits.
 Cumulative Attainment x Cumulative Area Treated reveals how attainment stacks up across all projects."

--- a/src/interface/src/styleguide/collapsible-panel/section.component.html
+++ b/src/interface/src/styleguide/collapsible-panel/section.component.html
@@ -3,7 +3,7 @@
   expanded="true"
   [disabled]="!isCollapsible">
   <mat-expansion-panel-header class="panel-header">
-    <div class="title-txt">{{ title }}</div>
+    <div class="title-txt">{{ headline }}</div>
     <button
       *ngIf="tooltipContent"
       (click)="stopPropagation($event)"

--- a/src/interface/src/styleguide/collapsible-panel/section.component.ts
+++ b/src/interface/src/styleguide/collapsible-panel/section.component.ts
@@ -24,7 +24,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
   styleUrl: './section.component.scss',
 })
 export class SectionComponent {
-  @Input() title = '';
+  @Input() headline = '';
   @Input() tooltipContent = '';
 
   @Input() isCollapsible = false;

--- a/src/interface/src/styleguide/collapsible-panel/section.stories.ts
+++ b/src/interface/src/styleguide/collapsible-panel/section.stories.ts
@@ -31,7 +31,7 @@ type Story = StoryObj<SectionComponent>;
 
 export const Default: Story = {
   args: {
-    title: 'Project Areas',
+    headline: 'Project Areas',
     tooltipContent:
       'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.',
   },
@@ -39,14 +39,14 @@ export const Default: Story = {
 
 export const NoTooltip: Story = {
   args: {
-    title: 'Project Areas',
+    headline: 'Project Areas',
   },
 };
 
 export const Collapsible: Story = {
   args: {
     isCollapsible: true,
-    title: 'Project Areas',
+    headline: 'Project Areas',
     tooltipContent:
       'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.',
   },


### PR DESCRIPTION
Noticed a small nit with the `section` component, by using `title` as Input im reusing the default `title` html property, which results on showing the title also as a native tooltip.

This pr updates `title` to `headline` to avoid this

<img width="295" height="156" alt="Screenshot 2025-07-16 at 10 29 31 AM" src="https://github.com/user-attachments/assets/5c6ee220-779a-4280-b176-3655e12f42f3" />
