### PR TITLE
Add fflag to download button

### DIFF
--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.html
@@ -110,6 +110,7 @@
     [scenarioName]="scenarioNameFormField?.value"
     [geoPackageURL]="geoPackageURL"
     *ngIf="
+      scenarioImprovementsFeature &&
       selectedTab !== SCENARIO_TABS.TREATMENTS &&
       selectedTab !== SCENARIO_TABS.DATA_LAYERS &&
       scenarioResults?.status === 'SUCCESS' &&

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -198,7 +198,7 @@ export class CreateScenariosComponent implements OnInit {
   }
 
   private shouldPollForGeoPackage() {
-    if (!this.geoPackageStatus) {
+    if (!this.geoPackageStatus || !this.scenarioImprovementsFeature) {
       return false; // if this is null, we can assume there will be no geopackage, ever
     }
     if (

--- a/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
+++ b/src/interface/src/app/plan/create-scenarios/create-scenarios.component.ts
@@ -40,6 +40,7 @@ import { MatTabGroup } from '@angular/material/tabs';
 import { DataLayersStateService } from '../../data-layers/data-layers.state.service';
 import { PlanState } from '../plan.state';
 import { nameMustBeNew } from 'src/app/validators/unique-scenario';
+import { FeatureService } from 'src/app/features/feature.service';
 
 export enum ScenarioTabs {
   CONFIG,
@@ -113,6 +114,10 @@ export class CreateScenariosComponent implements OnInit {
     })
   );
 
+  scenarioImprovementsFeature = this.featureService.isFeatureEnabled(
+    'SCENARIO_IMPROVEMENTS'
+  );
+
   constructor(
     private fb: FormBuilder,
     private scenarioService: ScenarioService,
@@ -122,7 +127,8 @@ export class CreateScenariosComponent implements OnInit {
     private scenarioStateService: ScenarioState,
     private dataLayersStateService: DataLayersStateService,
     private planState: PlanState,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private featureService: FeatureService
   ) {
     this.dataLayersStateService.paths$
       .pipe(untilDestroyed(this), skip(1))

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.html
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.html
@@ -34,3 +34,16 @@ Cumulative Attainment x Cumulative Area Treated reveals how attainment stacks up
     *ngIf="results"
     [scenarioResult]="results"></app-scenario-metrics-legend>
 </sg-section>
+
+<div class="actions" *ngIf="isScenarioImprovementsEnabled()">
+  <button
+    mat-raised-button
+    (click)="downloadShapeFiles()"
+    data-id="downloadShapeFiles">
+    Download Shape Files
+  </button>
+
+  <button mat-raised-button (click)="downloadCsv()" data-id="downloadCsv">
+    Download CSV data
+  </button>
+</div>

--- a/src/interface/src/app/plan/scenario-results/scenario-results.component.html
+++ b/src/interface/src/app/plan/scenario-results/scenario-results.component.html
@@ -35,7 +35,7 @@ Cumulative Attainment x Cumulative Area Treated reveals how attainment stacks up
     [scenarioResult]="results"></app-scenario-metrics-legend>
 </sg-section>
 
-<div class="actions" *ngIf="isScenarioImprovementsEnabled()">
+<div class="actions" *ngIf="!isScenarioImprovementsEnabled()">
   <button
     mat-raised-button
     (click)="downloadShapeFiles()"


### PR DESCRIPTION
- adds feature flag to download footer
- reinstates old download buttons when there is no feature flag
- skips the "extended" polling for geopackage_status/geopackage_url when there is no feature flag
