### PR TITLE
Use `outline` field for `get_coverage`

### DIFF
--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -159,12 +159,17 @@ class MapServiceChoices(models.TextChoices):
 
 
 class DataLayerQuerySet(models.QuerySet):
-    def geometric_intersection(self) -> Optional[GEOSGeometry]:
+    def geometric_intersection(
+        self, geometry_field: str = "geometry"
+    ) -> Optional[GEOSGeometry]:
         geometries = (
             self.all()
             .annotate(area=Area("geometry"))
             .order_by("-area")
-            .values_list("geometry", flat=True)
+            .values_list(
+                geometry_field,
+                flat=True,
+            )
         )
         temp_geometry = None
         for i, geometry in enumerate(geometries):

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -257,7 +257,7 @@ class TreatmentGoal(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model
     )
 
     def get_coverage(self) -> GEOSGeometry:
-        return self.datalayers.all().geometric_intersection()  # type: ignore
+        return self.datalayers.all().geometric_intersection(geometry_field="outline")  # type: ignore
 
     def get_raster_datalayers(self) -> Collection[DataLayer]:
         datalayers = list(


### PR DESCRIPTION
- made the `geometric_intersection` queryset function dynamic by taking the
  field name
- changed the `get_coverage` function on `TreatmentGoal` to use the specific
  `outline` field.
