### PR TITLE
Generic "List" Card component

### DIFF
--- a/src/interface/src/styleguide/list-card/list-card.component.html
+++ b/src/interface/src/styleguide/list-card/list-card.component.html
@@ -1,56 +1,77 @@
 <a [routerLink]="['/treatment/']" class="card-link">
-    <div class="card">
-        <div class="title-row">
-            <div class="record-name">{{ name }}</div>
+  <div class="card">
+    <div class="title-row">
+      <div class="record-name">{{ name }}</div>
 
-            <div class="controls-section">
-                <div *ngIf="showRecordChip" class="record-type-chip" [ngClass]="recordTypeChipConfig[recordType].class">
-                    {{ recordTypeChipConfig[recordType].label }}
-                </div>
-                <button [hidden]="!contextualMenuEnabled && hasFailed"
-                    [disabled]="isRunning() || !contextualMenuEnabled" [matMenuTriggerFor]="menu"
-                    aria-label="More options" class="more-menu-button" (click)="handleMoreMenuClick($event)"
-                    mat-icon-button matTooltip="More actions">
-                    <mat-icon>more_vert</mat-icon>
-                </button>
-                <mat-menu class="scenario-more-menu" #menu="matMenu">
-                    <button class="action-button" mat-menu-item *ngIf="contextualMenuEnabled && !isProjectArea"
-                        (click)="copyRecord.emit()">
-                        <mat-icon class="material-symbols-outlined">file_copy</mat-icon>
-                        <span>Copy & Edit</span>
-                    </button>
-                    <button mat-menu-item class="action-button" *ngIf="userCanRenameRecord" (click)="editRecord.emit()">
-                        <mat-icon class="material-symbols-outlined">edit</mat-icon>
-                        <span>Rename</span>
-                    </button>
-                    <button class="action-button delete" mat-menu-item *ngIf="userCanDeleteRecord"
-                        (click)="deleteRecord.emit()">
-                        <mat-icon class="material-symbols-outlined">delete</mat-icon>
-                        <span>Delete</span>
-                    </button>
-                </mat-menu>
-            </div>
+      <div class="controls-section">
+        <div
+          *ngIf="showRecordChip"
+          class="record-type-chip"
+          [ngClass]="recordTypeChipConfig[recordType].class">
+          {{ recordTypeChipConfig[recordType].label }}
         </div>
-        <div class="detail-row">
-            <div class="detail-column">
-                <div class="detail-header">Creator</div>
-                <div class="detail-info">
-                    {{ creator ?? 'N/A' }}
-                </div>
-            </div>
-            <div class="detail-column">
-                <div class="detail-header">Date Created</div>
-                <div class="detail-info">
-                    {{ created_at ? (created_at | date: 'MMM d, y') : '-' }}
-                </div>
-            </div>
-            <div class="detail-column" [hidden]="isProjectArea">
-                <div class="detail-header" [hidden]="isProjectArea">Status</div>
-                <div class="detail-info">
-                    <sg-status-chip class="status-chip" *ngIf="resultStatus"
-                        [status]="getChipStatus()" [label]="getChipLabel()"></sg-status-chip>
-                </div>
-            </div>
-        </div>
+        <button
+          [hidden]="!contextualMenuEnabled && hasFailed"
+          [disabled]="isRunning() || !contextualMenuEnabled"
+          [matMenuTriggerFor]="menu"
+          aria-label="More options"
+          class="more-menu-button"
+          (click)="handleMoreMenuClick($event)"
+          mat-icon-button
+          matTooltip="More actions">
+          <mat-icon>more_vert</mat-icon>
+        </button>
+        <mat-menu class="scenario-more-menu" #menu="matMenu">
+          <button
+            class="action-button"
+            mat-menu-item
+            *ngIf="contextualMenuEnabled && !isProjectArea"
+            (click)="copyRecord.emit()">
+            <mat-icon class="material-symbols-outlined">file_copy</mat-icon>
+            <span>Copy & Edit</span>
+          </button>
+          <button
+            mat-menu-item
+            class="action-button"
+            *ngIf="userCanRenameRecord"
+            (click)="editRecord.emit()">
+            <mat-icon class="material-symbols-outlined">edit</mat-icon>
+            <span>Rename</span>
+          </button>
+          <button
+            class="action-button delete"
+            mat-menu-item
+            *ngIf="userCanDeleteRecord"
+            (click)="deleteRecord.emit()">
+            <mat-icon class="material-symbols-outlined">delete</mat-icon>
+            <span>Delete</span>
+          </button>
+        </mat-menu>
+      </div>
     </div>
+    <div class="detail-row">
+      <div class="detail-column">
+        <div class="detail-header">Creator</div>
+        <div class="detail-info">
+          {{ creator ?? 'N/A' }}
+        </div>
+      </div>
+      <div class="detail-column">
+        <div class="detail-header">Date Created</div>
+        <div class="detail-info">
+          {{ created_at ? (created_at | date: 'MMM d, y') : '-' }}
+        </div>
+      </div>
+      <div class="detail-column" [hidden]="isProjectArea">
+        <div class="detail-header" [hidden]="isProjectArea">Status</div>
+        <div class="detail-info">
+          <sg-status-chip
+            class="status-chip"
+            *ngIf="resultStatus"
+            [status]="getChipStatus()"
+            [label]="getChipLabel()"></sg-status-chip>
+        </div>
+      </div>
+    </div>
+  </div>
 </a>

--- a/src/interface/src/styleguide/list-card/list-card.component.html
+++ b/src/interface/src/styleguide/list-card/list-card.component.html
@@ -1,0 +1,56 @@
+<a [routerLink]="['/treatment/']" class="card-link">
+    <div class="card">
+        <div class="title-row">
+            <div class="record-name">{{ name }}</div>
+
+            <div class="controls-section">
+                <div *ngIf="showRecordChip" class="record-type-chip" [ngClass]="recordTypeChipConfig[recordType].class">
+                    {{ recordTypeChipConfig[recordType].label }}
+                </div>
+                <button [hidden]="!contextualMenuEnabled && hasFailed"
+                    [disabled]="isRunning() || !contextualMenuEnabled" [matMenuTriggerFor]="menu"
+                    aria-label="More options" class="more-menu-button" (click)="handleMoreMenuClick($event)"
+                    mat-icon-button matTooltip="More actions">
+                    <mat-icon>more_vert</mat-icon>
+                </button>
+                <mat-menu class="scenario-more-menu" #menu="matMenu">
+                    <button class="action-button" mat-menu-item *ngIf="contextualMenuEnabled && !isProjectArea"
+                        (click)="copyRecord.emit()">
+                        <mat-icon class="material-symbols-outlined">file_copy</mat-icon>
+                        <span>Copy & Edit</span>
+                    </button>
+                    <button mat-menu-item class="action-button" *ngIf="userCanRenameRecord" (click)="editRecord.emit()">
+                        <mat-icon class="material-symbols-outlined">edit</mat-icon>
+                        <span>Rename</span>
+                    </button>
+                    <button class="action-button delete" mat-menu-item *ngIf="userCanDeleteRecord"
+                        (click)="deleteRecord.emit()">
+                        <mat-icon class="material-symbols-outlined">delete</mat-icon>
+                        <span>Delete</span>
+                    </button>
+                </mat-menu>
+            </div>
+        </div>
+        <div class="detail-row">
+            <div class="detail-column">
+                <div class="detail-header">Creator</div>
+                <div class="detail-info">
+                    {{ creator ?? 'N/A' }}
+                </div>
+            </div>
+            <div class="detail-column">
+                <div class="detail-header">Date Created</div>
+                <div class="detail-info">
+                    {{ created_at ? (created_at | date: 'MMM d, y') : '-' }}
+                </div>
+            </div>
+            <div class="detail-column" [hidden]="isProjectArea">
+                <div class="detail-header" [hidden]="isProjectArea">Status</div>
+                <div class="detail-info">
+                    <sg-status-chip class="status-chip" *ngIf="resultStatus"
+                        [status]="getChipStatus()" [label]="getChipLabel()"></sg-status-chip>
+                </div>
+            </div>
+        </div>
+    </div>
+</a>

--- a/src/interface/src/styleguide/list-card/list-card.component.scss
+++ b/src/interface/src/styleguide/list-card/list-card.component.scss
@@ -1,0 +1,139 @@
+@import 'mixins';
+@import 'colors';
+@import 'media';
+
+:host {
+    &.project-area .card {
+        border-left: 6px solid $color-gray;
+    }
+
+    &.scenario .card {
+        border-left: 6px solid $color-dirty-white;
+    }
+}
+
+.card-link {
+    text-decoration: none;
+    color: black;
+}
+
+.card {
+    display: flex;
+    padding: 16px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 24px;
+    border-radius: 8px;
+    box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.16);
+    background-color: $color-white;
+    cursor: pointer;
+
+    &.show-left-border {
+        border-left: 6px solid var(--border-color, none);
+    }
+
+    &:hover {
+        background: $color-lighter-gray;
+    }
+
+    &.disabled-content {
+        cursor: default;
+    }
+}
+
+.title-row {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+
+    .controls-section {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1px;
+    }
+
+    .record-name {
+        @include h5();
+    }
+
+    .record-type-chip {
+        padding: 6px 12px;
+        border-radius: 50px;
+        @include xs-label();
+    }
+
+    .record-type-chip.scenario {
+        background-color: $color-dirty-white;
+        color: $color-brand-teal;
+    }
+
+    .record-type-chip.project-area {
+        background-color: $color-gray;
+        color: $color-intense-purple;
+    }
+}
+
+.detail-row {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+
+    .detail-column {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+
+        .detail-header {
+            font-size: 14px;
+            font-weight: 700;
+            color: $color-md-gray;
+            text-transform: uppercase;
+        }
+
+        .detail-info {
+            @include xs-label();
+            color: $color-black;
+            line-height: 24px;
+            height: 24px;
+            text-overflow: ellipsis;
+            overflow-x: hidden;
+            white-space: nowrap;
+            width: 100%;
+        }
+
+        .status-chip {
+            height: 24px;
+        }
+    }
+}
+
+.action-button {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    width: 100%;
+    align-items: center;
+    padding: 12px;
+    @include small-paragraph();
+    color: $color-black;
+
+    mat-icon {
+        color: $color-black;
+        font-size: 20px;
+        height: 20px;
+        width: 20px;
+        margin: 0;
+    }
+}
+
+.action-button.delete {
+    color: $color-error;
+
+    mat-icon {
+        color: $color-error;
+    }
+}

--- a/src/interface/src/styleguide/list-card/list-card.component.spec.ts
+++ b/src/interface/src/styleguide/list-card/list-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ListCardComponent } from './list-card.component';
+
+describe('ListCardComponent', () => {
+  let component: ListCardComponent;
+  let fixture: ComponentFixture<ListCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ListCardComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ListCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/styleguide/list-card/list-card.component.spec.ts
+++ b/src/interface/src/styleguide/list-card/list-card.component.spec.ts
@@ -8,10 +8,9 @@ describe('ListCardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ListCardComponent]
-    })
-    .compileComponents();
-    
+      imports: [ListCardComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(ListCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/interface/src/styleguide/list-card/list-card.component.ts
+++ b/src/interface/src/styleguide/list-card/list-card.component.ts
@@ -1,4 +1,3 @@
-
 import {
   Component,
   EventEmitter,
@@ -26,8 +25,22 @@ import { ButtonComponent } from '@styleguide/button/button.component';
 import { LegacyMaterialModule } from '@app/material/legacy-material.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-export type ResultLabel = 'Done' | 'In Progress' | 'Running' | 'Failed' | 'Draft';
-export type ValidStatus = "LOADING" | "PENDING" | "RUNNING" | "SUCCESS" | "FAILURE" | "PANIC" | "TIMED_OUT" | "DRAFT" | 'INPROGRESS';
+export type ResultLabel =
+  | 'Done'
+  | 'In Progress'
+  | 'Running'
+  | 'Failed'
+  | 'Draft';
+export type ValidStatus =
+  | 'LOADING'
+  | 'PENDING'
+  | 'RUNNING'
+  | 'SUCCESS'
+  | 'FAILURE'
+  | 'PANIC'
+  | 'TIMED_OUT'
+  | 'DRAFT'
+  | 'INPROGRESS';
 
 /**
  * List Card for displaying scenario, project area, or treatment card data in a results list
@@ -49,27 +62,22 @@ export type ValidStatus = "LOADING" | "PENDING" | "RUNNING" | "SUCCESS" | "FAILU
     LegacyMaterialModule,
     MatTooltipModule,
   ],
-templateUrl: './list-card.component.html',
-  styleUrl: './list-card.component.scss'
+  templateUrl: './list-card.component.html',
+  styleUrl: './list-card.component.scss',
 })
-
 export class ListCardComponent {
-
   @Input() resultStatus: ScenarioResultStatus | 'INPROGRESS' = 'SUCCESS';
   @Input() name = '';
   @Input() creator?: string = '';
   @Input() created_at? = '';
- 
-  @Input() recordType: 'PROJECT_AREA' | 'SCENARIO' | 'TREATMENT' = 'SCENARIO'
+
+  @Input() recordType: 'PROJECT_AREA' | 'SCENARIO' | 'TREATMENT' = 'SCENARIO';
   @Input() origin?: 'USER' | 'SYSTEM' = 'SYSTEM';
   @Input() userCanDeleteRecord = false;
   @Input() userCanEditRecord = false;
   @Input() userCanRenameRecord = false;
   @Input() contextualMenuEnabled = true;
   @Input() disabled = false;
-
-
-  @Input() leftEdgeColor : string | null = null; 
 
   @Output() openRecord = new EventEmitter();
   @Output() openPlanningProgress = new EventEmitter();
@@ -78,12 +86,11 @@ export class ListCardComponent {
   @Output() copyRecord = new EventEmitter();
   @Output() clicked = new EventEmitter();
 
-// Define which types actually get a chip
+  // Define which types actually get a chip
   readonly recordTypeChipConfig = {
-    'SCENARIO': { label: 'Scenario', class: 'scenario' },
-    'PROJECT_AREA': { label: 'Project areas', class: 'project-area' }
+    SCENARIO: { label: 'Scenario', class: 'scenario' },
+    PROJECT_AREA: { label: 'Project areas', class: 'project-area' },
   };
-
 
   readonly chipsStatus: Record<
     ValidStatus,
@@ -92,7 +99,7 @@ export class ListCardComponent {
       label: ResultLabel;
     }
   > = {
-    INPROGRESS: {status: 'inProgress', label: 'In Progress'},
+    INPROGRESS: { status: 'inProgress', label: 'In Progress' },
     FAILURE: { status: 'failed', label: 'Failed' },
     LOADING: { status: 'running', label: 'Running' },
     PANIC: { status: 'failed', label: 'Failed' },
@@ -119,7 +126,7 @@ export class ListCardComponent {
   }
 
   get showRecordChip() {
-    return this.recordType !== 'TREATMENT'; 
+    return this.recordType !== 'TREATMENT';
   }
 
   @HostBinding('class.disabled-content')
@@ -142,12 +149,8 @@ export class ListCardComponent {
     return this.recordType === 'TREATMENT';
   }
 
-
-
   getChipStatus(): StatusChipStatus {
-    console.log('for this name:', this.name);
     if (this.resultStatus) {
-      console.log('we have this status:', this.resultStatus);
       return this.chipsStatus[this.resultStatus].status;
     }
     return 'failed';
@@ -163,15 +166,4 @@ export class ListCardComponent {
   handleMoreMenuClick(event: Event) {
     event.stopPropagation();
   }
-
-
-  @HostBinding('class.show-left-border') get hasBorder() {
-    return !!this.leftEdgeColor;
-  }
-
-  @HostBinding('style.show-left-border') get colorVar() {
-    return this.leftEdgeColor;
-  }
-
 }
-

--- a/src/interface/src/styleguide/list-card/list-card.component.ts
+++ b/src/interface/src/styleguide/list-card/list-card.component.ts
@@ -1,0 +1,177 @@
+
+import {
+  Component,
+  EventEmitter,
+  HostBinding,
+  Input,
+  Output,
+} from '@angular/core';
+import {
+  CurrencyPipe,
+  DatePipe,
+  NgClass,
+  NgIf,
+  NgSwitch,
+} from '@angular/common';
+
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonModule } from '@angular/material/button';
+import { ScenarioResultStatus } from '@types';
+import {
+  StatusChipComponent,
+  StatusChipStatus,
+} from '@styleguide/status-chip/status-chip.component';
+import { ButtonComponent } from '@styleguide/button/button.component';
+import { LegacyMaterialModule } from '@app/material/legacy-material.module';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+export type ResultLabel = 'Done' | 'In Progress' | 'Running' | 'Failed' | 'Draft';
+export type ValidStatus = "LOADING" | "PENDING" | "RUNNING" | "SUCCESS" | "FAILURE" | "PANIC" | "TIMED_OUT" | "DRAFT" | 'INPROGRESS';
+
+/**
+ * List Card for displaying scenario, project area, or treatment card data in a results list
+ */
+@Component({
+  selector: 'sg-list-card',
+  standalone: true,
+  imports: [
+    DatePipe,
+    NgIf,
+    CurrencyPipe,
+    NgSwitch,
+    NgClass,
+    StatusChipComponent,
+    ButtonComponent,
+    MatIconModule,
+    MatMenuModule,
+    MatButtonModule,
+    LegacyMaterialModule,
+    MatTooltipModule,
+  ],
+templateUrl: './list-card.component.html',
+  styleUrl: './list-card.component.scss'
+})
+
+export class ListCardComponent {
+
+  @Input() resultStatus: ScenarioResultStatus | 'INPROGRESS' = 'SUCCESS';
+  @Input() name = '';
+  @Input() creator?: string = '';
+  @Input() created_at? = '';
+ 
+  @Input() recordType: 'PROJECT_AREA' | 'SCENARIO' | 'TREATMENT' = 'SCENARIO'
+  @Input() origin?: 'USER' | 'SYSTEM' = 'SYSTEM';
+  @Input() userCanDeleteRecord = false;
+  @Input() userCanEditRecord = false;
+  @Input() userCanRenameRecord = false;
+  @Input() contextualMenuEnabled = true;
+  @Input() disabled = false;
+
+
+  @Input() leftEdgeColor : string | null = null; 
+
+  @Output() openRecord = new EventEmitter();
+  @Output() openPlanningProgress = new EventEmitter();
+  @Output() deleteRecord = new EventEmitter();
+  @Output() editRecord = new EventEmitter();
+  @Output() copyRecord = new EventEmitter();
+  @Output() clicked = new EventEmitter();
+
+// Define which types actually get a chip
+  readonly recordTypeChipConfig = {
+    'SCENARIO': { label: 'Scenario', class: 'scenario' },
+    'PROJECT_AREA': { label: 'Project areas', class: 'project-area' }
+  };
+
+
+  readonly chipsStatus: Record<
+    ValidStatus,
+    {
+      status: StatusChipStatus;
+      label: ResultLabel;
+    }
+  > = {
+    INPROGRESS: {status: 'inProgress', label: 'In Progress'},
+    FAILURE: { status: 'failed', label: 'Failed' },
+    LOADING: { status: 'running', label: 'Running' },
+    PANIC: { status: 'failed', label: 'Failed' },
+    PENDING: { status: 'running', label: 'Running' },
+    RUNNING: { status: 'running', label: 'Running' },
+    SUCCESS: { status: 'success', label: 'Done' },
+    TIMED_OUT: { status: 'failed', label: 'Failed' },
+    DRAFT: { status: 'draft', label: 'Draft' },
+  };
+
+  hasFailed(): boolean {
+    const failedValues = ['FAILURE', 'PANIC', 'TIMED_OUT'];
+    return failedValues.includes(this.resultStatus);
+  }
+
+  isRunning(): boolean {
+    const runningValues = ['LOADING', 'PENDING', 'RUNNING'];
+    return runningValues.includes(this.resultStatus);
+  }
+
+  isDone(): boolean {
+    const doneValues = ['SUCCESS'];
+    return doneValues.includes(this.resultStatus);
+  }
+
+  get showRecordChip() {
+    return this.recordType !== 'TREATMENT'; 
+  }
+
+  @HostBinding('class.disabled-content')
+  get disabledContent() {
+    return this.isRunning() || this.disabled;
+  }
+
+  @HostBinding('class.project-area')
+  get isProjectArea() {
+    return this.recordType === 'PROJECT_AREA';
+  }
+
+  @HostBinding('class.scenario')
+  get isScenario() {
+    return this.recordType === 'SCENARIO';
+  }
+
+  @HostBinding('class.treatment')
+  get isTreatmentArea() {
+    return this.recordType === 'TREATMENT';
+  }
+
+
+
+  getChipStatus(): StatusChipStatus {
+    console.log('for this name:', this.name);
+    if (this.resultStatus) {
+      console.log('we have this status:', this.resultStatus);
+      return this.chipsStatus[this.resultStatus].status;
+    }
+    return 'failed';
+  }
+
+  getChipLabel(): ResultLabel {
+    if (this.resultStatus) {
+      return this.chipsStatus[this.resultStatus].label;
+    }
+    return 'Failed';
+  }
+
+  handleMoreMenuClick(event: Event) {
+    event.stopPropagation();
+  }
+
+
+  @HostBinding('class.show-left-border') get hasBorder() {
+    return !!this.leftEdgeColor;
+  }
+
+  @HostBinding('style.show-left-border') get colorVar() {
+    return this.leftEdgeColor;
+  }
+
+}
+

--- a/src/interface/src/styleguide/list-card/list-card.stories.ts
+++ b/src/interface/src/styleguide/list-card/list-card.stories.ts
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig, argsToTemplate } from '@storybook/angular';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { ListCardComponent } from './list-card.component';
+
+const meta: Meta<ListCardComponent> = {
+  title: 'Components/List Card',
+  component: ListCardComponent,
+  decorators: [
+    applicationConfig({
+      providers: [provideAnimations()],
+    }),
+  ],
+  tags: ['autodocs'],
+  render: ({ ...args }) => ({
+    props: args,
+    template: `<sg-list-card ${argsToTemplate(args)}></sg-list-card>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<ListCardComponent>;
+
+export const Default: Story = {
+  args: {
+    name: 'Test Scenario',
+    recordType: 'SCENARIO',
+    resultStatus: 'SUCCESS',
+    creator: 'Larry Larrington',
+    created_at: '2024-01-01 12:34:00',
+  },
+};
+
+export const ProjectArea: Story = {
+  args: {
+    name: 'Test Project Area',
+    recordType: 'PROJECT_AREA',
+    resultStatus: 'SUCCESS',
+    creator: 'Larry Larrington',
+    created_at: '2024-01-01 12:34:00',
+    origin: 'USER',
+    leftEdgeColor: '#ffaaee',
+  },
+};
+
+export const Scenario: Story = {
+  args: {
+    name: 'Test Project Area',
+    resultStatus: 'SUCCESS',
+    creator: 'Larry Larrington',
+    created_at: '2024-01-01 12:34:00',
+    origin: 'USER',
+    leftEdgeColor: '#3344aa',
+  },
+};
+
+
+export const Running: Story = {
+  args: {
+    ...Default.args,
+    resultStatus: 'RUNNING',
+  },
+};
+
+export const Done: Story = {
+  args: {
+    ...Default.args,
+    resultStatus: 'SUCCESS',
+  },
+};
+
+export const Failed: Story = {
+  args: {
+    ...Default.args,
+    resultStatus: 'FAILURE',
+  },
+};
+
+export const DisabledScenario: Story = {
+  args: {
+    name: 'Test Scenario',
+    resultStatus: 'SUCCESS',
+    creator: 'Larry Larrington',
+    created_at: '2024-01-01 12:34:00',
+    disabled: true,
+    contextualMenuEnabled: false,
+    userCanDeleteRecord: true,
+  },
+};
+
+export const TreatmentCard: Story = {
+  args: {
+    name: 'Treatment Plan Name',
+    resultStatus: 'INPROGRESS',
+    recordType: 'TREATMENT',
+    creator: 'Planny Plannington',
+    created_at: '2024-01-01 12:34:00',
+  },
+};

--- a/src/interface/src/styleguide/list-card/list-card.stories.ts
+++ b/src/interface/src/styleguide/list-card/list-card.stories.ts
@@ -39,21 +39,28 @@ export const ProjectArea: Story = {
     creator: 'Larry Larrington',
     created_at: '2024-01-01 12:34:00',
     origin: 'USER',
-    leftEdgeColor: '#ffaaee',
+  },
+};
+
+export const TreatmentCard: Story = {
+  args: {
+    name: 'Treatment Plan Name',
+    resultStatus: 'INPROGRESS',
+    recordType: 'TREATMENT',
+    creator: 'Planny Plannington',
+    created_at: '2024-01-01 12:34:00',
   },
 };
 
 export const Scenario: Story = {
   args: {
-    name: 'Test Project Area',
+    name: 'Test Scenario',
     resultStatus: 'SUCCESS',
     creator: 'Larry Larrington',
     created_at: '2024-01-01 12:34:00',
     origin: 'USER',
-    leftEdgeColor: '#3344aa',
   },
 };
-
 
 export const Running: Story = {
   args: {
@@ -85,15 +92,5 @@ export const DisabledScenario: Story = {
     disabled: true,
     contextualMenuEnabled: false,
     userCanDeleteRecord: true,
-  },
-};
-
-export const TreatmentCard: Story = {
-  args: {
-    name: 'Treatment Plan Name',
-    resultStatus: 'INPROGRESS',
-    recordType: 'TREATMENT',
-    creator: 'Planny Plannington',
-    created_at: '2024-01-01 12:34:00',
   },
 };


### PR DESCRIPTION
This adds a generic "List Card" (open to renaming!) that can represent a scenario, project areas, or treatment record.

TBD / open questions for everyone else:
The "more" menu differs pretty significantly between these record types. Content projection apparently doesn't work quite right with matMenu triggers (or I'm wrong about this :D ). Alternatively, we could pass a configuration array, as we've done in other components -- although handling the emitted events will be a challenge.

Likewise, the various states for each record type ("In Progress", etc) -- also differ just enough to be complicated. I'm thinking we could support a larger set of these generically, but limit the valid versions per record type? I'm open to ideas on this.

<img width="1237" height="1135" alt="Screenshot From 2026-04-09 17-00-39" src="https://github.com/user-attachments/assets/0007e3ae-5ae8-47ba-ad1c-17dd092f984b" />
