### PR TITLE
Add draft only endpoints [WIP]

### DIFF
--- a/src/planscape/planning/permissions.py
+++ b/src/planscape/planning/permissions.py
@@ -17,7 +17,7 @@ class ScenarioViewPermission(PlanscapePermission):
         if not self.is_authenticated(request):
             return False
         match view.action:
-            case "create":
+            case "create" | "create_draft":
                 pa_id = request.data.get("planning_area") or None
                 if not pa_id:
                     return False

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -853,10 +853,8 @@ class PatchScenarioV3Serializer(serializers.ModelSerializer):
         allow_null=True,
         help_text="Treatment goal of the scenario.",
     )
-    configuration = serializers.DictField(
-        required=False,
-        help_text="Supports stand_size, included_areas, excluded_areas, constraints, targets, seed.",
-    )
+
+    configuration = ConfigurationV3Serializer
 
     class Meta:
         model = Scenario

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -248,7 +248,7 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             headers=headers,
         )
 
-    @action(detail=False,methods=['post'],url_path="draft")
+    @action(detail=False, methods=["post"], url_path="draft")
     def create_draft(self, request):
         serializer = self.get_serializer(data=request.data)
         try:
@@ -278,11 +278,9 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
     # TODO: create a 'draft' get/list endpoint
-    @action(detail=False, methods=['get'], url_path='draft')
+    @action(detail=False, methods=["get"], url_path="draft")
     def get_drafts(self, request):
-        # Logic to retrieve drafts
-        # drafts = self.queryset.filter(status='DRAFT')  # Example filter
-        serializer = ScenarioV3Serializer(drafts, many=True)  # Use a serializer for drafts
+        serializer = ScenarioV3Serializer(drafts, many=True)
         return Response(serializer.data)
 
     def perform_destroy(self, instance):
@@ -331,12 +329,12 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     @action(methods=["patch"], detail=True, url_path="draft")
     def patch_draft(self, request, *args, **kwargs):
         instance = self.get_object()
-        serializer = PatchScenarioV3Serializer(instance, data=request.data, partial=True)
+        serializer = PatchScenarioV3Serializer(
+            instance, data=request.data, partial=True
+        )
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
-        response_serializer = (
-            ScenarioV3Serializer(instance)
-        )
+        response_serializer = ScenarioV3Serializer(instance)
         return Response(response_serializer.data)
 
     # This is only called by DRAFT-enabled frontend

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -247,7 +247,7 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             headers=headers,
         )
 
-    @action(detail=False, methods=['post'], url_path="draft")
+    @action(detail=False,methods=['post'],url_path="draft")
     def create_draft(self, request):
         serializer = CreateScenarioV3Serializer(data=request.data, context={'request': request})
         try:
@@ -276,6 +276,12 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
+    @action(detail=False, methods=['get'], url_path='draft')
+    def get_drafts(self, request):
+        # Logic to retrieve drafts
+        drafts = self.queryset.filter(status='DRAFT')  # Example filter
+        serializer = DraftScenarioSerializer(drafts, many=True)  # Use a serializer for drafts
+        return Response(serializer.data)
 
     def perform_destroy(self, instance):
         delete_scenario(

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -209,21 +209,9 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     serializer_class = ScenarioSerializer
     serializer_classes = {
         "list": ListScenarioSerializer,
-        "create": (
-            CreateScenarioV3Serializer
-            if feature_enabled("SCENARIO_DRAFTS")
-            else CreateScenarioV2Serializer
-        ),
-        "retrieve": (
-            ScenarioV3Serializer
-            if feature_enabled("SCENARIO_DRAFTS")
-            else ScenarioV2Serializer
-        ),
-        "partial_update": (
-            PatchScenarioV3Serializer
-            if feature_enabled("SCENARIO_DRAFTS")
-            else UpsertConfigurationV2Serializer
-        ),
+        "create": CreateScenarioV2Serializer,
+        "retrieve": ScenarioV2Serializer,
+        "partial_update": UpsertConfigurationV2Serializer
     }
 
     filterset_class = ScenarioFilter
@@ -250,7 +238,22 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         scenario = create_scenario(**serializer.validated_data)
 
-        if feature_enabled("SCENARIO_DRAFTS"):
+        out_serializer = ScenarioV2Serializer(instance=scenario)
+
+        headers = self.get_success_headers(out_serializer.data)
+        return Response(
+            out_serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
+
+    @action(detail=False, methods=['post'], url_path="draft")
+    def create_draft(self, request):
+        serializer = CreateScenarioV3Serializer(data=request.data, context={'request': request})
+        try:
+            serializer.is_valid(raise_exception=True)
+            scenario = create_scenario(**serializer.validated_data)
+
             scenario_result, created = ScenarioResult.objects.get_or_create(
                 scenario=scenario,
                 defaults={
@@ -262,14 +265,17 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
                 scenario_result.save()
             scenario.refresh_from_db()
 
-        out_serializer = ScenarioV2Serializer(instance=scenario)
+            out_serializer = ScenarioV3Serializer(instance=scenario)
 
-        headers = self.get_success_headers(out_serializer.data)
-        return Response(
-            out_serializer.data,
-            status=status.HTTP_201_CREATED,
-            headers=headers,
-        )
+            headers = self.get_success_headers(out_serializer.data)
+            return Response(
+                out_serializer.data,
+                status=status.HTTP_201_CREATED,
+                headers=headers,
+            )
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
 
     def perform_destroy(self, instance):
         delete_scenario(
@@ -311,21 +317,27 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer(instance, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
+        response_serializer = ScenarioV2Serializer(instance)
+        return Response(response_serializer.data)
+
+    @action(methods=["patch"], detail=True, url_path="draft")
+    def patch_draft(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = PatchScenarioV3Serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
         response_serializer = (
             ScenarioV3Serializer(instance)
-            if feature_enabled("SCENARIO_DRAFTS")
-            else ScenarioV2Serializer(instance)
         )
         return Response(response_serializer.data)
 
+    # This is only called by DRAFT-enabled frontend
     @extend_schema(description="Trigger a ForSys run for this Scenario (V2 rules).")
     @action(methods=["post"], detail=True, url_path="run")
     def run(self, request, pk=None):
         scenario = self.get_object()
-
-        if feature_enabled("SCENARIO_DRAFTS") and scenario.results is not None:
-            scenario.results.status = ScenarioResultStatus.PENDING
-            scenario.results.save()
+        scenario.results.status = ScenarioResultStatus.PENDING
+        scenario.results.save()
 
         errors = validate_scenario_configuration(scenario)
         if errors:

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -251,31 +251,28 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     @action(detail=False, methods=["post"], url_path="draft")
     def create_draft(self, request):
         serializer = self.get_serializer(data=request.data)
-        try:
-            serializer.is_valid(raise_exception=True)
-            scenario = create_scenario(**serializer.validated_data)
+        serializer.is_valid(raise_exception=True)
+        scenario = create_scenario(**serializer.validated_data)
 
-            scenario_result, created = ScenarioResult.objects.get_or_create(
-                scenario=scenario,
-                defaults={
-                    "status": ScenarioResultStatus.DRAFT,
-                },
-            )
-            if not created:
-                scenario_result.status = ScenarioResultStatus.DRAFT
-                scenario_result.save()
-            scenario.refresh_from_db()
+        scenario_result, created = ScenarioResult.objects.get_or_create(
+            scenario=scenario,
+            defaults={
+                "status": ScenarioResultStatus.DRAFT,
+            },
+        )
+        if not created:
+            scenario_result.status = ScenarioResultStatus.DRAFT
+            scenario_result.save()
+        scenario.refresh_from_db()
 
-            out_serializer = ScenarioV3Serializer(instance=scenario)
+        out_serializer = ScenarioV3Serializer(instance=scenario)
 
-            headers = self.get_success_headers(out_serializer.data)
-            return Response(
-                out_serializer.data,
-                status=status.HTTP_201_CREATED,
-                headers=headers,
-            )
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        headers = self.get_success_headers(out_serializer.data)
+        return Response(
+            out_serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
 
     # TODO: create a 'draft' get/list endpoint
     @action(detail=False, methods=["get"], url_path="draft")
@@ -337,7 +334,6 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         response_serializer = ScenarioV3Serializer(instance)
         return Response(response_serializer.data)
 
-    # This is only called by DRAFT-enabled frontend
     @extend_schema(description="Trigger a ForSys run for this Scenario (V2 rules).")
     @action(methods=["post"], detail=True, url_path="run")
     def run(self, request, pk=None):


### PR DESCRIPTION
This WIP PR adds separate endpoints just for `draft` work, so we don't need to enable to SCENARIO_DRAFTS flag on the backend, in order to do frontend work.

So far, there's a create draft scenario endpoint at:
POST `planscape-backend/v2/scenarios/draft/`

And a patch endpoint at:
PATCH `planscape-backend/v2/scenarios/{:scenario_id}/draft/`

And updated tests for each.

TO DO:
1. I think we will also need GET endpoints, as well, since these use so-called "v3" serializers, which will have slightly different configuration data. See the embedded feature flag in ListScenarioSerializer. The simplest approach may just to add a `ListScenarioV3Serializer` as an alternative.

2.There are feature flag tests embedded in filters (for ordering) that may need an update, so again, maybe adding a `ScenarioV3OrderingFilter`  is the easiest option.

3. Some services also use the feature flag, so maybe these should be updated, as well.
