### PR TITLE
Remove 'Download GeoPackage' button on old scenarios

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -111,6 +111,8 @@
     [geoPackageURL]="geoPackageURL"
     *ngIf="
       selectedTab !== SCENARIO_TABS.TREATMENTS &&
-      scenarioResults?.status === 'SUCCESS'
+      selectedTab !== SCENARIO_TABS.DATA_LAYERS &&
+      scenarioResults?.status === 'SUCCESS' &&
+      geoPackageStatus !== null
     "></app-scenario-download-footer>
 </div>


### PR DESCRIPTION
The PR hides the DownloadGeopackage footer on data layers tabs and on old scenarios, (i.e., where the geopackageStatus field is supposed to be null).

