### PR TITLE
plan 2680 added feature flag in create_scenario service and bugfixes

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -277,7 +277,7 @@ def create_scenario(user: User, **kwargs) -> Scenario:
         action_object=scenario,
         target=scenario.planning_area,
     )
-    if treatment_goal and not feature_enabled("SCENARIO_DRAFTS"):
+    if not feature_enabled("SCENARIO_DRAFTS"):
         datalayers = treatment_goal.get_raster_datalayers()  # type: ignore
         truncated_stand_grid_keys = get_truncated_stands_grid_keys(
             scenario.planning_area, scenario.get_stand_size()

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -612,14 +612,6 @@ def validate_scenario_configuration(scenario: "Scenario") -> List[str]:
     if not scenario.treatment_goal:
         errors.append("Scenario has no Treatment Goal assigned.")
 
-    if (
-        scenario.planning_area.get_stands(stand_size=scenario.get_stand_size()).count()
-        == 0
-    ):
-        errors.append(
-            "No stands are available in this Planning Area for the selected `stand_size`."
-        )
-
     cfg = dict(getattr(scenario, "configuration", {}) or {})
 
     stand_size = cfg.get("stand_size")

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -298,7 +298,11 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer(instance, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
-        response_serializer = ScenarioV2Serializer(instance)
+        response_serializer = (
+            ScenarioV3Serializer(instance)
+            if feature_enabled("SCENARIO_DRAFTS")
+            else ScenarioV2Serializer(instance)
+        )
         return Response(response_serializer.data)
 
     @extend_schema(description="Trigger a ForSys run for this Scenario (V2 rules).")


### PR DESCRIPTION
Enabled creating scenarios without a treatment goal when SCENARIO_DRAFTS flag is active.
Simplified PATCH serializer to a minimal structure.
Removed redundant checks from validate_scenario_configuration to streamline validation logic.