### PR TITLE
plan-3495-automate-list-of-new-users-each-week

### DIFF
--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -1,10 +1,12 @@
 import logging
+from datetime import timedelta
 
 import rasterio
 from celery import chord, group
 from core.flags import feature_enabled
 from datasets.models import DataLayer, DataLayerType
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.gis.db.models import Union as UnionOp
 from django.contrib.gis.geos import MultiPolygon
 from django.core.mail import send_mail
@@ -45,6 +47,8 @@ from planning.services import (
 )
 
 log = logging.getLogger(__name__)
+
+User = get_user_model()
 
 
 @app.task()
@@ -289,7 +293,7 @@ def async_pre_forsys_process(scenario_id: int) -> None:
     run_config = build_run_configuration(scenario)
 
     variables = run_config["variables"]
-    
+
     forsys_input = {
         "stand_ids": stand_ids,
         "datalayers": run_config["datalayers"],
@@ -389,7 +393,7 @@ def trigger_scenario_post_processing():
     scenarios = Scenario.objects.filter(
         result_status__in=(ScenarioResultStatus.SUCCESS, ScenarioResultStatus.FAILURE),
         post_process_status=ScenarioPostProcessingStatus.PENDING,
-    ).values_list("id", flat=True) 
+    ).values_list("id", flat=True)
     log.info(f"Found {scenarios.count()} scenarios pending post_processing.")
     for scenario in scenarios:
         async_scenario_post_processing.delay(scenario)
@@ -406,7 +410,7 @@ def async_scenario_post_processing(scenario_id):
         scenario.post_process_status = ScenarioPostProcessingStatus.FAILURE
     else:
         scenario.post_process_status = ScenarioPostProcessingStatus.SUCCESS
-    
+
     scenario.save(update_fields=["post_process_status"])
 
 
@@ -584,3 +588,47 @@ def async_send_email_large_planning_area(planning_area_id: int) -> None:
             "Failed sending oversize planning area alert.",
             extra={"planning_area_id": planning_area_id},
         )
+
+
+@app.task()
+def send_weekly_new_users_report() -> None:
+    end = timezone.now()
+    start = end - timedelta(days=7)
+
+    users = User.objects.filter(date_joined__gte=start, date_joined__lt=end).order_by(
+        "date_joined", "id"
+    )
+
+    context = {
+        "start": start,
+        "end": end,
+        "count": users.count(),
+        "users": [
+            {
+                "email": (user.email or "").strip(),
+                "full_name": user.get_full_name().strip(),
+                "date_joined": user.date_joined,
+            }
+            for user in users
+        ],
+    }
+
+    subject = "Weekly New User Signup Report"
+    txt = render_to_string("email/new_users/weekly_new_users_report.txt", context)
+    html = render_to_string("email/new_users/weekly_new_users_report.html", context)
+
+    send_mail(
+        subject=subject,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[settings.SUPPORT_EMAIL],
+        message=txt,
+        html_message=html,
+    )
+
+    log.info(
+        "Sent weekly new users report to %s for %s to %s (%s users).",
+        settings.SUPPORT_EMAIL,
+        start.isoformat(),
+        end.isoformat(),
+        context["count"],
+    )

--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -592,6 +592,13 @@ def async_send_email_large_planning_area(planning_area_id: int) -> None:
 
 @app.task()
 def send_weekly_new_users_report() -> None:
+    if not settings.WEEKLY_NEW_USERS_REPORT_ENABLED:
+        log.info(
+            "Skipping weekly new users report because WEEKLY_NEW_USERS_REPORT_ENABLED is disabled for ENV=%s.",
+            settings.ENV,
+        )
+        return
+
     end = timezone.now()
     start = end - timedelta(days=7)
 
@@ -603,6 +610,7 @@ def send_weekly_new_users_report() -> None:
         "start": start,
         "end": end,
         "count": users.count(),
+        "environment": settings.ENV,
         "users": [
             {
                 "email": (user.email or "").strip(),
@@ -613,7 +621,7 @@ def send_weekly_new_users_report() -> None:
         ],
     }
 
-    subject = "Weekly New User Signup Report"
+    subject = f"[{settings.ENV}] Weekly New User Signup Report"
     txt = render_to_string("email/new_users/weekly_new_users_report.txt", context)
     html = render_to_string("email/new_users/weekly_new_users_report.html", context)
 
@@ -626,8 +634,9 @@ def send_weekly_new_users_report() -> None:
     )
 
     log.info(
-        "Sent weekly new users report to %s for %s to %s (%s users).",
+        "Sent weekly new users report to %s for ENV=%s from %s to %s (%s users).",
         settings.SUPPORT_EMAIL,
+        settings.ENV,
         start.isoformat(),
         end.isoformat(),
         context["count"],

--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -602,9 +602,7 @@ def send_weekly_new_users_report() -> None:
     end = timezone.now()
     start = end - timedelta(days=7)
 
-    users = User.objects.filter(date_joined__gte=start, date_joined__lt=end).order_by(
-        "date_joined", "id"
-    )
+    users = User.objects.filter(date_joined__gte=start).order_by("date_joined", "id")
 
     context = {
         "start": start,

--- a/src/planscape/planscape/celery.py
+++ b/src/planscape/planscape/celery.py
@@ -34,6 +34,7 @@ def get_catalog_restore_schedule() -> dict[str, dict]:
         }
     }
 
+
 beat_schedule = {
     "trigger-scenario-post-processing": {
         "task": "planning.tasks.trigger_scenario_post_processing",
@@ -46,6 +47,10 @@ beat_schedule = {
     "trigger-scenario-ready-emails": {
         "task": "planning.tasks.trigger_scenario_ready_emails",
         "schedule": 10.0,
+    },
+    "send-weekly-new-users-report": {
+        "task": "planning.tasks.send_weekly_new_users_report",
+        "schedule": crontab(day_of_week="monday", hour=13, minute=0),
     },
 }
 

--- a/src/planscape/planscape/celery.py
+++ b/src/planscape/planscape/celery.py
@@ -48,11 +48,13 @@ beat_schedule = {
         "task": "planning.tasks.trigger_scenario_ready_emails",
         "schedule": 10.0,
     },
-    "send-weekly-new-users-report": {
+}
+
+if settings.WEEKLY_NEW_USERS_REPORT_ENABLED:
+    beat_schedule["send-weekly-new-users-report"] = {
         "task": "planning.tasks.send_weekly_new_users_report",
         "schedule": crontab(day_of_week="monday", hour=13, minute=0),
-    },
-}
+    }
 
 beat_schedule.update(get_catalog_backup_schedule())
 beat_schedule.update(get_catalog_restore_schedule())

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -429,6 +429,9 @@ CELERY_TASK_DEFAULT_QUEUE = "default"
 CELERY_TASK_AUTODISCOVER = True
 
 CELERY_TASK_ROUTES = {
+    "planning.tasks.send_weekly_new_users_report": {
+        "queue": "default",
+    },
     "planning.tasks.*": {
         "queue": "forsys",
     },

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -483,6 +483,9 @@ CRONJOBS = [
 
 REPORT_RECIPIENT_EMAIL = config("REPORT_RECIPIENT_EMAIL", default=DEFAULT_FROM_EMAIL)
 
+WEEKLY_NEW_USERS_REPORT_ENABLED = config(
+    "WEEKLY_NEW_USERS_REPORT_ENABLED", default=False, cast=bool
+)
 
 AREA_SRID = 5070
 # Global hex grid origin (EPSG:5070) used to align ALL dynamic stands

--- a/src/planscape/templates/email/new_users/weekly_new_users_report.html
+++ b/src/planscape/templates/email/new_users/weekly_new_users_report.html
@@ -1,0 +1,49 @@
+<p>Hello,</p>
+
+<p>Here is the weekly new user signup report for the last 7 days.</p>
+
+<table role="presentation" cellspacing="0" cellpadding="6" border="0" style="border-collapse: collapse; margin-bottom: 16px;">
+  <tr>
+    <td><strong>Window start:</strong></td>
+    <td>{{ start }}</td>
+  </tr>
+  <tr>
+    <td><strong>Window end:</strong></td>
+    <td>{{ end }}</td>
+  </tr>
+  <tr>
+    <td><strong>Total new users:</strong></td>
+    <td>{{ count }}</td>
+  </tr>
+</table>
+
+{% if users %}
+<table role="presentation" cellspacing="0" cellpadding="8" border="1" style="border-collapse: collapse; width: 100%; max-width: 800px;">
+  <thead>
+    <tr>
+      <th align="left">Name</th>
+      <th align="left">Email</th>
+      <th align="left">Date joined</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for user in users %}
+    <tr>
+      <td>{{ user.full_name|default:"-" }}</td>
+      <td>
+        {% if user.email %}
+          <a href="mailto:{{ user.email }}">{{ user.email }}</a>
+        {% else %}
+          (no email)
+        {% endif %}
+      </td>
+      <td>{{ user.date_joined }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No new users signed up during this period.</p>
+{% endif %}
+
+<p style="margin-top: 16px;">— Planscape</p>

--- a/src/planscape/templates/email/new_users/weekly_new_users_report.html
+++ b/src/planscape/templates/email/new_users/weekly_new_users_report.html
@@ -4,6 +4,10 @@
 
 <table role="presentation" cellspacing="0" cellpadding="6" border="0" style="border-collapse: collapse; margin-bottom: 16px;">
   <tr>
+    <td><strong>Environment:</strong></td>
+    <td>{{ environment }}</td>
+  </tr>
+  <tr>
     <td><strong>Window start:</strong></td>
     <td>{{ start }}</td>
   </tr>

--- a/src/planscape/templates/email/new_users/weekly_new_users_report.txt
+++ b/src/planscape/templates/email/new_users/weekly_new_users_report.txt
@@ -1,0 +1,19 @@
+Weekly New User Signup Report
+
+Here is the weekly new user signup report for the last 7 days.
+
+Window start: {{ start }}
+Window end: {{ end }}
+Total new users: {{ count }}
+
+{% if users %}
+Name | Email | Date joined
+----------------------------------------
+{% for user in users %}
+{{ user.full_name|default:"-" }} | {{ user.email|default:"(no email)" }} | {{ user.date_joined }}
+{% endfor %}
+{% else %}
+No new users signed up during this period.
+{% endif %}
+
+— Planscape

--- a/src/planscape/templates/email/new_users/weekly_new_users_report.txt
+++ b/src/planscape/templates/email/new_users/weekly_new_users_report.txt
@@ -1,7 +1,8 @@
-Weekly New User Signup Report
+[{{ environment }}] Weekly New User Signup Report
 
 Here is the weekly new user signup report for the last 7 days.
 
+Environment: {{ environment }}
 Window start: {{ start }}
 Window end: {{ end }}
 Total new users: {{ count }}


### PR DESCRIPTION
@george-silva @roquebetioljr, 542 - Automate list of users that have signed up in the last week, https://sig-gis.atlassian.net/browse/PLAN-3495:

1. `src/planscape/planning/tasks.py`: Added a new weekly Celery task that collects users who signed up in the last 7 days and emails the report to support.

2. `src/planscape/planscape/celery.py`: Added a new Celery Beat schedule entry to run the weekly new-user report automatically every Monday morning.

3. `src/planscape/planscape/settings.py`: Added a specific Celery route so the weekly report task runs on the `default` queue instead of the broader `forsys` queue.

4. `src/planscape/templates/email/new_users/weekly_new_users_report.html`: Added the HTML version of the weekly signup report email with a summary section and readable user table.

5. `src/planscape/templates/email/new_users/weekly_new_users_report.txt`: Added the plain-text fallback version of the weekly signup report email.

------------------

May still need to fix Ruff auto-formater version. Report e-mail looks like this when I got it to send locally:

<img width="1371" height="621" alt="image" src="https://github.com/user-attachments/assets/a18d8ecb-89e7-4cfe-b1b9-83e25afc7c2b" />
