### PR TITLE
Funding module layers

### DIFF
--- a/src/planscape/modules/base.py
+++ b/src/planscape/modules/base.py
@@ -230,6 +230,31 @@ class FundingReportModule(BaseModule):
         scenario_geometry = runnable.planning_area.geometry
         return self.coverage.contains(scenario_geometry)
 
+    def _get_options(self, **kwargs):
+        user = kwargs.get("user")
+        layers = (
+            DataLayer.objects.all()
+            .accessible_by(user)
+            .by_meta_module(self.name)
+            .order_by("name")
+        )
+        groups: Dict[str, List[DataLayer]] = {}
+        for layer in layers:
+            group_key = (
+                (layer.metadata or {})
+                .get("modules", {})
+                .get(self.name, {})
+                .get("group")
+            )
+            if not group_key:
+                continue
+            groups.setdefault(group_key, []).append(layer)
+        return {
+            "groups": [
+                {"key": key, "layers": groups[key]} for key in sorted(groups)
+            ]
+        }
+
     def get_serializer_class(self, **kwargs) -> Type[BaseModuleSerializer]:
         return FundingReportModuleSerializer
 

--- a/src/planscape/modules/serializers.py
+++ b/src/planscape/modules/serializers.py
@@ -90,8 +90,13 @@ class PrioritizeSubUnitsModuleSerializer(BaseModuleSerializer):
     options = PrioritizeSubUnitsOptionsSerializer()
 
 
-class FundingReportOptionsSerializer(BaseModuleOptionsSerializer):
-    pass
+class FundingReportGroupSerializer(serializers.Serializer):
+    key = serializers.CharField()
+    layers = serializers.ListField(child=BrowseDataLayerSerializer())
+
+
+class FundingReportOptionsSerializer(serializers.Serializer):
+    groups = serializers.ListField(child=FundingReportGroupSerializer())
 
 
 class FundingReportModuleSerializer(BaseModuleSerializer):

--- a/src/planscape/modules/tests/test_modules.py
+++ b/src/planscape/modules/tests/test_modules.py
@@ -365,6 +365,73 @@ class PrioritizeSubUnitsModuleTest(TestCase):
         self.assertEqual(len(sub_units), 1)
 
 
+class FundingReportModuleTest(TestCase):
+    def test_returns_grouped_layers_sorted_by_name(self):
+        dataset = DatasetFactory.create(
+            name="funding-base",
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS,
+            visibility=VisibilityOptions.PUBLIC,
+            modules=["funding_report"],
+        )
+        DataLayerFactory.create(
+            dataset=dataset,
+            name="Standing Aboveground Live Tree Carbon",
+            metadata={"modules": {"funding_report": {"group": "carbon"}}},
+        )
+        DataLayerFactory.create(
+            dataset=dataset,
+            name="Smoke Production",
+            metadata={"modules": {"funding_report": {"group": "carbon"}}},
+        )
+        DataLayerFactory.create(
+            dataset=dataset,
+            name="Wildfire Hazard Potential",
+            metadata={"modules": {"funding_report": {"group": "wildfire_risk"}}},
+        )
+        # layer tagged for funding_report but without a group key is skipped
+        DataLayerFactory.create(
+            dataset=dataset,
+            name="Untagged",
+            metadata={"modules": {"funding_report": {}}},
+        )
+
+        module = get_module("funding_report")
+        configuration: Dict[str, Any] = module.get_configuration()
+
+        self.assertIn("options", configuration)
+        groups = configuration["options"]["groups"]
+
+        # groups are emitted in a deterministic (alphabetical) key order
+        self.assertEqual([g["key"] for g in groups], ["carbon", "wildfire_risk"])
+
+        carbon = next(g for g in groups if g["key"] == "carbon")
+        wildfire = next(g for g in groups if g["key"] == "wildfire_risk")
+
+        # layers within a group are sorted alphabetically by name
+        self.assertEqual(
+            [layer.name for layer in carbon["layers"]],
+            ["Smoke Production", "Standing Aboveground Live Tree Carbon"],
+        )
+        self.assertEqual(len(wildfire["layers"]), 1)
+
+    def test_excludes_layers_not_tagged_for_module(self):
+        dataset = DatasetFactory.create(
+            name="funding-base",
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS,
+            visibility=VisibilityOptions.PUBLIC,
+            modules=["funding_report"],
+        )
+        DataLayerFactory.create(
+            dataset=dataset,
+            name="Other Module Layer",
+            metadata={"modules": {"prioritize_sub_units": {"enabled": True}}},
+        )
+
+        module = get_module("funding_report")
+        configuration: Dict[str, Any] = module.get_configuration()
+        self.assertEqual(configuration["options"]["groups"], [])
+
+
 class ImpactsModulesTest(TestCase):
     def setUp(self):
         inside_california_goemtry = {


### PR DESCRIPTION
Extending layers metadata to configure which layers show up on funding report

Example layer metadata :

 ```
// <layer>
 "funding_report": {  
  "enabled": true, 
  "group": "carbon" 
}
 ```

funding module 

```
{ "name": "funding_report",
    "options": { "groups": [
        { "key": "carbon", "layers": [ {<layer>}, ... ] },
    ] }
}
```

