### PR TITLE
Login screen resizing

### DIFF
--- a/src/interface/src/app/standalone/login/login.component.scss
+++ b/src/interface/src/app/standalone/login/login.component.scss
@@ -4,6 +4,7 @@
 
 :host {
   display: flex;
+  height: 100%;
 
   ::ng-deep .mat-form-field-outline {
     background-color: $color-light-gray;
@@ -110,6 +111,8 @@ mat-form-field {
 .info-text-container {
   background-color: $color-soft-purple;
   width: 50%;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .login-form-buttons {


### PR DESCRIPTION
Avoids the white space on this screen:
<img width="661" height="505" alt="Screenshot From 2025-09-28 19-21-39" src="https://github.com/user-attachments/assets/30895521-1d9a-4939-9541-8e6be6a18e15" />

<img width="689" height="508" alt="Screenshot From 2025-09-28 19-21-05" src="https://github.com/user-attachments/assets/d261e683-ee7e-4be3-b53a-649cfecc063f" />

And on smaller windows, rather than letting the large text on the right extend beyond the height, just sets it to scroll
![Uploading Screenshot From 2025-09-28 19-25-16.png…]()


