### PR TITLE
Hide Proj Area Tools component when tools are empty

### DIFF
--- a/src/interface/src/app/scenario/project-area-dashboard/project-area-dashboard.component.html
+++ b/src/interface/src/app/scenario/project-area-dashboard/project-area-dashboard.component.html
@@ -25,20 +25,11 @@
       </app-map-viewer-card>
 
       <!-- Dashboard tools -->
-      <sg-details-card
+      <app-scenario-tools
         cardTitle="Project Area Tools"
-        class="project-area-tools-card">
-        <!--Subtitle-->
-        <p class="description">
-          Refine your project planning further by using our specialized project
-          area tools.
-        </p>
-        <!--Tools-->
-        <div class="tools">
-          <app-scenario-tools
-            (toolClicked)="onToolClick($event)"></app-scenario-tools>
-        </div>
-      </sg-details-card>
+        subtitle="Refine your project planning further by using our specialized
+            project area tools."
+        (toolClicked)="onToolClick($event)"></app-scenario-tools>
     </div>
     <div right-column class="project-area-column">
       <app-project-area-coming-soon></app-project-area-coming-soon>

--- a/src/interface/src/app/scenario/project-area-dashboard/project-area-dashboard.component.scss
+++ b/src/interface/src/app/scenario/project-area-dashboard/project-area-dashboard.component.scss
@@ -1,27 +1,9 @@
-@import 'mixins';
 @import 'colors';
 
 .plan-overview-column {
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-
-.tools {
-  display: flex;
-  width: 100%;
-  gap: 16px;
-  flex-wrap: wrap;
-}
-
-.description {
-  @include small-paragraph();
-  color: $color-dark-gray;
-  margin: 0;
-}
-
-.project-area-tools-card {
-  gap: 4px;
 }
 
 .project-area-dashboard-layout {

--- a/src/interface/src/app/scenario/scenario-dashboard/scenario-dashboard.component.html
+++ b/src/interface/src/app/scenario/scenario-dashboard/scenario-dashboard.component.html
@@ -19,19 +19,12 @@
         [planning_area_name]="plan?.name || ''"></sg-details-card>
       <!-- Dashboard tools: We display the tools just if our status didn't fail -->
       <ng-container *ngIf="currentScenario$ | async as scenario">
-        <sg-details-card
+        <app-scenario-tools
+          *ngIf="!scenarioHasFailed(scenario)"
           cardTitle="Project Area Tools"
-          class="scenario-tools-card"
-          *ngIf="!scenarioHasFailed(scenario)">
-          <!--Subtitle-->
-          <p class="description">
-            Refine your project planning further by using our specialized
-            project area tools.
-          </p>
-          <!--Tools-->
-          <app-scenario-tools
-            (toolClicked)="onToolClick($event)"></app-scenario-tools>
-        </sg-details-card>
+          subtitle="Refine your project planning further by using our specialized
+            project area tools."
+          (toolClicked)="onToolClick($event)"></app-scenario-tools>
       </ng-container>
     </div>
     <div right-column class="right-column-card">

--- a/src/interface/src/app/scenario/scenario-tools/scenario-tools.component.html
+++ b/src/interface/src/app/scenario/scenario-tools/scenario-tools.component.html
@@ -1,9 +1,22 @@
-<sg-tile-button
-  *ngFor="let tool of scenarioDashboardTools$ | async"
-  [backgroundImage]="tool.backgroundImage"
-  [backgroundColor]="tool.backgroundColor ?? ''"
-  [title]="tool.title"
-  size="lg"
-  [disabled]="!tool.enabled"
-  (tileClick)="onToolClick(tool.id)">
-</sg-tile-button>
+@if (scenarioDashboardTools$ | async; as dashboardTools) {
+  @if (dashboardTools.length) {
+    <sg-details-card [cardTitle]="cardTitle" class="project-area-tools-card">
+      <!--Subtitle-->
+      <p class="description">
+        {{ subtitle }}
+      </p>
+      <!--Tools-->
+      <div class="tools">
+        <sg-tile-button
+          *ngFor="let tool of dashboardTools"
+          [backgroundImage]="tool.backgroundImage"
+          [backgroundColor]="tool.backgroundColor ?? ''"
+          [title]="tool.title"
+          size="lg"
+          [disabled]="!tool.enabled"
+          (tileClick)="onToolClick(tool.id)">
+        </sg-tile-button>
+      </div>
+    </sg-details-card>
+  }
+}

--- a/src/interface/src/app/scenario/scenario-tools/scenario-tools.component.scss
+++ b/src/interface/src/app/scenario/scenario-tools/scenario-tools.component.scss
@@ -1,6 +1,26 @@
-:host {
+@import 'mixins';
+@import 'colors';
+
+.tools {
   display: flex;
   width: 100%;
   gap: 16px;
   flex-wrap: wrap;
+}
+
+.project-area-tools-card {
+  gap: 4px;
+}
+
+.tools {
+  display: flex;
+  width: 100%;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.description {
+  @include small-paragraph();
+  color: $color-dark-gray;
+  margin: 0;
 }

--- a/src/interface/src/app/scenario/scenario-tools/scenario-tools.component.ts
+++ b/src/interface/src/app/scenario/scenario-tools/scenario-tools.component.ts
@@ -1,10 +1,11 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FeatureService } from '@features/feature.service';
-import { AsyncPipe, NgForOf } from '@angular/common';
+import { AsyncPipe, NgForOf, NgIf } from '@angular/common';
 import { TileButtonComponent } from '@styleguide';
 import { Capabilities } from '@types';
 import { map } from 'rxjs';
 import { ScenarioState } from '../scenario.state';
+import { DetailsCardComponent } from '@styleguide/details-card/details-card.component';
 
 interface ScenarioTool {
   id: string;
@@ -17,12 +18,20 @@ interface ScenarioTool {
 @Component({
   selector: 'app-scenario-tools',
   standalone: true,
-  imports: [AsyncPipe, NgForOf, TileButtonComponent],
+  imports: [
+    AsyncPipe,
+    DetailsCardComponent,
+    NgForOf,
+    NgIf,
+    TileButtonComponent,
+  ],
   templateUrl: './scenario-tools.component.html',
   styleUrl: './scenario-tools.component.scss',
 })
 export class ScenarioToolsComponent {
   @Output() toolClicked = new EventEmitter<string>();
+  @Input() cardTitle = '';
+  @Input() subtitle = '';
 
   scenarioDashboardTools$ = this.scenarioState.scenarioCapabilities$.pipe(
     map((capabilities) => this.buildTools(capabilities))


### PR DESCRIPTION
This PR pulls the full card elements into scenario-tools component, and it adds logic to not display when the tools options are empty (e.g., in the case where funding reports aren't available, and when a scenario prioritizes subunits).