### PR TITLE
Hide co-benefits label when empty

### DIFF
--- a/src/interface/src/app/scenario/scenario-metrics-legend/scenario-metrics-legend.component.html
+++ b/src/interface/src/app/scenario/scenario-metrics-legend/scenario-metrics-legend.component.html
@@ -13,7 +13,7 @@
     </div>
   </mat-checkbox>
 </div>
-<div class="title" *ngIf="metrics.length > 0">Co-Benefits:</div>
+<div class="title" *ngIf="cobenefits.length > 0">Co-Benefits:</div>
 <div class="legend-box" *ngFor="let metric of cobenefits">
   <mat-checkbox
     [value]="metric"


### PR DESCRIPTION
I happened to notice this edge case on a few older scenarios, where the co-benefits label was visible even when no co-benefits were associated.