### PR TITLE
Simplify project area dashboard route

### DIFF
--- a/src/interface/src/app/app-routing.module.ts
+++ b/src/interface/src/app/app-routing.module.ts
@@ -165,13 +165,6 @@ const routes: Routes = [
           import('@scenario/scenario.module').then((m) => m.ScenarioModule),
       },
       {
-        // effectively an alias to /plan/:planId/scenario
-        path: 'plan/:planId/project-area',
-        resolve: { planId: planLoaderResolver },
-        loadChildren: () =>
-          import('@scenario/scenario.module').then((m) => m.ScenarioModule),
-      },
-      {
         path: 'plan/:planId/scenario/:scenarioId/treatment',
         pathMatch: 'full',
         canActivate: [AuthGuard],

--- a/src/interface/src/app/plan/plan-summary/plan-scenarios-list/plan-scenarios-list.component.ts
+++ b/src/interface/src/app/plan/plan-summary/plan-scenarios-list/plan-scenarios-list.component.ts
@@ -191,12 +191,9 @@ export class PlanScenariosListComponent implements OnInit {
       )
     ) {
       if (clickedScenario.origin === 'USER') {
-        this.router.navigate(
-          ['project-area', clickedScenario.id, 'dashboard'],
-          {
-            relativeTo: this.route,
-          }
-        );
+        this.router.navigate(['scenario', clickedScenario.id, 'pa-dashboard'], {
+          relativeTo: this.route,
+        });
       } else {
         this.router.navigate(['scenario', clickedScenario.id, 'dashboard'], {
           relativeTo: this.route,

--- a/src/interface/src/app/plan/upload-project-areas-modal/upload-project-areas-modal.component.html
+++ b/src/interface/src/app/plan/upload-project-areas-modal/upload-project-areas-modal.component.html
@@ -1,6 +1,6 @@
 <sg-modal
   class="upload-scenario-modal"
-  title="Upload Scenario to &ldquo;{{ data.planning_area_name }}&rdquo;"
+  title="Upload Project Areas to &ldquo;{{ data.planning_area_name }}&rdquo;"
   primaryButtonText="Create"
   [primaryButtonDisabled]="!canSubmit()"
   secondaryButtonText="Cancel"
@@ -26,7 +26,7 @@
 
       <div class="field-row">
         <div class="field-label-required">
-          Scenario name
+          Name
           <div class="required-star">*</div>
         </div>
         <sg-input-field
@@ -40,7 +40,7 @@
           <input
             sgInput
             cdkFocusInitial
-            placeholder="Scenario name"
+            placeholder="Name"
             name="scenarioName"
             formControlName="scenarioName"
             class="scenario-name-field" />

--- a/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.ts
+++ b/src/interface/src/app/scenario/dashboard-switcher/dashboard-switcher.component.ts
@@ -17,6 +17,6 @@ export class DashboardSwitcherComponent implements OnInit {
   constructor(private router: Router) {}
 
   ngOnInit() {
-    this.inProjectArea = this.router.url.includes('/project-area');
+    this.inProjectArea = this.router.url.includes('pa-dashboard');
   }
 }

--- a/src/interface/src/app/scenario/scenario-routing.module.ts
+++ b/src/interface/src/app/scenario/scenario-routing.module.ts
@@ -32,6 +32,20 @@ const routes: Routes = [
       dataLayerInit: resetDatalayerResolver,
     },
   },
+  {
+    path: ':scenarioId/pa-dashboard',
+    component: DashboardSwitcherComponent,
+    title: 'Scenario Dashboard',
+    canDeactivate: [canDeactivateGuard],
+    canActivate: [
+      createFeatureGuard({ featureName: 'SCENARIO_DASHBOARDS' }),
+      scenarioTypeRedirectGuard,
+    ],
+    resolve: {
+      scenarioId: scenarioLoaderResolver,
+      dataLayerInit: resetDatalayerResolver,
+    },
+  },
   // We need to keep this route when SCENARIO_DASHBOARDS be released since this is used for drafts creation
   {
     path: ':scenarioId',

--- a/src/interface/src/app/services/scenario-type.guard.ts
+++ b/src/interface/src/app/services/scenario-type.guard.ts
@@ -16,7 +16,7 @@ export const scenarioTypeRedirectGuard: CanActivateFn = (route, state) => {
 
   return scenarioService.getScenario(id).pipe(
     map((scenario: Scenario) => {
-      const isOnProjectRoute = state.url.includes('/project-area');
+      const isOnProjectRoute = state.url.includes('pa-dashboard');
 
       const planId = route.paramMap.get('planId') || scenario.planning_area;
 
@@ -24,9 +24,9 @@ export const scenarioTypeRedirectGuard: CanActivateFn = (route, state) => {
         return router.createUrlTree([
           'plan',
           planId,
-          'project-area',
+          'scenario',
           id,
-          'dashboard',
+          'pa-dashboard',
         ]);
       }
       if (!isProjectArea(scenario) && isOnProjectRoute) {


### PR DESCRIPTION
This PR changes the project-area dashboard path from `/project-area/:scenarioId/dashboard` to `/scenario/:scenarioId/pa-dashboard`, as we originally considered, in order to avoid various navigation side-effects under that single path, as well as the nested `/project-area` route portions during treatment plan creation.