### PR TITLE
Fix how to get maximum treatable area

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -386,13 +386,24 @@ def zip_directory(file_obj, source_dir):
                 )
 
 
-def get_max_treatable_area(configuration: Dict[str, Any]) -> float:
+def get_max_treatable_area(
+    configuration: Dict[str, Any],
+    min_project_area: Optional[float] = None,
+    number_of_projects: Optional[int] = None,
+) -> Optional[float]:
     max_budget = configuration.get("max_budget") or None
     cost_per_acre = configuration.get("est_cost") or settings.DEFAULT_ESTIMATED_COST
     if max_budget:
         return max_budget / cost_per_acre
 
-    return float(configuration.get("max_treatment_area_ratio"))
+    max_treatable_area_ratio = configuration.get("max_treatment_area_ratio")
+    if max_treatable_area_ratio:
+        return float(max_treatable_area_ratio)
+
+    if min_project_area and number_of_projects:
+        return min_project_area / number_of_projects
+
+    return None
 
 
 def get_max_treatable_stand_count(

--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -189,9 +189,13 @@ def async_pre_forsys_process(scenario_id: int) -> None:
     ]
 
     min_area_project = get_min_project_area(scenario)
-    max_area_project = get_max_treatable_area(scenario.configuration)
     number_of_projects = scenario.configuration.get(
         "max_project_count", settings.DEFAULT_MAX_PROJECT_COUNT
+    )
+    max_area_project = get_max_treatable_area(
+        configuration=scenario.configuration,
+        min_project_area=min_area_project,
+        number_of_projects=number_of_projects,
     )
     sdw = settings.FORSYS_SDW
     epw = settings.FORSYS_EPW


### PR DESCRIPTION
When max_treatment_area_ratio not present, calculate min_project_area/number_of_projects