### PR TITLE
update patch steps for scenario

### DIFF
--- a/src/interface/src/app/scenario/new-scenario.state.ts
+++ b/src/interface/src/app/scenario/new-scenario.state.ts
@@ -183,4 +183,12 @@ export class NewScenarioState {
   setBaseStandsLoaded(loaded: boolean) {
     this.baseStandsReady$.next(loaded);
   }
+
+  getSlopeId() {
+    return this.slopeId;
+  }
+
+  getDistanceToRoadsId() {
+    return this.distanceToRoadsId;
+  }
 }

--- a/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.html
+++ b/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.html
@@ -36,7 +36,7 @@
       (selectedIndexChange)="stepChanged($event)"
       (finished)="onFinish()"
       [outerForm]="form"
-      [savingStep]="creatingScenario"
+      [savingStep]="awaitingBackendResponse"
       [disabled]="(loading$ | async) || false">
       <sg-step>
         <app-step1 #step1></app-step1>

--- a/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.ts
+++ b/src/interface/src/app/scenario/scenario-creation/scenario-creation.component.ts
@@ -5,7 +5,15 @@ import { DataLayersComponent } from '../../data-layers/data-layers/data-layers.c
 import { StepsComponent } from '@styleguide';
 import { CdkStepperModule } from '@angular/cdk/stepper';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { firstValueFrom, map, Observable, of, skip, take } from 'rxjs';
+import {
+  firstValueFrom,
+  map,
+  Observable,
+  of,
+  skip,
+  take,
+  catchError,
+} from 'rxjs';
 import { DataLayersStateService } from '../../data-layers/data-layers.state.service';
 import {
   AbstractControl,
@@ -19,7 +27,12 @@ import { ScenarioService } from '@services';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LegacyMaterialModule } from 'src/app/material/legacy-material.module';
 import { nameMustBeNew } from 'src/app/validators/unique-scenario';
-import { ScenarioCreation } from '@types';
+import {
+  ScenarioConfig,
+  ScenarioConfigPayload,
+  ScenarioDraftPayload,
+  ScenarioCreation,
+} from '@types';
 import { GoalOverlayService } from '../../plan/goal-overlay/goal-overlay.service';
 import { Step1Component } from '../step1/step1.component';
 import { CanComponentDeactivate } from '@services/can-deactivate.guard';
@@ -74,8 +87,11 @@ export class ScenarioCreationComponent
   @ViewChild('tabGroup') tabGroup!: MatTabGroup;
 
   config: Partial<ScenarioCreation> = {};
+  draftConfig: Partial<ScenarioDraftPayload> = {};
 
   planId = this.route.snapshot.data['planId'];
+  scenarioId = this.route.snapshot.data['scenarioId'];
+
   plan$ = this.planState.currentPlan$;
   acres$ = this.plan$.pipe(map((plan) => (plan ? plan.area_acres : 0)));
   finished = false;
@@ -84,7 +100,7 @@ export class ScenarioCreationComponent
     scenarioName: new FormControl('', [Validators.required]),
   });
 
-  creatingScenario = false;
+  awaitingBackendResponse = false;
 
   isDynamicMapEnabled = this.featureService.isFeatureEnabled(
     'DYNAMIC_SCENARIO_MAP'
@@ -142,8 +158,38 @@ export class ScenarioCreationComponent
       label: 'Scenario: New Scenario',
       backUrl: getPlanPath(this.planId),
     });
-    // Adding scenario name validator
-    this.refreshScenarioNameValidator();
+    if (this.featureService.isFeatureEnabled('SCENARIO_DRAFTS')) {
+      if (this.scenarioId) {
+        this.loadExistingScenario();
+      }
+    } else {
+      // Adding scenario name validator
+      this.refreshScenarioNameValidator();
+    }
+  }
+
+  loadExistingScenario() {
+    this.scenarioService
+      .getScenario(this.scenarioId)
+      .pipe(untilDestroyed(this))
+      .subscribe((scenario) => {
+        this.form.controls.scenarioName.setValue(scenario.name);
+        const currentConfig = this.convertSavedConfigToNewConfig(
+          scenario.configuration
+        );
+        this.newScenarioState.setScenarioConfig(currentConfig);
+      });
+  }
+
+  convertSavedConfigToNewConfig(
+    config: ScenarioConfig
+  ): Partial<ScenarioConfigPayload> {
+    const newState = Object.fromEntries(
+      Object.entries(config)
+        .filter(([_, value]) => value != null)
+        .map(([key, value]) => [key, value as NonNullable<typeof value>])
+    );
+    return newState as Partial<ScenarioCreation>;
   }
 
   canDeactivate(): Observable<boolean> | boolean {
@@ -155,41 +201,95 @@ export class ScenarioCreationComponent
   }
 
   saveStep(data: Partial<ScenarioCreation>) {
-    // if dynamic map is not able just go forward.
-    // remove this once dynamic map enabled.
-    if (!this.isDynamicMapEnabled) {
-      this.config = { ...this.config, ...data };
-      this.newScenarioState.setScenarioConfig(this.config);
-      return of(true);
-    }
+    if (this.featureService.isFeatureEnabled('SCENARIO_DRAFTS')) {
+      this.draftConfig = { ...this.draftConfig, ...data };
+      return this.savePatch(this.draftConfig);
+    } else {
+      // if dynamic map is not able just go forward.
+      // remove this once dynamic map enabled.
+      if (!this.isDynamicMapEnabled) {
+        this.config = { ...this.config, ...data };
+        this.newScenarioState.setScenarioConfig(this.config);
+        return of(true);
+      }
 
-    return this.newScenarioState.isValidToGoNext$.pipe(
-      take(1),
-      map((valid) => {
-        if (valid) {
-          this.config = { ...this.config, ...data };
-          this.newScenarioState.setScenarioConfig(this.config);
-        } else {
-          this.dialog.open(ScenarioErrorModalComponent, {
-            data: {
-              title: 'Invalid Scenario Configuration',
-              message:
-                'Scenario must have Potential Treatable Area in order to move forward with planning. Update your selections to allow for available stands',
-            },
-          });
-        }
-        return valid;
-      })
-    );
+      return this.newScenarioState.isValidToGoNext$.pipe(
+        take(1),
+        map((valid) => {
+          if (valid) {
+            this.config = { ...this.config, ...data };
+            this.newScenarioState.setScenarioConfig(this.config);
+          } else {
+            this.dialog.open(ScenarioErrorModalComponent, {
+              data: {
+                title: 'Invalid Scenario Configuration',
+                message:
+                  'Scenario must have Potential Treatable Area in order to move forward with planning. Update your selections to allow for available stands',
+              },
+            });
+          }
+          return valid;
+        })
+      );
+    }
+  }
+
+  savePatch(data: Partial<ScenarioDraftPayload>): Observable<boolean> {
+    this.newScenarioState.setScenarioConfig(this.config);
+
+    return this.scenarioService
+      .patchScenarioConfig(this.scenarioId, this.draftConfig)
+      .pipe(
+        map((result) => {
+          if (result) {
+            return true; // Return true if the patch was successful
+          }
+          return false; // Return false if the result is not as expected
+        }),
+        catchError((e) => {
+          console.error('Patch error:', e);
+          return of(false); // Return false in case of an error
+        })
+      );
   }
 
   async onFinish() {
+    if (this.featureService.isFeatureEnabled('SCENARIO_DRAFTS')) {
+      this.runScenario();
+    } else {
+      this.finishFromFullConfig();
+    }
+  }
+
+  async runScenario() {
+    this.awaitingBackendResponse = true;
+    this.scenarioService.runScenario(this.scenarioId).subscribe({
+      next: (result) => {
+        this.finished = true; // ensure we don't get an alert when we navigate away
+        this.router.navigate([
+          'plan',
+          result.planning_area,
+          'scenario',
+          result.id,
+        ]);
+      },
+      error: (e) => {
+        this.dialog.open(ScenarioErrorModalComponent);
+        this.awaitingBackendResponse = false;
+      },
+      complete: () => {
+        this.awaitingBackendResponse = false;
+      },
+    });
+  }
+
+  async finishFromFullConfig() {
     const payload = getScenarioCreationPayloadScenarioCreation({
       ...this.config,
       name: this.form.getRawValue().scenarioName || '',
       planning_area: this.planId,
     });
-    this.creatingScenario = true;
+    this.awaitingBackendResponse = true;
     // Firing scenario name validation before finish
     const validated = await this.refreshScenarioNameValidator();
 
@@ -203,11 +303,11 @@ export class ScenarioCreationComponent
           this.dialog.open(ScenarioErrorModalComponent);
         },
         complete: () => {
-          this.creatingScenario = false;
+          this.awaitingBackendResponse = false;
         },
       });
     } else {
-      this.creatingScenario = false;
+      this.awaitingBackendResponse = false;
     }
   }
 

--- a/src/interface/src/app/scenario/step1/step1.component.ts
+++ b/src/interface/src/app/scenario/step1/step1.component.ts
@@ -96,7 +96,22 @@ export class Step1Component extends StepDirective<ScenarioCreation> {
     return b.key.localeCompare(a.key);
   }
 
-  getData() {
+  getPostData() {
     return this.form.value;
+  }
+
+  getDraftData() {
+    return {
+      treatment_goal: this.form.value.treatment_goal,
+      configuration: { stand_size: this.form.value.stand_size },
+    };
+  }
+
+  getData() {
+    if (this.featuresService.isFeatureEnabled('SCENARIO_DRAFTS')) {
+      return this.getDraftData();
+    } else {
+      return this.getPostData();
+    }
   }
 }

--- a/src/interface/src/app/scenario/step2/step2.component.ts
+++ b/src/interface/src/app/scenario/step2/step2.component.ts
@@ -12,6 +12,7 @@ import { StepDirective } from '../../../styleguide/steps/step.component';
 import { IdNamePair, ScenarioCreation } from '@types';
 import { NewScenarioState } from '../new-scenario.state';
 import { ForsysService } from '@services/forsys.service';
+import { FeatureService } from 'src/app/features/feature.service';
 
 @Component({
   selector: 'app-step2',
@@ -32,7 +33,8 @@ export class Step2Component
 {
   constructor(
     private newScenarioState: NewScenarioState,
-    private forsysService: ForsysService
+    private forsysService: ForsysService,
+    private featureService: FeatureService
   ) {
     super();
   }
@@ -71,7 +73,21 @@ export class Step2Component
     return selectedKeys;
   }
 
-  getData() {
+  getDraftData() {
+    return {
+      configuration: { excluded_areas: this.getSelectedExcludedAreas() },
+    };
+  }
+
+  getPostData() {
     return { excluded_areas: this.getSelectedExcludedAreas() };
+  }
+
+  getData() {
+    if (this.featureService.isFeatureEnabled('SCENARIO_DRAFTS')) {
+      return this.getDraftData();
+    } else {
+      return this.getPostData();
+    }
   }
 }

--- a/src/interface/src/app/scenario/step3/step3.component.ts
+++ b/src/interface/src/app/scenario/step3/step3.component.ts
@@ -13,7 +13,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { SectionComponent } from '@styleguide';
 import { NgxMaskModule } from 'ngx-mask';
 import { StepDirective } from 'src/styleguide/steps/step.component';
-import { NamedConstraint, ScenarioCreation } from '@types';
+import { NamedConstraint, ScenarioCreation, Constraint } from '@types';
 import { NewScenarioState } from '../new-scenario.state';
 import { debounceTime } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
@@ -58,7 +58,38 @@ export class Step3Component
     super();
   }
 
+  getDraftData() {
+    const constraintsData: Constraint[] = [];
+
+    if (this.form.value.max_slope && this.newScenarioState.getSlopeId()) {
+      constraintsData.push({
+        datalayer: this.newScenarioState.getSlopeId(),
+        operator: 'lt',
+        value: this.form.value.max_slope,
+      });
+    }
+    if (
+      this.form.value.min_distance_from_road &&
+      this.newScenarioState.getDistanceToRoadsId()
+    ) {
+      constraintsData.push({
+        datalayer: this.newScenarioState.getDistanceToRoadsId(),
+        operator: 'lte',
+        value: this.form.value.min_distance_from_road,
+      });
+    }
+    return { configuration: { constraints: constraintsData } };
+  }
+
   getData() {
+    if (this.featureService.isFeatureEnabled('SCENARIO_DRAFTS')) {
+      return this.getDraftData();
+    } else {
+      return this.getPostData();
+    }
+  }
+
+  getPostData() {
     return this.form.value;
   }
 

--- a/src/interface/src/app/scenario/step4/step4.component.ts
+++ b/src/interface/src/app/scenario/step4/step4.component.ts
@@ -169,8 +169,20 @@ export class Step4Component
     };
   }
 
-  getData() {
+  getDraftData() {
+    return { configuration: { targets: this.form.value } };
+  }
+
+  getPostData() {
     return this.form.value;
+  }
+
+  getData() {
+    if (this.featureService.isFeatureEnabled('SCENARIO_DRAFTS')) {
+      return this.getDraftData();
+    } else {
+      return this.getPostData();
+    }
   }
 
   // This enables and disables fields, based on what our current selection is

--- a/src/interface/src/app/services/scenario.service.ts
+++ b/src/interface/src/app/services/scenario.service.ts
@@ -6,6 +6,7 @@ import {
   Constraint,
   Scenario,
   ScenarioCreationPayload,
+  ScenarioDraftPayload,
 } from '@types';
 import { CreateScenarioError } from './errors';
 import { environment } from '../../environments/environment';
@@ -42,11 +43,24 @@ export class ScenarioService {
     });
   }
 
-  createScenarioFromName(name: string) {
-    const scenarioParameters = { name: name };
+  //TODO: make planId not optional
+  createScenarioFromName(name: string, planId?: number) {
+    const scenarioParameters = { name: name, planning_area: planId };
     return this.http.post<Scenario>(this.v2Path, scenarioParameters, {
       withCredentials: true,
     });
+  }
+
+  runScenario(scenarioId: number) {
+    // actually run the scenario
+    const runUrl = `${this.v2Path}${scenarioId}/run/`;
+    return this.http.post<Scenario>(
+      runUrl,
+      {},
+      {
+        withCredentials: true,
+      }
+    );
   }
 
   /** Creates a scenario in the backend with stepper Returns scenario ID. */
@@ -64,6 +78,29 @@ export class ScenarioService {
             'Please change your settings and try again.';
           throw new CreateScenarioError(
             'Your scenario config is invalid. ' + message
+          );
+        })
+      );
+  }
+
+  //sends a partial scenario configuration using PATCH
+  // returns success or failure, based on backend results
+  patchScenarioConfig(
+    scenarioId: number,
+    configPayload: Partial<ScenarioDraftPayload>
+  ) {
+    return this.http
+      .patch<Scenario>(this.v2Path + scenarioId, configPayload, {
+        withCredentials: true,
+      })
+      .pipe(
+        catchError((error) => {
+          //TODO: handle specific field error formats in step form
+          // We probably need to coordinate backend formats / messages here
+          const message =
+            error.error?.global?.[0] || 'Failed to save configuration';
+          throw new CreateScenarioError(
+            'Scenario Config is invalid. ' + message
           );
         })
       );

--- a/src/interface/src/app/types/scenario.types.ts
+++ b/src/interface/src/app/types/scenario.types.ts
@@ -66,25 +66,42 @@ export interface ScenarioResult {
   };
 }
 
-export interface ScenarioCreation extends ScenarioConfigPayload {
+export interface ScenarioCreation
+  extends ScenarioConfigPayload,
+    ScenarioDraftPayload {
   treatment_goal: number;
   excluded_areas: number[];
   name: string;
   planning_area: number;
 }
 
+export interface ScenarioDraftPayload {
+  configuration: {
+    excluded_areas: number[];
+    stand_size: STAND_SIZE;
+    includes: number[];
+    constraints: NamedConstraint[]; // the constraints for the scenario, like max slope or distance to roads
+    targets: {
+      estimated_cost: number;
+      max_area: number;
+      max_budget: number;
+      max_project_count: number;
+    };
+  };
+}
+
 export interface ScenarioConfigPayload {
+  stand_size: STAND_SIZE;
   estimated_cost: number;
   excluded_areas: number[];
   max_area: number;
   max_slope: number | null;
   min_distance_from_road: number | null;
-  stand_size: STAND_SIZE;
   max_budget?: number;
 }
 
 export interface ScenarioCreationPayload {
-  configuration: ScenarioConfigPayload;
+  configuration: ScenarioConfigPayload | ScenarioDraftPayload;
   name: string;
   planning_area: number;
   treatment_goal: number;
@@ -179,15 +196,15 @@ export interface CategorizedScenarioGoals {
 
 export interface Constraint {
   datalayer: number;
-  operator: 'eq' | 'lt' | 'lte' | 'gt' | 'gte';
-  value: number; // be supports string
+  operator: 'eq' | 'lt' | 'lte' | 'gt' | 'gte' | 'in' | 'neq';
+  value: number; // backend supports string
 }
 
 // TODO - remove this and use `Constraint` when we implement dynamic constraints
 export interface NamedConstraint {
   name: string;
-  operator: 'eq' | 'lt' | 'lte' | 'gt' | 'gte';
-  value: number; // be supports string
+  operator: 'eq' | 'lt' | 'lte' | 'gt' | 'gte' | 'in' | 'neq';
+  value: number; // backend supports string
 }
 
 export interface AvailableStands {


### PR DESCRIPTION
This PR:
- adds a ScenarioDraftPayload type for the new payload format
- adds a featureflagged saveDraft() to each Step that's called from save() in FFd version
- adds interface for the new patch endpoint, to incrementally update the configuration
- adds interface for the new "run" endpoint, to actually run the scenario with Forsys
- (small thing) renames creatingScenario attribute to awaitingBackendResponse, since it's multipurpose now
