### PR TITLE
PLAN-2872: Treatable area tooltip

### DIFF
--- a/src/interface/src/app/scenario/scenario-legend/scenario-legend.component.html
+++ b/src/interface/src/app/scenario/scenario-legend/scenario-legend.component.html
@@ -33,7 +33,7 @@
         % Treatable:
         <button
           sg-button
-          matTooltip="The percentage of the Potential Treatable Area that meets thresholds"
+          matTooltip="The percentage of the Potential Treatable Area that meets stand-level constraints"
           matTooltipClass="legend-tooltip"
           variant="icon-only"
           icon="info"


### PR DESCRIPTION
Updating tooltip for % of Treatable area.

Jira: https://sig-gis.atlassian.net/browse/PLAN-2872