### PR TITLE
dont save changes on include or excludes when going back on steps

### DIFF
--- a/src/interface/src/app/scenario-creation/exclude-areas-selector/exclude-areas-selector.component.spec.ts
+++ b/src/interface/src/app/scenario-creation/exclude-areas-selector/exclude-areas-selector.component.spec.ts
@@ -6,12 +6,18 @@ import { MockProvider } from 'ng-mocks';
 import { NewScenarioState } from '../new-scenario.state';
 import { BehaviorSubject, of } from 'rxjs';
 import { BaseLayersStateService } from '@base-layers/base-layers.state.service';
+import { ForsysService } from '@services/forsys.service';
+import { BaseLayer } from '@types';
 
 describe('ExcludeAreasSelectorComponent', () => {
   let component: ExcludeAreasSelectorComponent;
   let fixture: ComponentFixture<ExcludeAreasSelectorComponent>;
+  let scenarioConfig$: BehaviorSubject<any>;
+  let state: NewScenarioState;
 
   beforeEach(async () => {
+    scenarioConfig$ = new BehaviorSubject({});
+
     await TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -21,20 +27,45 @@ describe('ExcludeAreasSelectorComponent', () => {
       providers: [
         MockProvider(NewScenarioState, {
           excludedAreas$: of([]),
-          scenarioConfig$: new BehaviorSubject({}),
+          scenarioConfig$,
         }),
         MockProvider(BaseLayersStateService, {
           selectedBaseLayers$: of([]),
+        }),
+        MockProvider(ForsysService, {
+          excludedAreas$: of([]),
         }),
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExcludeAreasSelectorComponent);
     component = fixture.componentInstance;
+    state = TestBed.inject(NewScenarioState);
+    spyOn(state, 'setExcludedAreas');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('reverts unsaved selection to the saved config when leaving the step', () => {
+    scenarioConfig$.next({ excluded_areas: [1, 2] });
+    // user makes an unsaved change
+    component.handleSelectedItemsChange([{ id: 9 } as BaseLayer]);
+    expect(state.setExcludedAreas).toHaveBeenCalledWith([9]);
+
+    // going back (or saving) triggers the exit hook
+    component.beforeStepExit();
+
+    expect(state.setExcludedAreas).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it('reverts to an empty list when the saved config has no excluded areas', () => {
+    scenarioConfig$.next({});
+
+    component.beforeStepExit();
+
+    expect(state.setExcludedAreas).toHaveBeenCalledWith([]);
   });
 });

--- a/src/interface/src/app/scenario-creation/exclude-areas-selector/exclude-areas-selector.component.ts
+++ b/src/interface/src/app/scenario-creation/exclude-areas-selector/exclude-areas-selector.component.ts
@@ -111,5 +111,12 @@ export class ExcludeAreasSelectorComponent
 
   override beforeStepExit(): void {
     this.clearViewedLayers(); // clears layer selection after step in completed
+    // Revert any unsaved selection so going back doesn't persist changes.
+    // On save this is a no-op since the config was already updated.
+    this.newScenarioState.scenarioConfig$
+      .pipe(take(1))
+      .subscribe((config) =>
+        this.newScenarioState.setExcludedAreas(config.excluded_areas ?? [])
+      );
   }
 }

--- a/src/interface/src/app/scenario-creation/include-areas-selector/include-areas-selector.component.spec.ts
+++ b/src/interface/src/app/scenario-creation/include-areas-selector/include-areas-selector.component.spec.ts
@@ -8,12 +8,18 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ExcludeAreasSelectorComponent } from '../exclude-areas-selector/exclude-areas-selector.component';
 import { BaseLayersStateService } from '@app/base-layers/base-layers.state.service';
+import { ForsysService } from '@app/services/forsys.service';
+import { BaseLayer } from '@app/types';
 
 describe('IncludeAreasSelectorComponent', () => {
   let component: IncludeAreasSelectorComponent;
   let fixture: ComponentFixture<IncludeAreasSelectorComponent>;
+  let scenarioConfig$: BehaviorSubject<any>;
+  let state: NewScenarioState;
 
   beforeEach(async () => {
+    scenarioConfig$ = new BehaviorSubject({});
+
     await TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
@@ -22,21 +28,46 @@ describe('IncludeAreasSelectorComponent', () => {
       ],
       providers: [
         MockProvider(NewScenarioState, {
-          excludedAreas$: of([]),
-          scenarioConfig$: new BehaviorSubject({}),
+          includedAreas$: of([]),
+          scenarioConfig$,
         }),
         MockProvider(BaseLayersStateService, {
           selectedBaseLayers$: of([]),
+        }),
+        MockProvider(ForsysService, {
+          includedAreas$: of([]),
         }),
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(IncludeAreasSelectorComponent);
     component = fixture.componentInstance;
+    state = TestBed.inject(NewScenarioState);
+    spyOn(state, 'setIncludedAreas');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('reverts unsaved selection to the saved config when leaving the step', () => {
+    scenarioConfig$.next({ included_areas: [1, 2] });
+    // user makes an unsaved change
+    component.handleSelectedItemsChange([{ id: 9 } as BaseLayer]);
+    expect(state.setIncludedAreas).toHaveBeenCalledWith([9]);
+
+    // going back (or saving) triggers the exit hook
+    component.beforeStepExit();
+
+    expect(state.setIncludedAreas).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it('reverts to an empty list when the saved config has no included areas', () => {
+    scenarioConfig$.next({});
+
+    component.beforeStepExit();
+
+    expect(state.setIncludedAreas).toHaveBeenCalledWith([]);
   });
 });

--- a/src/interface/src/app/scenario-creation/include-areas-selector/include-areas-selector.component.ts
+++ b/src/interface/src/app/scenario-creation/include-areas-selector/include-areas-selector.component.ts
@@ -110,5 +110,12 @@ export class IncludeAreasSelectorComponent
 
   override beforeStepExit(): void {
     this.clearViewedLayers(); // clears layer selection after step in completed
+    // Revert any unsaved selection so going back doesn't persist changes.
+    // On save this is a no-op since the config was already updated.
+    this.newScenarioState.scenarioConfig$
+      .pipe(take(1))
+      .subscribe((config) =>
+        this.newScenarioState.setIncludedAreas(config.included_areas ?? [])
+      );
   }
 }


### PR DESCRIPTION
We have a bug where we are saving on the flow the changes on includes or excludes, even when the user goes back steps in the flow (without hitting "continue"/saving)