### PR TITLE
plan 2611 added run endpoint for scenario

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -458,7 +458,7 @@ class UpsertConfigurationV2Serializer(ConfigurationV2Serializer):
             )
 
         # Validate merged result still has at least one of them set.
-        current = self.instance.configuration or {}
+        current = getattr(self.instance, "configuration", {}) if self.instance else {}
         final_budget = (
             current.get("max_budget") if budget is serializers.empty else budget
         )

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -409,6 +409,20 @@ class ConfigurationV2Serializer(serializers.Serializer):
         help_text="Optional seed for reproducible randomization.",
     )
 
+    def validate(self, attrs):
+        budget = attrs.get("max_budget")
+        area = attrs.get("max_area")
+
+        if budget and area:
+            raise serializers.ValidationError(
+                "You should only provide `max_budget` or `max_area`."
+            )
+        if not budget and not area:
+            raise serializers.ValidationError(
+                "You should provide one of `max_budget` or `max_area`."
+            )
+        return attrs
+
 
 class UpsertConfigurationV2Serializer(ConfigurationV2Serializer):
     excluded_areas = serializers.ListField(
@@ -426,6 +440,36 @@ class UpsertConfigurationV2Serializer(ConfigurationV2Serializer):
 
     def validate_excluded_areas(self, excluded_areas):
         return [excluded_area.pk for excluded_area in excluded_areas]
+
+    def validate(self, attrs):
+        budget = attrs.get("max_budget", serializers.empty)
+        area = attrs.get("max_area", serializers.empty)
+
+        # If neither field is being patched, nothing to validate here.
+        if budget is serializers.empty and area is serializers.empty:
+            return attrs
+
+        # Reject if both provided and both non-null in the same PATCH.
+        if (budget is not serializers.empty and budget is not None) and (
+            area is not serializers.empty and area is not None
+        ):
+            raise serializers.ValidationError(
+                "You should only provide `max_budget` or `max_area`."
+            )
+
+        # Validate merged result still has at least one of them set.
+        current = self.instance.configuration or {}
+        final_budget = (
+            current.get("max_budget") if budget is serializers.empty else budget
+        )
+        final_area = current.get("max_area") if area is serializers.empty else area
+
+        if final_budget is None and final_area is None:
+            raise serializers.ValidationError(
+                "You should provide one of `max_budget` or `max_area`."
+            )
+
+        return attrs
 
     def update(self, instance, validated_data):
         instance.configuration = {**(instance.configuration or {}), **validated_data}

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -504,8 +504,8 @@ def build_run_configuration(scenario: "Scenario") -> Dict[str, Any]:
 def validate_scenario_configuration(scenario: "Scenario") -> List[str]:
     errors: List[str] = []
 
-    if scenario.result_status == ScenarioResultStatus.RUNNING:
-        return ["Scenario is already running."]
+    if scenario.result_status != ScenarioResultStatus.PENDING:
+        return [f"Scenario cannot be run on status {scenario.result_status}."]
 
     if scenario.status == ScenarioStatus.ARCHIVED:
         errors.append("Archived scenarios cannot be run.")

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -501,6 +501,80 @@ def build_run_configuration(scenario: "Scenario") -> Dict[str, Any]:
     }
 
 
+def validate_scenario_configuration(scenario: "Scenario") -> List[str]:
+    errors: List[str] = []
+
+    if scenario.result_status == ScenarioResultStatus.RUNNING:
+        return ["Scenario is already running."]
+
+    if scenario.status == ScenarioStatus.ARCHIVED:
+        errors.append("Archived scenarios cannot be run.")
+
+    if not scenario.treatment_goal:
+        errors.append("Scenario has no Treatment Goal assigned.")
+
+    if (
+        scenario.planning_area.get_stands(stand_size=scenario.get_stand_size()).count()
+        == 0
+    ):
+        errors.append(
+            "No stands are available in this Planning Area for the selected `stand_size`."
+        )
+
+    cfg = dict(getattr(scenario, "configuration", {}) or {})
+    max_budget = cfg.get("max_budget")
+    max_area = cfg.get("max_area")
+
+    has_budget = (max_budget is not None) and (max_budget > 0)
+    has_area = (max_area is not None) and (max_area > 0)
+
+    if not has_budget and not has_area:
+        errors.append("Provide either `max_budget` or `max_area`.")
+    if has_budget and has_area:
+        errors.append("Provide only one of `max_budget` or `max_area` (not both).")
+
+    return errors
+
+
+@transaction.atomic()
+def trigger_scenario_run(scenario: "Scenario", user: User) -> "Scenario":
+    from planning.tasks import (
+        async_calculate_stand_metrics_v2,
+        async_pre_forsys_process,
+        async_forsys_run,
+    )
+
+    # schedule: metrics → pre-forsys → forsys
+    tx_goal = scenario.treatment_goal
+    datalayers = tx_goal.get_raster_datalayers() if tx_goal else []
+    tasks = [
+        async_calculate_stand_metrics_v2.si(scenario_id=scenario.pk, datalayer_id=d.pk)
+        for d in datalayers
+    ]
+    tasks.append(async_pre_forsys_process.si(scenario_id=scenario.pk))
+
+    track_openpanel(
+        name="planning.scenario.triggered",
+        properties={
+            "origin": scenario.origin,
+            "treatment_goal_id": tx_goal.pk if tx_goal else None,
+            "treatment_goal_category": (tx_goal.category if tx_goal else None),
+            "treatment_goal_name": (tx_goal.name if tx_goal else None),
+            "email": user.email if user else None,
+        },
+        user_id=user.pk,
+    )
+
+    action.send(
+        user, verb="triggered", action_object=scenario, target=scenario.planning_area
+    )
+
+    transaction.on_commit(
+        lambda: chord(tasks)(async_forsys_run.si(scenario_id=scenario.pk))
+    )
+    return scenario
+
+
 def get_cost_per_acre(configuration: dict) -> float:
     return configuration.get("est_cost") or settings.DEFAULT_ESTIMATED_COST
 

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -766,3 +766,65 @@ class PatchScenarioConfigurationTest(APITransactionTestCase):
 
         response = self.client.patch(invalid_url, payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class RunScenarioEndpointTest(APITestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.other_user = UserFactory.create()
+        self.planning_area = PlanningAreaFactory.create(user=self.user)
+        self.treatment_goal = TreatmentGoalFactory.create()
+
+        self.scenario = ScenarioFactory.create(
+            user=self.user,
+            planning_area=self.planning_area,
+            treatment_goal=self.treatment_goal,
+            configuration={"stand_size": "LARGE", "max_budget": 1000},
+        )
+        self.url = reverse("api:planning:scenarios-run", args=[self.scenario.pk])
+
+    def test_run_success_returns_202_and_triggers_run(self):
+        self.client.force_authenticate(self.user)
+        with (
+            mock.patch(
+                "planning.views_v2.validate_scenario_configuration", return_value=[]
+            ) as validate_mock,
+            mock.patch("planning.views_v2.trigger_scenario_run") as trigger_mock,
+        ):
+            response = self.client.post(self.url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        trigger_mock.assert_called_once()
+        args, _ = trigger_mock.call_args
+        self.assertEqual(args[0].pk, self.scenario.pk)
+        self.assertEqual(args[1], self.user)
+
+        data = response.json()
+        self.assertEqual(data.get("id"), self.scenario.pk)
+
+    def test_run_validation_errors_return_400(self):
+        self.client.force_authenticate(self.user)
+        with (
+            mock.patch(
+                "planning.views_v2.validate_scenario_configuration",
+                return_value=["Provide either `max_budget` or `max_area`."],
+            ) as validate_mock,
+            mock.patch("planning.views_v2.trigger_scenario_run") as trigger_mock,
+        ):
+            response = self.client.post(self.url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(), {"errors": ["Provide either `max_budget` or `max_area`."]}
+        )
+        trigger_mock.assert_not_called()
+
+    def test_run_unauthenticated_returns_401(self):
+        response = self.client.post(self.url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_run_forbidden_for_other_user_returns_404(self):
+        self.client.force_authenticate(self.other_user)
+        response = self.client.post(self.url, format="json")
+        # get_object() hides unauthorized scenarios as 404
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
POST /api/v2/scenarios/{id}/run (views_v2)
Validates a scenario, then triggers the ForSys pipeline (metrics → pre-forsys → forsys).
validate_scenario_configuration method(services.py)
trigger_scenario_run (services.py)

Reference: https://sig-gis.atlassian.net/jira/software/c/projects/PLAN/boards/56?issueParent=24341&quickFilter=63&selectedIssue=PLAN-2611