### PR TITLE
Changes field to be MultiPolygon

### DIFF
--- a/src/planscape/planning/migrations/0046_alter_treatmentgoal_geometry.py
+++ b/src/planscape/planning/migrations/0046_alter_treatmentgoal_geometry.py
@@ -1,0 +1,20 @@
+import django.contrib.gis.db.models.fields
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("planning", "0045_auto_20250811_1507"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="treatmentgoal",
+            name="geometry",
+            field=django.contrib.gis.db.models.fields.MultiPolygonField(
+                help_text="Stores the bounding box that represents the union of all available layers. all planning areas must be inside this polygon.",
+                null=True,
+                srid=4269,
+            ),
+        ),
+    ]

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -250,7 +250,7 @@ class TreatmentGoal(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model
         ),
     )
 
-    geometry = models.PolygonField(
+    geometry = models.MultiPolygonField(
         srid=settings.DEFAULT_CRS,
         null=True,
         help_text="Stores the bounding box that represents the union of all available layers. all planning areas must be inside this polygon.",


### PR DESCRIPTION
- changes `TreatmentGoal` geometry to be `MultiPolygon` field.
- creates a migration to reset and recalculate all geometries for these.
