### PR TITLE
Creation of accessible_by filter on Dataset model

### DIFF
--- a/src/planscape/datasets/filters.py
+++ b/src/planscape/datasets/filters.py
@@ -14,7 +14,7 @@ def get_datasets_for_filter(request: Optional[Request]) -> "QuerySet[Dataset]":
     # TODO: this needs to be tweaked when we create the controls to associate users and
     # organizations. we should retrieve the organization(s) based on the request.user
     # and return all the organizations, so we can filter the datasets here.
-    return Dataset.objects.all()
+    return Dataset.objects.all().accessible_by(request.user).all()
 
 
 def get_styles_for_filter(request: Optional[Request]) -> "QuerySet[Style]":

--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -19,7 +19,7 @@ from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
-from django.db.models import Manager
+from django.db.models import Manager, Q
 from django_stubs_ext.db.models import TypedModelMeta
 from organizations.models import Organization
 from treebeard.mp_tree import MP_Node
@@ -60,6 +60,14 @@ class PreferredDisplayType(models.TextChoices):
 class DatasetQuerySet(models.QuerySet):
     def by_outline_intersects(self, geometry: GEOSGeometry) -> models.QuerySet:
         return self.all().filter(datalayers__outline__intersects=geometry)
+    
+    def accessible_by(self, user) -> models.QuerySet:
+        q = Q(visibility=VisibilityOptions.PUBLIC)
+        if user and user.is_authenticated:
+            q |= Q(created_by=user)
+            if user.is_staff or user.is_superuser:
+                q |= Q(visibility=VisibilityOptions.PRIVATE)
+        return self.filter(q).distinct()
 
 
 class DatasetManager(models.Manager):

--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -282,9 +282,9 @@ class DataLayerQuerySet(models.QuerySet):
         query = {"modules": {"forsys": {"capabilities": [capability]}}}
         return self.all().filter(metadata__contains=query)
     
-    def accessible_by(self, user):
-        self.all().select_related("datalayer")
-
+    def accessible_by(self, user) -> models.QuerySet:
+        accessible_datasets_ids = Dataset.objects.all().accessible_by(user).values_list("id", flat=True)
+        return self.all().filter(dataset_id__in=accessible_datasets_ids) 
 
 class DataLayerManager(models.Manager):
     def get_queryset(self):

--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -281,6 +281,9 @@ class DataLayerQuerySet(models.QuerySet):
     def by_meta_capability(self, capability: str):
         query = {"modules": {"forsys": {"capabilities": [capability]}}}
         return self.all().filter(metadata__contains=query)
+    
+    def accessible_by(self, user):
+        self.all().select_related("datalayer")
 
 
 class DataLayerManager(models.Manager):

--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -65,6 +65,7 @@ class DatasetQuerySet(models.QuerySet):
         q = Q(visibility=VisibilityOptions.PUBLIC)
         if user and user.is_authenticated:
             q |= Q(created_by=user)
+            q |= Q(workspace__user_access__user=user)
             if user.is_staff or user.is_superuser:
                 q |= Q(visibility=VisibilityOptions.PRIVATE)
         return self.filter(q).distinct()

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -458,6 +458,7 @@ def find_anything(
     type: DataLayerType,
     module: Optional[str] = None,
     geometry: Optional[GEOSGeometry] = None,
+    user: Optional[User] = None,
     **kwargs,
 ) -> Dict[str, SearchResult]:
     """
@@ -473,7 +474,7 @@ def find_anything(
         )
         dataset_ids = [
             d.pk
-            for d in mod.get_datasets()
+            for d in mod.get_datasets(user=user)
             if d.preferred_display_type == preferred_display_type
         ]
     else:

--- a/src/planscape/datasets/services.py
+++ b/src/planscape/datasets/services.py
@@ -482,23 +482,19 @@ def find_anything(
 
     datalayer_filter: Dict[str, Any] = {
         "name__icontains": term,
-        "dataset__visibility": VisibilityOptions.PUBLIC,
         "status": DataLayerStatus.READY,
         "type": layer_type,
     }
     category_filter: Dict[str, Any] = {
         "category__name__icontains": term,
-        "dataset__visibility": VisibilityOptions.PUBLIC,
         "status": DataLayerStatus.READY,
         "type": layer_type,
     }
     dataset_filter: Dict[str, Any] = {
         "name__icontains": term,
-        "visibility": VisibilityOptions.PUBLIC,
     }
     org_filter: Dict[str, Any] = {
         "organization__name__icontains": term,
-        "visibility": VisibilityOptions.PUBLIC,
     }
 
     if module:
@@ -518,25 +514,25 @@ def find_anything(
     raw_results = [
         [
             dataset_to_search_result(x)
-            for x in Dataset.objects.filter(
+            for x in Dataset.objects.all().accessible_by(user).filter(
                 **org_filter,
             )
         ],
         [
             dataset_to_search_result(x)
-            for x in Dataset.objects.filter(
+            for x in Dataset.objects.all().accessible_by(user).filter(
                 **dataset_filter,
             )
         ],
         [
             datalayer_to_search_result(x)
-            for x in DataLayer.objects.filter(
+            for x in DataLayer.objects.all().accessible_by(user).filter(
                 **category_filter,
             )
         ],
         [
             datalayer_to_search_result(x)
-            for x in DataLayer.objects.filter(
+            for x in DataLayer.objects.all().accessible_by(user).filter(
                 **datalayer_filter,
             )
         ],

--- a/src/planscape/datasets/tests/factories.py
+++ b/src/planscape/datasets/tests/factories.py
@@ -28,6 +28,7 @@ class DatasetFactory(factory.django.DjangoModelFactory):
     visibility = factory.Iterator(VisibilityOptions.values)
     selection_type = factory.Iterator(SelectionTypeOptions.values)
     preferred_display_type = factory.Iterator(PreferredDisplayType.values)
+    workspace = None
 
 
 class CategoryFactory(factory.django.DjangoModelFactory):
@@ -66,6 +67,7 @@ class DataLayerFactory(factory.django.DjangoModelFactory):
     metadata = {}
     url = None
     outline = None
+    workspace = None
 
     @factory.post_generation
     def style(self, create, extracted, **kwargs):

--- a/src/planscape/datasets/tests/test_serializers.py
+++ b/src/planscape/datasets/tests/test_serializers.py
@@ -333,6 +333,7 @@ class MapURLTests(TestCase):
         base = get_base_url(settings.ENV) or f"https://{get_domain(settings.ENV)}"
         return base + "/tiles/dynamic/{z}/{x}/{y}?layer=" + str(layer.id)
 
+    @override_settings(ENV="dev")
     def test_get_map_url_logic(self):
         raster = DataLayerFactory(type=DataLayerType.RASTER)
         self.assertEqual(raster.get_map_url(), raster.get_public_url())
@@ -356,6 +357,7 @@ class MapURLTests(TestCase):
             "http://localhost:3000/dynamic/{z}/{x}/{y}?layer=" + str(vector.id),
         )
 
+    @override_settings(ENV="dev")
     def test_map_url_present_in_serializers(self):
         vector = DataLayerFactory(
             type=DataLayerType.VECTOR,
@@ -365,6 +367,7 @@ class MapURLTests(TestCase):
         for Serializer in (DataLayerSerializer, BrowseDataLayerSerializer):
             self.assertIn("map_url", Serializer(vector).data)
 
+    @override_settings(ENV="dev")
     def test_map_url_none_when_no_table(self):
         layer = DataLayerFactory(type=DataLayerType.VECTOR, table=None)
         self.assertIsNone(layer.get_map_url())

--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -210,6 +210,46 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(1, data.get("count"))
         self.assertIsInstance(data.get("results")[0].get("styles"), list)
 
+    def test_datalayers_list_private_as_staff_user(self):
+        self.client.force_authenticate(user=self.admin)
+        private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
+
+        for i in range(2):
+            DataLayerFactory.create(
+                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+            )
+
+        for i in range(3):
+            DataLayerFactory.create(
+                dataset=self.dataset, name=f"public R {i}", type=DataLayerType.RASTER
+            )
+
+        url = reverse("api:datasets:datalayers-list")
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(data.get("results")), 5)
+
+    def test_datalayers_list_private_as_normal_user(self):
+        self.client.force_authenticate(user=self.normal)
+        private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
+
+        for i in range(2):
+            DataLayerFactory.create(
+                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+            )
+
+        for i in range(3):
+            DataLayerFactory.create(
+                dataset=self.dataset, name=f"public R {i}", type=DataLayerType.RASTER
+            )
+
+        url = reverse("api:datasets:datalayers-list")
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(data.get("results")), 3)
+
     def test_find_anything(self):
         self.client.force_authenticate(user=self.normal)
         DataLayerFactory.create(

--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -314,7 +314,6 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(5, data.get("count"))
         
-
     def test_find_anything_private_as_normal_user(self):
         self.client.force_authenticate(user=self.normal)
         private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
@@ -361,7 +360,7 @@ class TestDatasetViewSet(APITestCase):
         self.assertIn(dataset.pk, ids)
 
     def test_get_by_user_succeeds(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         dataset = DatasetFactory(visibility=VisibilityOptions.PUBLIC)
         url = reverse("api:datasets:datasets-list")
         response = self.client.get(url, format="json")
@@ -374,7 +373,7 @@ class TestDatasetViewSet(APITestCase):
         self.assertIn("modules", dataset_row)
 
     def test_browses_datalayers(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         dataset = DatasetFactory(visibility=VisibilityOptions.PUBLIC)
         datalayer = DataLayerFactory.create(dataset=dataset)
         url = reverse("api:datasets:datasets-browse", kwargs={"pk": dataset.pk})
@@ -384,7 +383,7 @@ class TestDatasetViewSet(APITestCase):
         self.assertEqual(datalayer.pk, data[0].get("id"))
 
     def test_browses_datalayers__filter_by_name_exact(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         dataset = DatasetFactory(visibility=VisibilityOptions.PUBLIC)
         datalayer = DataLayerFactory.create(dataset=dataset, name="Owl Habitat")
         query_params = {"name": datalayer.name}
@@ -395,7 +394,7 @@ class TestDatasetViewSet(APITestCase):
         self.assertEqual(datalayer.pk, data[0].get("id"))
 
     def test_browses_datalayers__filter_by_name_icontains(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         dataset = DatasetFactory(visibility=VisibilityOptions.PUBLIC)
         datalayer = DataLayerFactory.create(dataset=dataset, name="Owl Habitat")
         query_params = {"name": "owl"}
@@ -408,24 +407,38 @@ class TestDatasetViewSet(APITestCase):
 
 class TestPublicAccess(APITestCase):
     def setUp(self) -> None:
-        self.dataset = DatasetFactory.create(visibility=VisibilityOptions.PUBLIC)
-        self.datalayer = DataLayerFactory.create(dataset=self.dataset)
+        self.public_dataset = DatasetFactory.create(visibility=VisibilityOptions.PUBLIC)
+        self.public_datalayer = DataLayerFactory.create(dataset=self.public_dataset)
+
+        self.private_dataset = DatasetFactory.create(visibility=VisibilityOptions.PRIVATE)
+        self.private_datalayer = DataLayerFactory.create(dataset=self.private_dataset)
 
     def test_datasets_list_is_public(self):
         url = reverse("api:datasets:datasets-list")
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data.get("results")), 1)
 
     def test_all_public_endpoints_are_readable(self):
         urls = [
-            reverse("api:datasets:datasets-browse", kwargs={"pk": self.dataset.pk}),
+            reverse("api:datasets:datasets-browse", kwargs={"pk": self.public_dataset.pk}),
             f"{reverse('api:datasets:datalayers-find-anything')}?term=x&type=RASTER",
-            reverse("api:datasets:datalayers-urls", kwargs={"pk": self.datalayer.pk}),
+            reverse("api:datasets:datalayers-urls", kwargs={"pk": self.public_datalayer.pk}),
         ]
         for url in urls:
             with self.subTest(url=url):
                 resp = self.client.get(url)
                 self.assertEqual(resp.status_code, 200)
+
+    def test_private_endpoints_are_not_visible(self):
+        urls = [
+            reverse("api:datasets:datasets-browse", kwargs={"pk": self.private_dataset.pk}),
+            reverse("api:datasets:datalayers-urls", kwargs={"pk": self.private_datalayer.pk}),
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                resp = self.client.get(url)
+                self.assertEqual(resp.status_code, 404)
 
     def test_write_still_requires_authentication(self):
         url = reverse("api:datasets:datasets-list")

--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -39,7 +39,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_filter_by_name_exact_returns_record(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         datalayer = DataLayerFactory.create(
             dataset=self.dataset, type=DataLayerType.RASTER
         )
@@ -54,7 +54,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(datalayer.name, data.get("results")[0].get("name"))
 
     def test_filter_by_name_icontains_returns_record(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         datalayer = DataLayerFactory.create(
             dataset=self.dataset, type=DataLayerType.RASTER
         )
@@ -69,7 +69,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(datalayer.name, data.get("results")[0].get("name"))
 
     def test_filter_by_full_text_search_datalayer_name(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         datalayer = DataLayerFactory.create(
             dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
         )
@@ -91,7 +91,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(datalayer.name, data.get("results")[0].get("name"))
 
     def test_filter_by_full_text_search_datalayer_name_multiple_return(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         DataLayerFactory.create(
             dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
         )
@@ -108,7 +108,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(10, data.get("count"))
 
     def test_filter_by_full_text_search_dataset_name(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         DataLayerFactory.create(
             dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
         )
@@ -129,7 +129,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(21, data.get("count"))
 
     def test_filter_by_full_text_search_organization_name(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         DataLayerFactory.create(
             dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
         )
@@ -177,9 +177,9 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(datalayer.pk, data.get("results")[0].get("id"))
 
     def test_get_dataset_with_style(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         style = StyleFactory.create(
-            created_by=self.admin, organization=self.organization
+            created_by=self.normal, organization=self.organization
         )
         datalayer = DataLayerFactory.create(
             dataset=self.dataset,
@@ -194,7 +194,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(style.pk, data.get("results")[0].get("styles")[0].get("id"))
 
     def test_styles_shape_is_array_for_id_in_filter(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         datalayer = DataLayerFactory.create(
             dataset=self.dataset,
             type=DataLayerType.VECTOR,
@@ -211,7 +211,7 @@ class TestDataLayerViewSet(APITestCase):
         self.assertIsInstance(data.get("results")[0].get("styles"), list)
 
     def test_find_anything(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         DataLayerFactory.create(
             dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
         )
@@ -239,7 +239,7 @@ class TestDataLayerViewSet(APITestCase):
             self.assertEqual("RASTER", row["data"]["type"])
 
     def test_find_anything_type_vector_returns_vectors(self):
-        self.client.force_authenticate(user=self.admin)
+        self.client.force_authenticate(user=self.normal)
         for i in range(3):
             DataLayerFactory.create(
                 dataset=self.dataset, name=f"vefoo {i}", type=DataLayerType.VECTOR
@@ -257,6 +257,39 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(3, data.get("count"))
         for row in data["results"]:
             self.assertEqual("VECTOR", row["data"]["type"])
+
+    def test_find_anything_private_as_staff_user(self):
+        self.client.force_authenticate(user=self.admin)
+        private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
+
+        for i in range(5):
+            DataLayerFactory.create(
+                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+            )
+
+        params = {"term": "priv", "type": "RASTER"}
+        url = f"{reverse('api:datasets:datalayers-find-anything')}?{urlencode(params)}"
+        resp = self.client.get(url)
+        data = resp.json()
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(5, data.get("count"))
+        
+
+    def test_find_anything_private_as_normal_user(self):
+        self.client.force_authenticate(user=self.normal)
+        private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
+
+        for i in range(5):
+            DataLayerFactory.create(
+                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+            )
+
+        params = {"term": "priv", "type": "RASTER"}
+        url = f"{reverse('api:datasets:datalayers-find-anything')}?{urlencode(params)}"
+        resp = self.client.get(url)
+        data = resp.json()
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(0, data.get("count"))
 
 
 class TestDatasetViewSet(APITestCase):

--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -8,6 +8,7 @@ from rest_framework.test import APITestCase
 
 from datasets.models import DataLayer, DataLayerType, VisibilityOptions
 from datasets.tests.factories import DataLayerFactory, DatasetFactory, StyleFactory
+from workspaces.tests.factories import WorkspaceFactory
 
 User = get_user_model()
 
@@ -250,6 +251,54 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(data.get("results")), 3)
 
+    def test_datalayers_list_workpace_related(self):
+        collaborator = UserFactory.create()
+        viewer = UserFactory.create()
+        shared_workspace = WorkspaceFactory.create(
+            owner=self.normal,
+            collaborators=[collaborator],
+            viewers=[viewer],
+        )
+        shared_dataset = DatasetFactory(
+            visibility=VisibilityOptions.PRIVATE,
+            workspace=shared_workspace,
+        )
+
+        hidden_workspace = WorkspaceFactory.create(
+            owner=self.normal
+        )
+        hidden_dataset = DatasetFactory(
+            visibility=VisibilityOptions.PRIVATE,
+            workspace=hidden_workspace,
+        )
+
+        for i in range(5):
+            DataLayerFactory.create(
+                dataset=shared_dataset, 
+                name=f"shared private R {i}", 
+                type=DataLayerType.RASTER,
+                workspace=shared_workspace
+            )
+            DataLayerFactory.create(
+                dataset=hidden_dataset, 
+                name=f"hidden private R {i}", 
+                type=DataLayerType.RASTER,
+                workspace=hidden_workspace
+            )
+
+        for test in [
+            {"user": self.normal, "expected_result": 10},
+            {"user": collaborator, "expected_result": 5},
+            {"user": viewer, "expected_result": 5},
+        ]:
+            self.client.force_authenticate(user=test.get("user"))
+            url = reverse("api:datasets:datalayers-list")
+            response = self.client.get(url)
+            data = response.json()
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(data.get("results")), test.get("expected_result"))
+
+
     def test_find_anything(self):
         self.client.force_authenticate(user=self.normal)
         DataLayerFactory.create(
@@ -329,6 +378,54 @@ class TestDataLayerViewSet(APITestCase):
         data = resp.json()
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(0, data.get("count"))
+
+    def test_find_anything_workpace_related(self):
+        collaborator = UserFactory.create()
+        viewer = UserFactory.create()
+        shared_workspace = WorkspaceFactory.create(
+            owner=self.normal,
+            collaborators=[collaborator],
+            viewers=[viewer],
+        )
+        shared_dataset = DatasetFactory(
+            visibility=VisibilityOptions.PRIVATE,
+            workspace=shared_workspace,
+        )
+
+        hidden_workspace = WorkspaceFactory.create(
+            owner=self.normal
+        )
+        hidden_dataset = DatasetFactory(
+            visibility=VisibilityOptions.PRIVATE,
+            workspace=hidden_workspace,
+        )
+
+        for i in range(5):
+            DataLayerFactory.create(
+                dataset=shared_dataset, 
+                name=f"shared private R {i}", 
+                type=DataLayerType.RASTER,
+                workspace=shared_workspace
+            )
+            DataLayerFactory.create(
+                dataset=hidden_dataset, 
+                name=f"hidden private R {i}", 
+                type=DataLayerType.RASTER,
+                workspace=hidden_workspace
+            )
+
+        for test in [
+            {"user": self.normal, "expected_result": 10},
+            {"user": collaborator, "expected_result": 5},
+            {"user": viewer, "expected_result": 5},
+        ]:
+            self.client.force_authenticate(user=test.get("user"))
+            params = {"term": "priv", "type": "RASTER"}
+            url = f"{reverse('api:datasets:datalayers-find-anything')}?{urlencode(params)}"
+            resp = self.client.get(url)
+            data = resp.json()
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(data.get("count"), test.get("expected_result"))
 
 
 class TestDatasetViewSet(APITestCase):

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -125,7 +125,7 @@ class DataLayerViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
         serializer = FindAnythingSerializer(data=params)
         serializer.is_valid(raise_exception=True)
 
-        results = find_anything(**serializer.validated_data)
+        results = find_anything(user=request.user, **serializer.validated_data)
         search_results = list(results.values())
         page = self.paginate_queryset(search_results)  # type: ignore
         if page is not None:

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -154,9 +154,7 @@ class DataLayerViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
                 | Q(dataset_id=settings.CLIMATE_FORESIGHT_DATASET_ID)
             )
 
-        queryset = DataLayer.objects.all().accessible_by(user).filter(
-            dataset__visibility=VisibilityOptions.PUBLIC,
-        )
+        queryset = DataLayer.objects.all().accessible_by(user)
 
         if self.action == "list" and (
             search_query := self.request.query_params.get("search")

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -145,13 +145,15 @@ class DataLayerViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
         # by organization visibility too, so we return the public ones
         # PLUS all the datalayers accessible by the organization
 
+        user = self.request.user if self.request else None
+
         if self.action == "urls":
-            return DataLayer.objects.filter(
+            return DataLayer.objects.all().accessible_by(user).filter(
                 Q(dataset__visibility=VisibilityOptions.PUBLIC)
                 | Q(dataset_id=settings.CLIMATE_FORESIGHT_DATASET_ID)
             )
 
-        queryset = DataLayer.objects.filter(
+        queryset = DataLayer.objects.all().accessible_by(user).filter(
             dataset__visibility=VisibilityOptions.PUBLIC,
         )
 

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -39,13 +39,8 @@ class DatasetViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
     }
 
     def get_queryset(self):
-        # TODO: afterwards we need to implement the filtering
-        # by organization visibility too, so we return the public ones
-        # PLUS all the datasets accessible by the organization
-        filters = {"visibility": VisibilityOptions.PUBLIC}
-
         user = self.request.user if self.request else None
-        return Dataset.objects.all().accessible_by(user).filter(**filters).select_related(
+        return Dataset.objects.all().accessible_by(user).select_related(
             "organization", "created_by"
         )
 

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -44,7 +44,8 @@ class DatasetViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
         # PLUS all the datasets accessible by the organization
         filters = {"visibility": VisibilityOptions.PUBLIC}
 
-        return Dataset.objects.filter(**filters).select_related(
+        user = self.request.user if self.request else None
+        return Dataset.objects.all().accessible_by(user).filter(**filters).select_related(
             "organization", "created_by"
         )
 

--- a/src/planscape/modules/base.py
+++ b/src/planscape/modules/base.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Optional, Type, Union
 
-from datasets.models import DataLayer, Dataset, PreferredDisplayType, VisibilityOptions
+from datasets.models import DataLayer, Dataset, PreferredDisplayType
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.db.models import Q, QuerySet

--- a/src/planscape/modules/base.py
+++ b/src/planscape/modules/base.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, List, Optional, Type, Union
 
 from datasets.models import DataLayer, Dataset, PreferredDisplayType, VisibilityOptions
+from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.db.models import Q, QuerySet
 from planning.models import (
@@ -43,15 +44,19 @@ class BaseModule:
     def get_configuration(self, **kwargs) -> Dict[str, Any]:
         return {"name": self.name, "options": self._get_options(**kwargs)}
 
-    def get_datasets(self, geometry: Optional[GEOSGeometry] = None, **kwargs) -> QuerySet[Dataset]:
+    def get_datasets(
+            self, 
+            geometry: Optional[GEOSGeometry] = None, 
+            user: Optional[User] = None, 
+            **kwargs
+        ) -> QuerySet[Dataset]:
         queryset = Dataset.objects.all()
         if geometry:
             queryset = queryset.by_outline_intersects(geometry=geometry)
         
-        return queryset.filter(
+        return queryset.all().accessible_by(user).filter(
             modules__contains=[self.name],
             preferred_display_type__isnull=False,
-            visibility=VisibilityOptions.PUBLIC,
         ).select_related("organization").distinct()
 
     def _get_main_datasets(self, **kwargs):
@@ -129,7 +134,12 @@ class ImpactsModule(BaseModule):
             and runnable.planning_approach != ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
         )
 
-    def get_datasets(self, **kwargs):
+    def get_datasets(
+            self, 
+            geometry: Optional[GEOSGeometry] = None, 
+            user: Optional[User] = None, 
+            **kwargs
+        ) -> QuerySet[Dataset]:
         return Dataset.objects.none()
 
 
@@ -145,12 +155,17 @@ class MapModule(BaseModule):
     def _can_run_scenario(self, runnable: Scenario) -> bool:
         return True
 
-    def get_datasets(self, geometry: Optional[GEOSGeometry] = None, **kwargs) -> QuerySet[Dataset]:
+    def get_datasets(
+            self, 
+            geometry: Optional[GEOSGeometry] = None, 
+            user: Optional[User] = None, 
+            **kwargs
+        ) -> QuerySet[Dataset]:
         queryset = Dataset.objects.all()
         if geometry:
             queryset = queryset.by_outline_intersects(geometry=geometry)
         
-        return queryset.filter(
+        return queryset.all().accessible_by(user).filter(
             Q(preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS)
             | Q(preferred_display_type=PreferredDisplayType.BASE_DATALAYERS)
         ).select_related("organization").distinct()
@@ -177,12 +192,17 @@ class ClimateForesightModule(BaseModule):
         scenario_geometry = runnable.planning_area.geometry
         return self.future_climate_coverage.contains(scenario_geometry)
 
-    def get_datasets(self, geometry: Optional[GEOSGeometry] = None, **kwargs) -> QuerySet[Dataset]:
+    def get_datasets(
+            self, 
+            geometry: Optional[GEOSGeometry] = None, 
+            user: Optional[User] = None, 
+            **kwargs
+        ) -> QuerySet[Dataset]:
         queryset = Dataset.objects.all()
         if geometry:
             queryset = queryset.by_outline_intersects(geometry=geometry)
 
-        return queryset.filter(
+        return queryset.all().accessible_by(user).filter(
             Q(modules__contains=[self.name])
             & (
                 Q(preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS)

--- a/src/planscape/modules/base.py
+++ b/src/planscape/modules/base.py
@@ -224,8 +224,9 @@ class PrioritizeSubUnitsModule(BaseModule):
         return PrioritizeSubUnitsModuleSerializer
     
     def _get_options(self, **kwargs):
+        user = kwargs.get("user")
         options = super()._get_options(**kwargs)
-        sub_units_layers = DataLayer.objects.all().by_meta_module(self.name)
+        sub_units_layers = DataLayer.objects.all().accessible_by(user).by_meta_module(self.name)
         return {
             **options,
             "sub_units": list(sub_units_layers)

--- a/src/planscape/modules/tests/test_modules.py
+++ b/src/planscape/modules/tests/test_modules.py
@@ -9,6 +9,7 @@ from django.contrib.gis.geos import GEOSGeometry
 
 from modules.base import get_module
 
+from planscape.tests.factories import UserFactory
 from planning.tests.factories import PlanningAreaFactory, ScenarioFactory
 from planning.models import ScenarioPlanningApproach
 
@@ -140,6 +141,72 @@ class MapModuleTest(TestCase):
         self.assertGreaterEqual(len(base), 0)
 
 
+    def test_returns_private_dataset_for_staff_users(self):
+        DatasetFactory.create(
+            name="base-private", 
+            visibility=VisibilityOptions.PRIVATE,
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS
+        )
+        DatasetFactory.create(
+            name="base-public", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS
+        )
+        DatasetFactory.create(
+            name="main-private", 
+            visibility=VisibilityOptions.PRIVATE,
+            preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
+        )
+        DatasetFactory.create(
+            name="main-public", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
+        )
+        staff_user = UserFactory.create(is_staff=True)
+        standard_user = UserFactory.create(is_staff=False)
+
+        module = get_module("map")
+
+        # staff user
+        configuration: Dict[str, Any] = module.get_configuration(user=staff_user)
+        self.assertIn("name", configuration)
+        self.assertIn("options", configuration)
+
+        options: Dict[str, Any] = configuration["options"]
+
+        self.assertIn("datasets", options)
+
+        datasets: Dict[str, Any] = options["datasets"]
+
+        self.assertIn("main_datasets", datasets)
+        self.assertIn("base_datasets", datasets)
+
+        main = datasets["main_datasets"]
+        base = datasets["base_datasets"]
+
+        self.assertGreaterEqual(len(main), 2)
+        self.assertGreaterEqual(len(base), 2)
+
+        # standard user
+        configuration: Dict[str, Any] = module.get_configuration(user=standard_user)
+        self.assertIn("name", configuration)
+        self.assertIn("options", configuration)
+
+        options: Dict[str, Any] = configuration["options"]
+
+        self.assertIn("datasets", options)
+
+        datasets: Dict[str, Any] = options["datasets"]
+
+        self.assertIn("main_datasets", datasets)
+        self.assertIn("base_datasets", datasets)
+
+        main = datasets["main_datasets"]
+        base = datasets["base_datasets"]
+
+        self.assertGreaterEqual(len(main), 1)
+        self.assertGreaterEqual(len(base), 1)
+
 
 class PrioritizeSubUnitsModuleTest(TestCase):
     def test_returns_options_correctly(self):
@@ -159,6 +226,88 @@ class PrioritizeSubUnitsModuleTest(TestCase):
 
         module = get_module("prioritize_sub_units")
         configuration: Dict[str, Any] = module.get_configuration()
+        self.assertIn("name", configuration)
+        self.assertIn("options", configuration)
+
+        options: Dict[str, Any] = configuration["options"]
+
+        self.assertIn("datasets", options)
+        self.assertIn("sub_units", options)
+
+        datasets: Dict[str, Any] = options["datasets"]
+        sub_units = options["sub_units"]
+
+        self.assertIn("main_datasets", datasets)
+        self.assertIn("base_datasets", datasets)
+        
+
+        main = datasets["main_datasets"]
+        base = datasets["base_datasets"]
+
+        self.assertEqual(len(main), 1)
+        self.assertEqual(len(base), 1)
+        self.assertEqual(len(sub_units), 1)
+
+
+    def test_returns_private_dataset_for_staff_users(self):
+        private_base_dataset = DatasetFactory.create(
+            name="base-private",
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS, 
+            visibility=VisibilityOptions.PRIVATE,
+            modules=["prioritize_sub_units"],
+        )
+        public_base_dataset = DatasetFactory.create(
+            name="base-public",
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS, 
+            visibility=VisibilityOptions.PUBLIC,
+            modules=["prioritize_sub_units"],
+        )
+        DatasetFactory.create(
+            name="main-private", 
+            preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS, 
+            visibility=VisibilityOptions.PRIVATE, 
+            modules=["prioritize_sub_units"],
+        )
+        DatasetFactory.create(
+            name="main-public", 
+            preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS, 
+            visibility=VisibilityOptions.PUBLIC, 
+            modules=["prioritize_sub_units"],
+        )
+        DataLayerFactory.create(dataset=private_base_dataset, metadata={"modules": {"prioritize_sub_units": {"enabled": True}}})
+        DataLayerFactory.create(dataset=public_base_dataset, metadata={"modules": {"prioritize_sub_units": {"enabled": True}}})
+
+        staff_user = UserFactory.create(is_staff=True)
+        standard_user = UserFactory.create(is_staff=False)
+
+        module = get_module("prioritize_sub_units")
+
+        # staff user
+        configuration: Dict[str, Any] = module.get_configuration(user=staff_user)
+        self.assertIn("name", configuration)
+        self.assertIn("options", configuration)
+
+        options: Dict[str, Any] = configuration["options"]
+
+        self.assertIn("datasets", options)
+        self.assertIn("sub_units", options)
+
+        datasets: Dict[str, Any] = options["datasets"]
+        sub_units = options["sub_units"]
+
+        self.assertIn("main_datasets", datasets)
+        self.assertIn("base_datasets", datasets)
+        
+
+        main = datasets["main_datasets"]
+        base = datasets["base_datasets"]
+
+        self.assertEqual(len(main), 2)
+        self.assertEqual(len(base), 2)
+        self.assertEqual(len(sub_units), 2)
+
+        # standard user
+        configuration: Dict[str, Any] = module.get_configuration(user=standard_user)
         self.assertIn("name", configuration)
         self.assertIn("options", configuration)
 

--- a/src/planscape/modules/tests/test_modules.py
+++ b/src/planscape/modules/tests/test_modules.py
@@ -15,10 +15,14 @@ from planning.models import ScenarioPlanningApproach
 class MapModuleTest(TestCase):
     def test_returns_options_correctly(self):
         DatasetFactory.create(
-            name="base1", preferred_display_type=PreferredDisplayType.BASE_DATALAYERS
+            name="base1", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS
         )
         DatasetFactory.create(
-            name="main1", preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
+            name="main1", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
         )
 
         module = get_module("map")
@@ -50,14 +54,18 @@ class MapModuleTest(TestCase):
         geos_geometry = GEOSGeometry(json.dumps(geometry))
 
         base1 = DatasetFactory.create(
-            name="base1", preferred_display_type=PreferredDisplayType.BASE_DATALAYERS
+            name="base1", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS,
         )
         DataLayerFactory.create(
             dataset=base1,
             outline=geos_geometry,
         )
         main1 = DatasetFactory.create(
-            name="main1", preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
+            name="main1", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
         )
         DataLayerFactory.create(
             dataset=main1,
@@ -93,14 +101,18 @@ class MapModuleTest(TestCase):
         geos_geometry = GEOSGeometry(json.dumps(geometry))
 
         base1 = DatasetFactory.create(
-            name="base1", preferred_display_type=PreferredDisplayType.BASE_DATALAYERS
+            name="base1", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS
         )
         DataLayerFactory.create(
             dataset=base1,
             outline=None,
         )
         main1 = DatasetFactory.create(
-            name="main1", preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
+            name="main1", 
+            visibility=VisibilityOptions.PUBLIC,
+            preferred_display_type=PreferredDisplayType.MAIN_DATALAYERS
         )
         DataLayerFactory.create(
             dataset=main1,

--- a/src/planscape/modules/views.py
+++ b/src/planscape/modules/views.py
@@ -23,7 +23,7 @@ class ModuleViewSet(RetrieveModelMixin, GenericViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         my_module = self.get_object()
-        payload = my_module.get_configuration()
+        payload = my_module.get_configuration(user=request.user)
         SerializerClass = my_module.get_serializer_class()
         serializer = SerializerClass(instance=payload)
         return Response(serializer.data)
@@ -43,7 +43,7 @@ class ModuleViewSet(RetrieveModelMixin, GenericViewSet):
         input_serializer.is_valid(raise_exception=True)
         geometry = input_serializer.validated_data.get("geometry")
 
-        payload = my_module.get_configuration(geometry=geometry)
+        payload = my_module.get_configuration(geometry=geometry, user=request.user)
         SerializerClass = my_module.get_serializer_class()
         serializer = SerializerClass(instance=payload)
         return Response(serializer.data)

--- a/src/planscape/workspaces/tests/factories.py
+++ b/src/planscape/workspaces/tests/factories.py
@@ -13,6 +13,30 @@ class WorkspaceFactory(factory.django.DjangoModelFactory):
     visibility = VisibilityOptions.PRIVATE
 
 
+    @factory.post_generation
+    def owner(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+        UserAccessWorkspaceFactory.create(user=extracted, workspace=self, role=WorkspaceRole.OWNER)
+        return extracted
+
+    @factory.post_generation
+    def collaborators(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+        for collaborator in extracted:
+            UserAccessWorkspaceFactory.create(user=collaborator, workspace=self, role=WorkspaceRole.COLLABORATOR)
+        return extracted
+
+    @factory.post_generation
+    def viewers(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+        for viewer in extracted:
+            UserAccessWorkspaceFactory.create(user=viewer, workspace=self, role=WorkspaceRole.VIEWER)
+        return extracted
+    
+
 class UserAccessWorkspaceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = UserAccessWorkspace


### PR DESCRIPTION
* accesssible_by method is build to contain the Datasets visibility rules based on user
* Usage of `accesssible_by` to show module's datasets and datalayers
* Usage of `accesssible_by` on find_anything
* Usage of `accesssible_by` on datalayer's list endpoint