### PR TITLE
Add priorities on treatmentgoals endpoint

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -454,6 +454,7 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
             "category_text",
             "group",
             "group_text",
+            "priorities"
         )
 
     def get_description(self, instance):

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -454,7 +454,7 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
             "category_text",
             "group",
             "group_text",
-            "priorities"
+            "priorities",
         )
 
     def get_description(self, instance):

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -1057,6 +1057,7 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             category=TreatmentGoalCategory.BIODIVERSITY,
             geometry=MultiPolygon([self.poly1.intersection(self.poly2)]),
             group=ca_group,
+            priorities=['priority one' , 'priority two']
         )
         self.treatment_goals = TreatmentGoalFactory.create_batch(
             10,
@@ -1092,7 +1093,10 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             first_treatment_goal["group_text"],
             TreatmentGoalGroup(self.first_treatment_goal.group).label,
         )
-
+        self.assertEqual(
+            first_treatment_goal["priorities"],
+            ['priority one', 'priority two']
+        )
     def test_detail_treatment_goal(self):
         response = self.client.get(
             reverse(

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -1057,7 +1057,7 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             category=TreatmentGoalCategory.BIODIVERSITY,
             geometry=MultiPolygon([self.poly1.intersection(self.poly2)]),
             group=ca_group,
-            priorities=['priority one' , 'priority two']
+            priorities=["priority one", "priority two"],
         )
         self.treatment_goals = TreatmentGoalFactory.create_batch(
             10,
@@ -1094,9 +1094,9 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             TreatmentGoalGroup(self.first_treatment_goal.group).label,
         )
         self.assertEqual(
-            first_treatment_goal["priorities"],
-            ['priority one', 'priority two']
+            first_treatment_goal["priorities"], ["priority one", "priority two"]
         )
+
     def test_detail_treatment_goal(self):
         response = self.client.get(
             reverse(


### PR DESCRIPTION
I hope you don't mind the random backend PR, but I think this might be all we need on the front end, at least for now, in order to associate the priorities on some UI components.
