### PR TITLE
add admin restore from catalog

### DIFF
--- a/src/planscape/admin/admin_config.py
+++ b/src/planscape/admin/admin_config.py
@@ -8,10 +8,13 @@ from core.backup_state import (
     BACKUP_STATE_IDLE,
     BACKUP_STATE_QUEUED,
     get_backup_status,
+    get_restore_status,
     is_backup_active,
+    is_restore_active,
     set_backup_status,
+    set_restore_status,
 )
-from core.tasks import generate_backup_data_task
+from core.tasks import generate_backup_data_task, load_latest_catalog_backup_task
 
 
 class PlanscapeAdmin(admin.AdminSite):
@@ -25,6 +28,11 @@ class PlanscapeAdmin(admin.AdminSite):
                 self.admin_view(self.trigger_backup_data_view),
                 name="trigger_backup_data",
             ),
+            path(
+                "restore-data/trigger/",
+                self.admin_view(self.trigger_restore_data_view),
+                name="trigger_restore_data",
+            ),
             *super().get_urls(),
         ]
 
@@ -35,6 +43,9 @@ class PlanscapeAdmin(admin.AdminSite):
                 "backup_status": get_backup_status(),
                 "backup_in_progress": is_backup_active(),
                 "trigger_backup_data_url": reverse("admin:trigger_backup_data"),
+                "restore_status": get_restore_status(),
+                "restore_in_progress": is_restore_active(),
+                "trigger_restore_data_url": reverse("admin:trigger_restore_data"),
             }
         )
         return context
@@ -57,4 +68,24 @@ class PlanscapeAdmin(admin.AdminSite):
 
         set_backup_status(BACKUP_STATE_QUEUED, task_id=task.id)
         messages.success(request, "Backup queued.")
+        return HttpResponseRedirect(reverse("admin:index"))
+
+    def trigger_restore_data_view(self, request: WSGIRequest) -> HttpResponseRedirect:
+        if request.method != "POST":
+            messages.error(request, "Restore must be triggered with a POST request.")
+            return HttpResponseRedirect(reverse("admin:index"))
+
+        if is_restore_active():
+            messages.warning(request, "A restore is already queued or running.")
+            return HttpResponseRedirect(reverse("admin:index"))
+
+        set_restore_status(BACKUP_STATE_QUEUED)
+        try:
+            task = load_latest_catalog_backup_task.delay()
+        except Exception:
+            set_restore_status(BACKUP_STATE_IDLE)
+            raise
+
+        set_restore_status(BACKUP_STATE_QUEUED, task_id=task.id)
+        messages.success(request, "Restore queued.")
         return HttpResponseRedirect(reverse("admin:index"))

--- a/src/planscape/core/backup_state.py
+++ b/src/planscape/core/backup_state.py
@@ -7,6 +7,8 @@ from django.utils import timezone
 
 BACKUP_LOCK_KEY = "admin:generate_backup_data:lock"
 BACKUP_STATUS_KEY = "admin:generate_backup_data:status"
+RESTORE_LOCK_KEY = "admin:load_backup_data:lock"
+RESTORE_STATUS_KEY = "admin:load_backup_data:status"
 BACKUP_LOCK_TIMEOUT = 60 * 60 * 6
 
 BACKUP_STATE_IDLE = "idle"
@@ -17,39 +19,87 @@ BACKUP_STATE_FAILED = "failed"
 BACKUP_ACTIVE_STATES = {BACKUP_STATE_QUEUED, BACKUP_STATE_RUNNING}
 
 
-def acquire_backup_lock() -> bool:
-    return cache.add(BACKUP_LOCK_KEY, True, timeout=BACKUP_LOCK_TIMEOUT)
+def acquire_lock(lock_key: str) -> bool:
+    return cache.add(lock_key, True, timeout=BACKUP_LOCK_TIMEOUT)
 
 
-def release_backup_lock() -> None:
-    cache.delete(BACKUP_LOCK_KEY)
+def release_lock(lock_key: str) -> None:
+    cache.delete(lock_key)
 
 
-def is_backup_locked() -> bool:
-    return bool(cache.get(BACKUP_LOCK_KEY, False))
+def is_locked(lock_key: str) -> bool:
+    return bool(cache.get(lock_key, False))
 
 
-def is_backup_active() -> bool:
-    return (
-        get_backup_status().get("state") in BACKUP_ACTIVE_STATES or is_backup_locked()
-    )
-
-
-def set_backup_status(state: str, **extra: Any) -> dict[str, Any]:
+def set_status(status_key: str, state: str, **extra: Any) -> dict[str, Any]:
     status = {
         "state": state,
         "updated_at": timezone.now().isoformat(),
         **extra,
     }
-    cache.set(BACKUP_STATUS_KEY, status, timeout=BACKUP_LOCK_TIMEOUT)
+    cache.set(status_key, status, timeout=BACKUP_LOCK_TIMEOUT)
     return status
 
 
-def get_backup_status() -> dict[str, Any]:
-    status = cache.get(BACKUP_STATUS_KEY)
+def get_status(status_key: str) -> dict[str, Any]:
+    status = cache.get(status_key)
     if status:
         return status
     return {
         "state": BACKUP_STATE_IDLE,
         "updated_at": None,
     }
+
+
+def is_active(status_key: str, lock_key: str) -> bool:
+    return get_status(status_key).get("state") in BACKUP_ACTIVE_STATES or is_locked(
+        lock_key
+    )
+
+
+def acquire_backup_lock() -> bool:
+    return acquire_lock(BACKUP_LOCK_KEY)
+
+
+def release_backup_lock() -> None:
+    release_lock(BACKUP_LOCK_KEY)
+
+
+def is_backup_locked() -> bool:
+    return is_locked(BACKUP_LOCK_KEY)
+
+
+def is_backup_active() -> bool:
+    return is_active(BACKUP_STATUS_KEY, BACKUP_LOCK_KEY)
+
+
+def set_backup_status(state: str, **extra: Any) -> dict[str, Any]:
+    return set_status(BACKUP_STATUS_KEY, state, **extra)
+
+
+def get_backup_status() -> dict[str, Any]:
+    return get_status(BACKUP_STATUS_KEY)
+
+
+def acquire_restore_lock() -> bool:
+    return acquire_lock(RESTORE_LOCK_KEY)
+
+
+def release_restore_lock() -> None:
+    release_lock(RESTORE_LOCK_KEY)
+
+
+def is_restore_locked() -> bool:
+    return is_locked(RESTORE_LOCK_KEY)
+
+
+def is_restore_active() -> bool:
+    return is_active(RESTORE_STATUS_KEY, RESTORE_LOCK_KEY)
+
+
+def set_restore_status(state: str, **extra: Any) -> dict[str, Any]:
+    return set_status(RESTORE_STATUS_KEY, state, **extra)
+
+
+def get_restore_status() -> dict[str, Any]:
+    return get_status(RESTORE_STATUS_KEY)

--- a/src/planscape/core/management/commands/load_backup_data.py
+++ b/src/planscape/core/management/commands/load_backup_data.py
@@ -1,12 +1,13 @@
 import os
 import shutil
 import subprocess
+
+from datasets.models import DataLayer, DataLayerStatus, DataLayerType
+from datasets.tasks import datalayer_uploaded
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
-from datasets.models import DataLayer, DataLayerType, DataLayerStatus
-from datasets.tasks import datalayer_uploaded
 
 class Command(BaseCommand):
     help = "Loads backup data and trigger Vector layers post-upload tasks."
@@ -15,28 +16,53 @@ class Command(BaseCommand):
         parser.add_argument(
             "--file-name",
             default="latest_catalog_backup.json",
-            help="Load data from specific file. Default: `latest_catalog_backup.json`"
+            help="Load data from specific file. Default: `latest_catalog_backup.json`",
         )
         parser.add_argument(
             "--source-env",
             default="catalog",
-            help="Source which data will be copied from."
+            help="Source which data will be copied from.",
         )
-
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Skip confirmation prompt.",
+        )
 
     def handle(self, **options):
         source_env = options.get("source_env", "catalog")
-        self.stdout.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-        self.stdout.write(f"!!   WARNING: you are running this command on {settings.ENV}.    !!\n")
-        self.stdout.write(f"!!          and it will import data from {source_env}.           !!\n")
-        self.stdout.write("!! It will perform the following steps:                          !!\n")
-        self.stdout.write("!! 1. Sync source env datalayers bucket with targeted env bucket;!!\n")
-        self.stdout.write("!! 2. Load data from given JSON file to targeted env database;   !!\n")
-        self.stdout.write("!! 3. Update datalayers url to point to targeted env bucket;     !!\n")
-        self.stdout.write("!! 4. Execute post-update process for Vector Layers (Ready only);!!\n")
-        self.stdout.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+        force = options.get("force", False)
+        self.stdout.write(
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+        )
+        self.stdout.write(
+            f"!!   WARNING: you are running this command on {settings.ENV}.    !!\n"
+        )
+        self.stdout.write(
+            f"!!          and it will import data from {source_env}.           !!\n"
+        )
+        self.stdout.write(
+            "!! It will perform the following steps:                          !!\n"
+        )
+        self.stdout.write(
+            "!! 1. Sync source env datalayers bucket with targeted env bucket;!!\n"
+        )
+        self.stdout.write(
+            "!! 2. Load data from given JSON file to targeted env database;   !!\n"
+        )
+        self.stdout.write(
+            "!! 3. Update datalayers url to point to targeted env bucket;     !!\n"
+        )
+        self.stdout.write(
+            "!! 4. Execute post-update process for Vector Layers (Ready only);!!\n"
+        )
+        self.stdout.write(
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+        )
 
-        confirmed = input("Confirm to proceed with process? (y,N)") or "n"
+        confirmed = (
+            "y" if force else input("Confirm to proceed with process? (y,N)") or "n"
+        )
 
         if confirmed.lower() != "y":
             raise SystemExit(
@@ -73,7 +99,7 @@ class Command(BaseCommand):
                 "!!          Error: Backup file not found.             !!\n"
                 "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
             )
-        
+
         if source_env not in filename:
             raise SystemError(
                 "\n"
@@ -81,18 +107,18 @@ class Command(BaseCommand):
                 "!!  Error: Backup file and source env does not match. !!\n"
                 "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
             )
-        
+
         try:
             # Sync buckets
             subprocess.call(
                 [
                     "gcloud",
-                    "storage", 
+                    "storage",
                     "rsync",
                     f"--account={settings.STORAGE_SERVICE_ACCOUNT}",
                     f"gs://planscape-datastore-{source_env}/datalayers",
                     f"gs://planscape-datastore-{settings.ENV}/datalayers",
-                    "--recursive"
+                    "--recursive",
                 ]
             )
 
@@ -100,30 +126,41 @@ class Command(BaseCommand):
             self.stdout.write(f"Copying file from {file_path} to /tmp/{filename}.")
             shutil.copy(file_path, f"/tmp/{filename}")
 
-            self.stdout.write(f"Replacing  `planscape-datastore-{source_env}` with `planscape-datastore-{settings.ENV}` on /tmp/{filename}.")
+            self.stdout.write(
+                f"Replacing  `planscape-datastore-{source_env}` with `planscape-datastore-{settings.ENV}` on /tmp/{filename}."
+            )
             subprocess.call(
                 [
                     "sed",
                     "-i",
                     f"s/planscape-datastore-{source_env}/planscape-datastore-{settings.ENV}/g",
-                    f"/tmp/{filename}"
+                    f"/tmp/{filename}",
                 ]
             )
-            
+
             # Load data to DB
             self.stdout.write(f"Loading data from `/tmp/{filename}`")
             call_command(
-                "loaddata", 
+                "loaddata",
                 f"/tmp/{filename}",
             )
 
-            self.stdout.write(self.style.SUCCESS(f"Successfully loaded data from `/tmp/{filename}`"))
+            self.stdout.write(
+                self.style.SUCCESS(f"Successfully loaded data from `/tmp/{filename}`")
+            )
 
-            ready_vector_layers = DataLayer.objects.filter(type=DataLayerType.VECTOR, status=DataLayerStatus.READY)
+            ready_vector_layers = DataLayer.objects.filter(
+                type=DataLayerType.VECTOR, status=DataLayerStatus.READY
+            )
 
             for vector_layer in ready_vector_layers.iterator():
                 datalayer_uploaded.delay(vector_layer.pk)
 
-            self.stdout.write(self.style.SUCCESS(f"Triggered post-upload process for {ready_vector_layers.count()} Datalayers type=VECTOR and status=READY."))
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Triggered post-upload process for {ready_vector_layers.count()} Datalayers type=VECTOR and status=READY."
+                )
+            )
         except Exception as e:
+            self.stderr.write(self.style.ERROR(f"Error loading data: {e}"))
             self.stderr.write(self.style.ERROR(f"Error loading data: {e}"))

--- a/src/planscape/core/tasks.py
+++ b/src/planscape/core/tasks.py
@@ -12,8 +12,11 @@ from core.backup_state import (
     BACKUP_STATE_RUNNING,
     BACKUP_STATE_SUCCESS,
     acquire_backup_lock,
+    acquire_restore_lock,
     release_backup_lock,
+    release_restore_lock,
     set_backup_status,
+    set_restore_status,
 )
 from planscape.celery import app
 
@@ -55,3 +58,20 @@ def generate_backup_data_task() -> None:
         set_backup_status(BACKUP_STATE_SUCCESS)
     finally:
         release_backup_lock()
+
+
+@app.task()
+def load_latest_catalog_backup_task() -> None:
+    if not acquire_restore_lock():
+        raise RuntimeError("A restore is already running.")
+
+    set_restore_status(BACKUP_STATE_RUNNING)
+    try:
+        call_command("load_backup_data", force=True)
+    except Exception as exc:
+        set_restore_status(BACKUP_STATE_FAILED, error=str(exc))
+        raise
+    else:
+        set_restore_status(BACKUP_STATE_SUCCESS)
+    finally:
+        release_restore_lock()

--- a/src/planscape/core/tests/test_admin_backup.py
+++ b/src/planscape/core/tests/test_admin_backup.py
@@ -10,12 +10,17 @@ from core.backup_state import (
     BACKUP_STATE_RUNNING,
     BACKUP_STATE_SUCCESS,
     acquire_backup_lock,
+    acquire_restore_lock,
     get_backup_status,
+    get_restore_status,
     is_backup_active,
     is_backup_locked,
+    is_restore_active,
+    is_restore_locked,
     set_backup_status,
+    set_restore_status,
 )
-from core.tasks import generate_backup_data_task
+from core.tasks import generate_backup_data_task, load_latest_catalog_backup_task
 from planscape.tests.factories import UserFactory
 
 
@@ -35,6 +40,7 @@ class TestAdminBackupTrigger(TestCase):
         self.user = UserFactory.create(is_staff=True, is_superuser=False)
         self.index_url = reverse("admin:index")
         self.trigger_url = reverse("admin:trigger_backup_data")
+        self.restore_url = reverse("admin:trigger_restore_data")
 
     def test_index_shows_enabled_button_when_backup_not_running(self):
         self.client.force_login(self.superuser)
@@ -43,6 +49,8 @@ class TestAdminBackupTrigger(TestCase):
 
         self.assertContains(response, "Run backup")
         self.assertNotContains(response, "Backup in progress")
+        self.assertContains(response, "Restore from latest catalog")
+        self.assertNotContains(response, "Restore in progress")
 
     def test_index_shows_disabled_button_when_backup_running(self):
         self.client.force_login(self.superuser)
@@ -94,6 +102,56 @@ class TestAdminBackupTrigger(TestCase):
         delay_mock.assert_not_called()
         self.assertContains(response, "A backup is already queued or running.")
 
+    def test_index_shows_disabled_restore_button_when_restore_running(self):
+        self.client.force_login(self.superuser)
+        acquire_restore_lock()
+        set_restore_status(BACKUP_STATE_QUEUED)
+
+        response = self.client.get(self.index_url)
+
+        self.assertContains(response, "Restore in progress")
+        self.assertContains(response, "disabled")
+
+    def test_non_superuser_cannot_trigger_restore(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(self.restore_url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(is_restore_locked())
+        self.assertFalse(is_restore_active())
+
+    def test_trigger_restore_queues_task_and_sets_status(self):
+        self.client.force_login(self.superuser)
+
+        with mock.patch(
+            "admin.admin_config.load_latest_catalog_backup_task.delay"
+        ) as delay_mock:
+            delay_mock.return_value.id = "task-restore-123"
+
+            response = self.client.post(self.restore_url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        delay_mock.assert_called_once_with()
+        self.assertFalse(is_restore_locked())
+        self.assertTrue(is_restore_active())
+        self.assertEqual(get_restore_status()["state"], BACKUP_STATE_QUEUED)
+        self.assertContains(response, "Restore queued.")
+
+    def test_trigger_restore_does_not_queue_duplicate_task(self):
+        self.client.force_login(self.superuser)
+        acquire_restore_lock()
+        set_restore_status(BACKUP_STATE_QUEUED)
+
+        with mock.patch(
+            "admin.admin_config.load_latest_catalog_backup_task.delay"
+        ) as delay_mock:
+            response = self.client.post(self.restore_url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        delay_mock.assert_not_called()
+        self.assertContains(response, "A restore is already queued or running.")
+
 
 @override_settings(CACHES=TEST_CACHES)
 class TestGenerateBackupDataTask(TestCase):
@@ -133,3 +191,43 @@ class TestGenerateBackupDataTask(TestCase):
         call_command_mock.assert_not_called()
         self.assertTrue(is_backup_locked())
         self.assertEqual(get_backup_status()["state"], BACKUP_STATE_RUNNING)
+
+
+@override_settings(CACHES=TEST_CACHES)
+class TestLoadLatestCatalogBackupTask(TestCase):
+    def setUp(self) -> None:
+        cache.clear()
+
+    def test_task_runs_command_and_releases_lock(self):
+        set_restore_status(BACKUP_STATE_QUEUED)
+
+        with mock.patch("core.tasks.call_command") as call_command_mock:
+            load_latest_catalog_backup_task.run()
+
+        call_command_mock.assert_called_once_with("load_backup_data", force=True)
+        self.assertFalse(is_restore_locked())
+        self.assertEqual(get_restore_status()["state"], BACKUP_STATE_SUCCESS)
+
+    def test_task_marks_failure_and_releases_lock(self):
+        set_restore_status(BACKUP_STATE_QUEUED)
+
+        with mock.patch("core.tasks.call_command", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                load_latest_catalog_backup_task.run()
+
+        self.assertFalse(is_restore_locked())
+        status = get_restore_status()
+        self.assertEqual(status["state"], BACKUP_STATE_FAILED)
+        self.assertEqual(status["error"], "boom")
+
+    def test_task_fails_if_lock_already_held(self):
+        acquire_restore_lock()
+        set_restore_status(BACKUP_STATE_RUNNING)
+
+        with mock.patch("core.tasks.call_command") as call_command_mock:
+            with self.assertRaises(RuntimeError):
+                load_latest_catalog_backup_task.run()
+
+        call_command_mock.assert_not_called()
+        self.assertTrue(is_restore_locked())
+        self.assertEqual(get_restore_status()["state"], BACKUP_STATE_RUNNING)

--- a/src/planscape/core/tests/test_admin_backup.py
+++ b/src/planscape/core/tests/test_admin_backup.py
@@ -198,6 +198,12 @@ class TestLoadLatestCatalogBackupTask(TestCase):
     def setUp(self) -> None:
         cache.clear()
 
+    def test_backup_and_restore_use_different_locks(self):
+        self.assertTrue(acquire_backup_lock())
+        self.assertTrue(acquire_restore_lock())
+        self.assertTrue(is_backup_locked())
+        self.assertTrue(is_restore_locked())
+
     def test_task_runs_command_and_releases_lock(self):
         set_restore_status(BACKUP_STATE_QUEUED)
 

--- a/src/planscape/core/tests/test_load_backup_data_command.py
+++ b/src/planscape/core/tests/test_load_backup_data_command.py
@@ -1,0 +1,24 @@
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, override_settings
+
+
+@override_settings(ENV="dev", BACKUPS_PATH="/tmp/backups")
+class TestLoadBackupDataCommand(SimpleTestCase):
+    @mock.patch("core.management.commands.load_backup_data.input", return_value="n")
+    def test_command_prompts_for_confirmation_by_default(self, input_mock):
+        with self.assertRaises(SystemExit):
+            call_command("load_backup_data")
+
+        input_mock.assert_called_once_with("Confirm to proceed with process? (y,N)")
+
+    @mock.patch(
+        "core.management.commands.load_backup_data.os.path.exists", return_value=False
+    )
+    @mock.patch("core.management.commands.load_backup_data.input")
+    def test_force_skips_confirmation_prompt(self, input_mock, _exists_mock):
+        with self.assertRaises(SystemError):
+            call_command("load_backup_data", force=True)
+
+        input_mock.assert_not_called()

--- a/src/planscape/templates/admin/base_site.html
+++ b/src/planscape/templates/admin/base_site.html
@@ -146,5 +146,22 @@
         </form>
       </div>
     </div>
+    <div class="admin-backup-trigger-wrap">
+      <div class="admin-backup-trigger">
+        <div>
+          <div class="admin-backup-trigger__title">Restore from latest catalog</div>
+          <p class="admin-backup-trigger__text">
+            Trigger the `load_backup_data` management command with the default latest catalog backup.
+            Current status: {{ restore_status.state }}.
+          </p>
+        </div>
+        <form action="{{ trigger_restore_data_url }}" method="post" onsubmit="return confirm('Restore data from the latest catalog backup?');">
+          {% csrf_token %}
+          <button class="admin-backup-trigger__button" type="submit" {% if restore_in_progress %}disabled{% endif %}>
+            {% if restore_in_progress %}Restore in progress{% else %}Restore from latest catalog{% endif %}
+          </button>
+        </form>
+      </div>
+    </div>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a global Django admin button to queue restoring from the latest catalog backup with duplicate-run protection
- extend the cache-backed backup state helpers and Celery tasks to support restore status, locking, and background execution
- add a `--force` flag to `load_backup_data` so the Celery restore path can skip the interactive confirmation while keeping the browser confirmation in admin