### PR TITLE
add usage_types to TreatmentGoalSerializer

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -17,6 +17,7 @@ from planning.models import (
     TreatmentGoal,
     TreatmentGoalCategory,
     TreatmentGoalGroup,
+    TreatmentGoalUsesDataLayer,
     User,
     UserPrefs,
 )
@@ -432,6 +433,14 @@ class UpsertConfigurationV2Serializer(ConfigurationV2Serializer):
         return instance
 
 
+class TreatmentGoalUsageSerializer(serializers.ModelSerializer):
+    datalayer = serializers.CharField(source='datalayer.name', read_only=True)
+    
+    class Meta:
+        model = TreatmentGoalUsesDataLayer
+        fields = ('usage_type', 'datalayer')
+
+
 class TreatmentGoalSerializer(serializers.ModelSerializer):
     description = serializers.SerializerMethodField(
         help_text="Description of the Treatment Goal on HTML format.",
@@ -443,6 +452,7 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
         read_only=True,
         help_text="Text format of Treatment Goal Group.",
     )
+    usage_types = TreatmentGoalUsageSerializer(source='datalayer_usages', many=True, read_only=True)
 
     class Meta:
         model = TreatmentGoal
@@ -454,7 +464,7 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
             "category_text",
             "group",
             "group_text",
-            "priorities",
+            "usage_types"
         )
 
     def get_description(self, instance):
@@ -473,7 +483,6 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
             group = TreatmentGoalGroup(instance.group)
             return group.label
         return None
-
 
 class TreatmentGoalSimpleSerializer(serializers.ModelSerializer):
     class Meta:

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -434,11 +434,11 @@ class UpsertConfigurationV2Serializer(ConfigurationV2Serializer):
 
 
 class TreatmentGoalUsageSerializer(serializers.ModelSerializer):
-    datalayer = serializers.CharField(source='datalayer.name', read_only=True)
-    
+    datalayer = serializers.CharField(source="datalayer.name", read_only=True)
+
     class Meta:
         model = TreatmentGoalUsesDataLayer
-        fields = ('usage_type', 'datalayer')
+        fields = ("usage_type", "datalayer")
 
 
 class TreatmentGoalSerializer(serializers.ModelSerializer):
@@ -452,7 +452,9 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
         read_only=True,
         help_text="Text format of Treatment Goal Group.",
     )
-    usage_types = TreatmentGoalUsageSerializer(source='datalayer_usages', many=True, read_only=True)
+    usage_types = TreatmentGoalUsageSerializer(
+        source="datalayer_usages", many=True, read_only=True
+    )
 
     class Meta:
         model = TreatmentGoal
@@ -464,7 +466,7 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
             "category_text",
             "group",
             "group_text",
-            "usage_types"
+            "usage_types",
         )
 
     def get_description(self, instance):
@@ -483,6 +485,7 @@ class TreatmentGoalSerializer(serializers.ModelSerializer):
             group = TreatmentGoalGroup(instance.group)
             return group.label
         return None
+
 
 class TreatmentGoalSimpleSerializer(serializers.ModelSerializer):
     class Meta:

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -19,6 +19,7 @@ from planning.models import (
     ScenarioResult,
     TreatmentGoalCategory,
     TreatmentGoalGroup,
+    TreatmentGoalUsesDataLayer
 )
 from planning.tests.factories import (
     PlanningAreaFactory,
@@ -1035,6 +1036,7 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             geometry=self.poly3,
             outline=self.mpoly3,
         )
+
         self.markdown_description = (
             "# This is a h1\n"
             "## This is a h2\n"
@@ -1057,7 +1059,6 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             category=TreatmentGoalCategory.BIODIVERSITY,
             geometry=MultiPolygon([self.poly1.intersection(self.poly2)]),
             group=ca_group,
-            priorities=["priority one", "priority two"],
         )
         self.treatment_goals = TreatmentGoalFactory.create_batch(
             10,
@@ -1067,6 +1068,16 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
         self.inactive_treatment_goal = TreatmentGoalFactory.create(
             active=False,
             group=ca_group,
+        )
+        self.usage1 = TreatmentGoalUsesDataLayer.objects.create(
+            usage_type="PRIORITY", 
+            datalayer=self.dl1,
+            treatment_goal=self.first_treatment_goal
+        )
+        self.usage2 = TreatmentGoalUsesDataLayer.objects.create(
+            usage_type="THRESHOLD", 
+            datalayer=self.dl2,
+            treatment_goal=self.first_treatment_goal
         )
 
     def test_list_treatment_goals(self):
@@ -1094,7 +1105,7 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             TreatmentGoalGroup(self.first_treatment_goal.group).label,
         )
         self.assertCountEqual(
-            first_treatment_goal["priorities"], ["priority one", "priority two"]
+            first_treatment_goal["usage_types"], [{'usage_type': 'PRIORITY', 'datalayer': 'Layer 1'}, {'usage_type': 'THRESHOLD', 'datalayer': 'Layer 2'}]
         )
 
     def test_detail_treatment_goal(self):

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -19,7 +19,7 @@ from planning.models import (
     ScenarioResult,
     TreatmentGoalCategory,
     TreatmentGoalGroup,
-    TreatmentGoalUsesDataLayer
+    TreatmentGoalUsesDataLayer,
 )
 from planning.tests.factories import (
     PlanningAreaFactory,
@@ -1070,14 +1070,14 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             group=ca_group,
         )
         self.usage1 = TreatmentGoalUsesDataLayer.objects.create(
-            usage_type="PRIORITY", 
+            usage_type="PRIORITY",
             datalayer=self.dl1,
-            treatment_goal=self.first_treatment_goal
+            treatment_goal=self.first_treatment_goal,
         )
         self.usage2 = TreatmentGoalUsesDataLayer.objects.create(
-            usage_type="THRESHOLD", 
+            usage_type="THRESHOLD",
             datalayer=self.dl2,
-            treatment_goal=self.first_treatment_goal
+            treatment_goal=self.first_treatment_goal,
         )
 
     def test_list_treatment_goals(self):
@@ -1105,7 +1105,11 @@ class TreatmentGoalViewSetTest(APITransactionTestCase):
             TreatmentGoalGroup(self.first_treatment_goal.group).label,
         )
         self.assertCountEqual(
-            first_treatment_goal["usage_types"], [{'usage_type': 'PRIORITY', 'datalayer': 'Layer 1'}, {'usage_type': 'THRESHOLD', 'datalayer': 'Layer 2'}]
+            first_treatment_goal["usage_types"],
+            [
+                {"usage_type": "PRIORITY", "datalayer": "Layer 1"},
+                {"usage_type": "THRESHOLD", "datalayer": "Layer 2"},
+            ],
         )
 
     def test_detail_treatment_goal(self):


### PR DESCRIPTION
Replaces the 'priorities' field with a more appriopriate 'usage_types' field from related tables.