### PR TITLE
plan-3640-add-monthly-TWIG-treatment-layer-refresh

### DIFF
--- a/src/planscape/datasets/tasks.py
+++ b/src/planscape/datasets/tasks.py
@@ -173,3 +173,36 @@ def validate_datastore_table(datastore_table_name: str, datalayer: DataLayer):
             actual_count,
             expected_count,
         )
+
+
+@app.task()
+def refresh_twig_treatment_layers_task() -> None:
+    from django.conf import settings
+
+    from datasets.twig_treatments import refresh_twig_treatment_layers
+
+    if not settings.TWIG_TREATMENTS_API_URL:
+        logger.warning("TWIG_TREATMENTS_API_URL is not configured; skipping refresh.")
+        return
+
+    try:
+        output_files = refresh_twig_treatment_layers(
+            organization_id=settings.TWIG_TREATMENTS_PLANSCAPE_ORG_ID,
+            dataset_name=settings.TWIG_TREATMENTS_DATASET_NAME,
+            api_url=settings.TWIG_TREATMENTS_API_URL,
+            timeout=settings.TWIG_TREATMENTS_TIMEOUT,
+            page_size=settings.TWIG_TREATMENTS_PAGE_SIZE,
+            status_filter=settings.TWIG_TREATMENTS_STATUS_FILTER,
+        )
+        refreshed_layers = ", ".join(output_files.keys())
+        logger.info("Refreshed TWIG treatment layers: %s", refreshed_layers)
+        post_to_mattermost(
+            f"planscape-{settings.ENV} :white_check_mark: "
+            f"TWIG treatment layers refreshed successfully: {refreshed_layers}"
+        )
+    except Exception as exc:
+        logger.exception("TWIG treatment layer refresh failed.")
+        post_to_mattermost(
+            f"planscape-{settings.ENV} :x: TWIG treatment layer refresh failed: {exc}"
+        )
+        raise

--- a/src/planscape/datasets/tests/test_twig_treatments.py
+++ b/src/planscape/datasets/tests/test_twig_treatments.py
@@ -1,0 +1,360 @@
+import tempfile
+from datetime import date
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+
+from datasets.twig_treatments import (
+    TWIG_TREATMENT_LAYER_NAMES,
+    build_twig_where_clauses,
+    fetch_twig_count,
+    fetch_twig_feature_page,
+    get_query_url,
+    replace_twig_treatment_datalayer,
+    slugify_layer_name,
+    write_twig_feature_collection_to_file,
+)
+
+
+class TwigTreatmentsTest(SimpleTestCase):
+    def setUp(self):
+        self.feature_collection = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "objectid": 1,
+                        "name": "Example Treatment",
+                        "treatment_date": 1751241600000,
+                        "status": "Completed",
+                    },
+                    "geometry": {
+                        "type": "MultiPolygon",
+                        "coordinates": [],
+                    },
+                }
+            ],
+        }
+
+    def test_get_query_url_accepts_layer_url(self):
+        self.assertEqual(
+            get_query_url("https://example.test/FeatureServer/0"),
+            "https://example.test/FeatureServer/0/query",
+        )
+
+    def test_get_query_url_accepts_query_url(self):
+        self.assertEqual(
+            get_query_url("https://example.test/FeatureServer/0/query"),
+            "https://example.test/FeatureServer/0/query",
+        )
+
+    def test_slugify_layer_name(self):
+        self.assertEqual(
+            slugify_layer_name("TWIG - Years Since Treatment: 06-10"),
+            "twig_years_since_treatment_06_10",
+        )
+
+    def test_build_twig_where_clauses_uses_dynamic_cutoffs(self):
+        where_clauses = build_twig_where_clauses(today=date(2026, 6, 1))
+
+        self.assertEqual(
+            where_clauses[TWIG_TREATMENT_LAYER_NAMES["0-5"]],
+            "treatment_date >= TIMESTAMP '2021-06-01 00:00:00'",
+        )
+        self.assertEqual(
+            where_clauses[TWIG_TREATMENT_LAYER_NAMES["06-10"]],
+            "treatment_date >= TIMESTAMP '2016-06-01 00:00:00' "
+            "AND treatment_date < TIMESTAMP '2021-06-01 00:00:00'",
+        )
+        self.assertEqual(
+            where_clauses[TWIG_TREATMENT_LAYER_NAMES["11-15"]],
+            "treatment_date >= TIMESTAMP '2011-06-01 00:00:00' "
+            "AND treatment_date < TIMESTAMP '2016-06-01 00:00:00'",
+        )
+
+    def test_build_twig_where_clauses_can_add_status_filter(self):
+        where_clauses = build_twig_where_clauses(
+            today=date(2026, 6, 1),
+            status_filter="Completed",
+        )
+
+        self.assertIn(
+            "status = 'Completed'",
+            where_clauses[TWIG_TREATMENT_LAYER_NAMES["0-5"]],
+        )
+
+    def test_fetch_twig_count_returns_count(self):
+        response = Mock()
+        response.json.return_value = {"count": 123}
+        response.raise_for_status.return_value = None
+
+        session = Mock()
+        session.get.return_value = response
+
+        count = fetch_twig_count(
+            api_url="https://example.test/FeatureServer/0",
+            where_clause="1=1",
+            session=session,
+        )
+
+        self.assertEqual(count, 123)
+        request_kwargs = session.get.call_args.kwargs
+        self.assertEqual(request_kwargs["params"]["returnCountOnly"], "true")
+        self.assertEqual(request_kwargs["params"]["where"], "1=1")
+
+    def test_fetch_twig_count_rejects_missing_count(self):
+        response = Mock()
+        response.json.return_value = {"foo": "bar"}
+        response.raise_for_status.return_value = None
+
+        session = Mock()
+        session.get.return_value = response
+
+        with self.assertRaises(ValueError):
+            fetch_twig_count(
+                api_url="https://example.test/FeatureServer/0",
+                where_clause="1=1",
+                session=session,
+            )
+
+    def test_fetch_twig_feature_page_rejects_non_feature_collection(self):
+        response = Mock()
+        response.json.return_value = {"foo": "bar"}
+        response.raise_for_status.return_value = None
+
+        session = Mock()
+        session.get.return_value = response
+
+        with self.assertRaises(ValueError):
+            fetch_twig_feature_page(
+                api_url="https://example.test/FeatureServer/0",
+                where_clause="1=1",
+                result_offset=0,
+                result_record_count=1000,
+                session=session,
+            )
+
+    def test_fetch_twig_feature_page_passes_pagination_params(self):
+        response = Mock()
+        response.json.return_value = self.feature_collection
+        response.raise_for_status.return_value = None
+
+        session = Mock()
+        session.get.return_value = response
+
+        fetch_twig_feature_page(
+            api_url="https://example.test/FeatureServer/0",
+            where_clause="1=1",
+            result_offset=1000,
+            result_record_count=1000,
+            session=session,
+        )
+
+        request_kwargs = session.get.call_args.kwargs
+        self.assertEqual(request_kwargs["params"]["f"], "geojson")
+        self.assertEqual(request_kwargs["params"]["resultOffset"], 1000)
+        self.assertEqual(request_kwargs["params"]["resultRecordCount"], 1000)
+        self.assertEqual(request_kwargs["params"]["orderByFields"], "objectid ASC")
+
+    @patch("datasets.twig_treatments.fetch_twig_feature_page")
+    @patch("datasets.twig_treatments.fetch_twig_count")
+    def test_write_twig_feature_collection_to_file_paginates(
+        self,
+        count_mock,
+        page_mock,
+    ):
+        count_mock.return_value = 2
+        page_mock.side_effect = [
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {"type": "Feature", "properties": {"objectid": 1}},
+                ],
+            },
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {"type": "Feature", "properties": {"objectid": 2}},
+                ],
+            },
+        ]
+
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as temp_file:
+            count = write_twig_feature_collection_to_file(
+                api_url="https://example.test/FeatureServer/0",
+                where_clause="1=1",
+                output_file=temp_file,
+                page_size=1,
+            )
+            temp_file.seek(0)
+            output = temp_file.read()
+
+        self.assertEqual(count, 2)
+        self.assertEqual(page_mock.call_count, 2)
+        self.assertIn('"FeatureCollection"', output)
+        self.assertIn('"objectid":1', output)
+        self.assertIn('"objectid":2', output)
+
+    @patch("datasets.tasks.datalayer_uploaded")
+    @patch("datasets.twig_treatments.upload_geojson_file_to_storage")
+    @patch("datasets.twig_treatments.geometry_from_info")
+    @patch("datasets.twig_treatments.get_storage_url")
+    @patch("datasets.twig_treatments.fetch_geometry_type")
+    @patch("datasets.twig_treatments.detect_mimetype")
+    @patch("datasets.twig_treatments.get_layer_info")
+    @patch("datasets.twig_treatments.get_user_model")
+    @patch("datasets.twig_treatments.DataLayerHasStyle")
+    @patch("datasets.twig_treatments.DataLayer")
+    def test_replace_twig_treatment_datalayer_deletes_and_recreates(
+        self,
+        datalayer_model_mock,
+        datalayer_has_style_mock,
+        get_user_model_mock,
+        get_layer_info_mock,
+        detect_mimetype_mock,
+        fetch_geometry_type_mock,
+        get_storage_url_mock,
+        geometry_from_info_mock,
+        upload_geojson_mock,
+        datalayer_uploaded_mock,
+    ):
+        dataset = Mock(workspace=Mock())
+        organization = Mock(pk=1)
+        created_by = Mock()
+        created_datalayer = Mock(pk=123)
+
+        get_user_model_mock.return_value.objects.get.return_value = created_by
+        get_layer_info_mock.return_value = ("VECTOR", {"layer": {"count": 1}})
+        detect_mimetype_mock.return_value = "application/geo+json"
+        fetch_geometry_type_mock.return_value = "MULTIPOLYGON"
+        get_storage_url_mock.return_value = (
+            "gs://bucket/twig_years_since_treatment_0_5.geojson"
+        )
+        geometry = Mock()
+        geometry_from_info_mock.return_value = geometry
+        datalayer_model_mock.objects.create.return_value = created_datalayer
+
+        existing_layers = datalayer_model_mock.dead_or_alive.filter.return_value
+        existing_layers.filter.return_value.first.return_value = None
+
+        result = replace_twig_treatment_datalayer(
+            dataset=dataset,
+            organization=organization,
+            name="TWIG - Years Since Treatment: 0-5",
+            input_file="/tmp/twig.geojson",
+        )
+
+        datalayer_model_mock.dead_or_alive.filter.assert_called_once_with(
+            dataset=dataset,
+            name="TWIG - Years Since Treatment: 0-5",
+        )
+        existing_layers.filter.assert_called_once_with(deleted_at=None)
+        existing_layers.delete.assert_called_once()
+
+        upload_geojson_mock.assert_called_once_with(
+            storage_url="gs://bucket/twig_years_since_treatment_0_5.geojson",
+            input_file="/tmp/twig.geojson",
+        )
+
+        datalayer_model_mock.objects.create.assert_called_once()
+        create_kwargs = datalayer_model_mock.objects.create.call_args.kwargs
+
+        self.assertEqual(create_kwargs["name"], "TWIG - Years Since Treatment: 0-5")
+        self.assertEqual(
+            create_kwargs["original_name"],
+            "twig_years_since_treatment_0_5.geojson",
+        )
+        self.assertEqual(
+            create_kwargs["url"],
+            "gs://bucket/twig_years_since_treatment_0_5.geojson",
+        )
+        self.assertEqual(create_kwargs["map_service_type"], "VECTORTILES")
+        self.assertEqual(create_kwargs["status"], "PENDING")
+        self.assertIsNone(create_kwargs["category"])
+
+        datalayer_has_style_mock.objects.bulk_create.assert_called_once_with([])
+        datalayer_uploaded_mock.delay.assert_called_once_with(123, status="READY")
+        self.assertEqual(result, created_datalayer)
+
+    @patch("datasets.tasks.datalayer_uploaded")
+    @patch("datasets.twig_treatments.upload_geojson_file_to_storage")
+    @patch("datasets.twig_treatments.geometry_from_info")
+    @patch("datasets.twig_treatments.get_storage_url")
+    @patch("datasets.twig_treatments.fetch_geometry_type")
+    @patch("datasets.twig_treatments.detect_mimetype")
+    @patch("datasets.twig_treatments.get_layer_info")
+    @patch("datasets.twig_treatments.get_user_model")
+    @patch("datasets.twig_treatments.DataLayerHasStyle")
+    @patch("datasets.twig_treatments.DataLayer")
+    def test_replace_twig_treatment_datalayer_preserves_metadata_category_and_styles(
+        self,
+        datalayer_model_mock,
+        datalayer_has_style_mock,
+        get_user_model_mock,
+        get_layer_info_mock,
+        detect_mimetype_mock,
+        fetch_geometry_type_mock,
+        get_storage_url_mock,
+        geometry_from_info_mock,
+        upload_geojson_mock,
+        datalayer_uploaded_mock,
+    ):
+        dataset = Mock(workspace=Mock())
+        organization = Mock(pk=1)
+        category = Mock()
+        created_by = Mock()
+        created_datalayer = Mock(pk=123)
+
+        existing_datalayer = Mock(
+            metadata={"modules": {"twig": {"enabled": True}}},
+            category=category,
+        )
+        first_association = Mock(style_id=11, default=True)
+        second_association = Mock(style_id=22, default=False)
+        existing_datalayer.rel_styles.all.return_value = [
+            first_association,
+            second_association,
+        ]
+
+        get_user_model_mock.return_value.objects.get.return_value = created_by
+        get_layer_info_mock.return_value = ("VECTOR", {"layer": {"count": 1}})
+        detect_mimetype_mock.return_value = "application/geo+json"
+        fetch_geometry_type_mock.return_value = "MULTIPOLYGON"
+        get_storage_url_mock.return_value = (
+            "gs://bucket/twig_years_since_treatment_0_5.geojson"
+        )
+        geometry_from_info_mock.return_value = Mock()
+        datalayer_model_mock.objects.create.return_value = created_datalayer
+
+        existing_layers = datalayer_model_mock.dead_or_alive.filter.return_value
+        existing_layers.filter.return_value.first.return_value = existing_datalayer
+
+        replace_twig_treatment_datalayer(
+            dataset=dataset,
+            organization=organization,
+            name="TWIG - Years Since Treatment: 0-5",
+            input_file="/tmp/twig.geojson",
+        )
+
+        create_kwargs = datalayer_model_mock.objects.create.call_args.kwargs
+        self.assertEqual(
+            create_kwargs["metadata"],
+            {"modules": {"twig": {"enabled": True}}},
+        )
+        self.assertEqual(create_kwargs["category"], category)
+
+        datalayer_has_style_mock.objects.bulk_create.assert_called_once()
+        style_rows = datalayer_has_style_mock.objects.bulk_create.call_args.args[0]
+        self.assertEqual(len(style_rows), 2)
+
+        datalayer_has_style_mock.assert_any_call(
+            datalayer=created_datalayer,
+            style_id=11,
+            default=True,
+        )
+        datalayer_has_style_mock.assert_any_call(
+            datalayer=created_datalayer,
+            style_id=22,
+            default=False,
+        )

--- a/src/planscape/datasets/twig_treatments.py
+++ b/src/planscape/datasets/twig_treatments.py
@@ -1,0 +1,413 @@
+import json
+import logging
+import re
+import tempfile
+from copy import deepcopy
+from datetime import date
+from typing import Any, Dict, Optional, TextIO
+from uuid import uuid4
+
+import requests
+from core.gcs import get_bucket_and_key as get_gcs_bucket_and_key
+from core.gcs import is_gcs_file
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from gis.core import fetch_geometry_type, get_layer_info, with_vsi_prefix
+from gis.io import detect_mimetype
+from google.cloud import storage
+from organizations.models import Organization
+from workspaces.models import Workspace
+
+from datasets.models import (
+    DataLayer,
+    DataLayerHasStyle,
+    DataLayerStatus,
+    Dataset,
+    MapServiceChoices,
+    StorageTypeChoices,
+    VisibilityOptions,
+)
+from datasets.services import geometry_from_info, get_storage_url
+
+logger = logging.getLogger(__name__)
+
+TWIG_TREATMENTS_MIMETYPE = "application/geo+json"
+
+TWIG_TREATMENT_LAYER_NAMES = {
+    "0-5": "Years Since Treatment: 0-5",
+    "06-10": "Years Since Treatment: 06-10",
+    "11-15": "Years Since Treatment: 11-15",
+}
+
+
+def get_query_url(api_url: str) -> str:
+    api_url = api_url.rstrip("/")
+    if api_url.endswith("/query"):
+        return api_url
+    return f"{api_url}/query"
+
+
+def years_before(value: date, years: int) -> date:
+    try:
+        return value.replace(year=value.year - years)
+    except ValueError:
+        return value.replace(year=value.year - years, day=28)
+
+
+def format_arcgis_timestamp(value: date) -> str:
+    return value.strftime("%Y-%m-%d 00:00:00")
+
+
+def build_twig_where_clauses(
+    today: Optional[date] = None,
+    status_filter: Optional[str] = None,
+) -> Dict[str, str]:
+    today = today or timezone.localdate()
+
+    five_year_cutoff = years_before(today, 5)
+    ten_year_cutoff = years_before(today, 10)
+    fifteen_year_cutoff = years_before(today, 15)
+
+    five_year = format_arcgis_timestamp(five_year_cutoff)
+    ten_year = format_arcgis_timestamp(ten_year_cutoff)
+    fifteen_year = format_arcgis_timestamp(fifteen_year_cutoff)
+
+    where_clauses = {
+        TWIG_TREATMENT_LAYER_NAMES["0-5"]: (
+            f"treatment_date >= TIMESTAMP '{five_year}'"
+        ),
+        TWIG_TREATMENT_LAYER_NAMES["06-10"]: (
+            f"treatment_date >= TIMESTAMP '{ten_year}' "
+            f"AND treatment_date < TIMESTAMP '{five_year}'"
+        ),
+        TWIG_TREATMENT_LAYER_NAMES["11-15"]: (
+            f"treatment_date >= TIMESTAMP '{fifteen_year}' "
+            f"AND treatment_date < TIMESTAMP '{ten_year}'"
+        ),
+    }
+
+    if status_filter:
+        escaped_status = status_filter.replace("'", "''")
+        where_clauses = {
+            layer_name: f"({where_clause}) AND status = '{escaped_status}'"
+            for layer_name, where_clause in where_clauses.items()
+        }
+
+    return where_clauses
+
+
+def fetch_twig_count(
+    api_url: str,
+    where_clause: str,
+    timeout: int = 120,
+    session: Optional[requests.Session] = None,
+) -> int:
+    client = session or requests.Session()
+    response = client.get(
+        get_query_url(api_url),
+        params={
+            "where": where_clause,
+            "returnCountOnly": "true",
+            "f": "json",
+        },
+        headers={
+            "User-Agent": "Planscape/1.0",
+            "Accept": "application/json",
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError("Expected a JSON response from TWIG count query.") from exc
+
+    if "count" not in payload:
+        raise ValueError(f"Expected TWIG count response to include count: {payload}")
+
+    return int(payload["count"])
+
+
+def fetch_twig_feature_page(
+    api_url: str,
+    where_clause: str,
+    result_offset: int,
+    result_record_count: int,
+    timeout: int = 120,
+    session: Optional[requests.Session] = None,
+) -> Dict[str, Any]:
+    client = session or requests.Session()
+    response = client.get(
+        get_query_url(api_url),
+        params={
+            "where": where_clause,
+            "outFields": "*",
+            "returnGeometry": "true",
+            "f": "geojson",
+            "orderByFields": "objectid ASC",
+            "resultOffset": result_offset,
+            "resultRecordCount": result_record_count,
+        },
+        headers={
+            "User-Agent": "Planscape/1.0",
+            "Accept": "application/json",
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError("Expected a GeoJSON response from TWIG.") from exc
+
+    if payload.get("type") != "FeatureCollection":
+        raise ValueError("Expected a GeoJSON FeatureCollection from TWIG.")
+    if not isinstance(payload.get("features"), list):
+        raise ValueError("Expected TWIG FeatureCollection.features to be a list.")
+
+    return payload
+
+
+def write_twig_feature_collection_to_file(
+    api_url: str,
+    where_clause: str,
+    output_file: TextIO,
+    timeout: int = 120,
+    page_size: int = 1000,
+    session: Optional[requests.Session] = None,
+) -> int:
+    client = session or requests.Session()
+    expected_count = fetch_twig_count(
+        api_url=api_url,
+        where_clause=where_clause,
+        timeout=timeout,
+        session=client,
+    )
+
+    logger.info(
+        "Fetching %s TWIG features for where clause: %s",
+        expected_count,
+        where_clause,
+    )
+
+    actual_count = 0
+    offset = 0
+    first_feature = True
+
+    output_file.write('{"type":"FeatureCollection","features":[')
+
+    while offset < expected_count:
+        page = fetch_twig_feature_page(
+            api_url=api_url,
+            where_clause=where_clause,
+            result_offset=offset,
+            result_record_count=page_size,
+            timeout=timeout,
+            session=client,
+        )
+
+        features = page.get("features", [])
+        if not features:
+            break
+
+        for feature in features:
+            if not first_feature:
+                output_file.write(",")
+            json.dump(feature, output_file, separators=(",", ":"))
+            first_feature = False
+            actual_count += 1
+
+        logger.info(
+            "Fetched %s of %s TWIG features",
+            actual_count,
+            expected_count,
+        )
+
+        offset += page_size
+
+    output_file.write("]}")
+    output_file.flush()
+
+    return actual_count
+
+
+def get_or_create_twig_dataset(
+    dataset_name: str,
+    organization_id: int,
+) -> Dataset:
+    user_model = get_user_model()
+    created_by = user_model.objects.get(email=settings.DEFAULT_ADMIN_EMAIL)
+
+    workspace, _created = Workspace.objects.get_or_create(
+        name="Default",
+        visibility=VisibilityOptions.PUBLIC,
+    )
+
+    dataset, _created = Dataset.objects.get_or_create(
+        name=dataset_name,
+        organization_id=organization_id,
+        defaults={
+            "created_by": created_by,
+            "workspace": workspace,
+            "visibility": VisibilityOptions.PUBLIC,
+        },
+    )
+
+    return dataset
+
+
+def upload_geojson_file_to_storage(
+    storage_url: str,
+    input_file: str,
+) -> None:
+    if not is_gcs_file(storage_url):
+        raise ValueError(f"Unsupported datalayer storage URL: {storage_url}")
+
+    bucket_name, object_name = get_gcs_bucket_and_key(storage_url)
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(object_name)
+    blob.upload_from_filename(input_file, content_type=TWIG_TREATMENTS_MIMETYPE)
+
+
+def slugify_layer_name(name: str) -> str:
+    slug = name.lower()
+    slug = re.sub(r"[^a-z0-9]+", "_", slug)
+    return slug.strip("_")
+
+
+def replace_twig_treatment_datalayer(
+    dataset: Dataset,
+    organization: Organization,
+    name: str,
+    input_file: str,
+) -> DataLayer:
+    from datasets.tasks import datalayer_uploaded
+
+    user_model = get_user_model()
+    created_by = user_model.objects.get(email=settings.DEFAULT_ADMIN_EMAIL)
+
+    original_name = f"{slugify_layer_name(name)}.geojson"
+    uuid = str(uuid4())
+    storage_url = get_storage_url(
+        organization_id=organization.pk,
+        uuid=uuid,
+        original_name=original_name,
+        mimetype=TWIG_TREATMENTS_MIMETYPE,
+    )
+
+    upload_geojson_file_to_storage(
+        storage_url=storage_url,
+        input_file=input_file,
+    )
+
+    vsi_input_file = with_vsi_prefix(storage_url)
+    layer_type, layer_info = get_layer_info(input_file=vsi_input_file)
+    mimetype = detect_mimetype(input_file=vsi_input_file) or TWIG_TREATMENTS_MIMETYPE
+    geometry_type = fetch_geometry_type(layer_type=layer_type, info=layer_info)
+
+    existing_layers = DataLayer.dead_or_alive.filter(dataset=dataset, name=name)
+    existing_datalayer = existing_layers.filter(deleted_at=None).first()
+
+    if existing_datalayer is not None:
+        metadata = deepcopy(existing_datalayer.metadata) or {}
+        category = existing_datalayer.category
+        style_associations = [
+            (association.style_id, association.default)
+            for association in existing_datalayer.rel_styles.all()
+        ]
+    else:
+        metadata = {}
+        category = None
+        style_associations = []
+
+    existing_layers.delete()
+
+    datalayer = DataLayer.objects.create(
+        name=name,
+        uuid=uuid,
+        dataset=dataset,
+        organization=organization,
+        workspace=dataset.workspace,
+        category=category,
+        created_by=created_by,
+        original_name=original_name,
+        url=storage_url,
+        type=layer_type,
+        storage_type=StorageTypeChoices.DATABASE,
+        geometry_type=geometry_type,
+        geometry=geometry_from_info(layer_info, datalayer_type=layer_type),
+        info=layer_info,
+        mimetype=mimetype,
+        metadata=metadata,
+        map_service_type=MapServiceChoices.VECTORTILES,
+        status=DataLayerStatus.PENDING,
+    )
+
+    DataLayerHasStyle.objects.bulk_create(
+        [
+            DataLayerHasStyle(
+                datalayer=datalayer,
+                style_id=style_id,
+                default=default,
+            )
+            for style_id, default in style_associations
+        ]
+    )
+
+    datalayer_uploaded.delay(datalayer.pk, status=DataLayerStatus.READY)
+    return datalayer
+
+
+def refresh_twig_treatment_layers(
+    organization_id: int,
+    dataset_name: str,
+    api_url: str,
+    timeout: int = 120,
+    page_size: int = 1000,
+    status_filter: Optional[str] = None,
+) -> Dict[str, str]:
+    organization = Organization.objects.get(pk=organization_id)
+    dataset = get_or_create_twig_dataset(
+        dataset_name=dataset_name,
+        organization_id=organization_id,
+    )
+
+    refreshed_layers = {}
+    where_clauses = build_twig_where_clauses(status_filter=status_filter)
+
+    for layer_name, where_clause in where_clauses.items():
+        logger.info("Refreshing TWIG treatment layer %s", layer_name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            suffix=".geojson",
+        ) as temp_file:
+            feature_count = write_twig_feature_collection_to_file(
+                api_url=api_url,
+                where_clause=where_clause,
+                output_file=temp_file,
+                timeout=timeout,
+                page_size=page_size,
+            )
+
+            logger.info(
+                "Writing TWIG treatment layer %s with %s features",
+                layer_name,
+                feature_count,
+            )
+
+            datalayer = replace_twig_treatment_datalayer(
+                dataset=dataset,
+                organization=organization,
+                name=layer_name,
+                input_file=temp_file.name,
+            )
+
+        refreshed_layers[layer_name] = datalayer.url
+
+    return refreshed_layers

--- a/src/planscape/datasets/twig_treatments.py
+++ b/src/planscape/datasets/twig_treatments.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import requests
 from core.gcs import get_bucket_and_key as get_gcs_bucket_and_key
 from core.gcs import is_gcs_file
+from core.requests import RequestSessionWrap
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -39,6 +40,10 @@ TWIG_TREATMENT_LAYER_NAMES = {
     "06-10": "Years Since Treatment: 06-10",
     "11-15": "Years Since Treatment: 11-15",
 }
+
+
+def get_request_client(session: Optional[requests.Session] = None):
+    return session or RequestSessionWrap()
 
 
 def get_query_url(api_url: str) -> str:
@@ -103,7 +108,7 @@ def fetch_twig_count(
     timeout: int = 120,
     session: Optional[requests.Session] = None,
 ) -> int:
-    client = session or requests.Session()
+    client = get_request_client(session)
     response = client.get(
         get_query_url(api_url),
         params={
@@ -138,7 +143,7 @@ def fetch_twig_feature_page(
     timeout: int = 120,
     session: Optional[requests.Session] = None,
 ) -> Dict[str, Any]:
-    client = session or requests.Session()
+    client = get_request_client(session)
     response = client.get(
         get_query_url(api_url),
         params={
@@ -179,7 +184,7 @@ def write_twig_feature_collection_to_file(
     page_size: int = 1000,
     session: Optional[requests.Session] = None,
 ) -> int:
-    client = session or requests.Session()
+    client = get_request_client(session)
     expected_count = fetch_twig_count(
         api_url=api_url,
         where_clause=where_clause,

--- a/src/planscape/planscape/celery.py
+++ b/src/planscape/planscape/celery.py
@@ -47,6 +47,18 @@ def get_forisk_mills_schedule() -> dict[str, dict]:
     }
 
 
+def get_twig_treatments_schedule() -> dict[str, dict]:
+    if not settings.TWIG_TREATMENTS_CRON:
+        return {}
+
+    return {
+        "refresh-twig-treatment-layers": {
+            "task": "datasets.tasks.refresh_twig_treatment_layers_task",
+            "schedule": crontab.from_string(settings.TWIG_TREATMENTS_CRON),
+        }
+    }
+
+
 beat_schedule = {
     "trigger-scenario-post-processing": {
         "task": "planning.tasks.trigger_scenario_post_processing",
@@ -71,5 +83,6 @@ if settings.WEEKLY_NEW_USERS_REPORT_ENABLED:
 beat_schedule.update(get_catalog_backup_schedule())
 beat_schedule.update(get_catalog_restore_schedule())
 beat_schedule.update(get_forisk_mills_schedule())
+beat_schedule.update(get_twig_treatments_schedule())
 
 app.conf.beat_schedule = beat_schedule

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -474,6 +474,7 @@ CELERY_TASK_ROUTES = {
 CELERY_ALWAYS_EAGER = config("CELERY_ALWAYS_EAGER", False)
 CATALOG_BACKUP_CRON = config("CATALOG_BACKUP_CRON", default=None)
 CATALOG_RESTORE_CRON = config("CATALOG_RESTORE_CRON", default=None)
+
 FORISK_MILLS_CRON = config("FORISK_MILLS_CRON", default=None)
 FORISK_MILLS_DATASET_NAME = config(
     "FORISK_MILLS_DATASET_NAME", default="Mills & Other Biomass Facilities"
@@ -490,6 +491,30 @@ FORISK_MILLS_API_URL = config("FORISK_MILLS_API_URL", default=None)
 FORISK_MILLS_TIMEOUT = config("FORISK_MILLS_TIMEOUT", default=120, cast=int)
 FORISK_MILLS_PLANSCAPE_ORG_ID = config(
     "FORISK_MILLS_PLANSCAPE_ORG_ID", default=1, cast=int
+)
+
+TWIG_TREATMENTS_CRON = config("TWIG_TREATMENTS_CRON", default=None)
+TWIG_TREATMENTS_DATASET_NAME = config(
+    "TWIG_TREATMENTS_DATASET_NAME",
+    default="Treatments",
+)
+TWIG_TREATMENTS_API_URL = config(
+    "TWIG_TREATMENTS_API_URL",
+    default=(
+        "https://gis.reshapewildfire.org/arcgis/rest/services/Hosted/"
+        "Treatment_Index_View/FeatureServer/0"
+    ),
+)
+TWIG_TREATMENTS_TIMEOUT = config("TWIG_TREATMENTS_TIMEOUT", default=120, cast=int)
+TWIG_TREATMENTS_PAGE_SIZE = config("TWIG_TREATMENTS_PAGE_SIZE", default=1000, cast=int)
+TWIG_TREATMENTS_PLANSCAPE_ORG_ID = config(
+    "TWIG_TREATMENTS_PLANSCAPE_ORG_ID",
+    default=1,
+    cast=int,
+)
+TWIG_TREATMENTS_STATUS_FILTER = config(
+    "TWIG_TREATMENTS_STATUS_FILTER",
+    default=None,
 )
 
 TREATMENTS_TEST_FIXTURES_PATH = BASE_DIR / "scenario_fixtures"

--- a/src/planscape/planscape/tests/test_celery.py
+++ b/src/planscape/planscape/tests/test_celery.py
@@ -4,6 +4,7 @@ from planscape.celery import (
     get_catalog_backup_schedule,
     get_catalog_restore_schedule,
     get_forisk_mills_schedule,
+    get_twig_treatments_schedule,
 )
 
 
@@ -45,4 +46,25 @@ class TestCatalogBeatSchedule(SimpleTestCase):
         self.assertEqual(
             schedule["refresh-forisk-mill-layers"]["schedule"]._orig_minute,
             "30",
+        )
+
+    @override_settings(TWIG_TREATMENTS_CRON="30 5 1 * *")
+    def test_twig_treatments_schedule_uses_cron_env_var(self):
+        schedule = get_twig_treatments_schedule()
+
+        self.assertEqual(
+            schedule["refresh-twig-treatment-layers"]["task"],
+            "datasets.tasks.refresh_twig_treatment_layers_task",
+        )
+        self.assertEqual(
+            schedule["refresh-twig-treatment-layers"]["schedule"]._orig_minute,
+            "30",
+        )
+        self.assertEqual(
+            schedule["refresh-twig-treatment-layers"]["schedule"]._orig_hour,
+            "5",
+        )
+        self.assertEqual(
+            schedule["refresh-twig-treatment-layers"]["schedule"]._orig_day_of_month,
+            "1",
         )


### PR DESCRIPTION
@george-silva @dgh007786 @roquebetioljr, Create CRON job to update Treatment Data Monthly,  https://sig-gis.atlassian.net/browse/PLAN-3640.

The 3 layers are here: https://gis.reshapewildfire.org/arcgis/rest/services/Hosted/Treatment_Index_View/FeatureServer/0

--------------------------
 
1. `src/planscape/datasets/twig_treatments.py`: refreshed the 3 layers by querying the SWERI API, splitting records into 3 buckets, uploading the resulting GeoJSONs to GCS, and replacing the matching DataLayers.
2. `src/planscape/datasets/tasks.py`: added the Celery task that runs the layer re-fresh, and reports success/failure.
3. `src/planscape/planscape/settings.py`: added TWIG refresh settings for cron, API URL, dataset name, org ID, timeout, page size, and optional status filter, just like the forisk_mills task does.
4. `src/planscape/planscape/celery.py`: registered the TWIG refresh task with Celery Beat using a cron env var (which I'd need to set in our 3 `.envs`).
5. `src/planscape/planscape/tests/test_celery.py`: added test coverage for the TWIG Celery Beat schedule.
6. `src/planscape/datasets/tests/test_twig_treatments.py`: added tests for TWIG date filters, API pagination, GeoJSON writing, and DataLayer replacement.

-----------------------------

Was able to pull, split, and upload the 3 layers into local running terminal commands from `twig_treatments.py`:

<img width="1169" height="376" alt="image" src="https://github.com/user-attachments/assets/6cbc0f5a-39f2-4692-b2ea-8b8778ac1eea" />
