### PR TITLE
adding max to layout

### DIFF
--- a/src/interface/src/styleguide/dashboard-layout/dashboard-layout.component.scss
+++ b/src/interface/src/styleguide/dashboard-layout/dashboard-layout.component.scss
@@ -4,6 +4,7 @@
 @import 'variables';
 
 $plan-left-min: 300px;
+$layout-max-width: 1600px;
 
 :host {
   display: flex;
@@ -29,7 +30,9 @@ $plan-left-min: 300px;
   display: none;
 }
 
-.layout.normal {
+.layout {
+  max-width: $layout-max-width;
+  margin: 0 auto;
   display: flex;
   flex-direction: row;
   width: 100%;
@@ -37,7 +40,9 @@ $plan-left-min: 300px;
   min-height: 0;
   gap: 8px;
   padding: 0;
+}
 
+.layout.normal {
   overflow: hidden;
 
   .layout-column {
@@ -66,14 +71,6 @@ $plan-left-min: 300px;
 }
 
 .layout.disable-right-scroll {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  flex: 1 1 auto;
-  min-height: 0;
-  gap: 8px;
-  padding: 0;
-
   .layout-column {
     flex: 1 1 0;
     min-width: 0;


### PR DESCRIPTION
Adds a max height to the layout component, so the columns on bigger monitors dont span forever
<img width="1096" height="767" alt="Screenshot 2026-05-25 at 1 48 04 PM" src="https://github.com/user-attachments/assets/48d59db4-f0d8-4742-ac30-cbd1b159e7a5" />
<img width="1102" height="765" alt="Screenshot 2026-05-25 at 1 49 03 PM" src="https://github.com/user-attachments/assets/1f7c4a44-8c1b-4e00-bceb-82c9e914f593" />
