### PR TITLE
showing tooltip on base layer if metadata is provided

### DIFF
--- a/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.html
+++ b/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.html
@@ -29,6 +29,21 @@
             diameter="20"
             *ngIf="(loadingLayers$ | async)?.includes('source_' + layer.id)">
           </mat-spinner>
+
+          <button
+            *ngIf="layer.metadata?.['metadata']"
+            sg-button
+            variant="icon-only"
+            icon="info"
+            class="info-icon"
+            [outlined]="true"
+            [matMenuTriggerFor]="popoverMenu"></button>
+          <mat-menu #popoverMenu="matMenu" class="datalayer-tooltip-panel">
+            <app-data-layer-tooltip
+              [layer]="layer"
+              [showAllData]="false"></app-data-layer-tooltip>
+          </mat-menu>
+
           <span
             class="base-layer-legend"
             *ngIf="isSelectedLayer(layer.id)"

--- a/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.scss
+++ b/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.scss
@@ -79,3 +79,7 @@
 .side-spinner {
   flex-shrink: 0;
 }
+
+.info-icon {
+  color: $color-standard-blue;
+}

--- a/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.ts
+++ b/src/interface/src/app/base-layers/base-layers-list/base-layers-list.component.ts
@@ -22,6 +22,9 @@ import { DataLayersService } from '@services';
 import { catchError, map, tap } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MAP_MODULE_NAME } from '@services/map-module.token';
+import { ButtonComponent } from '@styleguide';
+import { DataLayerTooltipComponent } from '@data-layers/data-layer-tooltip/data-layer-tooltip.component';
+import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
   selector: 'app-base-layers-list',
@@ -33,6 +36,9 @@ import { MAP_MODULE_NAME } from '@services/map-module.token';
     MatRadioModule,
     MatCheckboxModule,
     MatProgressSpinnerModule,
+    ButtonComponent,
+    DataLayerTooltipComponent,
+    MatMenuModule,
   ],
   templateUrl: './base-layers-list.component.html',
   styleUrl: './base-layers-list.component.scss',

--- a/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.html
+++ b/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.html
@@ -22,14 +22,21 @@
     </ng-container>
 
     <dt>Source</dt>
+
     <dd>
-      <a
-        *ngIf="getSource() as source; else noSource"
-        [href]="source.url"
-        target="_blank">
-        {{ source.name }}
-      </a>
-      <ng-template #noSource>--</ng-template>
+      <div
+        *ngIf="getRichSource() as richSource; else normalSource"
+        [innerHTML]="richSource"></div>
+
+      <ng-template #normalSource>
+        <a
+          *ngIf="getSourceDownload() as source; else noSource"
+          [href]="source.url"
+          target="_blank">
+          {{ source.name }}
+        </a>
+        <ng-template #noSource>--</ng-template>
+      </ng-template>
     </dd>
 
     <ng-container *ngIf="showAllData">

--- a/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.html
+++ b/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.html
@@ -1,23 +1,25 @@
 <h3 class="header">Layer info</h3>
 <div class="content">
   <dl>
-    <dt>Layer Name</dt>
-    <dd>{{ layer.name || '--' }}</dd>
+    <ng-container *ngIf="showAllData">
+      <dt>Layer Name</dt>
+      <dd>{{ layer.name || '--' }}</dd>
 
-    <dt>Value Range</dt>
-    <dd>
-      @if (hasMinMax()) {
-        {{ this.layer.info.stats[0].min | number: '1.0-0' }} -
-        {{ this.layer.info.stats[0].max | number: '1.0-0' }}
-      } @else {
-        --
-      }
-    </dd>
+      <dt>Value Range</dt>
+      <dd>
+        @if (hasMinMax()) {
+          {{ this.layer.info.stats[0].min | number: '1.0-0' }} -
+          {{ this.layer.info.stats[0].max | number: '1.0-0' }}
+        } @else {
+          --
+        }
+      </dd>
 
-    <dt>Units</dt>
-    <dd>
-      {{ getUnits() }}
-    </dd>
+      <dt>Units</dt>
+      <dd>
+        {{ getUnits() }}
+      </dd>
+    </ng-container>
 
     <dt>Source</dt>
     <dd>
@@ -30,13 +32,15 @@
       <ng-template #noSource>--</ng-template>
     </dd>
 
-    <dt>Vintage</dt>
-    <dd>
-      {{ vintageDate ? (vintageDate | date: 'yyyy') : '--' }}
-    </dd>
+    <ng-container *ngIf="showAllData">
+      <dt>Vintage</dt>
+      <dd>
+        {{ vintageDate ? (vintageDate | date: 'yyyy') : '--' }}
+      </dd>
+    </ng-container>
   </dl>
 </div>
-<div class="footer">
+<div class="footer" *ngIf="showAllData">
   <button
     class="download-link"
     *ngIf="loadingLink"

--- a/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.scss
+++ b/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.scss
@@ -21,6 +21,7 @@
       grid-template-columns: max-content 1fr;
       gap: 0.5rem 1rem;
       align-items: baseline;
+      margin: 0;
     }
 
     dt {

--- a/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.ts
+++ b/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.ts
@@ -54,7 +54,13 @@ export class DataLayerTooltipComponent implements OnInit {
     );
   }
 
-  getSource() {
+  // html `source` field: takes precedence over download
+  getRichSource() {
+    return this.layer.metadata?.['metadata']?.['distribution']?.['source'];
+  }
+
+  // download link (no rich text, just shows button)
+  getSourceDownload() {
     return this.layer.metadata?.['metadata']?.['distribution']?.['download'];
   }
 

--- a/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.ts
+++ b/src/interface/src/app/data-layers/data-layer-tooltip/data-layer-tooltip.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { AsyncPipe, DatePipe, DecimalPipe, NgIf } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { DataLayer } from '@types';
+import { BaseLayer, DataLayer } from '@types';
 import { getFileExtensionFromFile, getSafeFileName } from '@shared/files';
 import { DataLayersService } from '@services/data-layers.service';
 import { Observable, shareReplay, take } from 'rxjs';
@@ -26,7 +26,8 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
   styleUrl: './data-layer-tooltip.component.scss',
 })
 export class DataLayerTooltipComponent implements OnInit {
-  @Input() layer!: DataLayer;
+  @Input() layer!: DataLayer | BaseLayer;
+  @Input() showAllData = true;
 
   downloadLink$: Observable<string> | null = null;
   loadingLink = false;

--- a/src/interface/src/app/scenario/scenario.constants.ts
+++ b/src/interface/src/app/scenario/scenario.constants.ts
@@ -100,15 +100,6 @@ export const CUSTOM_SCENARIO_OVERVIEW_STEPS: ScenarioStepConfig[] = [
     hasMap: true,
   },
   {
-    label: 'Include Areas',
-    description: 'Include and exclude specific areas based on your plan.',
-    icon: '/assets/svg/icons/overview/co-benefits.svg',
-    includeConstraints: false,
-    includeExcludedAreas: false,
-    refreshAvailableStands: true,
-    hasMap: true,
-  },
-  {
     label: 'Exclude Areas',
     description: 'Include and exclude specific areas based on your plan.',
     icon: '/assets/svg/icons/overview/exclude-areas.svg',

--- a/src/interface/src/app/scenario/scenario.constants.ts
+++ b/src/interface/src/app/scenario/scenario.constants.ts
@@ -100,6 +100,15 @@ export const CUSTOM_SCENARIO_OVERVIEW_STEPS: ScenarioStepConfig[] = [
     hasMap: true,
   },
   {
+    label: 'Include Areas',
+    description: 'Include and exclude specific areas based on your plan.',
+    icon: '/assets/svg/icons/overview/co-benefits.svg',
+    includeConstraints: false,
+    includeExcludedAreas: false,
+    refreshAvailableStands: true,
+    hasMap: true,
+  },
+  {
     label: 'Exclude Areas',
     description: 'Include and exclude specific areas based on your plan.',
     icon: '/assets/svg/icons/overview/exclude-areas.svg',


### PR DESCRIPTION
Adds a couple of things on the data-layer tooltip to support the usage on base layers:
- Hides some data via input flag
- Adds a rich source element using `['metadata']?.['distribution']?.['source']` 

On base layers, we only show the tooltip if the layer has metadata

<img width="654" height="312" alt="Screenshot 2026-05-14 at 5 34 00 PM" src="https://github.com/user-attachments/assets/af02586e-38f3-4051-beb4-501c0d5c44ab" />
