### PR TITLE
Tooltips on section

### DIFF
--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -10,6 +10,20 @@
 </nav>
 <mat-tab-nav-panel #tabPanel></mat-tab-nav-panel>
 
+<ng-template #tooltipContent let-close="close">
+  <sg-modal
+    title="tooltip title"
+    width="xsmall"
+    (clickedClose)="close()"
+    (clickedPrimary)="close()"
+    (clickedSecondary)="close()">
+    <div modalBodyContent>
+      Example of a tooltip displayed like a modal (close button, actions etc) but
+      in place (not like...full page modal)
+    </div>
+  </sg-modal>
+</ng-template>
+
 <div class="report-sections" #scrollContainer>
   <section id="map" class="report-section">
     <!-- TODO: map -->
@@ -20,6 +34,9 @@
     id="carbon"
     class="report-section"
     headline="Carbon"
+    tooltipSize="medium"
+    [tooltipTemplate]="tooltipContent"
+    [tooltipInteractive]="true"
     [isCollapsible]="true"
     [defaultExpanded]="true">
     <div>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -13,15 +13,15 @@
 <ng-template #tooltipContent let-close="close">
   <sg-modal
     [title]="tooltipName"
-    width="xsmall"
+    width="small"
+    [hasSecondaryButton]="false"
+    [hasLinkButton]="true"
+    primaryButtonText="Learn Mode"
+    linkButtonText="Download Dataset"
+    linkButtonIcon="download"
     (clickedClose)="close()"
-    (clickedPrimary)="close()"
-    (clickedSecondary)="close()">
-    <div modalBodyContent>
-      Tooltip for: {{ tooltipName }}<br />
-      Example of a tooltip displayed like a modal (close button, actions etc)
-      but in place (not like...full page modal)
-    </div>
+    (clickedPrimary)="close()">
+    <div modalBodyContent>Tooltip for: {{ tooltipName }}<br /></div>
   </sg-modal>
 </ng-template>
 
@@ -38,7 +38,7 @@
     tooltipSize="medium"
     [tooltipTemplate]="tooltipContent"
     [tooltipInteractive]="true"
-    (tooltipClicked)="tooltipName = 'carbon'"
+    (tooltipClicked)="tooltipName = 'Carbon'"
     [isCollapsible]="true"
     [defaultExpanded]="true">
     <div>
@@ -84,7 +84,14 @@
     <div>Metrics reflect outcomes within forested land only.</div>
 
     <div>
-      <h5>Flame Length</h5>
+      <h5>
+        Flame Length
+        <sg-popover
+          [modal]="true"
+          icon="info"
+          [contentTemplate]="tooltipContent"
+          (opened)="tooltipName = 'Flame Length'"></sg-popover>
+      </h5>
       <p class="chart-subtitle">(%) Percentage Change After Treatment</p>
       <sg-chart
         *ngIf="flameLengthChart$ | async as chart"
@@ -94,7 +101,14 @@
         type="bar"></sg-chart>
     </div>
     <div class="top-section-divider">
-      <h5>Burn Probability</h5>
+      <h5>
+        Burn Probability
+        <sg-popover
+          [modal]="true"
+          icon="info"
+          [contentTemplate]="tooltipContent"
+          (opened)="tooltipName = 'Burn Probability'"></sg-popover>
+      </h5>
       <sg-banner class="burn-probability-banner" customIcon="priority_high"
         >Please note that burn probability data is calculated for the entire
         planning boundary, encompassing both treated and untreated areas. Unlike
@@ -116,7 +130,7 @@
     headline="Water"
     [tooltipTemplate]="tooltipContent"
     [tooltipInteractive]="true"
-    (tooltipClicked)="tooltipName = 'water'"
+    (tooltipClicked)="tooltipName = 'Water'"
     [isCollapsible]="true"
     [defaultExpanded]="true">
     <div class="stat-cards">
@@ -143,7 +157,7 @@
     headline="Biomass"
     [tooltipTemplate]="tooltipContent"
     [tooltipInteractive]="true"
-    (tooltipClicked)="tooltipName = 'biomass'"
+    (tooltipClicked)="tooltipName = 'Biomass'"
     [isCollapsible]="true"
     [defaultExpanded]="true">
     <div>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -12,14 +12,15 @@
 
 <ng-template #tooltipContent let-close="close">
   <sg-modal
-    title="tooltip title"
+    [title]="tooltipName"
     width="xsmall"
     (clickedClose)="close()"
     (clickedPrimary)="close()"
     (clickedSecondary)="close()">
     <div modalBodyContent>
-      Example of a tooltip displayed like a modal (close button, actions etc) but
-      in place (not like...full page modal)
+      Tooltip for: {{ tooltipName }}<br />
+      Example of a tooltip displayed like a modal (close button, actions etc)
+      but in place (not like...full page modal)
     </div>
   </sg-modal>
 </ng-template>
@@ -37,6 +38,7 @@
     tooltipSize="medium"
     [tooltipTemplate]="tooltipContent"
     [tooltipInteractive]="true"
+    (tooltipClicked)="tooltipName = 'carbon'"
     [isCollapsible]="true"
     [defaultExpanded]="true">
     <div>
@@ -112,6 +114,9 @@
     id="water"
     class="report-section"
     headline="Water"
+    [tooltipTemplate]="tooltipContent"
+    [tooltipInteractive]="true"
+    (tooltipClicked)="tooltipName = 'water'"
     [isCollapsible]="true"
     [defaultExpanded]="true">
     <div class="stat-cards">
@@ -136,6 +141,9 @@
     id="biomass"
     class="report-section"
     headline="Biomass"
+    [tooltipTemplate]="tooltipContent"
+    [tooltipInteractive]="true"
+    (tooltipClicked)="tooltipName = 'biomass'"
     [isCollapsible]="true"
     [defaultExpanded]="true">
     <div>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.scss
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.scss
@@ -56,8 +56,11 @@ h5 {
   font-weight: 700;
   line-height: 15px;
   text-transform: uppercase;
-  margin: 8px 0 12px;
+  margin: 8px -8px 12px 0;
   color: $color-black;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .chart-subtitle {

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -78,6 +78,9 @@ export class FundingReportComponent
 
   activeId = this.sections[0].id;
 
+  /** Name of the section whose interactive tooltip was last opened. */
+  tooltipName = '';
+
   private suppressUntil = 0;
   private pendingScrollFrame: number | null = null;
 

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -17,6 +17,7 @@ import {
   ButtonComponent,
   ChartComponent,
   ModalComponent,
+  PopoverComponent,
   SectionComponent,
 } from '@styleguide';
 import { Chart, ChartData, ChartOptions } from 'chart.js';
@@ -58,6 +59,7 @@ interface ReportSection {
     ChartComponent,
     BannerComponent,
     ModalComponent,
+    PopoverComponent,
   ],
   templateUrl: './funding-report.component.html',
   styleUrl: './funding-report.component.scss',

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -16,6 +16,7 @@ import {
   BannerComponent,
   ButtonComponent,
   ChartComponent,
+  ModalComponent,
   SectionComponent,
 } from '@styleguide';
 import { Chart, ChartData, ChartOptions } from 'chart.js';
@@ -56,6 +57,7 @@ interface ReportSection {
     ButtonComponent,
     ChartComponent,
     BannerComponent,
+    ModalComponent,
   ],
   templateUrl: './funding-report.component.html',
   styleUrl: './funding-report.component.scss',

--- a/src/interface/src/styleguide/index.ts
+++ b/src/interface/src/styleguide/index.ts
@@ -22,6 +22,7 @@ export * from '@styleguide/opacity-slider/opacity-slider.component';
 export * from '@styleguide/overlay-loader/overlay-loader.component';
 export * from '@styleguide/paginator/paginator.component';
 export * from '@styleguide/panel/panel.component';
+export * from '@styleguide/popover/popover.component';
 export * from '@styleguide/project-area-expander/project-area-expander.component';
 export * from '@styleguide/scenario-card/scenario-card.component';
 export * from '@styleguide/search-bar/search-bar.component';

--- a/src/interface/src/styleguide/modal/modal.component.html
+++ b/src/interface/src/styleguide/modal/modal.component.html
@@ -36,6 +36,20 @@
   class="footer"
   *ngIf="hasFooter"
   [ngClass]="{ centered: centerFooter }">
+  <!-- Optional far-left link/text button (e.g. "Download Dataset"). Distinct
+       from the secondary action: different placement and a text-only style. -->
+  <button
+    *ngIf="hasLinkButton"
+    sg-button
+    type="button"
+    class="link-button-slot"
+    [variant]="linkButtonVariant"
+    [icon]="linkButtonIcon || ''"
+    [outlined]="true"
+    (click)="handleLinkButton()">
+    {{ linkButtonText }}
+  </button>
+
   <button
     *ngIf="hasSecondaryButton"
     sg-button

--- a/src/interface/src/styleguide/modal/modal.component.scss
+++ b/src/interface/src/styleguide/modal/modal.component.scss
@@ -126,6 +126,12 @@
   gap: 8px;
   flex-shrink: 0;
 
+  // Far-left link button: pushes the action buttons to the right.
+  .link-button-slot {
+    margin-right: auto;
+    margin-left: -6px;
+  }
+
   &.centered {
     justify-content: center;
     gap: 8px;

--- a/src/interface/src/styleguide/modal/modal.component.ts
+++ b/src/interface/src/styleguide/modal/modal.component.ts
@@ -120,6 +120,24 @@ export class ModalComponent {
   @Input() centerFooter? = false;
 
   /**
+   * Show/hide an optional far-left link/text button in the footer (distinct from
+   * the secondary action — different placement and a text-only style)
+   */
+  @Input() hasLinkButton = false;
+  /**
+   * Text for the optional far-left link button
+   */
+  @Input() linkButtonText?: string;
+  /**
+   * Optional Material icon for the far-left link button (e.g. "download")
+   */
+  @Input() linkButtonIcon?: string;
+  /**
+   * Style variant for the far-left link button
+   */
+  @Input() linkButtonVariant: ButtonVariant = 'text';
+
+  /**
    * If provided, the modal will show a tooltip on the header
    */
   @Input() tooltipContent = '';
@@ -132,6 +150,7 @@ export class ModalComponent {
   @Output() clickedSecondary = new EventEmitter<any>();
   @Output() clickedPrimary = new EventEmitter<any>();
   @Output() clickedClose = new EventEmitter<any>();
+  @Output() clickedLink = new EventEmitter<any>();
 
   constructor() {}
 
@@ -152,6 +171,11 @@ export class ModalComponent {
   /** @ignore */
   handlePrimaryButton(): void {
     this.clickedPrimary.emit();
+  }
+
+  /** @ignore */
+  handleLinkButton(): void {
+    this.clickedLink.emit();
   }
 
   @HostBinding('class.xsmall')

--- a/src/interface/src/styleguide/modal/modal.stories.ts
+++ b/src/interface/src/styleguide/modal/modal.stories.ts
@@ -304,6 +304,43 @@ export const Tooltip: Story = {
   }),
 };
 
+export const WithLinkButton: Story = {
+  args: {
+    title: 'Carbon Info',
+    primaryButtonText: 'Learn More',
+    hasSecondaryButton: false,
+    hasLinkButton: true,
+    linkButtonText: 'Download Dataset',
+    linkButtonIcon: 'download',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+*When to use*: When the footer needs a far-left link/text action (e.g. "Download
+Dataset") alongside the primary CTA.
+
+The link button:
+- Sits at the far left of the footer (pushing the action buttons right)
+- Uses the \`text\` button variant (configurable via \`linkButtonVariant\`)
+- Can show an optional icon via \`linkButtonIcon\`
+- Emits \`clickedLink\` when pressed
+- Is distinct from the secondary action — different placement and style
+      `,
+      },
+    },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<div ${containerStyle}>
+      <sg-modal ${argsToTemplate(args)}>
+        <div modalBodyContent>Carbon metrics are estimated using the Forest
+        Vegetation Simulator (FVS) with spatially explicit forest conditions from
+        the USFS TreeMap dataset (30 m resolution).</div>
+      </sg-modal><div>`,
+  }),
+};
+
 export const ScrollableContent: Story = {
   args: {
     title: 'A modal that scrolls!',

--- a/src/interface/src/styleguide/popover/popover.component.html
+++ b/src/interface/src/styleguide/popover/popover.component.html
@@ -5,17 +5,28 @@
   [outlined]="true"
   class="info-icon"
   [ngClass]="iconColor"
-  (click)="$event.stopPropagation()"
+  (click)="$event.stopPropagation(); opened.emit()"
   [matMenuTriggerFor]="menu"></button>
 
-<mat-menu #menu="matMenu" class="info-popover-menu {{ panelSize }}">
-  <div class="tooltip">
-    <ng-container *ngIf="content; else projected">
-      <div [innerHTML]="content"></div>
-    </ng-container>
+<mat-menu
+  #menu="matMenu"
+  class="info-popover-menu {{ panelSize }} {{ modal ? 'modal' : '' }}">
+  <!-- In modal mode the wrapper drops the tooltip padding and stops clicks from
+       bubbling to mat-menu's close logic, so you can interact without closing. -->
+  <div [class.tooltip]="!modal" (click)="modal && $event.stopPropagation()">
+    <ng-container
+      *ngIf="contentTemplate; else stringOrProjected"
+      [ngTemplateOutlet]="contentTemplate"
+      [ngTemplateOutletContext]="{ close: close }"></ng-container>
 
-    <ng-template #projected>
-      <ng-content></ng-content>
+    <ng-template #stringOrProjected>
+      <ng-container *ngIf="content && !modal; else projected">
+        <div [innerHTML]="content"></div>
+      </ng-container>
+
+      <ng-template #projected>
+        <ng-content></ng-content>
+      </ng-template>
     </ng-template>
   </div>
 </mat-menu>

--- a/src/interface/src/styleguide/popover/popover.component.scss
+++ b/src/interface/src/styleguide/popover/popover.component.scss
@@ -8,6 +8,14 @@
     max-width: 417px;
   }
 
+  // Modal mode: let the projected modal drive its own width and sit flush.
+  &.modal {
+    max-width: none;
+
+    .mat-mdc-menu-content {
+      padding: 0;
+    }
+  }
 }
 
 .tooltip {

--- a/src/interface/src/styleguide/popover/popover.component.ts
+++ b/src/interface/src/styleguide/popover/popover.component.ts
@@ -1,5 +1,12 @@
-import { Component, Input } from '@angular/core';
-import { MatMenuModule } from '@angular/material/menu';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 import { ButtonComponent } from '@styleguide/button/button.component';
@@ -11,6 +18,7 @@ import { ButtonComponent } from '@styleguide/button/button.component';
 @Component({
   selector: 'sg-popover',
   standalone: true,
+  exportAs: 'sgPopover',
   imports: [CommonModule, MatMenuModule, MatIconModule, ButtonComponent],
   templateUrl: './popover.component.html',
   styleUrls: ['./popover.component.scss'],
@@ -22,5 +30,30 @@ export class PopoverComponent {
   // We can pass either the content string or use the <ng-content>
   @Input() content: string | null = null;
 
+  /**
+   * Content as a template (takes precedence over `content`/projection). Rendered
+   * with a `{ close }` context so a shared template can dismiss the popover:
+   * `<ng-template #tpl let-close="close">…<button (click)="close()">…</ng-template>`.
+   */
+  @Input() contentTemplate: TemplateRef<unknown> | null = null;
+
   @Input() panelSize: 'small' | 'medium' = 'small';
+
+  /**
+   * When true, the popover behaves like an in-place modal: it stays open while
+   * you interact with its projected content, sits flush (no tooltip padding),
+   * and closes only via `close()` — typically wired to a projected sg-modal's
+   * actions. Grab a reference with `#ref="sgPopover"` and call `ref.close()`.
+   */
+  @Input() modal = false;
+
+  /** Emitted when the icon is clicked (e.g. to populate content before it opens). */
+  @Output() opened = new EventEmitter<void>();
+
+  @ViewChild(MatMenuTrigger) private trigger?: MatMenuTrigger;
+
+  /** Dismiss the panel. Arrow fn so it can be passed around already bound. */
+  close = () => {
+    this.trigger?.closeMenu();
+  };
 }

--- a/src/interface/src/styleguide/popover/popover.stories.ts
+++ b/src/interface/src/styleguide/popover/popover.stories.ts
@@ -125,6 +125,31 @@ export const Modal: Story = {
 };
 
 /**
+ * Modal mode doesn't require an `sg-modal` — any interactive content works.
+ * Here it's just plain text and a close button wired to `close()` (grabbed via
+ * `#pop="sgPopover"`). The panel stays open until you dismiss it.
+ */
+export const ModalPlainContent: Story = {
+  render: () => ({
+    template: `
+      <div ${containerStyle}>
+        <div style="display:flex; align-items:center; gap:10px;">
+          <span style="color: black;">Click the icon -> </span>
+          <sg-popover [modal]="true" icon="info" #pop="sgPopover">
+            <div style="padding: 16px; max-width: 240px;">
+              <p style="margin: 0 0 12px;">
+                Just some plain text inside a modal popover — no sg-modal needed.
+              </p>
+              <button sg-button variant="text" (click)="pop.close()">Close</button>
+            </div>
+          </sg-popover>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+/**
  * `contentTemplate` lets several popovers share ONE template instead of
  * repeating it. The template gets a `{ close }` context to dismiss the popover,
  * and `(opened)` fires on click — use it to populate which content to show

--- a/src/interface/src/styleguide/popover/popover.stories.ts
+++ b/src/interface/src/styleguide/popover/popover.stories.ts
@@ -10,6 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 import { PopoverComponent } from './popover.component';
 import { ButtonComponent } from '@styleguide/button/button.component';
+import { ModalComponent } from '@styleguide/modal/modal.component';
 
 const meta: Meta<PopoverComponent> = {
   title: 'Components/Info Popover',
@@ -23,6 +24,7 @@ const meta: Meta<PopoverComponent> = {
         MatIconModule,
         ButtonComponent,
         PopoverComponent,
+        ModalComponent,
       ],
     }),
   ],
@@ -89,4 +91,77 @@ export const CustomIcon: Story = {
     icon: 'help',
     content: 'The icon has black color',
   },
+};
+
+/**
+ * With `modal`, the popover hosts interactive content (e.g. an `sg-modal`): it
+ * stays open while you interact and closes only via `close()`. Projecting the
+ * modal as content, grab a reference with `#ref="sgPopover"` and wire it to the
+ * modal's actions.
+ */
+export const Modal: Story = {
+  render: () => ({
+    template: `
+      <div ${containerStyle}>
+        <div style="display:flex; align-items:center; gap:10px;">
+          <span style="color: black;">Click the icon -> </span>
+          <sg-popover [modal]="true" icon="info" #pop="sgPopover">
+            <sg-modal
+              title="Modal popover"
+              width="xsmall"
+              (clickedClose)="pop.close()"
+              (clickedPrimary)="pop.close()"
+              (clickedSecondary)="pop.close()">
+              <div modalBodyContent>
+                Opens like a popover but behaves like a modal — stays open while
+                you interact, closes via its own actions.
+              </div>
+            </sg-modal>
+          </sg-popover>
+        </div>
+      </div>
+    `,
+  }),
+};
+
+/**
+ * `contentTemplate` lets several popovers share ONE template instead of
+ * repeating it. The template gets a `{ close }` context to dismiss the popover,
+ * and `(opened)` fires on click — use it to populate which content to show
+ * before the panel opens. Here both icons reuse the same template.
+ */
+export const ModalSharedTemplate: Story = {
+  render: () => ({
+    props: { activeName: '' },
+    template: `
+      <ng-template #tip let-close="close">
+        <sg-modal
+          [title]="activeName"
+          width="xsmall"
+          (clickedClose)="close()"
+          (clickedPrimary)="close()"
+          (clickedSecondary)="close()">
+          <div modalBodyContent>Showing info for: {{ activeName }}</div>
+        </sg-modal>
+      </ng-template>
+
+      <div ${containerStyle}>
+        <div style="display:flex; align-items:center; gap:16px;">
+          <span style="color: black;">Carbon</span>
+          <sg-popover
+            [modal]="true"
+            icon="info"
+            [contentTemplate]="tip"
+            (opened)="activeName = 'Carbon'"></sg-popover>
+
+          <span style="color: black;">Water</span>
+          <sg-popover
+            [modal]="true"
+            icon="info"
+            [contentTemplate]="tip"
+            (opened)="activeName = 'Water'"></sg-popover>
+        </div>
+      </div>
+    `,
+  }),
 };

--- a/src/interface/src/styleguide/section/section.component.html
+++ b/src/interface/src/styleguide/section/section.component.html
@@ -34,7 +34,7 @@
         [outlined]="true"
         class="popover-right"
         #interactiveTrigger="matMenuTrigger"
-        (click)="stopPropagation($event)"
+        (click)="stopPropagation($event); tooltipClicked.emit()"
         [matMenuTriggerFor]="interactiveMenu"></button>
 
       <mat-menu

--- a/src/interface/src/styleguide/section/section.component.html
+++ b/src/interface/src/styleguide/section/section.component.html
@@ -25,30 +25,14 @@
         [ngTemplateOutlet]="tooltipTemplate"></ng-container>
     </sg-popover>
 
-    <!-- Interactive, modal-like tooltip: mat-menu, but clicks inside don't close -->
-    <ng-container *ngIf="tooltipTemplate && tooltipInteractive">
-      <button
-        sg-button
-        variant="icon-only"
-        [icon]="tooltipIcon"
-        [outlined]="true"
-        class="popover-right"
-        #interactiveTrigger="matMenuTrigger"
-        (click)="stopPropagation($event); tooltipClicked.emit()"
-        [matMenuTriggerFor]="interactiveMenu"></button>
-
-      <mat-menu
-        #interactiveMenu="matMenu"
-        xPosition="before"
-        yPosition="below"
-        class="sg-section-tooltip-panel">
-        <div (click)="$event.stopPropagation()">
-          <ng-container
-            [ngTemplateOutlet]="tooltipTemplate"
-            [ngTemplateOutletContext]="{ close: closeTooltip }"></ng-container>
-        </div>
-      </mat-menu>
-    </ng-container>
+    <!-- Interactive, modal-like tooltip: delegated to sg-popover's modal mode -->
+    <sg-popover
+      *ngIf="tooltipTemplate && tooltipInteractive"
+      [modal]="true"
+      class="popover-right"
+      [icon]="tooltipIcon"
+      [contentTemplate]="tooltipTemplate"
+      (opened)="tooltipClicked.emit()"></sg-popover>
     <button
       *ngIf="tooltipLink"
       sg-button

--- a/src/interface/src/styleguide/section/section.component.html
+++ b/src/interface/src/styleguide/section/section.component.html
@@ -8,8 +8,14 @@
       {{ headline }}<span class="required" *ngIf="required"> *</span>
     </div>
     <div class="headline-hint" *ngIf="headlineHint">{{ headlineHint }}</div>
+    <!-- Read-only tooltip (default): mat-menu-backed popover.
+         Interactive mode needs a template; without one we fall back here so a
+         content-only tooltip never silently disappears. -->
     <sg-popover
-      *ngIf="tooltipContent || tooltipTemplate"
+      *ngIf="
+        (tooltipContent || tooltipTemplate) &&
+        !(tooltipInteractive && tooltipTemplate)
+      "
       class="popover-right"
       [content]="tooltipTemplate ? null : tooltipContent"
       [icon]="tooltipIcon"
@@ -18,6 +24,31 @@
         *ngIf="tooltipTemplate"
         [ngTemplateOutlet]="tooltipTemplate"></ng-container>
     </sg-popover>
+
+    <!-- Interactive, modal-like tooltip: mat-menu, but clicks inside don't close -->
+    <ng-container *ngIf="tooltipTemplate && tooltipInteractive">
+      <button
+        sg-button
+        variant="icon-only"
+        [icon]="tooltipIcon"
+        [outlined]="true"
+        class="popover-right"
+        #interactiveTrigger="matMenuTrigger"
+        (click)="stopPropagation($event)"
+        [matMenuTriggerFor]="interactiveMenu"></button>
+
+      <mat-menu
+        #interactiveMenu="matMenu"
+        xPosition="before"
+        yPosition="below"
+        class="sg-section-tooltip-panel">
+        <div (click)="$event.stopPropagation()">
+          <ng-container
+            [ngTemplateOutlet]="tooltipTemplate"
+            [ngTemplateOutletContext]="{ close: closeTooltip }"></ng-container>
+        </div>
+      </mat-menu>
+    </ng-container>
     <button
       *ngIf="tooltipLink"
       sg-button

--- a/src/interface/src/styleguide/section/section.component.scss
+++ b/src/interface/src/styleguide/section/section.component.scss
@@ -1,6 +1,19 @@
 @import 'colors';
 @import 'mixins';
 
+// The interactive tooltip's menu panel is attached at the body level (outside
+// this component), so it must be targeted globally. mat-menu supplies the
+// elevation/animation; we only need to drop its default content padding so the
+// projected modal sits flush.
+::ng-deep .sg-section-tooltip-panel.mat-mdc-menu-panel {
+  // Let the projected modal's own width drive size (default cap is 280px).
+  max-width: none;
+
+  .mat-mdc-menu-content {
+    padding: 0;
+  }
+}
+
 :host {
   display: block;
 

--- a/src/interface/src/styleguide/section/section.component.ts
+++ b/src/interface/src/styleguide/section/section.component.ts
@@ -1,4 +1,11 @@
-import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
 import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
@@ -51,6 +58,13 @@ export class SectionComponent {
    * (e.g. `<ng-template #tpl let-close="close">`). Requires `tooltipTemplate`.
    */
   @Input() tooltipInteractive = false;
+
+  /**
+   * Emitted when the tooltip icon is clicked in interactive mode. Useful for
+   * populating/lazy-loading the tooltip content right before the panel opens,
+   * so a shared template can be reused across sections.
+   */
+  @Output() tooltipClicked = new EventEmitter<void>();
 
   @ViewChild('interactiveTrigger') interactiveTrigger?: MatMenuTrigger;
 

--- a/src/interface/src/styleguide/section/section.component.ts
+++ b/src/interface/src/styleguide/section/section.component.ts
@@ -47,12 +47,12 @@ export class SectionComponent {
   @Input() tooltipSize: 'small' | 'medium' = 'small';
 
   /**
-   * When true, the tooltip opens as an interactive, modal-like panel anchored
-   * to the icon, instead of the read-only `sg-popover`. It's backed by the same
-   * `mat-menu` (so it animates and is elevated), but clicks inside it don't
-   * close it — it only closes when the projected content calls the `close`
-   * function exposed on the template context
-   * (e.g. `<ng-template #tpl let-close="close">`). Requires `tooltipTemplate`.
+   * When true, the tooltip is delegated to `sg-popover`'s modal mode: it opens
+   * as an interactive, modal-like panel anchored to the icon instead of the
+   * read-only popover. It still animates and is elevated, but clicks inside it
+   * don't close it — it only closes when the template calls the `close` function
+   * exposed on its context (e.g. `<ng-template #tpl let-close="close">`).
+   * Requires `tooltipTemplate`.
    */
   @Input() tooltipInteractive = false;
 

--- a/src/interface/src/styleguide/section/section.component.ts
+++ b/src/interface/src/styleguide/section/section.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, TemplateRef } from '@angular/core';
+import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
-import { MatMenuModule } from '@angular/material/menu';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { PopoverComponent } from '@styleguide/popover/popover.component';
@@ -41,6 +41,23 @@ export class SectionComponent {
 
   @Input() tooltipIcon: 'help' | 'info' = 'info';
   @Input() tooltipSize: 'small' | 'medium' = 'small';
+
+  /**
+   * When true, the tooltip opens as an interactive, modal-like panel anchored
+   * to the icon, instead of the read-only `sg-popover`. It's backed by the same
+   * `mat-menu` (so it animates and is elevated), but clicks inside it don't
+   * close it — it only closes when the projected content calls the `close`
+   * function exposed on the template context
+   * (e.g. `<ng-template #tpl let-close="close">`). Requires `tooltipTemplate`.
+   */
+  @Input() tooltipInteractive = false;
+
+  @ViewChild('interactiveTrigger') interactiveTrigger?: MatMenuTrigger;
+
+  /** Passed to the projected template so its content can dismiss the panel. */
+  closeTooltip = () => {
+    this.interactiveTrigger?.closeMenu();
+  };
 
   stopPropagation(e: Event) {
     e.stopPropagation();

--- a/src/interface/src/styleguide/section/section.component.ts
+++ b/src/interface/src/styleguide/section/section.component.ts
@@ -4,10 +4,8 @@ import {
   Input,
   Output,
   TemplateRef,
-  ViewChild,
 } from '@angular/core';
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
-import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { PopoverComponent } from '@styleguide/popover/popover.component';
@@ -24,7 +22,6 @@ import { ButtonComponent } from '@styleguide/button/button.component';
   imports: [
     NgIf,
     NgTemplateOutlet,
-    MatMenuModule,
     MatButtonModule,
     MatExpansionModule,
     PopoverComponent,
@@ -65,17 +62,6 @@ export class SectionComponent {
    * so a shared template can be reused across sections.
    */
   @Output() tooltipClicked = new EventEmitter<void>();
-
-  @ViewChild('interactiveTrigger') interactiveTrigger?: MatMenuTrigger;
-
-  /** Passed to the projected template so its content can dismiss the panel. */
-  closeTooltip = () => {
-    this.interactiveTrigger?.closeMenu();
-  };
-
-  stopPropagation(e: Event) {
-    e.stopPropagation();
-  }
 
   navigateToLink() {
     if (this.tooltipLink) {

--- a/src/interface/src/styleguide/section/section.stories.ts
+++ b/src/interface/src/styleguide/section/section.stories.ts
@@ -3,6 +3,7 @@ import { argsToTemplate, moduleMetadata } from '@storybook/angular';
 import { SectionComponent } from './section.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { ModalComponent } from '@styleguide';
 
 const meta: Meta<SectionComponent> = {
   title: 'Components/Section',
@@ -10,7 +11,7 @@ const meta: Meta<SectionComponent> = {
   tags: ['autodocs'],
   decorators: [
     moduleMetadata({
-      imports: [BrowserAnimationsModule, MatExpansionModule],
+      imports: [BrowserAnimationsModule, MatExpansionModule, ModalComponent],
     }),
   ],
   render: (args) => ({
@@ -129,5 +130,53 @@ export const WithHint: Story = {
     headlineHint: '0/2 Selected',
     tooltipContent:
       'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.',
+  },
+};
+
+/**
+ * With `tooltipInteractive`, the tooltip opens as a modal-like panel anchored to
+ * the icon. It's backed by the same mat-menu (so it animates and is elevated),
+ * but clicks inside don't close it — it only closes when the projected content
+ * calls the `close` function exposed on the template context. Requires
+ * `tooltipTemplate`.
+ */
+export const InteractiveTooltip: Story = {
+  render: () => ({
+    template: `
+      <ng-template #tooltipTpl let-close="close">
+        <sg-modal
+          title="Interactive tooltip"
+          width="xsmall"
+          (clickedClose)="close()"
+          (clickedPrimary)="close()"
+          (clickedSecondary)="close()">
+          <div modalBodyContent>
+            This panel opens like a menu but behaves like a modal: it stays open
+            so you can interact with it, and only closes via its own actions
+            (Cancel, Done, or the close button).
+          </div>
+        </sg-modal>
+      </ng-template>
+      <sg-section
+        headline="Carbon"
+        [tooltipTemplate]="tooltipTpl"
+        [tooltipInteractive]="true">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </sg-section>
+    `,
+  }),
+};
+
+/**
+ * Interactive mode needs a `tooltipTemplate`. If `tooltipInteractive` is set but
+ * only `tooltipContent` (a string) is provided, the section gracefully falls
+ * back to the read-only popover instead of rendering nothing.
+ */
+export const InteractiveWithoutTemplateFallsBack: Story = {
+  args: {
+    headline: 'Carbon',
+    tooltipInteractive: true,
+    tooltipContent:
+      'Interactive mode needs a template — with only string content the section falls back to the read-only popover.',
   },
 };

--- a/src/interface/src/styleguide/section/section.stories.ts
+++ b/src/interface/src/styleguide/section/section.stories.ts
@@ -135,10 +135,9 @@ export const WithHint: Story = {
 
 /**
  * With `tooltipInteractive`, the tooltip opens as a modal-like panel anchored to
- * the icon. It's backed by the same mat-menu (so it animates and is elevated),
- * but clicks inside don't close it — it only closes when the projected content
- * calls the `close` function exposed on the template context. Requires
- * `tooltipTemplate`.
+ * the icon. It's delegated to `sg-popover`'s modal mode (so it animates and is
+ * elevated), but clicks inside don't close it — it only closes when the template
+ * calls the `close` function exposed on its context. Requires `tooltipTemplate`.
  */
 export const InteractiveTooltip: Story = {
   render: () => ({
@@ -179,4 +178,44 @@ export const InteractiveWithoutTemplateFallsBack: Story = {
     tooltipContent:
       'Interactive mode needs a template — with only string content the section falls back to the read-only popover.',
   },
+};
+
+/**
+ * `tooltipClicked` fires when the interactive icon is clicked (before the panel
+ * opens), so several sections can share ONE template and just set which content
+ * to show. Both sections below reuse the same template; the modal reflects the
+ * section you clicked.
+ */
+export const InteractiveSharedTemplate: Story = {
+  render: () => ({
+    props: { activeName: '' },
+    template: `
+      <ng-template #tip let-close="close">
+        <sg-modal
+          [title]="activeName"
+          width="xsmall"
+          (clickedClose)="close()"
+          (clickedPrimary)="close()"
+          (clickedSecondary)="close()">
+          <div modalBodyContent>Showing info for: {{ activeName }}</div>
+        </sg-modal>
+      </ng-template>
+
+      <sg-section
+        headline="Carbon"
+        [tooltipTemplate]="tip"
+        [tooltipInteractive]="true"
+        (tooltipClicked)="activeName = 'Carbon'">
+        Carbon section body.
+      </sg-section>
+
+      <sg-section
+        headline="Water"
+        [tooltipTemplate]="tip"
+        [tooltipInteractive]="true"
+        (tooltipClicked)="activeName = 'Water'">
+        Water section body.
+      </sg-section>
+    `,
+  }),
 };


### PR DESCRIPTION
Adding a bunch of extra configurations on styleguide components to support the tooltips/pop menus on funding opportunity report.

The content of the tooltips is still pending, but this PR focuses on  just the ui until we hook content up.

<img width="717" height="511" alt="Screenshot 2026-06-02 at 7 02 39 PM" src="https://github.com/user-attachments/assets/55efa07e-c3e2-42b5-ac63-a8bb98b50a9b" />
