### PR TITLE
Adjust field_name case

### DIFF
--- a/src/planscape/datasets/dynamic_models.py
+++ b/src/planscape/datasets/dynamic_models.py
@@ -119,6 +119,7 @@ def model_from_fiona(
     }
 
     for field_name, field_type in properties.items():
+        field_name = field_name.lower()
         base, clen, decimal_spec = field_from_fiona(field_type)
         match base:
             case "str":


### PR DESCRIPTION
When importing new data from our users, we ingest the data into Planscape with lowercase column names

Our code, when creating models, would honor the results from `fiona info`, which is the original case
  for column names

This changes our code so we lowercase the field name before processing.
