### PR TITLE
PLAN-2579: Create FF for new scenario

### DIFF
--- a/feature-flags.md
+++ b/feature-flags.md
@@ -14,3 +14,5 @@ The name and value of the flag will be shared by frontend and backend.
 `SCENARIO_IMPROVEMENTS` : Shows Scenario Analytics and other improvements
 
 `CONUS_WIDE_SCENARIOS` : Enable CONUS wide scenarios
+
+`SCENARIO_CONFIGURATION_STEPS` : Shows the new scenario configuration steps

--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -20,6 +20,7 @@ import {
   planResetResolver,
 } from './resolvers/plan-loader.resolver';
 import { scenarioLoaderResolver } from './resolvers/scenario-loader.resolver';
+import { createFeatureGuard } from './features/feature.guard';
 
 const routes: Routes = [
   {
@@ -104,7 +105,7 @@ const routes: Routes = [
         },
       },
       {
-        path: 'explore/:id',
+        path: 'explore/:planId',
         title: 'Explore',
         loadComponent: () =>
           import('./explore/explore/explore.component').then(
@@ -144,7 +145,33 @@ const routes: Routes = [
       {
         // follow the route structure of plan, but without nesting modules and components
         path: 'plan/:planId/config/:scenarioId/treatment/:treatmentId',
-        canActivate: [AuthGuard],
+        canActivate: [
+          AuthGuard,
+          createFeatureGuard({
+            featureName: 'SCENARIO_CONFIGURATION_STEPS',
+            inverted: true,
+          }),
+        ],
+        resolve: {
+          planInit: planLoaderResolver,
+          treatmentId: numberResolver('treatmentId', ''),
+          scenarioInit: scenarioLoaderResolver,
+        },
+        loadChildren: () =>
+          import('./treatments/treatments.module').then(
+            (m) => m.TreatmentsModule
+          ),
+      },
+      {
+        // follow the route structure of plan, but without nesting modules and components
+        path: 'plan/:planId/scenario/:scenarioId/treatment/:treatmentId',
+        canActivate: [
+          AuthGuard,
+          createFeatureGuard({
+            featureName: 'SCENARIO_CONFIGURATION_STEPS',
+            inverted: false,
+          }),
+        ],
         resolve: {
           planInit: planLoaderResolver,
           treatmentId: numberResolver('treatmentId', ''),

--- a/src/interface/src/app/plan/plan-routing.module.ts
+++ b/src/interface/src/app/plan/plan-routing.module.ts
@@ -2,11 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { PlanComponent } from './plan.component';
 import { AuthGuard } from '@services';
-import { CreateScenariosComponent } from './create-scenarios/create-scenarios.component';
-import { ScenarioRoutePlaceholderComponent } from './scenario-route-placeholder/scenario-route-placeholder';
 import { planLoaderResolver } from '../resolvers/plan-loader.resolver';
-import { scenarioLoaderResolver } from '../resolvers/scenario-loader.resolver';
-import { resetDatalayerResolver } from '../resolvers/reset-datalayer.resolver';
 
 const routes: Routes = [
   // the url `/plan/` is not being used and invalid, redirect
@@ -16,7 +12,7 @@ const routes: Routes = [
     pathMatch: 'full',
   },
   {
-    path: ':id',
+    path: ':planId',
     title: 'Plan Details',
     component: PlanComponent,
     canActivate: [AuthGuard],
@@ -26,30 +22,9 @@ const routes: Routes = [
     data: { showOverview: true },
     children: [
       {
-        path: 'config/',
-        title: 'Scenario Configuration',
-        component: CreateScenariosComponent,
-        data: {
-          showOverview: false,
-          showProjectAreas: false,
-        },
-        resolve: {
-          scenarioId: scenarioLoaderResolver,
-          dataLayerInit: resetDatalayerResolver,
-        },
-      },
-      {
-        path: 'config/:id',
-        title: 'Scenario Configuration',
-        component: ScenarioRoutePlaceholderComponent,
-        resolve: {
-          scenarioId: scenarioLoaderResolver,
-          dataLayerInit: resetDatalayerResolver,
-        },
-        data: {
-          showOverview: false,
-          showProjectAreas: true,
-        },
+        path: '',
+        loadChildren: () =>
+          import('../scenario/scenario.module').then((m) => m.ScenarioModule),
       },
     ],
   },

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.spec.ts
@@ -125,7 +125,7 @@ describe('SavedScenariosComponent', () => {
       By.css('[data-id="new-scenario"]')
     );
     button.nativeElement.click();
-    expect(router.navigate).toHaveBeenCalledOnceWith(['config', ''], {
+    expect(router.navigate).toHaveBeenCalledOnceWith(['config'], {
       relativeTo: route,
     });
     flush();

--- a/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
+++ b/src/interface/src/app/plan/plan-summary/saved-scenarios/saved-scenarios.component.ts
@@ -19,6 +19,7 @@ import { UploadProjectAreasModalComponent } from '../../upload-project-areas-mod
 import { ScenarioCreateConfirmationComponent } from '../../scenario-create-confirmation/scenario-create-confirmation.component';
 import { TreatmentsService } from '@services/treatments.service';
 import { BreadcrumbService } from '@services/breadcrumb.service';
+import { FeatureService } from 'src/app/features/feature.service';
 
 export interface ScenarioRow extends Scenario {
   selected?: boolean;
@@ -44,6 +45,11 @@ export class SavedScenariosComponent implements OnInit {
   selectedTabIndex = 0;
   totalScenarios = 0;
   sortSelection = '-created_at';
+  scenarioPath = this.featureService.isFeatureEnabled(
+    'SCENARIO_CONFIGURATION_STEPS'
+  )
+    ? 'scenario'
+    : 'config';
 
   constructor(
     private route: ActivatedRoute,
@@ -53,7 +59,8 @@ export class SavedScenariosComponent implements OnInit {
     private scenarioService: ScenarioService,
     private dialog: MatDialog,
     private treatmentsService: TreatmentsService,
-    private breadcrumbService: BreadcrumbService
+    private breadcrumbService: BreadcrumbService,
+    private featureService: FeatureService
   ) {}
 
   ngOnInit(): void {
@@ -112,11 +119,13 @@ export class SavedScenariosComponent implements OnInit {
 
   openConfig(configId?: number): void {
     if (!configId) {
-      this.router.navigate(['config', ''], {
+      this.router.navigate([this.scenarioPath], {
         relativeTo: this.route,
       });
     } else {
-      this.router.navigate(['config', configId], { relativeTo: this.route });
+      this.router.navigate([this.scenarioPath, configId], {
+        relativeTo: this.route,
+      });
     }
   }
 
@@ -126,7 +135,7 @@ export class SavedScenariosComponent implements OnInit {
       backUrl: getPlanPath(clickedScenario.planning_area),
     });
 
-    this.router.navigate(['config', clickedScenario.id], {
+    this.router.navigate([this.scenarioPath, clickedScenario.id], {
       relativeTo: this.route,
     });
   }
@@ -162,9 +171,12 @@ export class SavedScenariosComponent implements OnInit {
       .createTreatmentPlan(Number(scenarioId), 'New Treatment Plan')
       .subscribe({
         next: (result) => {
-          this.router.navigate(['config', scenarioId, 'treatment', result.id], {
-            relativeTo: this.route,
-          });
+          this.router.navigate(
+            [this.scenarioPath, scenarioId, 'treatment', result.id],
+            {
+              relativeTo: this.route,
+            }
+          );
         },
         error: () => {
           this.snackbar.open(

--- a/src/interface/src/app/plan/plan.component.spec.ts
+++ b/src/interface/src/app/plan/plan.component.spec.ts
@@ -61,7 +61,9 @@ describe('PlanComponent', () => {
         params: { id: 'scenario-99' },
         data: { showOverview: true },
         url: [{ path: 'config' }],
-        paramMap: convertToParamMap({ id: 'scenario-99' }),
+        paramMap: convertToParamMap({
+          scenarioId: 'scenario-99',
+        }),
       },
       data: of({ showOverview: true }),
       firstChild: null,
@@ -69,7 +71,7 @@ describe('PlanComponent', () => {
 
     const fakeRoute = {
       snapshot: {
-        paramMap: convertToParamMap({ id: '24' }),
+        paramMap: convertToParamMap({ planId: '24' }),
         url: [],
       },
       firstChild: mockChildRoute,

--- a/src/interface/src/app/plan/plan.component.ts
+++ b/src/interface/src/app/plan/plan.component.ts
@@ -6,6 +6,7 @@ import {
   filter,
   map,
   Observable,
+  of,
   startWith,
   switchMap,
   take,
@@ -61,35 +62,37 @@ export class PlanComponent implements OnInit {
       })
     );
 
-    combineLatest([
-      this.currentPlan$.pipe(filter((plan): plan is Plan => !!plan)),
-      this.scenarioState.currentScenario$.pipe(startWith(null)),
-      this.router.events.pipe(
-        filter((event) => event instanceof NavigationEnd)
-      ),
-    ])
-      .pipe(untilDestroyed(this))
+    this.router.events
+      .pipe(
+        filter(
+          (event): event is NavigationEnd => event instanceof NavigationEnd
+        ),
+        switchMap(() =>
+          combineLatest([
+            this.currentPlan$.pipe(filter((plan): plan is Plan => !!plan)),
+            this.scenario$,
+          ])
+        ),
+        untilDestroyed(this)
+      )
       .subscribe(([plan, scenario]) => {
-        const routeChild = this.route.snapshot.firstChild;
-        const path = routeChild?.url[0].path;
-        const id = routeChild?.paramMap.get('id') ?? null;
+        const deepestRoute = this.getDeepestChild(this.route);
+        const path = deepestRoute?.routeConfig?.path ?? null;
+        const scenarioId = deepestRoute.snapshot.data['scenarioId'];
 
-        if (!path) {
-          // on plan
+        if (!path && scenarioId === undefined) {
           this.breadcrumbService.updateBreadCrumb({
             label: 'Planning Area: ' + plan.name,
             backUrl: '/home',
           });
-        } else if (id) {
-          // on a specific scenario. Need to have scenario name to populate breadcrumbs.
-          if (scenario && scenario.id === Number(id)) {
-            this.breadcrumbService.updateBreadCrumb({
-              label: 'Scenario: ' + scenario.name,
-              backUrl: getPlanPath(plan.id),
-            });
-          }
+        } else if (scenarioId && scenario) {
+          // On specific scenario
+          this.breadcrumbService.updateBreadCrumb({
+            label: 'Scenario: ' + scenario.name,
+            backUrl: getPlanPath(plan.id),
+          });
         } else {
-          // creating new scenario
+          // Creating new scenario
           this.breadcrumbService.updateBreadCrumb({
             label: 'Scenario: New Scenario',
             backUrl: getPlanPath(plan.id),
@@ -98,10 +101,17 @@ export class PlanComponent implements OnInit {
       });
   }
 
+  scenario$ = this.scenarioState.currentScenarioId$.pipe(
+    untilDestroyed(this),
+    switchMap((id) => {
+      return !id ? of(null) : this.scenarioState.currentScenario$;
+    })
+  );
+
   currentPlan$ = this.planState.currentPlan$;
   planOwner$ = new Observable<User | null>();
 
-  planId = this.route.snapshot.paramMap.get('id');
+  planId = this.route.snapshot.paramMap.get('planId');
   planNotFound: boolean = !this.planId;
 
   sidebarNotes: Note[] = [];

--- a/src/interface/src/app/plan/plan.module.ts
+++ b/src/interface/src/app/plan/plan.module.ts
@@ -52,6 +52,7 @@ import { ScenarioMetricsLegendComponent } from './scenario-results/scenario-metr
 import { SectionComponent } from '../../styleguide/collapsible-panel/section.component';
 import { TreatmentOpportunityChartComponent } from './treatment-opportunity-chart/treatment-opportunity-chart.component';
 import { CumulativeAttainmentChartComponent } from './cumulative-attainment-chart/cumulative-attainment-chart.component';
+import { ScenarioCreationComponent } from '../scenario/scenario-creation/scenario-creation.component';
 
 /** Components used in the plan flow. */
 @NgModule({
@@ -117,6 +118,7 @@ import { CumulativeAttainmentChartComponent } from './cumulative-attainment-char
     SectionComponent,
     TreatmentOpportunityChartComponent,
     CumulativeAttainmentChartComponent,
+    ScenarioCreationComponent,
   ],
 })
 export class PlanModule {}

--- a/src/interface/src/app/resolvers/plan-loader.resolver.spec.ts
+++ b/src/interface/src/app/resolvers/plan-loader.resolver.spec.ts
@@ -31,22 +31,6 @@ describe('planLoaderResolver', () => {
     });
   });
 
-  it('should call setPlanId if "id" param is present', () => {
-    const planState = TestBed.inject(PlanState);
-    const spy = spyOn(planState, 'setPlanId');
-
-    const route = {
-      paramMap: createParamMap({ id: '123' }),
-    } as unknown as ActivatedRouteSnapshot;
-
-    const result = TestBed.runInInjectionContext(() =>
-      planLoaderResolver(route, {} as RouterStateSnapshot)
-    );
-
-    expect(result).toBe(123);
-    expect(spy).toHaveBeenCalledOnceWith(123);
-  });
-
   it('should call setPlanId if "planId" param is present', () => {
     const planState = TestBed.inject(PlanState);
     const spy = spyOn(planState, 'setPlanId');
@@ -63,11 +47,11 @@ describe('planLoaderResolver', () => {
     expect(spy).toHaveBeenCalledOnceWith(987);
   });
 
-  it('should NOT call setPlanId if neither param is present', () => {
+  it('should NOT call setPlanId if planId is NOT present', () => {
     const planState = TestBed.inject(PlanState);
     const spy = spyOn(planState, 'setPlanId');
 
-    // paramMap is empty object -> no "id" or "planId"
+    // paramMap is empty object -> no "planId"
     const route = {
       paramMap: createParamMap({}),
     } as unknown as ActivatedRouteSnapshot;

--- a/src/interface/src/app/resolvers/plan-loader.resolver.ts
+++ b/src/interface/src/app/resolvers/plan-loader.resolver.ts
@@ -17,8 +17,7 @@ export const planLoaderResolver: ResolveFn<number> = (
 ) => {
   const planState = inject(PlanState);
   const router = inject(Router);
-  const planIdParam =
-    route.paramMap.get('id') || route.paramMap.get('planId') || '';
+  const planIdParam = route.paramMap.get('planId') || '';
   const planId = parseInt(planIdParam, 10);
 
   if (planId) {

--- a/src/interface/src/app/resolvers/scenario-loader.resolver.spec.ts
+++ b/src/interface/src/app/resolvers/scenario-loader.resolver.spec.ts
@@ -33,8 +33,8 @@ describe('scenarioLoaderResolver', () => {
     } as any as ActivatedRouteSnapshot;
   }
 
-  it('sets scenarioId from `id` and returns it', () => {
-    const route = makeRoute({ id: '123' });
+  it('sets scenarioId and returns it', () => {
+    const route = makeRoute({ scenarioId: '123' });
 
     const result = TestBed.runInInjectionContext(() =>
       scenarioLoaderResolver(route, dummyState)
@@ -45,31 +45,7 @@ describe('scenarioLoaderResolver', () => {
     expect(result).toBe(123);
   });
 
-  it('falls back to `scenarioId` when `id` is absent', () => {
-    const route = makeRoute({ scenarioId: '456' });
-
-    const result = TestBed.runInInjectionContext(() =>
-      scenarioLoaderResolver(route, dummyState)
-    );
-
-    expect(mockScenarioState.setScenarioId).toHaveBeenCalledWith(456);
-    expect(mockScenarioState.resetScenarioId).not.toHaveBeenCalled();
-    expect(result).toBe(456);
-  });
-
-  it('prefers `id` over `scenarioId` when both are present', () => {
-    const route = makeRoute({ id: '100', scenarioId: '200' });
-
-    const result = TestBed.runInInjectionContext(() =>
-      scenarioLoaderResolver(route, dummyState)
-    );
-
-    expect(mockScenarioState.setScenarioId).toHaveBeenCalledWith(100);
-    expect(mockScenarioState.resetScenarioId).not.toHaveBeenCalled();
-    expect(result).toBe(100);
-  });
-
-  it('calls resetScenarioId and returns null when neither param is present', () => {
+  it('calls resetScenarioId and returns null when scenarioId param is not present', () => {
     const route = makeRoute({});
 
     const result = TestBed.runInInjectionContext(() =>
@@ -82,7 +58,7 @@ describe('scenarioLoaderResolver', () => {
   });
 
   it('calls resetScenarioId and returns null on invalid numeric value', () => {
-    const route = makeRoute({ id: 'foo' });
+    const route = makeRoute({ scenarioId: 'foo' });
 
     const result = TestBed.runInInjectionContext(() =>
       scenarioLoaderResolver(route, dummyState)

--- a/src/interface/src/app/resolvers/scenario-loader.resolver.ts
+++ b/src/interface/src/app/resolvers/scenario-loader.resolver.ts
@@ -7,8 +7,7 @@ export const scenarioLoaderResolver: ResolveFn<number | null> = (
 ) => {
   const scenarioState = inject(ScenarioState);
 
-  const scenarioIdParam =
-    route.paramMap.get('id') || route.paramMap.get('scenarioId') || '';
+  const scenarioIdParam = route.paramMap.get('scenarioId') ?? '';
 
   const scenarioId = parseInt(scenarioIdParam, 10);
   if (scenarioId) {

--- a/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.html
+++ b/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.html
@@ -1,0 +1,1 @@
+<p>scenario-creation works!</p>

--- a/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.spec.ts
+++ b/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ScenarioCreationComponent } from './scenario-creation.component';
+
+describe('ScenarioCreationComponent', () => {
+  let component: ScenarioCreationComponent;
+  let fixture: ComponentFixture<ScenarioCreationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ScenarioCreationComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ScenarioCreationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.ts
+++ b/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-scenario-creation',
+  standalone: true,
+  imports: [],
+  templateUrl: './scenario-creation.component.html',
+  styleUrl: './scenario-creation.component.scss',
+})
+export class ScenarioCreationComponent {}

--- a/src/interface/src/app/scenario/scenario-routing.module.ts
+++ b/src/interface/src/app/scenario/scenario-routing.module.ts
@@ -1,0 +1,100 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ScenarioCreationComponent } from './scenario-creation/scenario-creation.component';
+import { scenarioLoaderResolver } from '../resolvers/scenario-loader.resolver';
+import { resetDatalayerResolver } from '../resolvers/reset-datalayer.resolver';
+import { createFeatureGuard } from '../features/feature.guard';
+import { CreateScenariosComponent } from '../plan/create-scenarios/create-scenarios.component';
+import { ScenarioRoutePlaceholderComponent } from '../plan/scenario-route-placeholder/scenario-route-placeholder';
+
+const routes: Routes = [
+  {
+    path: 'scenario',
+    children: [
+      {
+        path: '',
+        component: ScenarioCreationComponent,
+        title: 'Scenario Configuration',
+        data: {
+          showOverview: false,
+          showProjectAreas: false,
+        },
+        canActivate: [
+          createFeatureGuard({
+            featureName: 'SCENARIO_CONFIGURATION_STEPS',
+            fallback: 'config',
+          }),
+        ],
+        resolve: {
+          scenarioId: scenarioLoaderResolver,
+          dataLayerInit: resetDatalayerResolver,
+        },
+      },
+      {
+        path: ':scenarioId',
+        component: ScenarioRoutePlaceholderComponent,
+        title: 'Scenario Configuration',
+        data: {
+          showOverview: false,
+          showProjectAreas: true,
+        },
+        canActivate: [
+          createFeatureGuard({
+            featureName: 'SCENARIO_CONFIGURATION_STEPS',
+            fallback: 'config/:scenarioId',
+          }),
+        ],
+        resolve: {
+          scenarioId: scenarioLoaderResolver,
+          dataLayerInit: resetDatalayerResolver,
+        },
+      },
+    ],
+  },
+  {
+    path: 'config',
+    component: CreateScenariosComponent,
+    title: 'Scenario Configuration',
+    data: {
+      showOverview: false,
+      showProjectAreas: false,
+    },
+    canActivate: [
+      createFeatureGuard({
+        featureName: 'SCENARIO_CONFIGURATION_STEPS',
+        fallback: 'scenario',
+        inverted: true,
+      }),
+    ],
+    resolve: {
+      scenarioId: scenarioLoaderResolver,
+      dataLayerInit: resetDatalayerResolver,
+    },
+  },
+  {
+    path: 'config/:scenarioId',
+    component: ScenarioRoutePlaceholderComponent,
+    title: 'Scenario Configuration',
+    data: {
+      showOverview: false,
+      showProjectAreas: true,
+    },
+    canActivate: [
+      createFeatureGuard({
+        featureName: 'SCENARIO_CONFIGURATION_STEPS',
+        fallback: 'scenario/:scenarioId',
+        inverted: true,
+      }),
+    ],
+    resolve: {
+      scenarioId: scenarioLoaderResolver,
+      dataLayerInit: resetDatalayerResolver,
+    },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ScenarioRoutingModule {}

--- a/src/interface/src/app/scenario/scenario.module.ts
+++ b/src/interface/src/app/scenario/scenario.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ScenarioRoutingModule } from './scenario-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, ScenarioRoutingModule],
+})
+export class ScenarioModule {}

--- a/src/interface/src/app/treatments/treatments.state.spec.ts
+++ b/src/interface/src/app/treatments/treatments.state.spec.ts
@@ -11,6 +11,7 @@ import { MOCK_SUMMARY, MOCK_TREATMENT_PLAN } from './mocks';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { DirectImpactsStateService } from './direct-impacts.state.service';
+import { FeatureService } from '../features/feature.service';
 
 describe('TreatmentsState', () => {
   let service: TreatmentsState;
@@ -33,7 +34,12 @@ describe('TreatmentsState', () => {
         { provide: ActivatedRoute, useValue: fakeRoute },
 
         TreatmentsState,
-        MockProviders(MapConfigState, TreatedStandsState, TreatmentsService),
+        MockProviders(
+          MapConfigState,
+          TreatedStandsState,
+          TreatmentsService,
+          FeatureService
+        ),
         MockProvider(DirectImpactsStateService, {
           selectedProjectArea$: of('All' as any),
         }),

--- a/src/interface/src/app/treatments/treatments.state.ts
+++ b/src/interface/src/app/treatments/treatments.state.ts
@@ -28,6 +28,7 @@ import { TreatmentRoutingData } from './treatments-routing-data';
 import { ActivatedRoute } from '@angular/router';
 import { getPrescriptionsFromSummary } from './prescriptions';
 import { DirectImpactsStateService } from './direct-impacts.state.service';
+import { FeatureService } from '../features/feature.service';
 
 /**
  * Class that holds data of the current state, and makes it available
@@ -40,7 +41,8 @@ export class TreatmentsState {
     private treatedStandsState: TreatedStandsState,
     private mapConfigState: MapConfigState,
     private route: ActivatedRoute,
-    private directImpactsState: DirectImpactsStateService
+    private directImpactsState: DirectImpactsStateService,
+    private featureService: FeatureService
   ) {}
 
   private _treatmentPlanId: number | undefined = undefined;
@@ -102,10 +104,16 @@ export class TreatmentsState {
         return null;
       }
 
+      const scenarioPath = this.featureService.isFeatureEnabled(
+        'SCENARIO_CONFIGURATION_STEPS'
+      )
+        ? 'scenario'
+        : 'config';
+
       if (projectArea) {
         // if we are currently viewing a Project Area
         navStateObject.label = `Project Area:  ${projectArea.project_area_name}`;
-        navStateObject.backUrl = `/plan/${summary.planning_area_id}/config/${summary.scenario_id}/treatment/${summary.treatment_plan_id}`;
+        navStateObject.backUrl = `/plan/${summary.planning_area_id}/${scenarioPath}/${summary.scenario_id}/treatment/${summary.treatment_plan_id}`;
       } else if (
         !!treatmentPlan &&
         !!treatmentPlan.name &&
@@ -113,7 +121,7 @@ export class TreatmentsState {
       ) {
         // if we are currently viewing Treatment Impacts
         navStateObject.label = `Direct Treatment Impacts: ${treatmentPlan.name}`;
-        navStateObject.backUrl = `/plan/${summary.planning_area_id}/config/${summary.scenario_id}`;
+        navStateObject.backUrl = `/plan/${summary.planning_area_id}/${scenarioPath}/${summary.scenario_id}`;
       } else if (
         // if we are currently viewing a Treatment Plan
         !!treatmentPlan &&
@@ -121,7 +129,7 @@ export class TreatmentsState {
         treatmentPlan.status !== 'SUCCESS'
       ) {
         navStateObject.label = `Treatment Plan:  ${treatmentPlan.name}`;
-        navStateObject.backUrl = `/plan/${summary.planning_area_id}/config/${summary.scenario_id}`;
+        navStateObject.backUrl = `/plan/${summary.planning_area_id}/${scenarioPath}/${summary.scenario_id}`;
       }
       return navStateObject;
     })


### PR DESCRIPTION
We have been done a partial refactor of the plan and scenario routing apart from adding the scenario view and creation component.

### Changes made to improve our routing and the new scenario steps:

- Added a feature flag for the new scenario creation flow.
- Created a dedicated scenario folder, with its own routing and module.
- Updated plan routing to lazy-load the scenario module.
- Refactored plan and scenario resolvers to use scenarioId or planId explicitly (previously both used id, which was confusing).
- Modified the plan component to set breadcrumbs based on the new routing
**TODO:** Once we finalize the steps, we might consider moving the scenario-related breadcrumbs to the ScenarioCreateComponent and ScenarioViewComponent.
- Kept the old configuration path available when the feature flag is turned off.








