### PR TITLE
tab/nav scrolling fixes for funding

### DIFF
--- a/src/interface/src/app/funding/full-report-view/full-report-view.component.html
+++ b/src/interface/src/app/funding/full-report-view/full-report-view.component.html
@@ -7,7 +7,7 @@
         defaultSelection="report"
         (emitSelection)="handleToggleSelection($event)"></sg-toggle-tabs>
     </div>
-    <div class="report-view" *ngIf="currentView === 'report'">
+    <div class="report-view" #reportScroll *ngIf="currentView === 'report'">
       <div class="section-row">
         <div class="section-title">Introduction</div>
         <div class="section-text">
@@ -40,6 +40,7 @@
             *ngIf="report.status === 'SUCCESS'; else loadingReport"
             [report]="report"
             [projectAreas]="selectedProjectAreas"
+            [scrollElement]="reportScroll"
             [reportType]="'full'"></app-funding-report>
         </ng-container>
         <ng-template #loadingReport>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -2,13 +2,17 @@
   mat-tab-nav-bar
   [tabPanel]="tabPanel"
   class="funding-report-tabs"
-  [ngClass]="{ fullview: !isPreview }">
+  [ngClass]="{ fullview: !isPreview }"
+  [appScrollSpy]="sectionIds"
+  [spyRoot]="scrollElement || scrollContainer"
+  (activeSection)="activeId = $event"
+  #spy="appScrollSpy">
   <a
     mat-tab-link
     *ngFor="let s of sections"
     [active]="activeId === s.id"
     [href]="'#' + s.id"
-    (click)="scrollTo($event, s.id)">
+    (click)="$event.preventDefault(); spy.scrollTo(s.id)">
     {{ s.label }}
   </a>
 </nav>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -1,18 +1,13 @@
 import { CommonModule } from '@angular/common';
 import {
-  AfterViewInit,
-  ChangeDetectorRef,
   Component,
-  ElementRef,
   EventEmitter,
   Input,
-  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
   Output,
   SimpleChanges,
-  ViewChild,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -50,6 +45,7 @@ import {
   FundingMapLayersComponent,
   MapLayer,
 } from '../funding-map-layers/funding-map-layers.component';
+import { ScrollSpyDirective } from '@app/standalone/scroll-spy-directive/scroll-spy.directive';
 
 interface ChartConfig {
   data: ChartData<'bar'>;
@@ -93,17 +89,15 @@ const flameLengthRangeValidator: ValidatorFn = (
     InputDirective,
     ReactiveFormsModule,
     MessageCardComponent,
+    ScrollSpyDirective,
   ],
   templateUrl: './funding-report.component.html',
   styleUrl: './funding-report.component.scss',
 })
-export class FundingReportComponent
-  implements OnInit, OnChanges, AfterViewInit, OnDestroy
-{
-  @ViewChild('scrollContainer', { static: true })
-  scrollContainer!: ElementRef<HTMLElement>;
-
+export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
   sections: ReportSection[] = [];
+  /** Section ids in document order, handed to the scrollspy directive. */
+  sectionIds: string[] = [];
 
   activeId = '';
   /** Name of the section whose interactive tooltip was last opened. */
@@ -128,14 +122,6 @@ export class FundingReportComponent
     Validators.required
   );
 
-  /** Scrollspy: notifies when sections cross the active line. No scroll listener. */
-  private observer?: IntersectionObserver;
-  /** Ids of sections currently below the active line, kept in sync by the observer. */
-  private readonly visible = new Set<string>();
-  /** Section a tab click is smooth-scrolling toward; spy holds here until it arrives. */
-  private seekId: string | null = null;
-  /** Safety release for `seekId` if the target is never reached (e.g. last section). */
-  private seekDeadline = 0;
   @Input() showMap = true;
   @Input() showFooter = true;
   @Input() reportType: 'preview' | 'full' = 'preview';
@@ -157,11 +143,6 @@ export class FundingReportComponent
     greaterThan: number;
     lesserThan: number;
   }>();
-
-  constructor(
-    private cdr: ChangeDetectorRef,
-    private zone: NgZone
-  ) {}
 
   ngOnInit(): void {
     Chart.register(ChartDataLabels);
@@ -188,78 +169,13 @@ export class FundingReportComponent
         { id: 'biomass', label: 'Biomass' },
       ]
     );
+    this.sectionIds = this.sections.map((s) => s.id);
     this.activeId = this.sections[0].id;
   }
 
-  ngAfterViewInit(): void {
-    const root = this.scrollElement ?? this.scrollContainer.nativeElement;
-    // The active line sits where a clicked section lands: scroll-margin-top below
-    // the scroll container's top. Reading it from CSS keeps spy and click in sync
-    // and absorbs each layout's sticky offset (16 preview / 184 full).
-    const first = document.getElementById(this.sections[0].id);
-    const offset = first
-      ? parseInt(getComputedStyle(first).scrollMarginTop, 10) || 0
-      : 0;
-    this.zone.runOutsideAngular(() => {
-      this.observer = new IntersectionObserver(this.onIntersect, {
-        root,
-        rootMargin: `-${offset}px 0px 0px 0px`,
-        threshold: 0,
-      });
-      for (const s of this.sections) {
-        const el = document.getElementById(s.id);
-        if (el) this.observer.observe(el);
-      }
-    });
-  }
-
   ngOnDestroy(): void {
-    this.observer?.disconnect();
     Chart.unregister(ChartDataLabels);
   }
-
-  scrollTo(event: Event, id: string): void {
-    event.preventDefault();
-    this.activeId = id;
-    // Hold the spy on this target so it doesn't flicker through the sections the
-    // smooth scroll passes over; released when we arrive or after a safety delay.
-    this.seekId = id;
-    this.seekDeadline = Date.now() + 1500;
-    // scroll-margin-top lands the section on the same line the spy reacts to,
-    // and scrollIntoView resolves the final position regardless of how the
-    // sticky elements are currently laid out — so it works even from the top.
-    document
-      .getElementById(id)
-      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
-
-  /** Active section = the first one still below the active line. */
-  private onIntersect = (entries: IntersectionObserverEntry[]): void => {
-    for (const e of entries) {
-      if (e.isIntersecting) this.visible.add(e.target.id);
-      else this.visible.delete(e.target.id);
-    }
-
-    const next = this.sections.find((s) => this.visible.has(s.id))?.id;
-    if (!next) return;
-
-    // While a tab-click scroll is in flight, hold on the target; release once we
-    // reach it (or the safety deadline elapses).
-    if (this.seekId) {
-      if (next === this.seekId || Date.now() >= this.seekDeadline) {
-        this.seekId = null;
-      } else {
-        return;
-      }
-    }
-
-    if (next !== this.activeId) {
-      this.zone.run(() => {
-        this.activeId = next;
-        this.cdr.markForCheck();
-      });
-    }
-  };
 
   private readonly labels = [0, 5, 10, 15, 20];
   private readonly xAxisLabel = 'Years Since Treatment';

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -128,14 +128,27 @@ export class FundingReportComponent
     Validators.required
   );
 
-  private suppressUntil = 0;
-  private pendingScrollFrame: number | null = null;
+  /** Scrollspy: notifies when sections cross the active line. No scroll listener. */
+  private observer?: IntersectionObserver;
+  /** Ids of sections currently below the active line, kept in sync by the observer. */
+  private readonly visible = new Set<string>();
+  /** Section a tab click is smooth-scrolling toward; spy holds here until it arrives. */
+  private seekId: string | null = null;
+  /** Safety release for `seekId` if the target is never reached (e.g. last section). */
+  private seekDeadline = 0;
   @Input() showMap = true;
   @Input() showFooter = true;
   @Input() reportType: 'preview' | 'full' = 'preview';
   @Input() report!: FundingReport;
   /** Selected project area ids; empty means show the whole-scenario summary. */
   @Input() projectAreas: number[] = [];
+  /**
+   * The element that actually scrolls the report. When the report is embedded
+   * in a host that owns the scroll (e.g. full-report-view), the host passes its
+   * scroll container here. Defaults to the component's own `#scrollContainer`,
+   * which is the scroller in the standalone/preview layout.
+   */
+  @Input() scrollElement?: HTMLElement;
 
   // todo datalayer probably
   @Output() showLayer = new EventEmitter<number>();
@@ -179,60 +192,64 @@ export class FundingReportComponent
   }
 
   ngAfterViewInit(): void {
+    const root = this.scrollElement ?? this.scrollContainer.nativeElement;
+    // The active line sits where a clicked section lands: scroll-margin-top below
+    // the scroll container's top. Reading it from CSS keeps spy and click in sync
+    // and absorbs each layout's sticky offset (16 preview / 184 full).
+    const first = document.getElementById(this.sections[0].id);
+    const offset = first
+      ? parseInt(getComputedStyle(first).scrollMarginTop, 10) || 0
+      : 0;
     this.zone.runOutsideAngular(() => {
-      this.scrollContainer.nativeElement.addEventListener(
-        'scroll',
-        this.onScroll,
-        { passive: true }
-      );
+      this.observer = new IntersectionObserver(this.onIntersect, {
+        root,
+        rootMargin: `-${offset}px 0px 0px 0px`,
+        threshold: 0,
+      });
+      for (const s of this.sections) {
+        const el = document.getElementById(s.id);
+        if (el) this.observer.observe(el);
+      }
     });
-    this.updateActiveNav();
   }
 
   ngOnDestroy(): void {
-    this.scrollContainer?.nativeElement.removeEventListener(
-      'scroll',
-      this.onScroll
-    );
-    if (this.pendingScrollFrame !== null)
-      cancelAnimationFrame(this.pendingScrollFrame);
+    this.observer?.disconnect();
     Chart.unregister(ChartDataLabels);
   }
 
   scrollTo(event: Event, id: string): void {
     event.preventDefault();
     this.activeId = id;
-    // mute scrollspy until smooth-scroll settles so it doesn't flicker
-    // through intermediate sections
-    this.suppressUntil = Date.now() + 700;
+    // Hold the spy on this target so it doesn't flicker through the sections the
+    // smooth scroll passes over; released when we arrive or after a safety delay.
+    this.seekId = id;
+    this.seekDeadline = Date.now() + 1500;
+    // scroll-margin-top lands the section on the same line the spy reacts to,
+    // and scrollIntoView resolves the final position regardless of how the
+    // sticky elements are currently laid out — so it works even from the top.
     document
       .getElementById(id)
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
-  private onScroll = (): void => {
-    if (this.pendingScrollFrame !== null) return;
-    this.pendingScrollFrame = requestAnimationFrame(() => {
-      this.pendingScrollFrame = null;
-      if (Date.now() < this.suppressUntil) return;
-      this.updateActiveNav();
-    });
-  };
+  /** Active section = the first one still below the active line. */
+  private onIntersect = (entries: IntersectionObserverEntry[]): void => {
+    for (const e of entries) {
+      if (e.isIntersecting) this.visible.add(e.target.id);
+      else this.visible.delete(e.target.id);
+    }
 
-  private updateActiveNav(): void {
-    const containerTop =
-      this.scrollContainer.nativeElement.getBoundingClientRect().top;
-    // 80px is the height of the header approximately
-    const activeLineY = containerTop + 80;
+    const next = this.sections.find((s) => this.visible.has(s.id))?.id;
+    if (!next) return;
 
-    let next = this.sections[0].id;
-    for (const s of this.sections) {
-      const el = document.getElementById(s.id);
-      if (!el) continue;
-      if (el.getBoundingClientRect().top <= activeLineY) {
-        next = s.id;
+    // While a tab-click scroll is in flight, hold on the target; release once we
+    // reach it (or the safety deadline elapses).
+    if (this.seekId) {
+      if (next === this.seekId || Date.now() >= this.seekDeadline) {
+        this.seekId = null;
       } else {
-        break;
+        return;
       }
     }
 
@@ -242,7 +259,7 @@ export class FundingReportComponent
         this.cdr.markForCheck();
       });
     }
-  }
+  };
 
   private readonly labels = [0, 5, 10, 15, 20];
   private readonly xAxisLabel = 'Years Since Treatment';

--- a/src/interface/src/app/standalone/scroll-spy-directive/scroll-spy.directive.spec.ts
+++ b/src/interface/src/app/standalone/scroll-spy-directive/scroll-spy.directive.spec.ts
@@ -1,0 +1,65 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ScrollSpyDirective } from './scroll-spy.directive';
+
+@Component({
+  standalone: true,
+  imports: [ScrollSpyDirective],
+  template: `
+    <nav
+      [appScrollSpy]="ids"
+      [spyRoot]="root"
+      (activeSection)="active = $event"
+      #spy="appScrollSpy"></nav>
+    <div #root class="root" style="height: 100px; overflow: auto">
+      <section id="a" style="height: 300px; scroll-margin-top: 10px"></section>
+      <section id="b" style="height: 300px; scroll-margin-top: 10px"></section>
+    </div>
+  `,
+})
+class TestHostComponent {
+  @ViewChild(ScrollSpyDirective) spy!: ScrollSpyDirective;
+  ids = ['a', 'b'];
+  root!: HTMLElement;
+  active = '';
+}
+
+describe('ScrollSpyDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    component.root = fixture.nativeElement.querySelector('.root');
+    fixture.detectChanges();
+  });
+
+  it('creates the directive', () => {
+    expect(component.spy).toBeTruthy();
+  });
+
+  it('scrollTo emits the target section and scrolls it into view', () => {
+    const target = fixture.nativeElement.querySelector('#b') as HTMLElement;
+    const spy = spyOn(target, 'scrollIntoView');
+
+    component.spy.scrollTo('b');
+
+    expect(component.active).toBe('b');
+    expect(spy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('scrollTo is a no-op emit when the target is already active', () => {
+    component.spy.scrollTo('a');
+    component.active = 'changed';
+
+    // 'a' is already the active target, so no new emission overwrites the test value
+    component.spy.scrollTo('a');
+
+    expect(component.active).toBe('changed');
+  });
+});

--- a/src/interface/src/app/standalone/scroll-spy-directive/scroll-spy.directive.ts
+++ b/src/interface/src/app/standalone/scroll-spy-directive/scroll-spy.directive.ts
@@ -1,0 +1,124 @@
+import {
+  AfterViewInit,
+  Directive,
+  EventEmitter,
+  Input,
+  NgZone,
+  OnDestroy,
+  Output,
+} from '@angular/core';
+
+/**
+ * Scrollspy: highlights navigation as sections scroll past an "active line".
+ *
+ * Place it on the nav element and give it the ids of the sections to track. It
+ * watches them with an `IntersectionObserver` — no scroll listener and no layout
+ * reads on scroll — and emits the id of the section currently at the top of the
+ * reading area. Call `scrollTo(id)` from a tab click to smooth-scroll there.
+ *
+ * The active line sits at each section's CSS `scroll-margin-top` below the scroll
+ * container's top — the same offset `scrollIntoView` uses — so the spy and
+ * click-to-scroll always agree, with the offset defined once in CSS.
+ *
+ * @example
+ * <nav [appScrollSpy]="sectionIds"
+ *      [spyRoot]="scrollElement"
+ *      (activeSection)="activeId = $event"
+ *      #spy="appScrollSpy">
+ *   <a *ngFor="let s of sections"
+ *      [class.active]="activeId === s.id"
+ *      (click)="$event.preventDefault(); spy.scrollTo(s.id)">{{ s.label }}</a>
+ * </nav>
+ */
+@Directive({
+  selector: '[appScrollSpy]',
+  standalone: true,
+  exportAs: 'appScrollSpy',
+})
+export class ScrollSpyDirective implements AfterViewInit, OnDestroy {
+  /** Ids of the section elements to track, in document order. */
+  @Input('appScrollSpy') sectionIds: string[] = [];
+  /** The element that scrolls the sections. */
+  @Input({ required: true }) spyRoot!: HTMLElement;
+  /** Emits the active section id whenever it changes. */
+  @Output() activeSection = new EventEmitter<string>();
+
+  private observer?: IntersectionObserver;
+  /** Ids of sections currently below the active line, kept in sync by the observer. */
+  private readonly visible = new Set<string>();
+  private activeId = '';
+  /** Section a click is scrolling toward; the spy holds here until it arrives. */
+  private seekId: string | null = null;
+  /** Safety release for `seekId` if the target is never reached (e.g. last section). */
+  private seekDeadline = 0;
+
+  constructor(private zone: NgZone) {}
+
+  ngAfterViewInit(): void {
+    const offset = this.activeLineOffset();
+    this.zone.runOutsideAngular(() => {
+      this.observer = new IntersectionObserver(this.onIntersect, {
+        root: this.spyRoot,
+        rootMargin: `-${offset}px 0px 0px 0px`,
+        threshold: 0,
+      });
+      for (const id of this.sectionIds) {
+        const el = document.getElementById(id);
+        if (el) this.observer.observe(el);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+  }
+
+  /** Smooth-scroll a section to the active line, holding the spy on it en route. */
+  scrollTo(id: string): void {
+    this.emit(id);
+    // Hold the spy on this target so it doesn't flicker through the sections the
+    // smooth scroll passes over; released when we arrive or after a safety delay.
+    this.seekId = id;
+    this.seekDeadline = Date.now() + 1500;
+    document
+      .getElementById(id)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  /** Distance below the container's top where a section becomes active. */
+  private activeLineOffset(): number {
+    const first = document.getElementById(this.sectionIds[0]);
+    return first
+      ? parseInt(getComputedStyle(first).scrollMarginTop, 10) || 0
+      : 0;
+  }
+
+  private onIntersect = (entries: IntersectionObserverEntry[]): void => {
+    for (const e of entries) {
+      if (e.isIntersecting) this.visible.add(e.target.id);
+      else this.visible.delete(e.target.id);
+    }
+
+    // Active section = the first one still below the active line.
+    const next = this.sectionIds.find((id) => this.visible.has(id));
+    if (!next) return;
+
+    // While a click scroll is in flight, hold on the target; release once we
+    // reach it (or the safety deadline elapses).
+    if (this.seekId) {
+      if (next === this.seekId || Date.now() >= this.seekDeadline) {
+        this.seekId = null;
+      } else {
+        return;
+      }
+    }
+
+    this.emit(next);
+  };
+
+  private emit(id: string): void {
+    if (id === this.activeId) return;
+    this.activeId = id;
+    this.zone.run(() => this.activeSection.emit(id));
+  }
+}


### PR DESCRIPTION
Fixes a couple of issues with tab/nav scrolling, passing a scroll element so it also works when the scroll element is not on the report itself (like on the full report view), and moves the logic to a directive 