### PR TITLE
avoids dragging or selecting base map images

### DIFF
--- a/src/interface/src/app/maplibre-map/map-base-dropdown/map-base-dropdown.component.html
+++ b/src/interface/src/app/maplibre-map/map-base-dropdown/map-base-dropdown.component.html
@@ -4,6 +4,7 @@
   matTooltipPosition="below"
   (click)="openOverlay($event)"
   class="base-map-icon"
+  draggable="false"
   *ngIf="selectedBaseMap$ | async as selectedBaseMap"
   [src]="'assets/png/baseMaps/' + selectedBaseMap + '.png'" />
 
@@ -32,6 +33,7 @@
       <img
         (click)="updateBaseMap(baseMap)"
         class="base-map-icon"
+        draggable="false"
         *ngIf="selectedBaseMap$ | async as selectedLayer"
         [src]="'assets/png/baseMaps/' + baseMap + '.png'" />
       <span class="base-map-label">

--- a/src/interface/src/app/maplibre-map/map-base-dropdown/map-base-dropdown.component.scss
+++ b/src/interface/src/app/maplibre-map/map-base-dropdown/map-base-dropdown.component.scss
@@ -7,6 +7,8 @@
 
 .base-map {
   &-icon {
+    user-select: none;
+    
     height: 38px;
     width: 38px;
     border: 1px solid $color-soft-gray;


### PR DESCRIPTION
avoids this (selecting):

<img width="453" height="475" alt="Screenshot 2025-09-17 at 6 51 19 PM" src="https://github.com/user-attachments/assets/1bf9ed5e-ec91-49d0-b00e-2bf442fa0000" />

and this (dragging):

<img width="447" height="432" alt="Screenshot 2025-09-17 at 6 52 02 PM" src="https://github.com/user-attachments/assets/fff7721a-8b33-42f3-9a8f-826eab6c8da8" />
