### PR TITLE
Changing export_to_geopackage log level to exception

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -738,7 +738,7 @@ def export_to_geopackage(scenario: Scenario, regenerate=False) -> str:
 
         return str(geopackage_path)
     except Exception:
-        logger.error("Failed to export to geopackage")
+        logger.exception("Failed to export to geopackage")
         scenario.geopackage_url = None
         scenario.geopackage_status = GeoPackageStatus.FAILED
         scenario.save(


### PR DESCRIPTION
 Changing export_to_geopackage log level to **exception** when it fails in order to capture the stack trace.