### PR TITLE
Geopackage generation cronjob

### DIFF
--- a/src/planscape/planning/tests/test_cron.py
+++ b/src/planscape/planning/tests/test_cron.py
@@ -1,0 +1,61 @@
+from unittest import mock
+
+from django.test import TestCase
+from planning.models import GeoPackageStatus, ScenarioResultStatus
+from planning.tests.factories import ScenarioFactory
+from planning.cron import trigger_geopackage_generation
+
+
+class TriggerGeopackageGenerationCronJobTestCase(TestCase):
+    @mock.patch("planning.cron.async_generate_scenario_geopackage.apply_async")
+    def test_trigger_geopackage_generation_cron_job(self, mock_async_generate):
+        scenario = ScenarioFactory.create(
+            result_status=ScenarioResultStatus.SUCCESS,
+            geopackage_status=GeoPackageStatus.PENDING,
+        )
+
+        trigger_geopackage_generation()
+
+        mock_async_generate.assert_called_once_with(scenario.pk)
+
+    @mock.patch("planning.cron.async_generate_scenario_geopackage.apply_async")
+    def test_trigger_geopackage_generation_no_pending(self, mock_async_generate):
+        ScenarioFactory.create(
+            result_status=ScenarioResultStatus.SUCCESS,
+            geopackage_status=GeoPackageStatus.PROCESSING,
+        )
+        ScenarioFactory.create(
+            result_status=ScenarioResultStatus.SUCCESS,
+            geopackage_status=GeoPackageStatus.SUCCEEDED,
+        )
+        ScenarioFactory.create(
+            result_status=ScenarioResultStatus.SUCCESS,
+            geopackage_status=GeoPackageStatus.FAILED,
+        )
+        ScenarioFactory.create(
+            result_status=ScenarioResultStatus.SUCCESS,
+            geopackage_status=None,
+        )
+
+        trigger_geopackage_generation()
+        mock_async_generate.assert_not_called()
+
+    @mock.patch("planning.cron.async_generate_scenario_geopackage.apply_async")
+    def test_trigger_geopackage_generation_result_status_not_success(
+        self, mock_async_generate
+    ):
+        ScenarioFactory.create(
+            result_status=ScenarioResultStatus.PENDING,
+            geopackage_status=GeoPackageStatus.PENDING,
+        )
+        ScenarioFactory.create(
+            result_status=ScenarioResultStatus.RUNNING,
+            geopackage_status=GeoPackageStatus.PENDING,
+        )
+        ScenarioFactory.create(
+            result_status=ScenarioResultStatus.FAILURE,
+            geopackage_status=GeoPackageStatus.PENDING,
+        )
+
+        trigger_geopackage_generation()
+        mock_async_generate.assert_not_called()

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -418,6 +418,7 @@ TREATMENTS_TEST_FIXTURES_PATH = BASE_DIR / "scenario_fixtures"
 SHARED_LINKS_NUM_DAYS_VALID = 60
 CRONJOBS = [
     ("0 0 * * *", "planning.cron.delete_old_shared_links"),  # Runs at midnight daily
+    ("* * * * *", "planning.cron.trigger_geopackage_generation"),  # Runs every minute
 ]
 
 REPORT_RECIPIENT_EMAIL = config("REPORT_RECIPIENT_EMAIL", default=DEFAULT_FROM_EMAIL)


### PR DESCRIPTION
* cronjob that triggers geopackage generations for Scenarios that succeeded and geopackage is pending
* removal of caching logic from geopackage generation, as it relies on geopackage_status field
* removal of task's retries and backoffs
* not raising exception on task, as retry will be done by crojob