### PR TITLE
Exit workflow modal

### DIFF
--- a/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.html
+++ b/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.html
@@ -1,0 +1,17 @@
+<sg-modal
+  title="Exit Workflow?"
+  [shortHeader]="false"
+  [showBorders]="false"
+  [centerFooter]="false"
+  [padBody]="true"
+  [showClose]="false"
+  primaryButtonText="Keep Editing"
+  [hasSecondaryButton]="true"
+  secondaryButtonText="Leave"
+  (clickedPrimary)="cancelExit()"
+  (clickedSecondary)="confirmExit()">
+  <div modalBodyContent class="padded">
+    Are you sure you want to exit "Create New Scenario"? All unsaved changes
+    will be lost.
+  </div>
+</sg-modal>

--- a/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.scss
+++ b/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.scss
@@ -1,0 +1,3 @@
+.padded {
+    padding: 0 12px;
+}

--- a/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.spec.ts
+++ b/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ExitWorkflowModalComponent } from './exit-workflow-modal.component';
+
+describe('ExitWorkflowModalComponent', () => {
+  let component: ExitWorkflowModalComponent;
+  let fixture: ComponentFixture<ExitWorkflowModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExitWorkflowModalComponent],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {
+            close: () => {},
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExitWorkflowModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.ts
+++ b/src/interface/src/app/scenario/exit-workflow-modal/exit-workflow-modal.component.ts
@@ -1,0 +1,22 @@
+import { Component, inject } from '@angular/core';
+import { ModalComponent } from '@styleguide';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-exit-workflow-modal',
+  standalone: true,
+  imports: [ModalComponent],
+  templateUrl: './exit-workflow-modal.component.html',
+  styleUrl: './exit-workflow-modal.component.scss',
+})
+export class ExitWorkflowModalComponent {
+  readonly dialogRef = inject(MatDialogRef<ExitWorkflowModalComponent>);
+
+  cancelExit(): void {
+    this.dialogRef.close(false);
+  }
+
+  confirmExit(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.ts
+++ b/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.ts
@@ -27,6 +27,10 @@ import {
 } from '@types';
 import { GoalOverlayService } from '../../plan/create-scenarios/goal-overlay/goal-overlay.service';
 import { Step1Component } from '../step1/step1.component';
+import { CanComponentDeactivate } from '@services/can-deactivate.guard';
+import { ExitWorkflowModalComponent } from '../exit-workflow-modal/exit-workflow-modal.component';
+import { MatDialog } from '@angular/material/dialog';
+import { Observable } from 'rxjs';
 
 enum ScenarioTabs {
   CONFIG,
@@ -51,7 +55,7 @@ enum ScenarioTabs {
   templateUrl: './scenario-creation.component.html',
   styleUrl: './scenario-creation.component.scss',
 })
-export class ScenarioCreationComponent {
+export class ScenarioCreationComponent implements CanComponentDeactivate {
   @ViewChild('tabGroup') tabGroup!: MatTabGroup;
 
   config: Partial<ScenarioCreation> = {};
@@ -70,7 +74,8 @@ export class ScenarioCreationComponent {
     private dataLayersStateService: DataLayersStateService,
     private scenarioService: ScenarioService,
     private route: ActivatedRoute,
-    private goalOverlayService: GoalOverlayService
+    private goalOverlayService: GoalOverlayService,
+    private dialog: MatDialog
   ) {
     this.dataLayersStateService.paths$
       .pipe(untilDestroyed(this), skip(1))
@@ -79,6 +84,14 @@ export class ScenarioCreationComponent {
           this.tabGroup.selectedIndex = ScenarioTabs.DATA_LAYERS;
         }
       });
+  }
+
+  canDeactivate(): Observable<boolean> | boolean {
+    if (this.finished) {
+      return true;
+    }
+    const dialogRef = this.dialog.open(ExitWorkflowModalComponent);
+    return dialogRef.afterClosed();
   }
 
   // Async validator

--- a/src/interface/src/app/scenario/scenario-routing.module.ts
+++ b/src/interface/src/app/scenario/scenario-routing.module.ts
@@ -6,6 +6,7 @@ import { resetDatalayerResolver } from '../resolvers/reset-datalayer.resolver';
 import { createFeatureGuard } from '../features/feature.guard';
 import { CreateScenariosComponent } from '../plan/create-scenarios/create-scenarios.component';
 import { ScenarioRoutePlaceholderComponent } from '../plan/scenario-route-placeholder/scenario-route-placeholder';
+import { canDeactivateGuard } from '../../app/services/can-deactivate.guard';
 
 const routes: Routes = [
   {
@@ -25,6 +26,7 @@ const routes: Routes = [
             fallback: 'config',
           }),
         ],
+        canDeactivate: [canDeactivateGuard],
         resolve: {
           scenarioId: scenarioLoaderResolver,
           dataLayerInit: resetDatalayerResolver,

--- a/src/interface/src/app/services/can-deactivate.guard.ts
+++ b/src/interface/src/app/services/can-deactivate.guard.ts
@@ -1,0 +1,12 @@
+import { CanDeactivateFn } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export interface CanComponentDeactivate {
+  canDeactivate(): Observable<boolean> | boolean;
+}
+
+export const canDeactivateGuard: CanDeactivateFn<CanComponentDeactivate> = (
+  component
+) => {
+  return component.canDeactivate ? component.canDeactivate() : true;
+};


### PR DESCRIPTION
Adds an Exit Modal that appears when the user starts to create a scenario, but tries to navigate to another page in Planscape while the `finished` boolean is not true.

<img width="528" height="252" alt="Screenshot 2025-08-06 at 9 33 54 AM" src="https://github.com/user-attachments/assets/2e7202b4-c893-4d22-8355-9f5acebcc610" />
