### PR TITLE
fixing treatment plan email link

### DIFF
--- a/src/planscape/impacts/tasks.py
+++ b/src/planscape/impacts/tasks.py
@@ -251,7 +251,7 @@ def async_send_email_process_finished(treatment_plan_pk, *args, **kwargs):
         link = urljoin(
             settings.PLANSCAPE_BASE_URL,
             f"plan/{treatment_plan.scenario.planning_area_id}/"
-            f"config/{treatment_plan.scenario.pk}/treatment/{treatment_plan_pk}/impacts",
+            f"scenario/{treatment_plan.scenario.pk}/treatment/{treatment_plan_pk}/impacts",
         )
 
         context = {


### PR DESCRIPTION
We renamed the url on the frontend but didnt update the email link url