### PR TITLE
Catalog: Admin user set on created_by field when dumpdata

### DIFF
--- a/src/planscape/core/management/commands/generate_backup_data.py
+++ b/src/planscape/core/management/commands/generate_backup_data.py
@@ -12,7 +12,6 @@ import shutil
 from core.mattermost import post_to_mattermost
 
 
-
 class Command(BaseCommand):
     help = "Generates backup data by pushing it into json file to be loaded in another env."
 

--- a/src/planscape/core/management/commands/generate_backup_data.py
+++ b/src/planscape/core/management/commands/generate_backup_data.py
@@ -1,3 +1,8 @@
+from datasets.models import DataLayer, Dataset, Style, Category
+from planning.models import TreatmentGoal
+from organizations.models import Organization
+from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
@@ -5,6 +10,7 @@ from datetime import datetime
 import os
 import shutil
 from core.mattermost import post_to_mattermost
+
 
 
 class Command(BaseCommand):
@@ -35,6 +41,28 @@ class Command(BaseCommand):
         output_path = os.path.join(backups_dir, output_filename)
 
         try:
+            with transaction.atomic():
+                User = get_user_model()
+                admin = User.objects.get(email=settings.DEFAULT_ADMIN_EMAIL)
+
+                count = TreatmentGoal.objects.exclude(created_by=admin).update(created_by=admin)
+                self.stdout.write(f"Updated {count} TreatmentGoal(s) by setting admin as creator.")
+
+                count = Category.objects.exclude(created_by=admin).update(created_by=admin)
+                self.stdout.write(f"Deleted {count} Category(s) by setting admin as creator.")
+
+                count = Style.objects.exclude(created_by=admin).update(created_by=admin)
+                self.stdout.write(f"Deleted {count} Style(s) by setting admin as creator.")
+
+                count = DataLayer.objects.exclude(created_by=admin).update(created_by=admin)
+                self.stdout.write(f"Deleted {count} DataLayer(s) by setting admin as creator.")
+
+                count = Dataset.objects.exclude(created_by=admin).update(created_by=admin)
+                self.stdout.write(f"Deleted {count} Dataset(s) by setting admin as creator.")
+
+                count = Organization.objects.exclude(created_by=admin).update(created_by=admin)
+                self.stdout.write(f"Deleted {count} Organization(s) by setting admin as creator.")
+
             with open(output_path, "w", encoding="utf-8") as output_file:
                 call_command(
                     "dumpdata",


### PR DESCRIPTION
Admin user set on created_by field for all catalog related entries before dumpdata execution