### PR TITLE
Allow point vector datalayers to ingest without polygon outlines

### DIFF
--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -599,7 +599,7 @@ FROM (
 """
         cursor.execute(query)
         row = cursor.fetchone()
-        if row:
+        if row and row[0]:
             return GEOSGeometry(row[0], srid=srid)
 
         return None

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -568,12 +568,16 @@ def get_table_mask(datalayer: DataLayer) -> Optional[GEOSGeometry]:
     """
     Given a datalayer, returns a polygonal mask for all table geometries.
     """
-    if datalayer.geometry_type in {GeometryType.NO_GEOM, GeometryType.RASTER, None}:
+    geometry_type = datalayer.geometry_type
+    if geometry_type in {None, GeometryType.NO_GEOM, GeometryType.RASTER}:
         return None
-    if datalayer.geometry_type in {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}:
-        mask_expression = "ST_UnaryUnion(ST_Collect(ST_Envelope(geometry)))"
-    else:
-        mask_expression = "ST_ConvexHull(ST_Collect(geometry))"
+
+    is_polygonal = geometry_type in {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}
+    mask_expression = (
+        "ST_UnaryUnion(ST_Collect(ST_Envelope(geometry)))"
+        if is_polygonal
+        else "ST_ConvexHull(ST_Collect(geometry))"
+    )
 
     srid = 4269  # hardcoded as we only import stuff in 4269
     schema, table = datalayer.table.split(".")
@@ -595,7 +599,7 @@ FROM (
 """
         cursor.execute(query)
         row = cursor.fetchone()
-        if row and row[0]:
+        if row:
             return GEOSGeometry(row[0], srid=srid)
 
         return None

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -566,25 +566,32 @@ def get_datalayer_by_module_atribute(
 
 def get_table_mask(datalayer: DataLayer) -> Optional[GEOSGeometry]:
     """
-    Given a datalayer, returns the UNION of all geometries bounding boxes.
+    Given a datalayer, returns a polygonal mask for all table geometries.
     """
     srid = 4269  # hardcoded as we only import stuff in 4269
     schema, table = datalayer.table.split(".")
     with connection.cursor() as cursor:
         query = f"""SELECT
-ST_AsText(
-    ST_UnaryUnion(
-        ST_Collect(
-            ST_Envelope(geometry)
-        )
-    )
-) as geometry
-FROM "{schema}"."{table}"
-WHERE geometry IS NOT NULL;
+    ST_AsText(
+        CASE
+            WHEN GeometryType(envelope_union) IN ('POLYGON', 'MULTIPOLYGON')
+                THEN ST_Multi(envelope_union)
+            WHEN GeometryType(convex_hull) IN ('POLYGON', 'MULTIPOLYGON')
+                THEN ST_Multi(convex_hull)
+            ELSE NULL
+        END
+    ) as geometry
+FROM (
+    SELECT
+        ST_UnaryUnion(ST_Collect(ST_Envelope(geometry))) AS envelope_union,
+        ST_ConvexHull(ST_Collect(geometry)) AS convex_hull
+    FROM "{schema}"."{table}"
+    WHERE geometry IS NOT NULL
+) masks;
 """
         cursor.execute(query)
         row = cursor.fetchone()
-        if row:
+        if row and row[0]:
             return GEOSGeometry(row[0], srid=srid)
 
         return None

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -572,17 +572,25 @@ def get_table_mask(datalayer: DataLayer) -> Optional[GEOSGeometry]:
     if geometry_type in {None, GeometryType.NO_GEOM}:
         return None
 
-    is_polygonal = geometry_type in {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}
-    mask_expression = (
-        "ST_UnaryUnion(ST_Collect(ST_Envelope(geometry)))"
-        if is_polygonal
-        else "ST_ConvexHull(ST_Collect(geometry))"
-    )
-
     srid = 4269  # hardcoded as we only import stuff in 4269
     schema, table = datalayer.table.split(".")
     with connection.cursor() as cursor:
-        query = f"""SELECT
+        if geometry_type in {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}:
+            query = f"""SELECT
+    ST_AsText(
+        ST_UnaryUnion(
+            ST_Collect(
+                ST_Envelope(geometry)
+            )
+        )
+    ) as geometry
+FROM "{schema}"."{table}"
+WHERE geometry IS NOT NULL;
+"""
+        else:
+            # ConvexHull can return POINT or LINESTRING for sparse point/line layers;
+            # only area masks are valid here, and ST_Multi normalizes POLYGON output.
+            query = f"""SELECT
     ST_AsText(
         CASE
             WHEN GeometryType(mask) IN ('POLYGON', 'MULTIPOLYGON')
@@ -592,7 +600,7 @@ def get_table_mask(datalayer: DataLayer) -> Optional[GEOSGeometry]:
     ) as geometry
 FROM (
     SELECT
-        {mask_expression} AS mask
+        ST_ConvexHull(ST_Collect(geometry)) AS mask
     FROM "{schema}"."{table}"
     WHERE geometry IS NOT NULL
 ) masks;

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -568,23 +568,27 @@ def get_table_mask(datalayer: DataLayer) -> Optional[GEOSGeometry]:
     """
     Given a datalayer, returns a polygonal mask for all table geometries.
     """
+    if datalayer.geometry_type in {GeometryType.NO_GEOM, GeometryType.RASTER, None}:
+        return None
+    if datalayer.geometry_type in {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}:
+        mask_expression = "ST_UnaryUnion(ST_Collect(ST_Envelope(geometry)))"
+    else:
+        mask_expression = "ST_ConvexHull(ST_Collect(geometry))"
+
     srid = 4269  # hardcoded as we only import stuff in 4269
     schema, table = datalayer.table.split(".")
     with connection.cursor() as cursor:
         query = f"""SELECT
     ST_AsText(
         CASE
-            WHEN GeometryType(envelope_union) IN ('POLYGON', 'MULTIPOLYGON')
-                THEN ST_Multi(envelope_union)
-            WHEN GeometryType(convex_hull) IN ('POLYGON', 'MULTIPOLYGON')
-                THEN ST_Multi(convex_hull)
+            WHEN GeometryType(mask) IN ('POLYGON', 'MULTIPOLYGON')
+                THEN ST_Multi(mask)
             ELSE NULL
         END
     ) as geometry
 FROM (
     SELECT
-        ST_UnaryUnion(ST_Collect(ST_Envelope(geometry))) AS envelope_union,
-        ST_ConvexHull(ST_Collect(geometry)) AS convex_hull
+        {mask_expression} AS mask
     FROM "{schema}"."{table}"
     WHERE geometry IS NOT NULL
 ) masks;

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -569,7 +569,7 @@ def get_table_mask(datalayer: DataLayer) -> Optional[GEOSGeometry]:
     Given a datalayer, returns a polygonal mask for all table geometries.
     """
     geometry_type = datalayer.geometry_type
-    if geometry_type in {None, GeometryType.NO_GEOM, GeometryType.RASTER}:
+    if geometry_type in {None, GeometryType.NO_GEOM}:
         return None
 
     is_polygonal = geometry_type in {GeometryType.POLYGON, GeometryType.MULTIPOLYGON}

--- a/src/planscape/datasets/tasks.py
+++ b/src/planscape/datasets/tasks.py
@@ -13,6 +13,14 @@ from datasets.models import DataLayer, DataLayerStatus, DataLayerType
 logger = logging.getLogger(__name__)
 
 
+def to_datalayer_outline(geometry):
+    if not geometry:
+        return None
+    if geometry.geom_type in {"Polygon", "MultiPolygon"}:
+        return to_multipolygon(geometry)
+    return None
+
+
 def process_datalayer(
     datalayer_id: int,
     status: DataLayerStatus = DataLayerStatus.READY,
@@ -36,7 +44,7 @@ def process_datalayer(
             validate_datastore_table(datastore_table, datalayer)
             datalayer.table = datastore_table
         outline = get_datalayer_outline(datalayer)
-        datalayer.outline = to_multipolygon(outline) if outline else None
+        datalayer.outline = to_datalayer_outline(outline)
     except Exception:
         logger.exception(
             "Something went wrong while ingesting and processing datalayer %s",
@@ -100,7 +108,7 @@ def calculate_datalayer_outline(datalayer_id: int) -> None:
 
     try:
         result = get_datalayer_outline(datalayer)
-        datalayer.outline = to_multipolygon(result) if result else None
+        datalayer.outline = to_datalayer_outline(result)
         datalayer.save(update_fields=["outline", "updated_at"])
     except Exception:
         logger.exception(

--- a/src/planscape/datasets/tasks.py
+++ b/src/planscape/datasets/tasks.py
@@ -13,14 +13,6 @@ from datasets.models import DataLayer, DataLayerStatus, DataLayerType
 logger = logging.getLogger(__name__)
 
 
-def to_datalayer_outline(geometry):
-    if not geometry:
-        return None
-    if geometry.geom_type in {"Polygon", "MultiPolygon"}:
-        return to_multipolygon(geometry)
-    return None
-
-
 def process_datalayer(
     datalayer_id: int,
     status: DataLayerStatus = DataLayerStatus.READY,
@@ -44,7 +36,7 @@ def process_datalayer(
             validate_datastore_table(datastore_table, datalayer)
             datalayer.table = datastore_table
         outline = get_datalayer_outline(datalayer)
-        datalayer.outline = to_datalayer_outline(outline)
+        datalayer.outline = to_multipolygon(outline) if outline else None
     except Exception:
         logger.exception(
             "Something went wrong while ingesting and processing datalayer %s",
@@ -108,7 +100,7 @@ def calculate_datalayer_outline(datalayer_id: int) -> None:
 
     try:
         result = get_datalayer_outline(datalayer)
-        datalayer.outline = to_datalayer_outline(result)
+        datalayer.outline = to_multipolygon(result) if result else None
         datalayer.save(update_fields=["outline", "updated_at"])
     except Exception:
         logger.exception(

--- a/src/planscape/datasets/tests/test_services.py
+++ b/src/planscape/datasets/tests/test_services.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+from django.db import connection
 from django.test import TestCase, override_settings
 from organizations.tests.factories import OrganizationFactory
 
@@ -14,6 +15,7 @@ from datasets.services import (
     get_bucket_url,
     get_object_name,
     get_storage_url,
+    get_table_mask,
 )
 from datasets.tests.factories import DataLayerFactory, DatasetFactory
 
@@ -161,6 +163,79 @@ class TestCreateDataLayer(TestCase):
                 original_name="foo.tif",
             )
             self.assertEqual(0, DataLayer.objects.all().count())
+
+
+class TestGetTableMask(TestCase):
+    def create_datastore_table(self, geometry_type, geometries):
+        table_name = f"test_table_mask_{uuid4().hex}"
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                CREATE TABLE datastore.{table_name} (
+                    id serial PRIMARY KEY,
+                    geometry geometry({geometry_type}, 4269)
+                );
+                """
+            )
+            for geometry in geometries:
+                cursor.execute(
+                    f"""
+                    INSERT INTO datastore.{table_name} (geometry)
+                    VALUES (ST_GeomFromText(%s, 4269));
+                    """,
+                    [geometry],
+                )
+        self.addCleanup(self.drop_datastore_table, table_name)
+        return f"datastore.{table_name}"
+
+    def drop_datastore_table(self, table_name):
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS datastore.{table_name};")
+
+    def test_get_table_mask_returns_envelope_union_for_polygon_layer(self):
+        table = self.create_datastore_table(
+            "Polygon",
+            [
+                "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                "POLYGON ((2 2, 3 2, 3 3, 2 3, 2 2))",
+            ],
+        )
+        datalayer = DataLayerFactory(table=table, type=DataLayerType.VECTOR)
+
+        result = get_table_mask(datalayer)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.geom_type, "MultiPolygon")
+
+    def test_get_table_mask_returns_convex_hull_for_point_layer(self):
+        table = self.create_datastore_table(
+            "Point",
+            [
+                "POINT (0 0)",
+                "POINT (1 0)",
+                "POINT (0 1)",
+            ],
+        )
+        datalayer = DataLayerFactory(table=table, type=DataLayerType.VECTOR)
+
+        result = get_table_mask(datalayer)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.geom_type, "MultiPolygon")
+
+    def test_get_table_mask_returns_none_for_non_polygonal_point_hull(self):
+        table = self.create_datastore_table(
+            "Point",
+            [
+                "POINT (0 0)",
+                "POINT (1 1)",
+            ],
+        )
+        datalayer = DataLayerFactory(table=table, type=DataLayerType.VECTOR)
+
+        result = get_table_mask(datalayer)
+
+        self.assertIsNone(result)
 
 
 class TestSearch(TestCase):

--- a/src/planscape/datasets/tests/test_services.py
+++ b/src/planscape/datasets/tests/test_services.py
@@ -7,7 +7,13 @@ from django.db import connection
 from django.test import TestCase, override_settings
 from organizations.tests.factories import OrganizationFactory
 
-from datasets.models import Category, DataLayer, DataLayerStatus, DataLayerType
+from datasets.models import (
+    Category,
+    DataLayer,
+    DataLayerStatus,
+    DataLayerType,
+    GeometryType,
+)
 from datasets.services import (
     create_datalayer,
     create_upload_url_for_org,
@@ -200,7 +206,11 @@ class TestGetTableMask(TestCase):
                 "POLYGON ((2 2, 3 2, 3 3, 2 3, 2 2))",
             ],
         )
-        datalayer = DataLayerFactory(table=table, type=DataLayerType.VECTOR)
+        datalayer = DataLayerFactory(
+            table=table,
+            type=DataLayerType.VECTOR,
+            geometry_type=GeometryType.POLYGON,
+        )
 
         result = get_table_mask(datalayer)
 
@@ -216,7 +226,11 @@ class TestGetTableMask(TestCase):
                 "POINT (0 1)",
             ],
         )
-        datalayer = DataLayerFactory(table=table, type=DataLayerType.VECTOR)
+        datalayer = DataLayerFactory(
+            table=table,
+            type=DataLayerType.VECTOR,
+            geometry_type=GeometryType.POINT,
+        )
 
         result = get_table_mask(datalayer)
 
@@ -231,7 +245,11 @@ class TestGetTableMask(TestCase):
                 "POINT (1 1)",
             ],
         )
-        datalayer = DataLayerFactory(table=table, type=DataLayerType.VECTOR)
+        datalayer = DataLayerFactory(
+            table=table,
+            type=DataLayerType.VECTOR,
+            geometry_type=GeometryType.POINT,
+        )
 
         result = get_table_mask(datalayer)
 


### PR DESCRIPTION
This PR updates datalayer post-processing so non-polygon vector layers, such as point GeoJSON layers, do not fail during outline calculation.