### PR TITLE
Disable GeoPackage button on processing state

### DIFF
--- a/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.html
+++ b/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.html
@@ -25,7 +25,7 @@
     *ngIf="geoPackageStatus"
     variant="primary"
     class="footer-button"
-    [disabled]="downloadingScenario || geoPackageStatus === 'PENDING'"
+    [disabled]="downloadingScenario || geoPackageStatus === 'PENDING' || geoPackageStatus === 'PROCESSING'"
     (click)="handleButton()">
     {{ buttonLabels[geoPackageStatus] || 'Generating GeoPackage' }}
   </button>

--- a/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.html
+++ b/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.html
@@ -25,7 +25,11 @@
     *ngIf="geoPackageStatus"
     variant="primary"
     class="footer-button"
-    [disabled]="downloadingScenario || geoPackageStatus === 'PENDING' || geoPackageStatus === 'PROCESSING'"
+    [disabled]="
+      downloadingScenario ||
+      geoPackageStatus === 'PENDING' ||
+      geoPackageStatus === 'PROCESSING'
+    "
     (click)="handleButton()">
     {{ buttonLabels[geoPackageStatus] || 'Generating GeoPackage' }}
   </button>

--- a/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.ts
+++ b/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.ts
@@ -36,7 +36,7 @@ export class ScenarioDownloadFooterComponent {
     private fileServerService: FileSaverService,
     private snackbar: MatSnackBar,
     private dialog: MatDialog
-  ) {}
+  ) { }
 
   @Input() scenarioId!: number | undefined;
   @Input() scenarioName!: string;
@@ -56,9 +56,10 @@ export class ScenarioDownloadFooterComponent {
   handleButton() {
     if (this.geoPackageStatus === 'SUCCEEDED') {
       this.handleDownload();
-    } else {
+    } else if (this.geoPackageStatus === 'FAILED') {
       this.displayFailureModal();
     }
+    // other states should be disabled, so do nothing
   }
 
   handleDownload() {

--- a/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.ts
+++ b/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.ts
@@ -36,7 +36,7 @@ export class ScenarioDownloadFooterComponent {
     private fileServerService: FileSaverService,
     private snackbar: MatSnackBar,
     private dialog: MatDialog
-  ) { }
+  ) {}
 
   @Input() scenarioId!: number | undefined;
   @Input() scenarioName!: string;


### PR DESCRIPTION
A small fix to ensure that the Download GeoPackage/ Generating GeoPackage button is disabled on _both_ 'PENDING' and 'PROCESSING' states. And for certainty, also ensures we don't display the failure state when something hasn't explicitly FAILED.