### PR TITLE
Allow scenarios without stand_size

### DIFF
--- a/src/planscape/modules/base.py
+++ b/src/planscape/modules/base.py
@@ -89,7 +89,7 @@ class ForsysModule(BaseModule):
         return True
 
     def _can_run_scenario(self, runnable: Scenario) -> bool:
-        return True
+        return bool((runnable.configuration or {}).get("stand_size"))
 
     def _get_options(self, **kwargs):
         options = super()._get_options(**kwargs)

--- a/src/planscape/modules/tests/test_modules.py
+++ b/src/planscape/modules/tests/test_modules.py
@@ -40,7 +40,7 @@ class ForsysModuleTest(TestCase):
         self.assertFalse(module.can_run(scenario))
 
     def test_cannot_run_scenario_with_empty_configuration(self):
-        scenario = ScenarioFactory.create(
+        scenario = ScenarioFactory.build(
             planning_area=self.planning_area,
             configuration=None,
         )

--- a/src/planscape/modules/tests/test_modules.py
+++ b/src/planscape/modules/tests/test_modules.py
@@ -13,6 +13,40 @@ from planscape.tests.factories import UserFactory
 from planning.tests.factories import PlanningAreaFactory, ScenarioFactory
 from planning.models import ScenarioPlanningApproach
 
+
+class ForsysModuleTest(TestCase):
+    def setUp(self):
+        self.planning_area = PlanningAreaFactory.create()
+        return super().setUp()
+
+    def test_can_run_planning_area(self):
+        module = get_module("forsys")
+        self.assertTrue(module.can_run(self.planning_area))
+
+    def test_can_run_scenario_with_stand_size(self):
+        scenario = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            configuration={"stand_size": "LARGE"},
+        )
+        module = get_module("forsys")
+        self.assertTrue(module.can_run(scenario))
+
+    def test_cannot_run_scenario_without_stand_size(self):
+        scenario = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            configuration={},
+        )
+        module = get_module("forsys")
+        self.assertFalse(module.can_run(scenario))
+
+    def test_cannot_run_scenario_with_empty_configuration(self):
+        scenario = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            configuration=None,
+        )
+        module = get_module("forsys")
+        self.assertFalse(module.can_run(scenario))
+
 class MapModuleTest(TestCase):
     def test_returns_options_correctly(self):
         DatasetFactory.create(

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -1378,7 +1378,7 @@ class GeoJSONSerializer(serializers.Serializer):
 class UploadedScenarioDataSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=100, required=True)
     stand_size = serializers.ChoiceField(
-        choices=["SMALL", "MEDIUM", "LARGE"], required=True
+        choices=["SMALL", "MEDIUM", "LARGE"], required=False, allow_null=True, default=None
     )
     planning_area = serializers.IntegerField(min_value=1, required=True)
     geometry = serializers.JSONField(required=True)
@@ -1443,7 +1443,7 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
         return planning_area_covers(
             planning_area=planning_area,
             geometry=uploaded_geos,
-            stand_size=stand_size,
+            stand_size=stand_size or StandSizeChoices.SMALL,
         )
 
 

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -421,7 +421,7 @@ def create_scenario_from_upload(validated_data, user) -> Scenario:
         name=validated_data["name"],
         planning_area=planning_area,
         user=user,
-        configuration={"stand_size": validated_data["stand_size"]},
+        configuration={k: v for k, v in {"stand_size": validated_data.get("stand_size")}.items() if v is not None},
         origin=ScenarioOrigin.USER,
     )
     scenario.capabilities = compute_scenario_capabilities(scenario)

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -1449,7 +1449,10 @@ class TriggerScenarioTest(TestCase):
         self.planning_area = PlanningAreaFactory(
             geometry=GEOSGeometry(json.dumps(geometry))
         )
-        self.scenario = ScenarioFactory(planning_area=self.planning_area)
+        self.scenario = ScenarioFactory(
+            planning_area=self.planning_area,
+            configuration={"stand_size": "LARGE"},
+        )
 
     def test_compute_scenario_capability_before_run(self):
         trigger_scenario_run(self.scenario, self.scenario.user)

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -1576,6 +1576,35 @@ class PatchScenarioConfigurationTest(APITestCase):
         response = self.client.patch(url, payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_patch_draft_with_stand_size_adds_forsys_capability(self):
+        scenario = ScenarioFactory.create(
+            user=self.user,
+            planning_area=self.planning_area,
+            configuration={},
+        )
+        url = reverse("api:planning:scenarios-patch-draft", args=[scenario.pk])
+        payload = {"configuration": {"stand_size": "LARGE"}}
+
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("FORSYS", response.data.get("capabilities", []))
+
+    def test_patch_draft_without_stand_size_excludes_forsys_capability(self):
+        scenario = ScenarioFactory.create(
+            user=self.user,
+            planning_area=self.planning_area,
+            configuration={},
+        )
+        url = reverse("api:planning:scenarios-patch-draft", args=[scenario.pk])
+        payload = {"configuration": {"targets": {"max_area": 100}}}
+
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("FORSYS", response.data.get("capabilities", []))
+
+
 class ScenarioCapabilitiesViewTest(APITestCase):
     def setUp(self):
         westwide_geom = MultiPolygon(

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -1146,6 +1146,21 @@ class CreateScenariosFromUpload(APITestCase):
         }
         self.assertEqual(response.json(), expected_error)
 
+    def test_create_without_stand_size(self):
+        self.client.force_authenticate(self.owner_user)
+        payload = {
+            "geometry": json.dumps(self.riverside),
+            "name": "no stand size scenario",
+            "planning_area": self.planning_area.pk,
+        }
+        response = self.client.post(
+            reverse("api:planning:scenarios-upload-shapefiles"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["origin"], "USER")
+
     @mock.patch("planning.views_v2.create_scenario_from_upload")
     def test_invalid_geometry_returns_400_with_global_error(self, mock_create):
         from planscape.exceptions import InvalidGeometry

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -56,6 +56,7 @@ from planning.serializers import (
     UpsertConfigurationV2Serializer,
     UpsertScenarioV3Serializer,
 )
+from modules.base import compute_scenario_capabilities
 from planning.services import (
     create_config,
     create_planning_area,
@@ -355,6 +356,9 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         )
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
+        instance.refresh_from_db()
+        instance.capabilities = compute_scenario_capabilities(instance)
+        instance.save(update_fields=["capabilities"])
         response_serializer = ScenarioV2Serializer(instance)
         planning_area = instance.planning_area
         planning_area.updated_at = timezone.now()
@@ -389,6 +393,9 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
                 updated_config[key] = incoming_config.get(key)
             serializer.validated_data["configuration"] = updated_config
         self.perform_update(serializer)
+        instance.refresh_from_db()
+        instance.capabilities = compute_scenario_capabilities(instance)
+        instance.save(update_fields=["capabilities"])
         response_serializer = ScenarioV3Serializer(instance)
         planning_area = instance.planning_area
         planning_area.updated_at = timezone.now()


### PR DESCRIPTION
Allow scenarios without stand size during upload. Make sure to recalculate capabilities whenever we patch the config.