### PR TITLE
Removal of text_geometry field from Scenario(s) endpoints

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -258,6 +258,8 @@ class PlanningAreaNoteListSerializer(serializers.ModelSerializer):
 
 
 class ScenarioResultSerializer(serializers.ModelSerializer):
+    result = serializers.SerializerMethodField()
+
     class Meta:
         fields = (
             "id",
@@ -270,6 +272,14 @@ class ScenarioResultSerializer(serializers.ModelSerializer):
             "run_details",
         )
         model = ScenarioResult
+
+    def get_result(self, instance):
+        result = instance.result
+        features = result.get("features")
+        for feature in features:
+            feature["properties"].pop("text_geometry")
+        result["features"] = features
+        return result
 
 
 class ConfigurationSerializer(serializers.Serializer):

--- a/src/planscape/planning/tests/factories.py
+++ b/src/planscape/planning/tests/factories.py
@@ -200,6 +200,52 @@ class ScenarioResultFactory(factory.django.DjangoModelFactory):
 
     scenario = factory.SubFactory(ScenarioFactory)
 
+    result = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "crs": {"type": "name", "properties": {"name": "EPSG:4269"}},
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [1, 1],
+                            [1, 2],
+                            [2, 2],
+                            [1, 1],
+                        ]
+                    ],
+                },
+                "properties": {
+                    "YR": 1,
+                    "proj_id": 1,
+                    "pct_area": 3.45,
+                    "area_acres": 12345.987,
+                    "attainment": {
+                        "Foo Bar": 5.12345,
+                        "Bar Baz": 4.12345,
+                        "Baz Foo": 3.12345,
+                        "Foo Baz": 2.12345,
+                        "Baz Bar": 1.12345,
+                    },
+                    "total_cost": 12345.987,
+                    "stand_count": 123,
+                    "pct_excluded": 0,
+                    "cost_per_acre": 2470,
+                    "text_geometry": "POLYGON((1 1, 1 2, 2 2, 1 1))",
+                    "datalayer_1": 12345.987,
+                    "datalayer_2": 987.12345,
+                    "datalayer_3": 12345.987,
+                    "datalayer_4": 987.12345,
+                    "datalayer_5": 12345.987,
+                    "treatment_rank": 1,
+                    "weightedPriority": 12345.987,
+                },
+            }
+        ],
+    }
+
 
 class ProjectAreaFactory(factory.django.DjangoModelFactory):
     created_by = factory.SelfAttribute("scenario.user")

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -712,6 +712,25 @@ class ScenarioDetailTest(APITestCase):
             self.assertIn("usage_type", entry)
             self.assertIn("datalayer", entry)
 
+    def test_detail_scenario_v2_scenario_result(self):
+        ScenarioResultFactory(scenario=self.scenario)
+        self.client.force_authenticate(self.owner_user)
+        response = self.client.get(
+            reverse(
+                "api:planning:scenarios-detail",
+                kwargs={
+                    "pk": self.scenario.pk,
+                },
+            ),
+            content_type="application/json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(
+            "text_geometry",
+            data["scenario_result"]["result"]["features"][0]["properties"].keys(),
+        )
+
 
 class PatchScenarioConfigurationTest(APITransactionTestCase):
     def setUp(self):


### PR DESCRIPTION
 Removal of text_geometry field from Scenario(s) endpoints due to its lack of usage and considerable size