### PR TITLE
fix(planning): Fix delete Planning Area as co-Owner (owner that did not create PA)

### DIFF
--- a/src/planscape/collaboration/migrations/0005_auto_20251007_1624.py
+++ b/src/planscape/collaboration/migrations/0005_auto_20251007_1624.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+from collaboration.models import Role
+
+
+DELETE_PLANNING_AREA_PERMISSION = "delete_planningarea"
+
+
+def forwards(apps, schema_editor):
+    Permission = apps.get_model("collaboration", "Permissions")
+    Permission.objects.update_or_create(
+        role=Role.OWNER, permission=DELETE_PLANNING_AREA_PERMISSION
+    )
+
+
+def backwards(apps, schema_editor):
+    Permission = apps.get_model("collaboration", "Permissions")
+    Permission.objects.filter(
+        role=Role.OWNER, permissions=DELETE_PLANNING_AREA_PERMISSION
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("collaboration", "0004_change_permissions"),
+    ]
+
+    operations = [migrations.RunPython(forwards, backwards)]

--- a/src/planscape/collaboration/permissions.py
+++ b/src/planscape/collaboration/permissions.py
@@ -47,7 +47,10 @@ class PlanningAreaPermission(CheckPermissionMixin):
 
     @staticmethod
     def can_remove(user: AbstractUser, planning_area: PlanningArea):
-        return is_creator(user, planning_area)
+        if is_creator(user, planning_area):
+            return True
+
+        return check_for_permission(user.pk, planning_area, "delete_planningarea")
 
     @staticmethod
     def can_add_scenario(user: AbstractUser, planning_area: PlanningArea):

--- a/src/planscape/impacts/permissions.py
+++ b/src/planscape/impacts/permissions.py
@@ -32,6 +32,7 @@ OWNER_PERMISSIONS = COLLABORATOR_PERMISSIONS + [
     "add_collaborator",
     "delete_collaborator",
     "change_collaborator",
+    "delete_planningarea",
 ]
 PERMISSIONS = {
     Role.OWNER: OWNER_PERMISSIONS,

--- a/src/planscape/planning/migrations/0058_alter_scenario_result_status_and_more.py
+++ b/src/planscape/planning/migrations/0058_alter_scenario_result_status_and_more.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("planning", "0057_planningarea_metrics_ready_at_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="scenario",
+            name="result_status",
+            field=models.CharField(
+                choices=[
+                    ("PENDING", "Pending"),
+                    ("RUNNING", "Running"),
+                    ("SUCCESS", "Success"),
+                    ("FAILURE", "Failure"),
+                    ("PANIC", "Panic"),
+                    ("TIMED_OUT", "Timed Out"),
+                    ("DRAFT", "Draft"),
+                ],
+                help_text="Result status of the Scenario.",
+                max_length=32,
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="scenarioresult",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("PENDING", "Pending"),
+                    ("RUNNING", "Running"),
+                    ("SUCCESS", "Success"),
+                    ("FAILURE", "Failure"),
+                    ("PANIC", "Panic"),
+                    ("TIMED_OUT", "Timed Out"),
+                    ("DRAFT", "Draft"),
+                ],
+                default="PENDING",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -886,7 +886,7 @@ class ListPlanningAreasWithPermissionsTest(APITestCase):
         self.assertCountEqual(the_area["permissions"], VIEWER_PERMISSIONS)
 
 
-class DeletePlanningAreaTest(APITransactionTestCase):
+class DeletePlanningAreaTest(APITestCase):
     def setUp(self):
         self.creator = UserFactory.create()
         self.owner = UserFactory()


### PR DESCRIPTION
- Enabling Planning Area Owners to delete Planning Area
- Test Cases