### PR TITLE
Don't render txplan until status is resolved

### DIFF
--- a/src/interface/src/app/treatments/treatment-config/treatment-config.component.html
+++ b/src/interface/src/app/treatments/treatment-config/treatment-config.component.html
@@ -8,7 +8,7 @@
       redirectToNewPlan($event)
     "></app-treatment-navbar-menu>
 </app-nav-bar>
-<section class="treatment">
+<section class="treatment" *ngIf="!loading">
   <div class="left-side">
     <router-outlet></router-outlet>
   </div>

--- a/src/interface/src/app/treatments/treatment-config/treatment-config.component.ts
+++ b/src/interface/src/app/treatments/treatment-config/treatment-config.component.ts
@@ -112,6 +112,7 @@ export class TreatmentConfigComponent {
         filter((event) => event instanceof NavigationEnd) // Only react to navigation events
       )
       .subscribe(() => {
+        this.loading = true;
         const data = getMergedRouteData(this.route.snapshot);
         this.treatmentsState
           .loadTreatmentByRouteData(data)


### PR DESCRIPTION
This only loads the view once the scenario has loaded. It looks like this has been a bug prior to scenario_dashboards.