### PR TITLE
Downgrade zope-event lib to 5.1.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5309,14 +5309,14 @@ type = ["pytest-mypy"]
 
 [[package]]
 name = "zope-event"
-version = "6.0"
+version = "5.1.1"
 description = "Very basic event publishing system"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "zope_event-6.0-py3-none-any.whl", hash = "sha256:6f0922593407cc673e7d8766b492c519f91bdc99f3080fe43dcec0a800d682a3"},
-    {file = "zope_event-6.0.tar.gz", hash = "sha256:0ebac894fa7c5f8b7a89141c272133d8c1de6ddc75ea4b1f327f00d1f890df92"},
+    {file = "zope_event-5.1.1-py3-none-any.whl", hash = "sha256:8d5ea7b992c42ce73a6fa9c2ba99a004c52cd9f05d87f3220768ef0329b92df7"},
+    {file = "zope_event-5.1.1.tar.gz", hash = "sha256:c1ac931abf57efba71a2a313c5f4d57768a19b15c37e3f02f50eb1536be12d4e"},
 ]
 
 [package.dependencies]
@@ -5324,7 +5324,7 @@ setuptools = ">=75.8.2"
 
 [package.extras]
 docs = ["Sphinx"]
-test = ["zope.testrunner (>=6.4)"]
+test = ["zope.testrunner"]
 
 [[package]]
 name = "zope-interface"
@@ -5491,4 +5491,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "2117f26c33c81586ee6a496c751cf8cc7152c3f6097842d36050c55bb18ba6a0"
+content-hash = "55ecd215691c8d772c7c3f54e39f70641e6dbb95c48e2eba2575f5b23cb1a556"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ martor = "^1.6.45"
 django-redis = ">=5.4,<6"
 google-cloud-storage = "^3.1.1"
 gevent = "^25.9.1"
-zope-event = "^6.0"
+zope-event = "5.1.1"
 
 [tool.poetry.group.dev.dependencies]
 colorama = "^0.4.6"


### PR DESCRIPTION
```
Sep 22 19:45:13 dev-planscape-service systemd[1301]: celery-impacts-worker-1.service: Scheduled restart job, restart counter is at 4.
Sep 22 19:45:13 dev-planscape-service systemd[1301]: Stopped celery-impacts-worker-1.
Sep 22 19:45:13 dev-planscape-service systemd[1301]: Started celery-impacts-worker-1.
Sep 22 19:45:13 dev-planscape-service python3[2628210]: Traceback (most recent call last):
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     return _run_code(code, main_globals, None,
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     exec(code, run_globals)
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/home/planscape/.local/lib/python3.10/site-packages/celery/__main__.py", line 19, in <module>
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     main()
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/home/planscape/.local/lib/python3.10/site-packages/celery/__main__.py", line 13, in main
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     maybe_patch_concurrency()
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/home/planscape/.local/lib/python3.10/site-packages/celery/__init__.py", line 140, in maybe_patch_concurrency
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     patcher()
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/home/planscape/.local/lib/python3.10/site-packages/celery/__init__.py", line 113, in _patch_gevent
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     gevent.monkey.patch_all()
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/home/planscape/.local/lib/python3.10/site-packages/gevent/monkey/__init__.py", line 686, in patch_all
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     from gevent import events
Sep 22 19:45:13 dev-planscape-service python3[2628210]:   File "/home/planscape/.local/lib/python3.10/site-packages/gevent/events.py", line 75, in <module>
Sep 22 19:45:13 dev-planscape-service python3[2628210]:     from zope.event import subscribers
Sep 22 19:45:13 dev-planscape-service python3[2628210]: ModuleNotFoundError: No module named 'zope.event'
Sep 22 19:45:13 dev-planscape-service systemd[1301]: celery-impacts-worker-1.service: Main process exited, code=exited, status=1/FAILURE
Sep 22 19:45:13 dev-planscape-service systemd[1301]: celery-impacts-worker-1.service: Failed with result 'exit-code'.
Sep 22 19:45:13 dev-planscape-service systemd[1301]: celery-impacts-worker-1.service: Scheduled restart job, restart counter is at 5.
Sep 22 19:45:13 dev-planscape-service systemd[1301]: Stopped celery-impacts-worker-1.
Sep 22 19:45:13 dev-planscape-service systemd[1301]: celery-impacts-worker-1.service: Start request repeated too quickly.
Sep 22 19:45:13 dev-planscape-service systemd[1301]: celery-impacts-worker-1.service: Failed with result 'exit-code'.
Sep 22 19:45:13 dev-planscape-service systemd[1301]: Failed to start celery-impacts-worker-1.
```