### PR TITLE
Check for analytics, add optional chaining

### DIFF
--- a/src/interface/src/app/chart-helper.ts
+++ b/src/interface/src/app/chart-helper.ts
@@ -146,15 +146,17 @@ export function getGroupedAttainment(features: FeatureCollection[]) {
   const groupedAttainment: { [key: string]: number[] } = {};
 
   features.forEach((feature) => {
-    const attainment = feature.properties.attainment;
-    for (const [key, value] of Object.entries(attainment)) {
-      if (!groupedAttainment[key]) {
-        groupedAttainment[key] = [];
-      }
-      const _value = Number(value);
-      // Preventing "NaN"
-      if (_value) {
-        groupedAttainment[key].push(convertTo2DecimalsNumbers(_value));
+    const attainment = feature.properties?.attainment;
+    if (attainment && typeof attainment === 'object') {
+      for (const [key, value] of Object.entries(attainment)) {
+        if (!groupedAttainment[key]) {
+          groupedAttainment[key] = [];
+        }
+        const _value = Number(value);
+        // Preventing "NaN"
+        if (_value) {
+          groupedAttainment[key].push(convertTo2DecimalsNumbers(_value));
+        }
       }
     }
   });

--- a/src/interface/src/app/scenario/scenario-results/scenario-results.component.ts
+++ b/src/interface/src/app/scenario/scenario-results/scenario-results.component.ts
@@ -55,7 +55,7 @@ export class ScenarioResultsComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     // parse ScenarioResult
-    if (this.results) {
+    if (this.results && hasAnalytics(this.results)) {
       this.areas = parseResultsToProjectAreas(this.results);
       const metrics = Object.keys(
         getGroupedAttainment(this.results.result.features)


### PR DESCRIPTION
It looks like one issue was being thrown from inside getGroupedAttainment(), but we should also check for analytics inside the condition in ngOnChanges. 

I don't have an easy way to test an old scenario, but will do some checks locally