### PR TITLE
Trigger of tasks to calculated stand metrics changed on Scenario execution

### DIFF
--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -3,6 +3,7 @@ import logging
 import rasterio
 from core.flags import feature_enabled
 from datasets.models import DataLayer
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 from gis.core import get_storage_session
@@ -251,7 +252,7 @@ def prepare_scenarios_for_forsys_and_run(scenario_id: int):
             log.info(
                 f"Calculating missing stand metrics for datalayer {datalayer.pk} and {len(missing_stand_ids)} stands"
             )
-            batch_size = 1000
+            batch_size = settings.STAND_METRICS_PAGE_SIZE
             for i in range(0, len(missing_stand_ids), batch_size):
                 batch_stand_ids = list(missing_stand_ids)[i : i + batch_size]
                 tasks.append(

--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -6,12 +6,13 @@ from datasets.models import DataLayer
 from django.db import transaction
 from django.utils import timezone
 from gis.core import get_storage_session
-from stands.models import Stand, StandSizeChoices
+from stands.models import Stand, StandMetric, StandSizeChoices
 from stands.services import (
     calculate_stand_vector_stats3,
     calculate_stand_zonal_stats,
     calculate_stand_zonal_stats_api,
     create_stands_for_geometry,
+    get_missing_stand_ids_for_datalayer,
 )
 from utils.cli_utils import call_forsys
 
@@ -28,6 +29,7 @@ from planning.services import (
     get_available_stand_ids,
 )
 from planscape.celery import app
+from celery import chain, chord, group
 from planscape.exceptions import ForsysException, ForsysTimeoutException
 
 log = logging.getLogger(__name__)
@@ -166,6 +168,30 @@ def async_calculate_stand_metrics(
         return
 
 
+@app.task(max_retries=3, retry_backoff=True)
+def async_calculate_stand_metrics_with_stand_list(
+    stand_ids: list,
+    datalayer_id: int,
+) -> None:
+    """
+    Calculates stand metrics based on stands list and datalayer.
+    """
+    try:
+        stands = Stand.objects.filter(id__in=stand_ids).order_by("grid_key")
+        datalayer: DataLayer = DataLayer.objects.get(pk=datalayer_id)
+        if feature_enabled("API_ZONAL_STATS"):
+            calculate_stand_zonal_stats_api(stands, datalayer)
+        else:
+            with rasterio.Env(get_storage_session()):
+                calculate_stand_zonal_stats(stands, datalayer)
+    except PlanningArea.DoesNotExist:
+        log.warning(f"PlanningArea with id {datalayer_id} does not exist.")
+        return
+    except DataLayer.DoesNotExist:
+        log.warning(f"DataLayer with id {datalayer_id} does not exist.")
+        return
+
+
 @app.task()
 def async_pre_forsys_process(scenario_id: int) -> None:
     scenario = Scenario.objects.get(id=scenario_id)
@@ -197,6 +223,46 @@ def async_pre_forsys_process(scenario_id: int) -> None:
         scenario = Scenario.objects.select_for_update().get(id=scenario_id)
         scenario.forsys_input = forsys_input  # type: ignore
         scenario.save(update_fields=["forsys_input", "updated_at"])
+
+
+@app.task()
+def prepare_scenarios_for_forsys_and_run(scenario_id: int):
+    log.info(f"Preparing scenario {scenario_id} for Forsys run.")
+    scenario = Scenario.objects.get(id=scenario_id)
+    if scenario.result_status != ScenarioResultStatus.PENDING:
+        log.info(
+            f"Scenario {scenario_id} is not in a pending state. Current status: {scenario.result_status}"
+        )
+        return
+
+    treatment_goal = scenario.treatment_goal
+
+    datalayers = treatment_goal.get_raster_datalayers()  # type: ignore
+
+    tasks = [async_pre_forsys_process.si(scenario_id=scenario.pk)]
+    for datalayer in datalayers:
+        missing_stand_ids = get_missing_stand_ids_for_datalayer(
+            geometry=scenario.planning_area.geometry,
+            stand_size=scenario.get_stand_size(),
+            datalayer=datalayer,
+        )
+
+        if missing_stand_ids:
+            log.info(
+                f"Calculating missing stand metrics for datalayer {datalayer.pk} and {len(missing_stand_ids)} stands"
+            )
+            batch_size = 1000
+            for i in range(0, len(missing_stand_ids), batch_size):
+                batch_stand_ids = list(missing_stand_ids)[i : i + batch_size]
+                tasks.append(
+                    async_calculate_stand_metrics_with_stand_list.si(
+                        stand_ids=batch_stand_ids,
+                        datalayer_id=datalayer.pk,
+                    )
+                )
+
+    lambda: chord(tasks)(async_forsys_run.si(scenario_id=scenario.pk))
+    log.info(f"Prepared scenario {scenario_id} for Forsys run and triggered the run.")
 
 
 @app.task()

--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -6,7 +6,7 @@ from datasets.models import DataLayer
 from django.db import transaction
 from django.utils import timezone
 from gis.core import get_storage_session
-from stands.models import Stand, StandMetric, StandSizeChoices
+from stands.models import Stand, StandSizeChoices
 from stands.services import (
     calculate_stand_vector_stats3,
     calculate_stand_zonal_stats,
@@ -29,7 +29,7 @@ from planning.services import (
     get_available_stand_ids,
 )
 from planscape.celery import app
-from celery import chain, chord, group
+from celery import chord
 from planscape.exceptions import ForsysException, ForsysTimeoutException
 
 log = logging.getLogger(__name__)

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -50,8 +50,8 @@ class CreateScenarioTest(APITransactionTestCase):
             "max_treatment_area_ratio": 40000,
         }
 
-    @mock.patch("planning.services.chord", autospec=True)
-    def test_create_with_explicit_treatment_goal(self, chord_mock):
+    @mock.patch("planning.tasks.prepare_scenarios_for_forsys_and_run", autospec=True)
+    def test_create_with_explicit_treatment_goal(self, task_mock):
         configuration = self.configuration.copy()
         configuration.pop("question_id")
         payload = {
@@ -70,7 +70,7 @@ class CreateScenarioTest(APITransactionTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIsNotNone(response.json().get("id"))
-        self.assertEqual(chord_mock.call_count, 1)
+        self.assertEqual(task_mock.delay.call_count, 1)
         self.assertEqual(1, Scenario.objects.count())
         scenario = Scenario.objects.get()
         self.assertEqual(scenario.treatment_goal, self.treatment_goal)

--- a/src/planscape/stands/services.py
+++ b/src/planscape/stands/services.py
@@ -348,7 +348,7 @@ def get_missing_stand_ids_for_datalayer(
     that are within the geometry and of the given size, but do not have a metric
     for the given datalayer.
     """
-    
+
     query = """
     SELECT s.id FROM stands_stand s
     LEFT OUTER JOIN stands_standmetric sm


### PR DESCRIPTION
Getting only stands that requires Stand Metrics calculation to be enqueued to tasks.