### PR TITLE
Export shapefile fixes

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -426,7 +426,7 @@ def map_property(key_value_pair):
     type = ""
     match value:
         case int() as v:
-            type = "int"
+            type = "int64"
         case str() as v:
             type = "str:128"
         case float() as v:
@@ -437,6 +437,8 @@ def map_property(key_value_pair):
             type = "date"
         case time() as v:
             type = "time"
+        case dict() as v:
+            type = "json"
     return (key, type)
 
 

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -477,19 +477,24 @@ def export_to_shapefile(scenario: Scenario) -> Path:
     shapefile_path = shapefile_folder / shapefile_file
     if not shapefile_folder.exists():
         shapefile_folder.mkdir(parents=True)
-    with fiona.Env(**get_gdal_env(allowed_extensions=".shp")):
-        crs = from_epsg(settings.CRS_INTERNAL_REPRESENTATION)
-        with fiona.open(
-            str(shapefile_path),
-            "w",
-            crs=crs,
-            driver="ESRI Shapefile",
-            schema=schema,
-        ) as c:
-            for feature in geojson.get("features", []):
-                geometry = to_multi(feature.get("geometry"))
-                feature = {**feature, "geometry": geometry}
-                c.write(feature)
+    try:
+        with fiona.Env(**get_gdal_env(allowed_extensions=".shp")):
+            crs = from_epsg(settings.CRS_INTERNAL_REPRESENTATION)
+            with fiona.open(
+                str(shapefile_path),
+                "w",
+                crs=crs,
+                driver="ESRI Shapefile",
+                schema=schema,
+            ) as c:
+                for feature in geojson.get("features", []):
+                    geometry = to_multi(feature.get("geometry"))
+                    feature = {**feature, "geometry": geometry}
+                    c.write(feature)
+    except Exception as e:
+        logger.exception("Error exporting scenario %s to shapefile: %s", scenario.pk, e)
+        shapefile_folder.rmdir()  # Clean up the folder if export fails
+        raise e
     return shapefile_folder
 
 


### PR DESCRIPTION
- Init environment to generate shapefile to be exported
- JSON added to property map
- Remove shapefile folder if export fails to avoid keep corrupted files
- Flatten geojson's properties field to avoid nested objects