### PR TITLE
Hide treatment plan button / tab from Conus scenarios

### DIFF
--- a/src/interface/src/app/plan/permissions.ts
+++ b/src/interface/src/app/plan/permissions.ts
@@ -12,7 +12,7 @@ export function canDeletePlanningArea(plan: Plan | PreviewPlan, user: User) {
   return plan.user == user.id;
 }
 
-export function canAddTreatmentPlan(plan: Plan | PreviewPlan) {
+export function userCanAddTreatmentPlan(plan: Plan | PreviewPlan) {
   return plan.permissions?.includes('add_tx_plan');
 }
 

--- a/src/interface/src/app/plan/plan-summary/scenarios-card-list/scenarios-card-list.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenarios-card-list/scenarios-card-list.component.html
@@ -17,5 +17,6 @@
   (openNewTreatment)="openNewTreatmentDialog($event, s)"
   [userCanArchiveScenario]="userCanArchiveScenario(s)"
   [userCanCreateTreatmentPlans]="userCanCreateTreatmentPlan()"
+  [hasTreatmentPlanCapability]="hasTreatmentPlanCapability(s)"
   (toggleArchiveStatus)="toggleScenarioStatus(s)">
 </sg-scenario-card>

--- a/src/interface/src/app/plan/plan-summary/scenarios-card-list/scenarios-card-list.component.ts
+++ b/src/interface/src/app/plan/plan-summary/scenarios-card-list/scenarios-card-list.component.ts
@@ -11,6 +11,7 @@ import {
   parseResultsToProjectAreas,
   parseResultsToTotals,
 } from '../../plan-helpers';
+import { scenarioCanHaveTreatmentPlans } from 'src/app/scenario/scenario-helper';
 import { Plan, Scenario, ScenarioResult } from '@types';
 import { AuthService, ScenarioService } from '@services';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -22,7 +23,7 @@ import { CreateTreatmentDialogComponent } from '../../../scenario/create-treatme
 import { take } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { AnalyticsService } from '@services/analytics.service';
-import { canAddTreatmentPlan } from '../../permissions';
+import { userCanAddTreatmentPlan } from '../../permissions';
 
 @Component({
   selector: 'app-scenarios-card-list',
@@ -93,7 +94,11 @@ export class ScenariosCardListComponent {
     if (!this.plan) {
       return false;
     }
-    return canAddTreatmentPlan(this.plan) || false;
+    return userCanAddTreatmentPlan(this.plan) || false;
+  }
+
+  hasTreatmentPlanCapability(scenario: Scenario) {
+    return scenarioCanHaveTreatmentPlans(scenario);
   }
 
   toggleScenarioStatus(scenario: Scenario) {

--- a/src/interface/src/app/scenario/scenario-helper.ts
+++ b/src/interface/src/app/scenario/scenario-helper.ts
@@ -4,6 +4,7 @@ import {
   ScenarioCreation,
   ScenarioCreationPayload,
   ScenarioGoal,
+  Scenario
 } from '@types';
 
 /**
@@ -78,4 +79,22 @@ export function legacyGetCategorizedGoals(
     acc[category].push(goal);
     return acc;
   }, {});
+}
+
+/***
+ * This function contains the business logic for whether a particular scenario can
+ * create a treatment plan.
+ * 
+ * e.g., For now, that logic means the scope is not CONUS, but this may change, so 
+ * that logic is encapsulated here. 
+ * 
+ * TODO: This version assumes no backfill, so allows 
+ * treatment plan options if the capabilities scope is not present
+ */
+export function scenarioCanHaveTreatmentPlans(scenario : Scenario) : boolean {
+  // scenario must exist AND (scenario either does NOT have a capabilities value OR it does, AND scope is NOT CONUS)
+  if (scenario && (!scenario.capabilities.scope || scenario.capabilities?.scope !== 'CONUS')) {
+    return true;
+  }
+  return false;
 }

--- a/src/interface/src/app/scenario/uploaded-scenario-view/uploaded-scenario-view.component.html
+++ b/src/interface/src/app/scenario/uploaded-scenario-view/uploaded-scenario-view.component.html
@@ -7,5 +7,5 @@
     [planningArea]="plan$ | async"></app-treatments-tab>
   <app-new-treatment-footer
     [scenarioId]="scenario?.id!"
-    *ngIf="showTreatmentFooter$ | async"></app-new-treatment-footer>
+    *ngIf="(showTreatmentFooter$ | async) && scenarioCanHaveTreatmentPlans(scenario)"></app-new-treatment-footer>
 </div>

--- a/src/interface/src/app/scenario/uploaded-scenario-view/uploaded-scenario-view.component.ts
+++ b/src/interface/src/app/scenario/uploaded-scenario-view/uploaded-scenario-view.component.ts
@@ -6,7 +6,8 @@ import { TreatmentsTabComponent } from 'src/app/scenario/treatments-tab/treatmen
 import { NewTreatmentFooterComponent } from 'src/app/scenario/new-treatment-footer/new-treatment-footer.component';
 import { AsyncPipe, NgIf } from '@angular/common';
 import { PlanState } from 'src/app/plan/plan.state';
-import { canAddTreatmentPlan } from 'src/app/plan/permissions';
+import { userCanAddTreatmentPlan } from 'src/app/plan/permissions';
+import { scenarioCanHaveTreatmentPlans } from '../scenario-helper';
 
 @UntilDestroy()
 @Component({
@@ -22,13 +23,21 @@ import { canAddTreatmentPlan } from 'src/app/plan/permissions';
   styleUrl: './uploaded-scenario-view.component.scss',
 })
 export class UploadedScenarioViewComponent {
-  constructor(private planState: PlanState) {}
+  constructor(private planState: PlanState) { }
 
   @Input() scenario?: Scenario;
 
   plan$ = this.planState.currentPlan$;
 
+  scenarioCanHaveTreatmentPlans(scenario: Scenario | undefined) {
+    if (scenario) {
+    return scenarioCanHaveTreatmentPlans(scenario);
+    }
+    return false;
+  }
+
   showTreatmentFooter$ = this.plan$.pipe(
-    map((plan) => canAddTreatmentPlan(plan))
-  );
+    map((plan) =>
+      userCanAddTreatmentPlan(plan)
+    ))
 }

--- a/src/interface/src/app/scenario/view-scenario/view-scenario.component.html
+++ b/src/interface/src/app/scenario/view-scenario/view-scenario.component.html
@@ -32,7 +32,7 @@
     <mat-tab label="Base Layers">
       <app-base-layers class="white-background"></app-base-layers>
     </mat-tab>
-    <mat-tab label="Treatment Plans" *ngIf="scenarioHasResults(scenario)">
+    <mat-tab label="Treatment Plans" *ngIf="scenarioHasResults(scenario) && scenarioCanHaveTreatmentPlans(scenario)">
       <app-treatments-tab
         [scenarioId]="scenarioId"
         [planningArea]="plan$ | async"></app-treatments-tab>

--- a/src/interface/src/app/scenario/view-scenario/view-scenario.component.ts
+++ b/src/interface/src/app/scenario/view-scenario/view-scenario.component.ts
@@ -27,11 +27,12 @@ import { DataLayersComponent } from 'src/app/data-layers/data-layers/data-layers
 import { ScenarioFailureComponent } from '../scenario-failure/scenario-failure.component';
 import { ScenarioResultsComponent } from '../scenario-results/scenario-results.component';
 import { ScenarioPendingComponent } from '../scenario-pending/scenario-pending.component';
-import { canAddTreatmentPlan } from 'src/app/plan/permissions';
+import { userCanAddTreatmentPlan } from 'src/app/plan/permissions';
 import { PlanState } from 'src/app/plan/plan.state';
 import { getPlanPath, POLLING_INTERVAL } from 'src/app/plan/plan-helpers';
 import { BaseLayersComponent } from 'src/app/base-layers/base-layers/base-layers.component';
 import { BreadcrumbService } from '@services/breadcrumb.service';
+import { scenarioCanHaveTreatmentPlans } from '../scenario-helper';
 
 enum ScenarioTabs {
   RESULTS,
@@ -74,7 +75,7 @@ export class ViewScenarioComponent {
   showTreatmentFooter$ = combineLatest([this.plan$, this.scenario$]).pipe(
     map(
       ([plan, scenario]) =>
-        this.scenarioHasResults(scenario) && !!plan && canAddTreatmentPlan(plan)
+        this.scenarioHasResults(scenario) && !!plan && userCanAddTreatmentPlan(plan) && this.scenarioCanHaveTreatmentPlans(scenario)
     )
   );
 
@@ -172,6 +173,10 @@ export class ViewScenarioComponent {
 
   scenarioPriorities(s: Scenario) {
     return s.configuration.treatment_question?.scenario_priorities || [];
+  }
+
+  scenarioCanHaveTreatmentPlans(s: Scenario) {
+    return scenarioCanHaveTreatmentPlans(s);
   }
 
   get onTreatmentsTab() {

--- a/src/interface/src/app/types/scenario.types.ts
+++ b/src/interface/src/app/types/scenario.types.ts
@@ -26,6 +26,7 @@ export interface Scenario {
   version?: string;
   geopackage_status: GeoPackageStatus;
   geopackage_url: string | null;
+  capabilities: ScenarioCapabilities;
 }
 
 /**
@@ -63,6 +64,12 @@ export interface ScenarioResult {
     features: FeatureCollection[]; // TODO this is actually Features[]
     type: string;
   };
+}
+
+export interface ScenarioCapabilities { 
+  scope: string;
+  conus_feature_enabled: boolean;
+  can_request_conus_run: boolean;
 }
 
 export interface ScenarioCreation extends ScenarioConfigPayload {

--- a/src/interface/src/styleguide/scenario-card/scenario-card.component.html
+++ b/src/interface/src/styleguide/scenario-card/scenario-card.component.html
@@ -15,7 +15,7 @@
       class="new-treatment-btn"
       [disabled]="!isDone()"
       type="button"
-      *ngIf="!hasFailed() && userCanCreateTreatmentPlans"
+      *ngIf="!hasFailed() && userCanCreateTreatmentPlans && hasTreatmentPlanCapability"
       (click)="openNewTreatment.emit($event)">
       New Treatment Plan
     </button>

--- a/src/interface/src/styleguide/scenario-card/scenario-card.component.ts
+++ b/src/interface/src/styleguide/scenario-card/scenario-card.component.ts
@@ -61,6 +61,7 @@ export class ScenarioCardComponent {
   @Input() origin?: 'USER' | 'SYSTEM' = 'SYSTEM';
   @Input() userCanArchiveScenario = false;
   @Input() userCanCreateTreatmentPlans = false;
+  @Input() hasTreatmentPlanCapability = true;
 
   @Output() openScenario = new EventEmitter();
   @Output() openPlanningProgress = new EventEmitter();


### PR DESCRIPTION
This PR:
- hides the New Treatment Plan button from scenario cards, the treatment footer, and the Treatment Plans tab in the scenario views.
- renames `canAddTreatmentPlan` to `userCanAddTreatmentPlan` just to clarify that it's a permission-based function

This PR assumes the `capabilities` structure of the backend that's in process, so we can wait to merge this until that's final.

I'm also very open to renaming any of the functions or attributes in here--I know they're beginningToLookLikeJavaFunctionNames.
