### PR TITLE
plan-3689-send-funding-report-completion-email

### DIFF
--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -157,14 +157,12 @@ def async_calculate_aet_improvement(
 
 
 @app.task(
-    bind=True,
     autoretry_for=(smtplib.SMTPException, OSError),
     retry_backoff=True,
     retry_jitter=True,
     retry_kwargs={"max_retries": 3},
 )
 def async_send_email_funding_report_finished(
-    self,
     funding_opportunity_report_id: int,
 ) -> None:
     try:
@@ -173,65 +171,53 @@ def async_send_email_funding_report_finished(
             "scenario",
             "scenario__planning_area",
         ).get(pk=funding_opportunity_report_id)
-
-        user = report.created_by
-        email = (user.email or "").strip() if user else ""
-        if not email:
-            log.info(
-                "FundingOpportunityReport %s completed but has no recipient email; skipping.",
-                funding_opportunity_report_id,
-            )
-            return
-
-        funding_report_link = get_frontend_url(
-            f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}"
-        )
-
-        context = {
-            "user_full_name": user.get_full_name(),
-            "funding_report_link": funding_report_link,
-        }
-
-        subject = "Planscape Funding Opportunity Report is Ready"
-        txt = render_to_string(
-            "email/funding_report/funding_report_completed.txt",
-            context,
-        )
-        html = render_to_string(
-            "email/funding_report/funding_report_completed.html",
-            context,
-        )
-
-        send_mail(
-            subject=subject,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[email],
-            message=txt,
-            html_message=html,
-        )
-
-        log.info(
-            "Email sent informing user that FundingOpportunityReport %s is finished.",
-            report.pk,
-        )
-
     except FundingOpportunityReport.DoesNotExist:
         log.warning(
             "FundingOpportunityReport with pk %s does not exist. Cannot send email.",
             funding_opportunity_report_id,
         )
-    except (smtplib.SMTPException, OSError):
-        if self.request.retries >= self.max_retries:
-            log.exception("Failed to send funding report email.")
-        else:
-            log.warning("Failed to send funding report email. Retrying.")
-        raise
-    except Exception:
-        log.exception(
-            "Unexpected error while sending funding report finished email.",
-            extra={"funding_opportunity_report_id": funding_opportunity_report_id},
+        return
+
+    user = report.created_by
+    if not user:
+        log.info(
+            "FundingOpportunityReport %s completed but has no created_by user; skipping email.",
+            funding_opportunity_report_id,
         )
-        raise
+        return
+
+    funding_report_link = get_frontend_url(
+        f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}"
+    )
+
+    context = {
+        "user_full_name": user.get_full_name(),
+        "scenario_name": report.scenario.name,
+        "funding_report_link": funding_report_link,
+    }
+
+    subject = "Planscape Funding Opportunity Report is Ready"
+    txt = render_to_string(
+        "email/funding_report/funding_report_completed.txt",
+        context,
+    )
+    html = render_to_string(
+        "email/funding_report/funding_report_completed.html",
+        context,
+    )
+
+    send_mail(
+        subject=subject,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[user.email],
+        message=txt,
+        html_message=html,
+    )
+
+    log.info(
+        "Email sent informing user that FundingOpportunityReport %s is finished.",
+        report.pk,
+    )
 
 
 @app.task()

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -12,6 +12,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from planning.models import ProjectArea
 from planscape.celery import app
+from utils.frontend import get_frontend_url
 
 from funding_report.models import (
     AET_IMPROVEMENT_DEFAULT_PERCENTAGE,
@@ -216,6 +217,84 @@ def async_calculate_aet_improvement(
         return {"kind": "aet_improvement", "error": str(exc)}
 
 
+@app.task(
+    bind=True,
+    autoretry_for=(smtplib.SMTPException, OSError),
+    retry_backoff=True,
+    retry_jitter=True,
+    retry_kwargs={"max_retries": 3},
+)
+def async_send_email_funding_report_finished(
+    self,
+    funding_opportunity_report_id: int,
+) -> None:
+    try:
+        report = FundingOpportunityReport.objects.select_related(
+            "created_by",
+            "scenario",
+            "scenario__planning_area",
+        ).get(pk=funding_opportunity_report_id)
+
+        user = report.created_by
+        email = (user.email or "").strip() if user else ""
+        if not email:
+            log.info(
+                "FundingOpportunityReport %s completed but has no recipient email; skipping.",
+                funding_opportunity_report_id,
+            )
+            return
+
+        funding_report_link = get_frontend_url(
+            f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}"
+        )
+
+        context = {
+            "user_full_name": user.get_full_name(),
+            "funding_report_link": funding_report_link,
+        }
+
+        subject = "Planscape Funding Opportunity Report is Ready"
+        txt = render_to_string(
+            "email/funding_report/funding_report_completed.txt",
+            context,
+        )
+        html = render_to_string(
+            "email/funding_report/funding_report_completed.html",
+            context,
+        )
+
+        send_mail(
+            subject=subject,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[email],
+            message=txt,
+            html_message=html,
+        )
+
+        log.info(
+            "Email sent informing user that FundingOpportunityReport %s is finished.",
+            report.pk,
+        )
+
+    except FundingOpportunityReport.DoesNotExist:
+        log.warning(
+            "FundingOpportunityReport with pk %s does not exist. Cannot send email.",
+            funding_opportunity_report_id,
+        )
+    except (smtplib.SMTPException, OSError):
+        if self.request.retries >= self.max_retries:
+            log.exception("Failed to send funding report email.")
+        else:
+            log.warning("Failed to send funding report email. Retrying.")
+        raise
+    except Exception:
+        log.exception(
+            "Unexpected error while sending funding report finished email.",
+            extra={"funding_opportunity_report_id": funding_opportunity_report_id},
+        )
+        raise
+
+
 @app.task()
 def async_calculate_biomass_volumes(
     funding_opportunity_report_id: int,
@@ -309,13 +388,15 @@ def async_finalize_funding_report_results(
     if errors:
         results["errors"] = errors
 
+    final_status = (
+        FundingOpportunityReportStatus.FAILED
+        if errors
+        else FundingOpportunityReportStatus.SUCCESS
+    )
+
     update_fields: dict = {
         "results": results,
-        "status": (
-            FundingOpportunityReportStatus.FAILED
-            if errors
-            else FundingOpportunityReportStatus.SUCCESS
-        ),
+        "status": final_status,
     }
     if treatment_datalayer_id is not None:
         update_fields["treatment_datalayer_id"] = treatment_datalayer_id
@@ -324,8 +405,9 @@ def async_finalize_funding_report_results(
         **update_fields
     )
 
-    if update_fields["status"] == FundingOpportunityReportStatus.SUCCESS:
+    if final_status == FundingOpportunityReportStatus.SUCCESS:
         async_generate_funding_report_geopackage.delay(funding_opportunity_report_id)
+        async_send_email_funding_report_finished.delay(funding_opportunity_report_id)
 
 
 @app.task()

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -1,10 +1,18 @@
 import logging
+import smtplib
 from datetime import timedelta
 
 from celery import chord
-from django.db import transaction
-from django.utils import timezone
 from datasets.models import DataLayer
+from django.conf import settings
+from django.core.mail import send_mail
+from django.db import transaction
+from django.template.loader import render_to_string
+from django.utils import timezone
+from planning.models import ProjectArea
+from planscape.celery import app
+from utils.frontend import get_frontend_url
+
 from funding_report.models import (
     AET_IMPROVEMENT_DEFAULT_PERCENTAGE,
     FUNDING_REPORT_YEARS,
@@ -22,8 +30,6 @@ from funding_report.services import (
     generate_treatment_clip_datalayer,
     get_treatment_datalayer,
 )
-from planning.models import ProjectArea
-from planscape.celery import app
 
 log = logging.getLogger(__name__)
 
@@ -98,9 +104,7 @@ def async_generate_treatment_datalayer(
         return None
 
     try:
-        report = FundingOpportunityReport.objects.get(
-            pk=funding_opportunity_report_id
-        )
+        report = FundingOpportunityReport.objects.get(pk=funding_opportunity_report_id)
         datalayer = generate_treatment_clip_datalayer(report=report)
         return {"kind": "treatment_datalayer", "datalayer_id": datalayer.pk}
     except Exception as exc:
@@ -124,9 +128,7 @@ def async_calculate_treatment_areas(
         return None
 
     try:
-        report = FundingOpportunityReport.objects.get(
-            pk=funding_opportunity_report_id
-        )
+        report = FundingOpportunityReport.objects.get(pk=funding_opportunity_report_id)
         result = calculate_treatment_pixel_areas(report=report)
         return {"kind": "treatment_areas", **result}
     except Exception as exc:
@@ -152,6 +154,84 @@ def async_calculate_aet_improvement(
             funding_opportunity_report_id,
         )
         return {"kind": "aet_improvement", "error": str(exc)}
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(smtplib.SMTPException, OSError),
+    retry_backoff=True,
+    retry_jitter=True,
+    retry_kwargs={"max_retries": 3},
+)
+def async_send_email_funding_report_finished(
+    self,
+    funding_opportunity_report_id: int,
+) -> None:
+    try:
+        report = FundingOpportunityReport.objects.select_related(
+            "created_by",
+            "scenario",
+            "scenario__planning_area",
+        ).get(pk=funding_opportunity_report_id)
+
+        user = report.created_by
+        email = (user.email or "").strip() if user else ""
+        if not email:
+            log.info(
+                "FundingOpportunityReport %s completed but has no recipient email; skipping.",
+                funding_opportunity_report_id,
+            )
+            return
+
+        funding_report_link = get_frontend_url(
+            f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}"
+        )
+
+        context = {
+            "user_full_name": user.get_full_name(),
+            "funding_report_link": funding_report_link,
+        }
+
+        subject = "Planscape Funding Opportunity Report is Ready"
+        txt = render_to_string(
+            "email/funding_report/funding_report_completed.txt",
+            context,
+        )
+        html = render_to_string(
+            "email/funding_report/funding_report_completed.html",
+            context,
+        )
+
+        send_mail(
+            subject=subject,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[email],
+            message=txt,
+            html_message=html,
+        )
+
+        log.info(
+            "Email sent informing user that FundingOpportunityReport %s is finished.",
+            report.pk,
+        )
+
+    except FundingOpportunityReport.DoesNotExist:
+        log.warning(
+            "FundingOpportunityReport with pk %s does not exist. Cannot send email.",
+            funding_opportunity_report_id,
+        )
+    except (smtplib.SMTPException, OSError):
+        if self.request.retries >= self.max_retries:
+            log.exception("Failed to send funding report email.")
+        else:
+            log.warning("Failed to send funding report email. Retrying.")
+        raise
+    except Exception:
+        log.exception(
+            "Unexpected error while sending funding report finished email.",
+            extra={"funding_opportunity_report_id": funding_opportunity_report_id},
+        )
+        raise
 
 
 @app.task()
@@ -221,13 +301,15 @@ def async_finalize_funding_report_results(
     if errors:
         results["errors"] = errors
 
+    final_status = (
+        FundingOpportunityReportStatus.FAILED
+        if errors
+        else FundingOpportunityReportStatus.SUCCESS
+    )
+
     update_fields: dict = {
         "results": results,
-        "status": (
-            FundingOpportunityReportStatus.FAILED
-            if errors
-            else FundingOpportunityReportStatus.SUCCESS
-        ),
+        "status": final_status,
     }
     if treatment_datalayer_id is not None:
         update_fields["treatment_datalayer_id"] = treatment_datalayer_id
@@ -235,6 +317,9 @@ def async_finalize_funding_report_results(
     FundingOpportunityReport.objects.filter(pk=funding_opportunity_report_id).update(
         **update_fields
     )
+
+    if final_status == FundingOpportunityReportStatus.SUCCESS:
+        async_send_email_funding_report_finished.delay(funding_opportunity_report_id)
 
 
 @app.task()
@@ -261,7 +346,9 @@ def run_funding_opportunity_report(funding_opportunity_report_id: int) -> None:
             return
         report.status = FundingOpportunityReportStatus.RUNNING
         report.save(update_fields=["status", "updated_at"])
-        project_area_ids = list(report.scenario.project_areas.values_list("id", flat=True))
+        project_area_ids = list(
+            report.scenario.project_areas.values_list("id", flat=True)
+        )
 
     try:
         if not project_area_ids:

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -218,14 +218,12 @@ def async_calculate_aet_improvement(
 
 
 @app.task(
-    bind=True,
     autoretry_for=(smtplib.SMTPException, OSError),
     retry_backoff=True,
     retry_jitter=True,
     retry_kwargs={"max_retries": 3},
 )
 def async_send_email_funding_report_finished(
-    self,
     funding_opportunity_report_id: int,
 ) -> None:
     try:
@@ -234,65 +232,53 @@ def async_send_email_funding_report_finished(
             "scenario",
             "scenario__planning_area",
         ).get(pk=funding_opportunity_report_id)
-
-        user = report.created_by
-        email = (user.email or "").strip() if user else ""
-        if not email:
-            log.info(
-                "FundingOpportunityReport %s completed but has no recipient email; skipping.",
-                funding_opportunity_report_id,
-            )
-            return
-
-        funding_report_link = get_frontend_url(
-            f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}"
-        )
-
-        context = {
-            "user_full_name": user.get_full_name(),
-            "funding_report_link": funding_report_link,
-        }
-
-        subject = "Planscape Funding Opportunity Report is Ready"
-        txt = render_to_string(
-            "email/funding_report/funding_report_completed.txt",
-            context,
-        )
-        html = render_to_string(
-            "email/funding_report/funding_report_completed.html",
-            context,
-        )
-
-        send_mail(
-            subject=subject,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[email],
-            message=txt,
-            html_message=html,
-        )
-
-        log.info(
-            "Email sent informing user that FundingOpportunityReport %s is finished.",
-            report.pk,
-        )
-
     except FundingOpportunityReport.DoesNotExist:
         log.warning(
             "FundingOpportunityReport with pk %s does not exist. Cannot send email.",
             funding_opportunity_report_id,
         )
-    except (smtplib.SMTPException, OSError):
-        if self.request.retries >= self.max_retries:
-            log.exception("Failed to send funding report email.")
-        else:
-            log.warning("Failed to send funding report email. Retrying.")
-        raise
-    except Exception:
-        log.exception(
-            "Unexpected error while sending funding report finished email.",
-            extra={"funding_opportunity_report_id": funding_opportunity_report_id},
+        return
+
+    user = report.created_by
+    if not user:
+        log.info(
+            "FundingOpportunityReport %s completed but has no created_by user; skipping email.",
+            funding_opportunity_report_id,
         )
-        raise
+        return
+
+    funding_report_link = get_frontend_url(
+        f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}"
+    )
+
+    context = {
+        "user_full_name": user.get_full_name(),
+        "scenario_name": report.scenario.name,
+        "funding_report_link": funding_report_link,
+    }
+
+    subject = "Planscape Funding Opportunity Report is Ready"
+    txt = render_to_string(
+        "email/funding_report/funding_report_completed.txt",
+        context,
+    )
+    html = render_to_string(
+        "email/funding_report/funding_report_completed.html",
+        context,
+    )
+
+    send_mail(
+        subject=subject,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[user.email],
+        message=txt,
+        html_message=html,
+    )
+
+    log.info(
+        "Email sent informing user that FundingOpportunityReport %s is finished.",
+        report.pk,
+    )
 
 
 @app.task()

--- a/src/planscape/funding_report/tests/test_tasks.py
+++ b/src/planscape/funding_report/tests/test_tasks.py
@@ -27,6 +27,7 @@ from funding_report.tasks import (
     STALE_RUNNING_TIMEOUT,
     async_calculate_funding_report_delta,
     async_finalize_funding_report_results,
+    async_send_email_funding_report_finished,
     run_funding_opportunity_report,
     send_weekly_funding_report_users_report,
 )
@@ -188,7 +189,13 @@ class FundingOpportunityReportTaskTest(TestCase):
             },
         )
 
-    def test_finalize_task_saves_results_and_success_status(self):
+    @mock.patch("funding_report.tasks.async_generate_funding_report_geopackage.delay")
+    @mock.patch("funding_report.tasks.async_send_email_funding_report_finished.delay")
+    def test_finalize_task_saves_results_and_success_status(
+        self,
+        email_task_mock,
+        geopackage_task_mock,
+    ):
         async_finalize_funding_report_results(
             project_results=[
                 {
@@ -205,6 +212,8 @@ class FundingOpportunityReportTaskTest(TestCase):
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.SUCCESS)
+        geopackage_task_mock.assert_called_once_with(self.report.pk)
+        email_task_mock.assert_called_once_with(self.report.pk)
         self.assertEqual(
             self.report.results,
             {
@@ -228,7 +237,13 @@ class FundingOpportunityReportTaskTest(TestCase):
             },
         )
 
-    def test_finalize_task_buckets_flame_severity_by_interval(self):
+    @mock.patch("funding_report.tasks.async_generate_funding_report_geopackage.delay")
+    @mock.patch("funding_report.tasks.async_send_email_funding_report_finished.delay")
+    def test_finalize_task_buckets_flame_severity_by_interval(
+        self,
+        email_task_mock,
+        geopackage_task_mock,
+    ):
         async_finalize_funding_report_results(
             project_results=[
                 {
@@ -263,6 +278,8 @@ class FundingOpportunityReportTaskTest(TestCase):
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.SUCCESS)
+        geopackage_task_mock.assert_called_once_with(self.report.pk)
+        email_task_mock.assert_called_once_with(self.report.pk)
         results = self.report.results
 
         # Non-flame metrics keep their existing flat shape, untouched.
@@ -298,7 +315,13 @@ class FundingOpportunityReportTaskTest(TestCase):
         self.assertEqual(six_four_summary["value"], 5)
         self.assertEqual(six_four_summary["raw_value"], 5)
 
-    def test_finalize_task_sets_failed_status_with_errors(self):
+    @mock.patch("funding_report.tasks.async_generate_funding_report_geopackage.delay")
+    @mock.patch("funding_report.tasks.async_send_email_funding_report_finished.delay")
+    def test_finalize_task_sets_failed_status_with_errors(
+        self,
+        email_task_mock,
+        geopackage_task_mock,
+    ):
         async_finalize_funding_report_results(
             project_results=[
                 {
@@ -322,6 +345,8 @@ class FundingOpportunityReportTaskTest(TestCase):
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.FAILED)
+        geopackage_task_mock.assert_not_called()
+        email_task_mock.assert_not_called()
         self.assertEqual(
             self.report.results["errors"],
             [
@@ -480,3 +505,23 @@ class FundingOpportunityReportTaskTest(TestCase):
         send_weekly_funding_report_users_report()
 
         send_mail_mock.assert_not_called()
+
+    @mock.patch("funding_report.tasks.send_mail")
+    def test_send_email_funding_report_finished_sends_to_report_creator(
+        self,
+        send_mail_mock,
+    ):
+        self.user.email = "planner@example.com"
+        self.user.first_name = "Test"
+        self.user.last_name = "Planner"
+        self.user.save(update_fields=["email", "first_name", "last_name"])
+
+        async_send_email_funding_report_finished(self.report.pk)
+
+        send_mail_mock.assert_called_once()
+        kwargs = send_mail_mock.call_args.kwargs
+        self.assertEqual(kwargs["recipient_list"], ["planner@example.com"])
+        self.assertEqual(kwargs["from_email"], settings.DEFAULT_FROM_EMAIL)
+        self.assertIn("Funding Opportunity Report", kwargs["subject"])
+        self.assertIn("message", kwargs)
+        self.assertIn("html_message", kwargs)

--- a/src/planscape/funding_report/tests/test_tasks.py
+++ b/src/planscape/funding_report/tests/test_tasks.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from datasets.models import DataLayerType
 from datasets.tests.factories import DataLayerFactory
+from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 from planning.tests.factories import (
@@ -22,6 +23,7 @@ from funding_report.tasks import (
     STALE_RUNNING_TIMEOUT,
     async_calculate_funding_report_delta,
     async_finalize_funding_report_results,
+    async_send_email_funding_report_finished,
     run_funding_opportunity_report,
 )
 
@@ -93,7 +95,11 @@ class FundingOpportunityReportTaskTest(TestCase):
             metric=FundingReportMetric.ABOVEGROUND_TOTAL.value,
             year=2026,
             datalayer_lookup={
-                (FundingReportMetric.ABOVEGROUND_TOTAL.value, 2026, True): baseline_layer,
+                (
+                    FundingReportMetric.ABOVEGROUND_TOTAL.value,
+                    2026,
+                    True,
+                ): baseline_layer,
                 (FundingReportMetric.ABOVEGROUND_TOTAL.value, 2026, False): value_layer,
             },
         )
@@ -127,7 +133,8 @@ class FundingOpportunityReportTaskTest(TestCase):
             },
         )
 
-    def test_finalize_task_saves_results_and_success_status(self):
+    @mock.patch("funding_report.tasks.async_send_email_funding_report_finished.delay")
+    def test_finalize_task_saves_results_and_success_status(self, email_task_mock):
         async_finalize_funding_report_results(
             project_results=[
                 {
@@ -144,6 +151,7 @@ class FundingOpportunityReportTaskTest(TestCase):
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.SUCCESS)
+        email_task_mock.assert_called_once_with(self.report.pk)
         self.assertEqual(
             self.report.results,
             {
@@ -167,7 +175,8 @@ class FundingOpportunityReportTaskTest(TestCase):
             },
         )
 
-    def test_finalize_task_sets_failed_status_with_errors(self):
+    @mock.patch("funding_report.tasks.async_send_email_funding_report_finished.delay")
+    def test_finalize_task_sets_failed_status_with_errors(self, email_task_mock):
         async_finalize_funding_report_results(
             project_results=[
                 {
@@ -191,6 +200,7 @@ class FundingOpportunityReportTaskTest(TestCase):
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.FAILED)
+        email_task_mock.assert_not_called()
         self.assertEqual(
             self.report.results["errors"],
             [
@@ -261,3 +271,22 @@ class FundingOpportunityReportTaskTest(TestCase):
         chord_mock.assert_called_once()
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.RUNNING)
+
+    @mock.patch("funding_report.tasks.send_mail")
+    def test_send_email_funding_report_finished_sends_to_report_creator(
+        self, send_mail_mock
+    ):
+        self.user.email = "planner@example.com"
+        self.user.first_name = "Test"
+        self.user.last_name = "Planner"
+        self.user.save(update_fields=["email", "first_name", "last_name"])
+
+        async_send_email_funding_report_finished(self.report.pk)
+
+        send_mail_mock.assert_called_once()
+        kwargs = send_mail_mock.call_args.kwargs
+        self.assertEqual(kwargs["recipient_list"], ["planner@example.com"])
+        self.assertEqual(kwargs["from_email"], settings.DEFAULT_FROM_EMAIL)
+        self.assertIn("Funding Opportunity Report", kwargs["subject"])
+        self.assertIn("message", kwargs)
+        self.assertIn("html_message", kwargs)

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -457,10 +457,14 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     @action(methods=["post"], detail=True, url_path="run-report")
     def run_report(self, request, pk=None):
         scenario = self.get_object()
-        report, _ = FundingOpportunityReport.objects.get_or_create(
+        report, created = FundingOpportunityReport.objects.get_or_create(
             scenario=scenario,
             defaults={"created_by": request.user},
         )
+
+        if not created and report.created_by_id != request.user.pk:
+            report.created_by = request.user
+            report.save(update_fields=["created_by", "updated_at"])
 
         FundingOpportunityReportRun.objects.create(
             report=report,

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -3,12 +3,33 @@ import logging
 from core.serializers import MultiSerializerMixin
 from datasets.models import DataLayer
 from django.contrib.auth import get_user_model
-from django.shortcuts import get_object_or_404
 from django.db.models import Q
 from django.db.models.expressions import RawSQL
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from funding_report.models import (
+    FundingOpportunityReport,
+    FundingOpportunityReportStatus,
+)
+from funding_report.openapi_examples import (
+    FLAME_LENGTH_REDUCTION_RESPONSE_EXAMPLE,
+    FUNDING_OPPORTUNITY_REPORT_RESPONSE_EXAMPLE,
+)
+from funding_report.serializers import (
+    FundingOpportunityReportSerializer,
+    FundingReportAETImprovementRequestSerializer,
+    FundingReportAETImprovementResponseSerializer,
+    FundingReportFlameLengthReductionRequestSerializer,
+    FundingReportFlameLengthReductionResponseSerializer,
+)
+from funding_report.services import (
+    calculate_aet_improvement,
+    calculate_funding_report_flame_length_reduction,
+)
+from funding_report.tasks import run_funding_opportunity_report
+from modules.base import compute_scenario_capabilities
 from planscape.serializers import BaseErrorMessageSerializer
 from rest_framework import mixins, pagination, permissions, status, viewsets
 from rest_framework.decorators import action
@@ -55,27 +76,6 @@ from planning.serializers import (
     UpsertConfigurationV2Serializer,
     UpsertScenarioV3Serializer,
 )
-from funding_report.models import (
-    FundingOpportunityReport,
-    FundingOpportunityReportStatus,
-)
-from funding_report.openapi_examples import (
-    FLAME_LENGTH_REDUCTION_RESPONSE_EXAMPLE,
-    FUNDING_OPPORTUNITY_REPORT_RESPONSE_EXAMPLE,
-)
-from funding_report.serializers import (
-    FundingOpportunityReportSerializer,
-    FundingReportAETImprovementRequestSerializer,
-    FundingReportAETImprovementResponseSerializer,
-    FundingReportFlameLengthReductionRequestSerializer,
-    FundingReportFlameLengthReductionResponseSerializer,
-)
-from funding_report.services import (
-    calculate_aet_improvement,
-    calculate_funding_report_flame_length_reduction,
-)
-from funding_report.tasks import run_funding_opportunity_report
-from modules.base import compute_scenario_capabilities
 from planning.services import (
     create_config,
     create_planning_area,
@@ -427,10 +427,15 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     @action(methods=["post"], detail=True, url_path="run-report")
     def run_report(self, request, pk=None):
         scenario = self.get_object()
-        report, _ = FundingOpportunityReport.objects.get_or_create(
+        report, created = FundingOpportunityReport.objects.get_or_create(
             scenario=scenario,
             defaults={"created_by": request.user},
         )
+
+        if not created and report.created_by_id != request.user.pk:
+            report.created_by = request.user
+            report.save(update_fields=["created_by", "updated_at"])
+
         run_funding_opportunity_report.delay(report.pk)
         serializer = FundingOpportunityReportSerializer(instance=report)
         return Response(serializer.data, status=status.HTTP_202_ACCEPTED)

--- a/src/planscape/templates/email/funding_report/funding_report_completed.html
+++ b/src/planscape/templates/email/funding_report/funding_report_completed.html
@@ -1,0 +1,16 @@
+<p>Dear {{ user_full_name }},</p>
+
+<p>
+  Your Planscape Funding Opportunity Report is ready.
+  <a href="{{ funding_report_link }}" target="_blank">Click here</a> to review.
+</p>
+
+<p>
+  If you have questions or need support, please refer to the
+  <a href="https://www.planscape.org/documentation/user-guide/" target="_blank">Knowledge Base</a>.
+</p>
+
+<p>
+  Thank you,<br />
+  Team Planscape
+</p>

--- a/src/planscape/templates/email/funding_report/funding_report_completed.txt
+++ b/src/planscape/templates/email/funding_report/funding_report_completed.txt
@@ -1,0 +1,8 @@
+Dear {{ user_full_name }},
+
+Your Planscape Funding Opportunity Report is ready. Click here to review: {{ funding_report_link }}
+
+If you have questions or need support, please refer to the Knowledge Base: https://www.planscape.org/documentation/user-guide/
+
+Thank you,
+Team Planscape


### PR DESCRIPTION
@george-silva @roquebetioljr, Send email after generating funding report, https://sig-gis.atlassian.net/browse/PLAN-3689:

1. `src/planscape/funding_report/tasks.py`: created function to send the e-mail
2. `src/planscape/funding_report/tests/test_tasks.py`: created tests to test the e-mail
3. `src/planscape/planning/views_v2.py`: small change to make the e-mail send to whomever RE-RUNS the report, rather than sending it to the original runner
4. `src/planscape/templates/email/funding_report/funding_report_completed.html`: html of the e-mail
5. src/planscape/templates/email/funding_report/funding_report_completed.txt: txt of the email

-------------------------

I ran the unit tests and they passed, and also sent the e-mail locally via terminal. 

Will likely need to test on dev to make sure it sends as intended.