### PR TITLE
available_stands endpoint to receive sub_unit id

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -1424,7 +1424,11 @@ class GetAvailableStandsSerializer(serializers.Serializer):
         child=ConstraintSerializer(),
         required=False,
     )
-
+    sub_unit = serializers.PrimaryKeyRelatedField(
+        queryset=DataLayer.objects.filter(type=DataLayerType.VECTOR, status=DataLayerStatus.READY).all(),
+        required=False,
+        help_text="Vector Layer ID that contains Sub Units.",
+    )
 
 class UnavailableStandsSerializer(serializers.Serializer):
     by_inclusions = serializers.ListField(child=serializers.IntegerField())

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -1564,6 +1564,7 @@ def get_available_stands(
     includes: Optional[List[DataLayer]] = None,
     excludes: Optional[List[DataLayer]] = None,
     constraints: Optional[List[Dict[str, Any]]] = None,
+    sub_unit: Optional[DataLayer] = None,
     **kwargs,
 ):
     if not includes:
@@ -1588,16 +1589,11 @@ def get_available_stands(
         feature_enabled("PLANNING_APPROACH")
         and feature_enabled("RENDER_SUB_UNITS_FILTERED")
         and scenario.planning_approach == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
-        and scenario.configuration.get("sub_units_layer")
+        and sub_unit
     ):
         # Exclude stands that is not included to any sub-unit
         stands_queryset = stands.all()
-        datalayer = DataLayer.objects.get(
-            pk=scenario.configuration.get("sub_units_layer")
-        )
-        sub_units_stands = get_stands_from_sub_units(
-            stands_queryset, planning_area, scenario.get_stand_size(), datalayer
-        )
+        sub_units_stands = get_stands_from_sub_units(stands_queryset, planning_area, scenario.get_stand_size(), sub_unit)
         sub_units_stands_ids = set(sub_units_stands.values_list("id", flat=True))
         stand_ids = stands_queryset.exclude(id__in=sub_units_stands_ids).values_list(
             "id", flat=True

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -470,7 +470,7 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
 
         return Response(details, status=status.HTTP_200_OK)
 
-    @action(methods=["POST"], detail=True)
+    @action(methods=["POST"], detail=True, serializer_class=GetAvailableStandsSerializer)
     def available_stands(self, request, pk=None):
         scenario = self.get_object()
         serializer = GetAvailableStandsSerializer(data=request.data)


### PR DESCRIPTION
Receiving sub_unit on available_stands endpoint to filter out stands that are not included on sub-units.
<img width="519" height="281" alt="Captura de tela de 2026-04-22 17-14-12" src="https://github.com/user-attachments/assets/8f9e4840-4ff0-4f33-bf97-96842a379158" />
