### PR TITLE
remove legacy slider module

### DIFF
--- a/src/interface/src/app/material/legacy-material.module.ts
+++ b/src/interface/src/app/material/legacy-material.module.ts
@@ -17,7 +17,6 @@ import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@ang
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { MatSortModule } from '@angular/material/sort';
@@ -48,7 +47,6 @@ import { MatDialogModule } from '@angular/material/dialog';
     MatRadioModule,
     MatSelectModule,
     MatSidenavModule,
-    MatSliderModule,
     MatSlideToggleModule,
     MatSnackBarModule,
     MatSortModule,


### PR DESCRIPTION
The legacy module was not used anywhere, and the slider we are using (from storybook) uses the right non-legacy module