### PR TITLE
Services restart steps reorder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ status:
 reload:
 	${SYS_CTL} daemon-reload
 
-restart: reload stop stop-celery stop-forsys-server start start-celery stop-martin start-martin start-forsys-server
+restart: reload stop-celery stop stop-forsys-server stop-martin start-martin start-forsys-server start start-celery
 
 nginx-restart:
 	sudo service nginx restart


### PR DESCRIPTION
With celery warm shut down, it can take a while for celery tasks to stop. So, to minimize downtime celery tasks will be stopped first, than other services. Celery tasks will be started as last step, as it needs other services up to work properly