### PR TITLE
disable opacity transition animations on scenario stands

### DIFF
--- a/src/interface/src/app/maplibre-map/scenario-stands/scenario-stands.component.ts
+++ b/src/interface/src/app/maplibre-map/scenario-stands/scenario-stands.component.ts
@@ -119,6 +119,7 @@ export class ScenarioStandsComponent implements OnInit, OnDestroy {
       ] as const;
 
       return {
+        'fill-opacity-transition': { duration: 0 },
         'fill-color': [
           'case',
           hidden,
@@ -141,6 +142,7 @@ export class ScenarioStandsComponent implements OnInit, OnDestroy {
             this.excludedKey
           ),
           'line-opacity': opacity,
+          'line-opacity-transition': { duration: 0 },
         }) as any
     )
   );
@@ -149,6 +151,7 @@ export class ScenarioStandsComponent implements OnInit, OnDestroy {
     map(
       (opacity) =>
         ({
+          'fill-opacity-transition': { duration: 0 },
           'fill-pattern': 'exclude-pattern', // constant pattern
           'fill-opacity': this.featureStatePaint(opacity, 0, this.excludedKey),
         }) as any
@@ -159,6 +162,7 @@ export class ScenarioStandsComponent implements OnInit, OnDestroy {
     map(
       (opacity) =>
         ({
+          'fill-opacity-transition': { duration: 0 },
           'fill-pattern': 'thresholds-pattern', // constant pattern
           'fill-opacity': this.featureStatePaint(
             opacity,


### PR DESCRIPTION
There are some shortcomings with using feature state + patterns + opacity, where the patterns do not have the transition animation the same way as fills do (or rather things not using feature state) and it looks kinda weird / out of sync.

This pr disables the default opacity transitions making the layers sync better when moving opacity

