### PR TITLE
PLAN-2755, PLAN-2756: Styling scenarios

### DIFF
--- a/src/interface/src/app/scenario/step1/step1.component.html
+++ b/src/interface/src/app/scenario/step1/step1.component.html
@@ -76,7 +76,7 @@
 </sg-section>
 
 <!-- Stand size -->
-<sg-section headline="Stand Size" [required]="true">
+<sg-section headline="Stand Size" class="stand-step" [required]="true">
   <div class="stand-label">
     <mat-icon class="stand-icon" *appFeatureFlag="'DYNAMIC_SCENARIO_MAP'"
       >hexagon

--- a/src/interface/src/app/scenario/step1/step1.component.scss
+++ b/src/interface/src/app/scenario/step1/step1.component.scss
@@ -1,5 +1,6 @@
 @import 'colors';
 @import 'mixins';
+@import 'variables';
 
 .mat-radio-group {
   display: flex;
@@ -10,7 +11,7 @@
 
 :host {
   ::ng-deep .mat-radio-label {
-    padding-left: 20px;
+    padding-left: 10px;
   }
 
   ::ng-deep .mat-radio-label-content {
@@ -33,7 +34,7 @@
   display: flex;
   flex-direction: row;
   width: auto;
-  margin: 5px;
+  margin: 0px;
   background: $color-white;
 }
 
@@ -83,7 +84,7 @@
 }
 
 sg-section {
-  margin-top: 16px;
+  margin-bottom: 10px;
 }
 
 .error-message {
@@ -122,10 +123,6 @@ sg-section {
   color: $color-error;
 }
 
-.stand-size ::ng-deep .mdc-floating-label {
-  height: 100%;
-}
-
 .stand-label {
   margin: 0 0 8px 0;
   display: flex;
@@ -141,7 +138,7 @@ sg-section {
 
   // add a smaller layer on top to simulate fill
   &::after {
-    content: "hexagon";
+    content: 'hexagon';
     display: block;
     color: $color-light-magenta;
     position: absolute;
@@ -151,5 +148,19 @@ sg-section {
     top: 2px;
     font-size: 20px;
     left: 2px;
+  }
+}
+
+.goal-control-container ::ng-deep .mat-expansion-panel-header {
+  padding: 0 4px;
+}
+
+::ng-deep .stand-step {
+  .mdc-text-field--outlined {
+    padding: 0;
+  }
+
+  .mat-mdc-select-trigger {
+    padding: $steps-padding;
   }
 }

--- a/src/interface/src/app/scenario/step2/step2.component.scss
+++ b/src/interface/src/app/scenario/step2/step2.component.scss
@@ -1,11 +1,17 @@
-
-
 .checkbox-column {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .exclude-checkbox {
-    height: 30px;
+  height: 30px;
 }
 
+/*
+  Shift checkboxes left to offset the extra padding reserved by material 
+  for the checkbox ripple (hover circle), so the list aligns consistently 
+*/
+.area-selection {
+  position: relative;
+  left: -8px;
+}

--- a/src/interface/src/app/scenario/step3/step3.component.html
+++ b/src/interface/src/app/scenario/step3/step3.component.html
@@ -1,5 +1,7 @@
 <!-- Stand levels constraints -->
-<sg-section headline="Stand Level Constraints (OPTIONAL)">
+<sg-section
+  headline="Stand Level Constraints (OPTIONAL)"
+  class="constraints-step">
   <p class="stand-label">
     Set the conditions that must be met for ForSys to consider units for
     treatment.

--- a/src/interface/src/app/scenario/step3/step3.component.scss
+++ b/src/interface/src/app/scenario/step3/step3.component.scss
@@ -1,4 +1,5 @@
 @import 'colors';
+@import 'variables';
 
 .stand-label {
   margin: 0 0 16px 0;
@@ -27,4 +28,24 @@
 
 .stand-level-input ::ng-deep .mat-mdc-form-field-error-wrapper {
   padding: 0;
+}
+
+.stand-level-input ::ng-deep .mat-mdc-form-field-infix {
+  display: flex;
+  align-items: center;
+}
+
+::ng-deep .constraints-step {
+  .mdc-text-field--outlined {
+    padding: 0;
+  }
+
+  .mdc-text-field__input {
+    padding: $steps-padding 0 $steps-padding $steps-padding;
+    margin-right: 2px;
+  }
+
+  .suffix[_ngcontent-ng-c1011767879] {
+    padding-right: $steps-padding;
+  }
 }

--- a/src/interface/src/app/scenario/step4/step4.component.html
+++ b/src/interface/src/app/scenario/step4/step4.component.html
@@ -46,7 +46,7 @@
       </div>
     </div>
     <div class="or-divider">OR</div>
-    <div class="flex-row space-evenly">
+    <div class="flex-row">
       <div>
         <mat-form-field
           class="input-field"
@@ -55,7 +55,7 @@
           <mat-label>Max Budget</mat-label>
           <input
             id="maxBudget"
-            class="right-align"
+            class="right-align max-budget"
             formControlName="max_budget"
             matInput
             type="text"
@@ -75,7 +75,7 @@
         <mat-label>Treatment cost</mat-label>
         <input
           id="estimatedCost"
-          class="right-align"
+          class="right-align treatment-cost"
           formControlName="estimated_cost"
           matInput
           type="text"

--- a/src/interface/src/app/scenario/step4/step4.component.scss
+++ b/src/interface/src/app/scenario/step4/step4.component.scss
@@ -1,10 +1,12 @@
 @import 'colors';
 @import 'mixins';
+@import 'variables';
 
 .flex-row {
   align-items: center;
   display: flex;
   gap: 20px;
+  justify-content: space-between;
 }
 
 .section-label {
@@ -13,7 +15,7 @@
 
 .input-field {
   padding-top: 4px;
-  width: 180px;
+  width: 100%;
   border: black;
 
   &.disabled {
@@ -64,13 +66,33 @@
     display: none;
   }
 
-  .mat-mdc-form-field-icon-suffix {
-    width: 80px;
+  .mdc-text-field__input {
+    padding: $steps-padding;
+    margin-right: 2px;
   }
 
-  .mdc-text-field__input {
-    padding-top: 12px;
-  margin-right: 2px;
-  padding-bottom: 12px;
+  .mdc-text-field--outlined {
+    padding: 0;
   }
+
+  .prefix {
+    padding-left: $steps-padding;
+  }
+
+  .suffix {
+    padding-right: $steps-padding;
+  }
+
+  .max-budget.mdc-text-field__input {
+    padding: $steps-padding $steps-padding $steps-padding 0;
+  }
+
+  .treatment-cost.mdc-text-field__input {
+    padding: $steps-padding 0 $steps-padding $steps-padding;
+  }
+}
+
+.treatment-step ::ng-deep .mat-mdc-form-field-infix {
+  display: flex;
+  align-items: center;
 }

--- a/src/interface/src/styles/_variables.scss
+++ b/src/interface/src/styles/_variables.scss
@@ -3,3 +3,4 @@ $navbar-height: 56px;
 $info-bar-height: 50px;
 $map-nav-bar-height: 60px;
 $map-bottom-name-height: 36px;
+$steps-padding: 14px;


### PR DESCRIPTION
Fixing some paddings on scenarios.

Step 1:
<img width="1916" height="942" alt="image" src="https://github.com/user-attachments/assets/41b89151-5a3d-46d5-8804-53a725790801" />



Step2:
<img width="1913" height="940" alt="image" src="https://github.com/user-attachments/assets/c62f5f5c-f6de-4847-9494-23502d8c5ab3" />


Step3:
<img width="1913" height="942" alt="image" src="https://github.com/user-attachments/assets/740f688f-f20a-4d1b-b1ac-4ddf30747362" />


Step4:
<img width="1911" height="941" alt="image" src="https://github.com/user-attachments/assets/33e80dde-637a-49d6-b8e7-0b6c41454298" />
