### PR TITLE
plan-3493-scenario-draft-only-seen-by-creator

### DIFF
--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -18,6 +18,7 @@ from planning.models import (
     PlanningArea,
     RegionChoices,
     ScenarioResult,
+    ScenarioResultStatus,
     TreatmentGoal,
     TreatmentGoalCategory,
     TreatmentGoalGroup,
@@ -1149,7 +1150,9 @@ class CreateScenariosFromUpload(APITestCase):
     def test_invalid_geometry_returns_400_with_global_error(self, mock_create):
         from planscape.exceptions import InvalidGeometry
 
-        mock_create.side_effect = InvalidGeometry("Geometry is invalid and cannot be processed.")
+        mock_create.side_effect = InvalidGeometry(
+            "Geometry is invalid and cannot be processed."
+        )
         self.client.force_authenticate(self.owner_user)
         payload = {
             "geometry": json.dumps(self.riverside),
@@ -1170,7 +1173,9 @@ class CreateScenariosFromUpload(APITestCase):
 
     @mock.patch("planning.views_v2.create_scenario_from_upload")
     def test_oversize_planning_area_returns_400_with_global_error(self, mock_create):
-        mock_create.side_effect = ValueError("Planning area is oversize; scenarios are disabled.")
+        mock_create.side_effect = ValueError(
+            "Planning area is oversize; scenarios are disabled."
+        )
         self.client.force_authenticate(self.owner_user)
         payload = {
             "geometry": json.dumps(self.riverside),
@@ -1352,3 +1357,73 @@ class TreatmentGoalViewSetTest(APITestCase):
         treatment_goals = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(treatment_goals), 1)
+
+
+class ListScenarioDraftVisibilityTest(APITestCase):
+    def setUp(self):
+        self.creator = UserFactory.create()
+        self.collaborator = UserFactory.create()
+
+        self.planning_area = PlanningAreaFactory.create(
+            user=self.creator,
+            collaborators=[self.collaborator],
+        )
+
+        self.creator_draft = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.creator,
+            name="Creator draft",
+        )
+        ScenarioResult.objects.update_or_create(
+            scenario=self.creator_draft,
+            defaults={"status": ScenarioResultStatus.DRAFT},
+        )
+
+        self.collaborator_draft = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.collaborator,
+            name="Collaborator draft",
+        )
+        ScenarioResult.objects.update_or_create(
+            scenario=self.collaborator_draft,
+            defaults={"status": ScenarioResultStatus.DRAFT},
+        )
+
+        self.completed_scenario = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.creator,
+            name="Completed scenario",
+        )
+        ScenarioResult.objects.update_or_create(
+            scenario=self.completed_scenario,
+            defaults={"status": ScenarioResultStatus.SUCCESS},
+        )
+
+    def get_scenario_ids_for_user(self, user):
+        self.client.force_authenticate(user)
+        response = self.client.get(
+            reverse("api:planning:scenarios-list"),
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        results = (
+            data["results"] if isinstance(data, dict) and "results" in data else data
+        )
+        return {scenario["id"] for scenario in results}
+
+    def test_creator_only_sees_their_own_draft_scenarios(self):
+        scenario_ids = self.get_scenario_ids_for_user(self.creator)
+
+        self.assertIn(self.creator_draft.id, scenario_ids)
+        self.assertIn(self.completed_scenario.id, scenario_ids)
+        self.assertNotIn(self.collaborator_draft.id, scenario_ids)
+
+    def test_collaborator_only_sees_their_own_draft_scenarios(self):
+        scenario_ids = self.get_scenario_ids_for_user(self.collaborator)
+
+        self.assertIn(self.collaborator_draft.id, scenario_ids)
+        self.assertIn(self.completed_scenario.id, scenario_ids)
+        self.assertNotIn(self.creator_draft.id, scenario_ids)

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -4,6 +4,7 @@ from core.flags import feature_enabled
 from core.serializers import MultiSerializerMixin
 from datasets.models import DataLayer
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from django.db.models.expressions import RawSQL
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
@@ -224,11 +225,17 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
+        draft_status = Q(result_status=ScenarioResultStatus.DRAFT) | Q(
+            results__status=ScenarioResultStatus.DRAFT
+        )
+
         qs = (
             Scenario.objects.list_by_user(user=user)
+            .filter(Q(user=user) | ~draft_status)
             .select_related(
                 "planning_area",
                 "user",
+                "results",
             )
             .prefetch_related("project_areas")
         )
@@ -472,7 +479,9 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
 
         return Response(details, status=status.HTTP_200_OK)
 
-    @action(methods=["POST"], detail=True, serializer_class=GetAvailableStandsSerializer)
+    @action(
+        methods=["POST"], detail=True, serializer_class=GetAvailableStandsSerializer
+    )
     def available_stands(self, request, pk=None):
         scenario = self.get_object()
         serializer = GetAvailableStandsSerializer(data=request.data)


### PR DESCRIPTION
@george-silva @roquebetioljr, 542 - Only Scenario Creators should see Draft Scenarios, https://sig-gis.atlassian.net/browse/PLAN-3493

1. `src/planscape/planning/views_v2.py`: updated the scenario queryset to hide draft scenarios from non-creators while still showing users their own drafts and all non-draft scenarios they have access to.

2. `src/planscape/planning/tests/test_v2_views.py`: added tests confirming draft scenarios are only visible to their creators, while shared users can still see non-draft scenarios in the same planning area.
