### PR TITLE
modules: Forsys Includes serializer change to bring more details about includes datalayers.

### DIFF
--- a/src/planscape/modules/serializers.py
+++ b/src/planscape/modules/serializers.py
@@ -52,7 +52,7 @@ class OptionThresholdsSerializer(serializers.Serializer):
 
 
 class ForsysOptionsSerializer(BaseModuleOptionsSerializer):
-    inclusions = serializers.ListField(child=OptionDataLayerSerializer())
+    inclusions = serializers.ListField(child=BrowseDataLayerSerializer())
     exclusions = serializers.ListField(child=BrowseDataLayerSerializer())
     thresholds = OptionThresholdsSerializer()
 


### PR DESCRIPTION
Using `BrowseDataLayerSerializer` to bring more details about includes datalayers, so Front-end can render it with applied style.