### PR TITLE
Scenario / projarea dashboard route guard

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -148,6 +148,7 @@ const routes: Routes = [
           import('@scenario/scenario.module').then((m) => m.ScenarioModule),
       },
       {
+        // effectively an alias to /plan/:planId/scenario
         path: 'plan/:planId/project-area',
         resolve: { planId: planLoaderResolver },
         loadChildren: () =>

--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -148,6 +148,12 @@ const routes: Routes = [
           import('@scenario/scenario.module').then((m) => m.ScenarioModule),
       },
       {
+        path: 'plan/:planId/project-area',
+        resolve: { planId: planLoaderResolver },
+        loadChildren: () =>
+          import('@scenario/scenario.module').then((m) => m.ScenarioModule),
+      },
+      {
         // follow the route structure of plan, but without nesting modules and components
         path: 'plan/:planId/scenario/:scenarioId/treatment/:treatmentId',
         canActivate: [AuthGuard],

--- a/src/interface/src/app/plan/plan-summary/plan-scenarios-list/plan-scenarios-list.component.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-scenarios-list/plan-scenarios-list.component.ts
@@ -192,7 +192,7 @@ export class PlanScenariosListComponent implements OnInit {
     ) {
       if (clickedScenario.origin === 'USER') {
         this.router.navigate(
-          ['scenario', clickedScenario.id, 'projdashboard'],
+          ['project-area', clickedScenario.id, 'dashboard'],
           {
             relativeTo: this.route,
           }

--- a/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.html
+++ b/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.html
@@ -1,0 +1,6 @@
+<app-project-area-dashboard *ngIf="inProjectArea; else scenarioDash">
+</app-project-area-dashboard>
+
+<ng-template #scenarioDash>
+  <app-scenario-dashboard></app-scenario-dashboard>
+</ng-template>

--- a/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.spec.ts
+++ b/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardSwitcherComponent } from './dashboard-switcher.component';
+
+describe('DashboardSwitcherComponent', () => {
+  let component: DashboardSwitcherComponent;
+  let fixture: ComponentFixture<DashboardSwitcherComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardSwitcherComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardSwitcherComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.spec.ts
+++ b/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DashboardSwitcherComponent } from './dashboard-switcher.component';
+import { ActivatedRoute } from '@angular/router';
 
 describe('DashboardSwitcherComponent', () => {
   let component: DashboardSwitcherComponent;
@@ -8,7 +9,8 @@ describe('DashboardSwitcherComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DashboardSwitcherComponent],
+      imports: [DashboardSwitcherComponent, HttpClientTestingModule],
+      providers: [{ provide: ActivatedRoute, useValue: { snapshot: {} } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DashboardSwitcherComponent);

--- a/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.ts
+++ b/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { ScenarioDashboardComponent } from '../scenario-dashboard/scenario-dashboard.component';
+import { ProjectAreaDashboardComponent } from '../project-area-dashboard/project-area-dashboard.component';
+import { NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-dashboard-switcher',
+  templateUrl: 'dashboard-switcher.component.html',
+  standalone: true,
+
+  imports: [NgIf, ProjectAreaDashboardComponent, ScenarioDashboardComponent],
+})
+export class DashboardSwitcherComponent implements OnInit {
+  inProjectArea = false;
+
+  constructor(private router: Router) {}
+
+  ngOnInit() {
+    this.inProjectArea = this.router.url.includes('/project-area');
+  }
+}

--- a/src/interface/src/app/scenario/scenario-routing.module.ts
+++ b/src/interface/src/app/scenario/scenario-routing.module.ts
@@ -8,6 +8,7 @@ import { ScenarioRoutePlaceholderComponent } from './scenario-route-placeholder/
 import { ScenarioDashboardComponent } from './scenario-dashboard/scenario-dashboard.component';
 import { createFeatureGuard } from '@app/features/feature.guard';
 import { ProjectAreaDashboardComponent } from '@app/scenario/project-area-dashboard/project-area-dashboard.component';
+import { scenarioTypeRedirectGuard } from '@app/services/scenario-type.guard';
 
 const routes: Routes = [
   {
@@ -23,7 +24,10 @@ const routes: Routes = [
     component: ScenarioDashboardComponent,
     title: 'Scenario Dashboard',
     canDeactivate: [canDeactivateGuard],
-    canActivate: [createFeatureGuard({ featureName: 'SCENARIO_DASHBOARDS' })],
+    canActivate: [
+      createFeatureGuard({ featureName: 'SCENARIO_DASHBOARDS' }),
+      scenarioTypeRedirectGuard,
+    ],
     resolve: {
       scenarioId: scenarioLoaderResolver,
       dataLayerInit: resetDatalayerResolver,
@@ -34,7 +38,10 @@ const routes: Routes = [
     component: ProjectAreaDashboardComponent,
     title: 'Project Area Dashboard',
     canDeactivate: [canDeactivateGuard],
-    canActivate: [createFeatureGuard({ featureName: 'SCENARIO_DASHBOARDS' })],
+    canActivate: [
+      createFeatureGuard({ featureName: 'SCENARIO_DASHBOARDS' }),
+      scenarioTypeRedirectGuard,
+    ],
     resolve: {
       scenarioId: scenarioLoaderResolver,
       dataLayerInit: resetDatalayerResolver,

--- a/src/interface/src/app/scenario/scenario-routing.module.ts
+++ b/src/interface/src/app/scenario/scenario-routing.module.ts
@@ -5,10 +5,9 @@ import { scenarioLoaderResolver } from '@resolvers/scenario-loader.resolver';
 import { ScenarioComponent } from './scenario.component';
 import { canDeactivateGuard } from '@services/can-deactivate.guard';
 import { ScenarioRoutePlaceholderComponent } from './scenario-route-placeholder/scenario-route-placeholder';
-import { ScenarioDashboardComponent } from './scenario-dashboard/scenario-dashboard.component';
 import { createFeatureGuard } from '@app/features/feature.guard';
-import { ProjectAreaDashboardComponent } from '@app/scenario/project-area-dashboard/project-area-dashboard.component';
 import { scenarioTypeRedirectGuard } from '@app/services/scenario-type.guard';
+import { DashboardSwitcherComponent } from './dashboard-switcher/dashboard-switcher.component';
 
 const routes: Routes = [
   {
@@ -21,22 +20,8 @@ const routes: Routes = [
   },
   {
     path: ':scenarioId/dashboard',
-    component: ScenarioDashboardComponent,
+    component: DashboardSwitcherComponent,
     title: 'Scenario Dashboard',
-    canDeactivate: [canDeactivateGuard],
-    canActivate: [
-      createFeatureGuard({ featureName: 'SCENARIO_DASHBOARDS' }),
-      scenarioTypeRedirectGuard,
-    ],
-    resolve: {
-      scenarioId: scenarioLoaderResolver,
-      dataLayerInit: resetDatalayerResolver,
-    },
-  },
-  {
-    path: ':scenarioId/projdashboard', // temporary route just for testing
-    component: ProjectAreaDashboardComponent,
-    title: 'Project Area Dashboard',
     canDeactivate: [canDeactivateGuard],
     canActivate: [
       createFeatureGuard({ featureName: 'SCENARIO_DASHBOARDS' }),

--- a/src/interface/src/app/services/scenario-type.guard.ts
+++ b/src/interface/src/app/services/scenario-type.guard.ts
@@ -1,0 +1,50 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { ScenarioService } from './scenario.service';
+import { Scenario } from '@app/types';
+import { inject } from '@angular/core';
+import { catchError, map, of } from 'rxjs';
+
+export const scenarioTypeRedirectGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+  const scenarioService = inject(ScenarioService); // Access your actual service
+
+  const id = Number(route.paramMap.get('scenarioId')!);
+
+  function isProjectArea(record: Scenario) {
+    return record.origin === 'USER';
+  }
+
+  return scenarioService.getScenario(id).pipe(
+    map((scenario: Scenario) => {
+      const isOnProjectRoute = state.url.includes('/project-area');
+
+      const planId = route.paramMap.get('planId') || scenario.planning_area;
+
+      if (isProjectArea(scenario) && !isOnProjectRoute) {
+        const rediroute = router.createUrlTree([
+          'plan',
+          planId,
+          'project-area',
+          id,
+          'projdashboard',
+        ]);
+        return rediroute;
+      }
+      if (!isProjectArea(scenario) && isOnProjectRoute) {
+        const rediroute = router.createUrlTree([
+          'plan',
+          planId,
+          'scenario',
+          id,
+          'dashboard',
+        ]);
+        return rediroute;
+      }
+      return true;
+    }),
+    catchError(() => {
+      // Redirect to error page if scenarioId doesn't exist
+      return of(router.createUrlTree(['/404']));
+    })
+  );
+};

--- a/src/interface/src/app/services/scenario-type.guard.ts
+++ b/src/interface/src/app/services/scenario-type.guard.ts
@@ -26,7 +26,7 @@ export const scenarioTypeRedirectGuard: CanActivateFn = (route, state) => {
           planId,
           'project-area',
           id,
-          'projdashboard',
+          'dashboard',
         ]);
         return rediroute;
       }

--- a/src/interface/src/app/services/scenario-type.guard.ts
+++ b/src/interface/src/app/services/scenario-type.guard.ts
@@ -21,25 +21,24 @@ export const scenarioTypeRedirectGuard: CanActivateFn = (route, state) => {
       const planId = route.paramMap.get('planId') || scenario.planning_area;
 
       if (isProjectArea(scenario) && !isOnProjectRoute) {
-        const rediroute = router.createUrlTree([
+        return router.createUrlTree([
           'plan',
           planId,
           'project-area',
           id,
           'dashboard',
         ]);
-        return rediroute;
       }
       if (!isProjectArea(scenario) && isOnProjectRoute) {
-        const rediroute = router.createUrlTree([
+        return router.createUrlTree([
           'plan',
           planId,
           'scenario',
           id,
           'dashboard',
         ]);
-        return rediroute;
       }
+      // just proceed - no need to change anything
       return true;
     }),
     catchError(() => {

--- a/src/interface/src/app/services/scenario-type.guard.ts
+++ b/src/interface/src/app/services/scenario-type.guard.ts
@@ -6,7 +6,7 @@ import { catchError, map, of } from 'rxjs';
 
 export const scenarioTypeRedirectGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
-  const scenarioService = inject(ScenarioService); // Access your actual service
+  const scenarioService = inject(ScenarioService);
 
   const id = Number(route.paramMap.get('scenarioId')!);
 
@@ -43,8 +43,8 @@ export const scenarioTypeRedirectGuard: CanActivateFn = (route, state) => {
       return true;
     }),
     catchError(() => {
-      // Redirect to error page if scenarioId doesn't exist
-      return of(router.createUrlTree(['/404']));
+      // if scenarioId doesn't exist
+      return of(router.createUrlTree(['/']));
     })
   );
 };


### PR DESCRIPTION
This PR adds routes, a route guard, and a switcher component to allow routes such as `/project-area/:scenarioId/dashboard` and and`/scenario/:scenarioId/dashboard`, instead of something like `/scenario/:scenarioId/dashboard` and `/scenario/:scenarioId/projdashboard`.

I think this makes more sense, conceptually, but I'm open to switching back to the latter, if we think that's easier to manage.

