### PR TITLE
Calculate merchantable biomass volumes by wood type in funding report

### DIFF
--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -43,6 +43,22 @@ FUNDING_REPORT_DATALAYER_NAME_REGEX = re.compile(
 TREATMENT_VARIABLE = "TREATMENT"
 TREATMENT_ROLE = "treatment"
 
+BIOMASS_VARIABLE = "BIOMASS"
+
+WOOD_TYPE_SOFTWOOD = 1
+WOOD_TYPE_HARDWOOD = 2
+WOOD_TYPE_MIXED = 3
+
+# Conversion factor from cubic feet to board feet (Scribner scale).
+# Confirm with data team before changing.
+MERCHANTABLE_CF_TO_BF_FACTOR = 5.5
+
+
+class BiomassRole(models.TextChoices):
+    MERCHANTABLE = "merchantable", "Merchantable"
+    TOTAL = "total", "Total"
+    WOOD_TYPE = "wood_type", "Wood Type"
+
 # Label for pixels that are nodata in the treatments raster.
 TREATMENT_NO_TREATMENT_LABEL = "No Treatment"
 

--- a/src/planscape/funding_report/openapi_examples.py
+++ b/src/planscape/funding_report/openapi_examples.py
@@ -47,6 +47,14 @@ FUNDING_OPPORTUNITY_REPORT_RESPONSE_EXAMPLE = OpenApiExample(
                     "total_project_area_acres": 5000.0,
                     "improved_area_percent": 24.69,
                 },
+                "BIOMASS_VOLUMES": {
+                    "merchantable_softwood_bf_ac": 1820.5,
+                    "merchantable_hardwood_bf_ac": 430.2,
+                    "merchantable_mixed_bf_ac": 95.1,
+                    "non_merchantable_softwood_cuft_ac": 12.4,
+                    "non_merchantable_hardwood_cuft_ac": 3.1,
+                    "non_merchantable_mixed_cuft_ac": 0.9,
+                },
             },
             "projects": {
                 "ABOVEGROUND_TOTAL": [
@@ -65,6 +73,18 @@ FUNDING_OPPORTUNITY_REPORT_RESPONSE_EXAMPLE = OpenApiExample(
                         "improved_acres": 1234.5,
                         "total_acres": 5000.0,
                         "improved_area_percent": 24.69,
+                    }
+                ],
+                "BIOMASS_VOLUMES": [
+                    {
+                        "project_id": 14,
+                        "proj_id": None,
+                        "merchantable_softwood_bf_ac": 1820.5,
+                        "merchantable_hardwood_bf_ac": 430.2,
+                        "merchantable_mixed_bf_ac": 95.1,
+                        "non_merchantable_softwood_cuft_ac": 12.4,
+                        "non_merchantable_hardwood_cuft_ac": 3.1,
+                        "non_merchantable_mixed_cuft_ac": 0.9,
                     }
                 ],
             },

--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -745,13 +745,16 @@ def _extract_raw_biomass_volumes(
     wood_type_src: rasterio.DatasetReader,
 ) -> Dict[str, float]:
     """
-    Returns raw cubic-feet totals per wood type for one project area geometry.
-    Keys: merch_{softwood,hardwood,mixed}_cuft and nm_{softwood,hardwood,mixed}_cuft.
+    Sums raster pixel values per wood type for one project area geometry.
+    Keys: merch_{softwood,hardwood,mixed}_cuft_ac and nm_{softwood,hardwood,mixed}_cuft_ac.
+
+    Raster pixels are already in output units (cuft/ac), so values are summed
+    directly with no area conversion.
     """
     empty: Dict[str, float] = {}
     for name in _BIOMASS_WOOD_TYPES.values():
-        empty[f"merch_{name}_cuft"] = 0.0
-        empty[f"nm_{name}_cuft"] = 0.0
+        empty[f"merch_{name}_cuft_ac"] = 0.0
+        empty[f"nm_{name}_cuft_ac"] = 0.0
 
     try:
         merch_data, _ = mask(merch_src, [geometry], crop=True, filled=False)
@@ -777,27 +780,19 @@ def _extract_raw_biomass_volumes(
     result: Dict[str, float] = {}
     for wt_value, wt_name in _BIOMASS_WOOD_TYPES.items():
         wt_match = ~wt_nodata & (wt_raw == wt_value)
-        result[f"merch_{wt_name}_cuft"] = float(merch_vals[wt_match & merch_ok].sum())
-        result[f"nm_{wt_name}_cuft"] = float(nm_vals[wt_match & nm_ok].sum())
+        result[f"merch_{wt_name}_cuft_ac"] = float(merch_vals[wt_match & merch_ok].sum())
+        result[f"nm_{wt_name}_cuft_ac"] = float(nm_vals[wt_match & nm_ok].sum())
 
     return result
 
 
-def _biomass_volumes_per_acre(
-    raw_cuft: Dict[str, float], total_acres: float
-) -> Dict[str, float]:
+def _biomass_volumes_to_output(raw: Dict[str, float]) -> Dict[str, float]:
     result: Dict[str, float] = {}
     for wt_name in _BIOMASS_WOOD_TYPES.values():
-        merch_cuft = raw_cuft.get(f"merch_{wt_name}_cuft", 0.0)
-        nm_cuft = raw_cuft.get(f"nm_{wt_name}_cuft", 0.0)
-        result[f"merchantable_{wt_name}_bf_ac"] = (
-            merch_cuft / total_acres * MERCHANTABLE_CF_TO_BF_FACTOR
-            if total_acres
-            else 0.0
-        )
-        result[f"non_merchantable_{wt_name}_cuft_ac"] = (
-            nm_cuft / total_acres if total_acres else 0.0
-        )
+        merch_cuft_ac = raw.get(f"merch_{wt_name}_cuft_ac", 0.0)
+        nm_cuft_ac = raw.get(f"nm_{wt_name}_cuft_ac", 0.0)
+        result[f"merchantable_{wt_name}_bf_ac"] = merch_cuft_ac * MERCHANTABLE_CF_TO_BF_FACTOR
+        result[f"non_merchantable_{wt_name}_cuft_ac"] = nm_cuft_ac
     return result
 
 
@@ -822,15 +817,14 @@ def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any
                 f"Biomass raster CRS {merch_src.crs} does not resolve to an EPSG SRID."
             )
 
-        accumulated: Dict[str, float] = {}
-        for wt_name in _BIOMASS_WOOD_TYPES.values():
-            accumulated[f"merch_{wt_name}_cuft"] = 0.0
-            accumulated[f"nm_{wt_name}_cuft"] = 0.0
-        total_acres = 0.0
+        accumulated: Dict[str, float] = {
+            f"merch_{wt_name}_cuft_ac": 0.0 for wt_name in _BIOMASS_WOOD_TYPES.values()
+        } | {
+            f"nm_{wt_name}_cuft_ac": 0.0 for wt_name in _BIOMASS_WOOD_TYPES.values()
+        }
 
         project_area_results = []
         for project_area in project_areas:
-            area_ac = get_acreage(project_area.geometry)
             geometry = json.loads(
                 maybe_transform(project_area.geometry, raster_srid).geojson
             )
@@ -840,15 +834,14 @@ def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any
                 {
                     "project_id": project_area.pk,
                     "proj_id": (project_area.data or {}).get("proj_id"),
-                    **_biomass_volumes_per_acre(raw, area_ac),
+                    **_biomass_volumes_to_output(raw),
                 }
             )
 
             for key in accumulated:
                 accumulated[key] += raw.get(key, 0.0)
-            total_acres += area_ac
 
     return {
-        "summary": _biomass_volumes_per_acre(accumulated, total_acres),
+        "summary": _biomass_volumes_to_output(accumulated),
         "project_areas": project_area_results,
     }

--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -32,12 +32,18 @@ from rasterio.features import geometry_mask
 from rasterio.mask import mask
 
 from funding_report.models import (
+    BIOMASS_VARIABLE,
     FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
     FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT,
     FUNDING_REPORT_YEARS,
+    MERCHANTABLE_CF_TO_BF_FACTOR,
     TREATMENT_NO_TREATMENT_LABEL,
     TREATMENT_PIXEL_VALUE_LABELS,
     TREATMENT_ROLE,
+    WOOD_TYPE_HARDWOOD,
+    WOOD_TYPE_MIXED,
+    WOOD_TYPE_SOFTWOOD,
+    BiomassRole,
     TREATMENT_VARIABLE,
     FundingOpportunityReport,
     FundingReportMetric,
@@ -697,4 +703,152 @@ def calculate_funding_report_flame_length_reduction(
         "projects": built["projects"].get(
             FundingReportMetric.TOTAL_FLAME_SEVERITY.value, []
         ),
+    }
+
+
+_BIOMASS_WOOD_TYPES: Dict[int, str] = {
+    WOOD_TYPE_SOFTWOOD: "softwood",
+    WOOD_TYPE_HARDWOOD: "hardwood",
+    WOOD_TYPE_MIXED: "mixed",
+}
+
+
+def get_biomass_datalayer(role: str) -> DataLayer:
+    datalayers = list(
+        DataLayer.objects.filter(
+            type=DataLayerType.RASTER,
+            metadata__contains={
+                "modules": {
+                    "funding_report": {
+                        "variable": BIOMASS_VARIABLE,
+                        "role": role,
+                    }
+                }
+            },
+        )[:2]
+    )
+    if not datalayers:
+        raise ValueError(
+            f"Missing funding report biomass datalayer with role={role!r}."
+        )
+    if len(datalayers) > 1:
+        raise ValueError(
+            f"Multiple funding report biomass datalayers found with role={role!r}."
+        )
+    return datalayers[0]
+
+
+def _extract_raw_biomass_volumes(
+    geometry: Dict[str, Any],
+    merch_src: rasterio.DatasetReader,
+    total_src: rasterio.DatasetReader,
+    wood_type_src: rasterio.DatasetReader,
+) -> Dict[str, float]:
+    """
+    Returns raw cubic-feet totals per wood type for one project area geometry.
+    Keys: merch_{softwood,hardwood,mixed}_cuft and nm_{softwood,hardwood,mixed}_cuft.
+    """
+    empty: Dict[str, float] = {}
+    for name in _BIOMASS_WOOD_TYPES.values():
+        empty[f"merch_{name}_cuft"] = 0.0
+        empty[f"nm_{name}_cuft"] = 0.0
+
+    try:
+        merch_data, _ = mask(merch_src, [geometry], crop=True, filled=False)
+        total_data, _ = mask(total_src, [geometry], crop=True, filled=False)
+        wt_data, _ = mask(wood_type_src, [geometry], crop=True, filled=False)
+    except ValueError:
+        return empty
+
+    merch_arr = np.ma.array(merch_data[0], dtype=float)
+    total_arr = np.ma.array(total_data[0], dtype=float)
+    non_merch_arr = total_arr - merch_arr
+    wt_arr = np.ma.array(wt_data[0])
+
+    wt_nodata = np.ma.getmaskarray(wt_arr)
+    wt_raw = wt_arr.filled(0)
+    merch_ok = ~np.ma.getmaskarray(merch_arr) & np.isfinite(merch_arr.filled(np.nan))
+    nm_ok = ~np.ma.getmaskarray(non_merch_arr) & np.isfinite(
+        non_merch_arr.filled(np.nan)
+    )
+    merch_vals = merch_arr.filled(0.0)
+    nm_vals = non_merch_arr.filled(0.0)
+
+    result: Dict[str, float] = {}
+    for wt_value, wt_name in _BIOMASS_WOOD_TYPES.items():
+        wt_match = ~wt_nodata & (wt_raw == wt_value)
+        result[f"merch_{wt_name}_cuft"] = float(merch_vals[wt_match & merch_ok].sum())
+        result[f"nm_{wt_name}_cuft"] = float(nm_vals[wt_match & nm_ok].sum())
+
+    return result
+
+
+def _biomass_volumes_per_acre(
+    raw_cuft: Dict[str, float], total_acres: float
+) -> Dict[str, float]:
+    result: Dict[str, float] = {}
+    for wt_name in _BIOMASS_WOOD_TYPES.values():
+        merch_cuft = raw_cuft.get(f"merch_{wt_name}_cuft", 0.0)
+        nm_cuft = raw_cuft.get(f"nm_{wt_name}_cuft", 0.0)
+        result[f"merchantable_{wt_name}_bf_ac"] = (
+            merch_cuft / total_acres * MERCHANTABLE_CF_TO_BF_FACTOR
+            if total_acres
+            else 0.0
+        )
+        result[f"non_merchantable_{wt_name}_cuft_ac"] = (
+            nm_cuft / total_acres if total_acres else 0.0
+        )
+    return result
+
+
+def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any]:
+    report = FundingOpportunityReport.objects.select_related("scenario").get(
+        pk=report.pk
+    )
+    project_areas = list(report.scenario.project_areas.all())
+
+    merch_layer = get_biomass_datalayer(BiomassRole.MERCHANTABLE)
+    total_layer = get_biomass_datalayer(BiomassRole.TOTAL)
+    wt_layer = get_biomass_datalayer(BiomassRole.WOOD_TYPE)
+
+    with (
+        rasterio.open(_datalayer_path(merch_layer)) as merch_src,
+        rasterio.open(_datalayer_path(total_layer)) as total_src,
+        rasterio.open(_datalayer_path(wt_layer)) as wt_src,
+    ):
+        raster_srid = merch_src.crs.to_epsg() if merch_src.crs else None
+        if raster_srid is None:
+            raise ValueError(
+                f"Biomass raster CRS {merch_src.crs} does not resolve to an EPSG SRID."
+            )
+
+        accumulated: Dict[str, float] = {}
+        for wt_name in _BIOMASS_WOOD_TYPES.values():
+            accumulated[f"merch_{wt_name}_cuft"] = 0.0
+            accumulated[f"nm_{wt_name}_cuft"] = 0.0
+        total_acres = 0.0
+
+        project_area_results = []
+        for project_area in project_areas:
+            area_ac = get_acreage(project_area.geometry)
+            geometry = json.loads(
+                maybe_transform(project_area.geometry, raster_srid).geojson
+            )
+            raw = _extract_raw_biomass_volumes(geometry, merch_src, total_src, wt_src)
+
+            project_area_results.append(
+                {
+                    "project_id": project_area.pk,
+                    "proj_id": (project_area.data or {}).get("proj_id"),
+                    **_biomass_volumes_per_acre(raw, area_ac),
+                }
+            )
+
+            for key in accumulated:
+                accumulated[key] += raw.get(key, 0.0)
+            total_acres += area_ac
+
+    return {
+        "summary": _biomass_volumes_per_acre(accumulated, total_acres),
+        "project_areas": project_area_results,
     }

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -16,6 +16,7 @@ from funding_report.services import (
     build_datalayer_lookup,
     build_funding_report_results,
     calculate_aet_improvement,
+    calculate_biomass_volumes,
     calculate_project_area_delta,
     calculate_treatment_pixel_areas,
     generate_treatment_clip_datalayer,
@@ -154,6 +155,22 @@ def async_calculate_aet_improvement(
 
 
 @app.task()
+def async_calculate_biomass_volumes(
+    funding_opportunity_report_id: int,
+) -> dict | None:
+    try:
+        report = FundingOpportunityReport.objects.get(pk=funding_opportunity_report_id)
+        result = calculate_biomass_volumes(report=report)
+        return {"kind": "biomass_volumes", **result}
+    except Exception as exc:
+        log.exception(
+            "Failed to calculate biomass volumes for funding report %s.",
+            funding_opportunity_report_id,
+        )
+        return {"kind": "biomass_volumes", "error": str(exc)}
+
+
+@app.task()
 def async_finalize_funding_report_results(
     project_results: list[dict | None],
     funding_opportunity_report_id: int,
@@ -164,6 +181,7 @@ def async_finalize_funding_report_results(
     treatment_datalayer_id = None
     treatment_areas = None
     aet_improvement = None
+    biomass_volumes = None
 
     for result in project_results:
         if result is None:
@@ -190,6 +208,12 @@ def async_finalize_funding_report_results(
             else:
                 aet_improvement = result
             continue
+        if kind == "biomass_volumes":
+            if "error" in result:
+                treatment_errors.append(result)
+            else:
+                biomass_volumes = result
+            continue
         if "error" in result:
             errors.append(result)
         else:
@@ -204,6 +228,9 @@ def async_finalize_funding_report_results(
             "improved_area_percent": aet_improvement["improved_area_percent"],
         }
         results["projects"]["AET"] = aet_improvement["project_areas"]
+    if biomass_volumes is not None:
+        results["summary"]["BIOMASS_VOLUMES"] = biomass_volumes["summary"]
+        results["projects"]["BIOMASS_VOLUMES"] = biomass_volumes["project_areas"]
     if treatment_areas is not None:
         results["treatment_areas"] = treatment_areas
     if treatment_errors:
@@ -295,6 +322,11 @@ def run_funding_opportunity_report(funding_opportunity_report_id: int) -> None:
         )
         tasks.append(
             async_calculate_aet_improvement.si(
+                funding_opportunity_report_id=funding_opportunity_report_id,
+            )
+        )
+        tasks.append(
+            async_calculate_biomass_volumes.si(
                 funding_opportunity_report_id=funding_opportunity_report_id,
             )
         )

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -187,37 +187,20 @@ def async_finalize_funding_report_results(
         if result is None:
             continue
         kind = result.get("kind")
-        if kind == "treatment_datalayer":
-            if "error" in result:
-                treatment_errors.append(result)
-            else:
-                treatment_datalayer_id = result["datalayer_id"]
-            continue
-        if kind == "treatment_areas":
-            if "error" in result:
-                treatment_errors.append(result)
-            else:
-                treatment_areas = {
-                    "projects": result["projects"],
-                    "total": result["total"],
-                }
-            continue
-        if kind == "aet_improvement":
-            if "error" in result:
-                treatment_errors.append(result)
-            else:
-                aet_improvement = result
-            continue
-        if kind == "biomass_volumes":
-            if "error" in result:
-                treatment_errors.append(result)
-            else:
-                biomass_volumes = result
-            continue
         if "error" in result:
-            errors.append(result)
-        else:
-            successes.append(result)
+            (treatment_errors if kind else errors).append(result)
+            continue
+        match kind:
+            case "treatment_datalayer":
+                treatment_datalayer_id = result["datalayer_id"]
+            case "treatment_areas":
+                treatment_areas = {"projects": result["projects"], "total": result["total"]}
+            case "aet_improvement":
+                aet_improvement = result
+            case "biomass_volumes":
+                biomass_volumes = result
+            case _:
+                successes.append(result)
 
     results = build_funding_report_results(successes)
     if aet_improvement is not None:

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -579,7 +579,7 @@ def write_biomass_rasters(tmp_dir: str):
         dst.write(np.array([[100, 200], [300, 400]], dtype=np.float32), 1)
     with rasterio.open(total_path, "w", dtype=np.float32, **profile) as dst:
         dst.write(np.array([[150, 280], [380, 500]], dtype=np.float32), 1)
-    with rasterio.open(wt_path, "w", dtype=np.uint8, nodata=0, **{**profile, "nodata": 0}) as dst:
+    with rasterio.open(wt_path, "w", dtype=np.uint8, **{**profile, "nodata": 0}) as dst:
         dst.write(np.array([[1, 2], [3, 1]], dtype=np.uint8), 1)
 
     return merch_path, total_path, wt_path

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -675,10 +675,10 @@ class BiomassVolumesCalculationTest(TestCase):
     def test_calculate_biomass_volumes_nonoverlapping_project_area_returns_zeros(self):
         self._create_all_biomass_datalayers()
         far_away = MultiPolygon(
-            Polygon(((1e7, 1e7), (1e7, 1e7 + 10), (1e7 + 10, 1e7 + 10), (1e7 + 10, 1e7), (1e7, 1e7)), srid=3857),
+            Polygon(((10, 10), (10, 11), (11, 11), (11, 10), (10, 10)), srid=4269),
             srid=4269,
         )
-        self.project_area.geometry = far_away.transform(4269, clone=True)
+        self.project_area.geometry = far_away
         self.project_area.save(update_fields=["geometry"])
 
         results = calculate_biomass_volumes(self.report)

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -658,19 +658,20 @@ class BiomassVolumesCalculationTest(TestCase):
 
         results = calculate_biomass_volumes(self.report)
 
-        area_ac = get_acreage(self.project_area.geometry)
+        # Pixel values are already in output units (cuft/ac). Values are summed
+        # directly per wood type, then merchantable is converted cuft/ac → bf/ac.
+        #
+        # Softwood pixels: (0,0) merch=100, nm=50; (1,1) merch=400, nm=100
+        # Hardwood pixels: (0,1) merch=200, nm=80
+        # Mixed pixels:    (1,0) merch=300, nm=80
         cf_to_bf = MERCHANTABLE_CF_TO_BF_FACTOR
-
-        # Softwood pixels: (0,0) merch=100 nm=50; (1,1) merch=400 nm=100
-        # Hardwood pixels: (0,1) merch=200 nm=80
-        # Mixed pixels: (1,0) merch=300 nm=80
         summary = results["summary"]
-        self.assertAlmostEqual(summary["merchantable_softwood_bf_ac"], 500 / area_ac * cf_to_bf, places=4)
-        self.assertAlmostEqual(summary["merchantable_hardwood_bf_ac"], 200 / area_ac * cf_to_bf, places=4)
-        self.assertAlmostEqual(summary["merchantable_mixed_bf_ac"], 300 / area_ac * cf_to_bf, places=4)
-        self.assertAlmostEqual(summary["non_merchantable_softwood_cuft_ac"], 150 / area_ac, places=4)
-        self.assertAlmostEqual(summary["non_merchantable_hardwood_cuft_ac"], 80 / area_ac, places=4)
-        self.assertAlmostEqual(summary["non_merchantable_mixed_cuft_ac"], 80 / area_ac, places=4)
+        self.assertAlmostEqual(summary["merchantable_softwood_bf_ac"], (100 + 400) * cf_to_bf, places=4)
+        self.assertAlmostEqual(summary["merchantable_hardwood_bf_ac"], 200 * cf_to_bf, places=4)
+        self.assertAlmostEqual(summary["merchantable_mixed_bf_ac"], 300 * cf_to_bf, places=4)
+        self.assertAlmostEqual(summary["non_merchantable_softwood_cuft_ac"], 50 + 100, places=4)
+        self.assertAlmostEqual(summary["non_merchantable_hardwood_cuft_ac"], 80, places=4)
+        self.assertAlmostEqual(summary["non_merchantable_mixed_cuft_ac"], 80, places=4)
 
     def test_calculate_biomass_volumes_nonoverlapping_project_area_returns_zeros(self):
         self._create_all_biomass_datalayers()

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -20,6 +20,8 @@ from rasterio.mask import mask
 
 from funding_report.models import (
     FUNDING_REPORT_YEARS,
+    MERCHANTABLE_CF_TO_BF_FACTOR,
+    BiomassRole,
     FundingOpportunityReport,
     FundingOpportunityReportStatus,
     FundingReportMetric,
@@ -29,11 +31,13 @@ from funding_report.services import (
     calculate_aet_improvement,
     build_datalayer_lookup,
     build_funding_report_results,
+    calculate_biomass_volumes,
     calculate_funding_report_flame_length_reduction,
     calculate_pixel_deltas,
     calculate_project_area_aet_improvement,
     calculate_project_area_delta,
     get_aet_delta_datalayer,
+    get_biomass_datalayer,
 )
 
 
@@ -545,3 +549,140 @@ class FlameLengthReductionCalculationTest(TestCase):
         for entry in results["projects"]:
             self.assertEqual(entry["project_id"], self.project_area.pk)
             self.assertNotIn("interval", entry)
+
+
+def write_biomass_rasters(tmp_dir: str):
+    """
+    Write three aligned 2x2 rasters (10 m pixels, EPSG:3857) for biomass tests.
+
+    Layout (row, col):
+      (0,0) softwood  merch=100  total=150  → nm=50
+      (0,1) hardwood  merch=200  total=280  → nm=80
+      (1,0) mixed     merch=300  total=380  → nm=80
+      (1,1) softwood  merch=400  total=500  → nm=100
+    """
+    transform = from_origin(0, 20, 10, 10)
+    profile = dict(
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        crs="EPSG:3857",
+        transform=transform,
+        nodata=-9999,
+    )
+    merch_path = Path(tmp_dir) / "merchantable_biomass.tif"
+    total_path = Path(tmp_dir) / "total_biomass.tif"
+    wt_path = Path(tmp_dir) / "wood_type.tif"
+
+    with rasterio.open(merch_path, "w", dtype=np.float32, **profile) as dst:
+        dst.write(np.array([[100, 200], [300, 400]], dtype=np.float32), 1)
+    with rasterio.open(total_path, "w", dtype=np.float32, **profile) as dst:
+        dst.write(np.array([[150, 280], [380, 500]], dtype=np.float32), 1)
+    with rasterio.open(wt_path, "w", dtype=np.uint8, nodata=0, **{**profile, "nodata": 0}) as dst:
+        dst.write(np.array([[1, 2], [3, 1]], dtype=np.uint8), 1)
+
+    return merch_path, total_path, wt_path
+
+
+class BiomassVolumesCalculationTest(TestCase):
+    def setUp(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.merch_path, self.total_path, self.wt_path = write_biomass_rasters(
+            tmp_dir.name
+        )
+
+        self.geometry = raster_bounds_geometry(self.merch_path)
+        planning_area = PlanningAreaFactory.create(
+            with_stands=False, geometry=self.geometry
+        )
+        self.scenario = ScenarioFactory.create(planning_area=planning_area)
+        self.project_area = ProjectAreaFactory.create(
+            scenario=self.scenario, geometry=self.geometry
+        )
+        self.report = FundingOpportunityReport.objects.create(
+            scenario=self.scenario,
+            created_by=self.scenario.user,
+        )
+        self.pixel_area_sq_m = 100.0  # 10 m × 10 m
+
+    def _create_biomass_datalayer(self, role: str, path: Path):
+        return DataLayerFactory.create(
+            name=f"Biomass {role}",
+            type=DataLayerType.RASTER,
+            url=str(path),
+            metadata={"modules": {"funding_report": {"variable": "BIOMASS", "role": role}}},
+        )
+
+    def _create_all_biomass_datalayers(self):
+        self._create_biomass_datalayer(BiomassRole.MERCHANTABLE, self.merch_path)
+        self._create_biomass_datalayer(BiomassRole.TOTAL, self.total_path)
+        self._create_biomass_datalayer(BiomassRole.WOOD_TYPE, self.wt_path)
+
+    def test_get_biomass_datalayer_returns_correct_layer(self):
+        layer = self._create_biomass_datalayer(BiomassRole.MERCHANTABLE, self.merch_path)
+
+        self.assertEqual(get_biomass_datalayer(BiomassRole.MERCHANTABLE), layer)
+
+    def test_get_biomass_datalayer_raises_when_missing(self):
+        with self.assertRaises(ValueError):
+            get_biomass_datalayer(BiomassRole.MERCHANTABLE)
+
+    def test_calculate_biomass_volumes_returns_six_values_per_project_and_summary(self):
+        self._create_all_biomass_datalayers()
+
+        results = calculate_biomass_volumes(self.report)
+
+        self.assertIn("summary", results)
+        self.assertIn("project_areas", results)
+
+        summary = results["summary"]
+        expected_keys = {
+            "merchantable_softwood_bf_ac",
+            "merchantable_hardwood_bf_ac",
+            "merchantable_mixed_bf_ac",
+            "non_merchantable_softwood_cuft_ac",
+            "non_merchantable_hardwood_cuft_ac",
+            "non_merchantable_mixed_cuft_ac",
+        }
+        self.assertEqual(set(summary.keys()), expected_keys)
+
+        self.assertEqual(len(results["project_areas"]), 1)
+        project_result = results["project_areas"][0]
+        self.assertEqual(project_result["project_id"], self.project_area.pk)
+        self.assertEqual(set(project_result.keys()), expected_keys | {"project_id", "proj_id"})
+
+    def test_calculate_biomass_volumes_correct_values(self):
+        self._create_all_biomass_datalayers()
+
+        results = calculate_biomass_volumes(self.report)
+
+        area_ac = get_acreage(self.project_area.geometry)
+        cf_to_bf = MERCHANTABLE_CF_TO_BF_FACTOR
+
+        # Softwood pixels: (0,0) merch=100 nm=50; (1,1) merch=400 nm=100
+        # Hardwood pixels: (0,1) merch=200 nm=80
+        # Mixed pixels: (1,0) merch=300 nm=80
+        summary = results["summary"]
+        self.assertAlmostEqual(summary["merchantable_softwood_bf_ac"], 500 / area_ac * cf_to_bf, places=4)
+        self.assertAlmostEqual(summary["merchantable_hardwood_bf_ac"], 200 / area_ac * cf_to_bf, places=4)
+        self.assertAlmostEqual(summary["merchantable_mixed_bf_ac"], 300 / area_ac * cf_to_bf, places=4)
+        self.assertAlmostEqual(summary["non_merchantable_softwood_cuft_ac"], 150 / area_ac, places=4)
+        self.assertAlmostEqual(summary["non_merchantable_hardwood_cuft_ac"], 80 / area_ac, places=4)
+        self.assertAlmostEqual(summary["non_merchantable_mixed_cuft_ac"], 80 / area_ac, places=4)
+
+    def test_calculate_biomass_volumes_nonoverlapping_project_area_returns_zeros(self):
+        self._create_all_biomass_datalayers()
+        far_away = MultiPolygon(
+            Polygon(((1e7, 1e7), (1e7, 1e7 + 10), (1e7 + 10, 1e7 + 10), (1e7 + 10, 1e7), (1e7, 1e7)), srid=3857),
+            srid=4269,
+        )
+        self.project_area.geometry = far_away.transform(4269, clone=True)
+        self.project_area.save(update_fields=["geometry"])
+
+        results = calculate_biomass_volumes(self.report)
+
+        summary = results["summary"]
+        for key in summary:
+            self.assertEqual(summary[key], 0.0, msg=f"{key} should be 0 for non-overlapping area")

--- a/src/planscape/funding_report/tests/test_tasks.py
+++ b/src/planscape/funding_report/tests/test_tasks.py
@@ -215,7 +215,7 @@ class FundingOpportunityReportTaskTest(TestCase):
         tasks = chord_mock.call_args.args[0]
         self.assertEqual(
             len(tasks),
-            1 * len(FundingReportMetric) * len(FUNDING_REPORT_YEARS) + 3,
+            1 * len(FundingReportMetric) * len(FUNDING_REPORT_YEARS) + 4,
         )
 
     @mock.patch("funding_report.tasks.chord")

--- a/upload_funding_report_datalayers.sh
+++ b/upload_funding_report_datalayers.sh
@@ -11,6 +11,9 @@ AET_BASELINE_METADATA='{"modules":{"funding_report":{"variable":"AET","role":"ba
 AET_TARGET_METADATA='{"modules":{"funding_report":{"variable":"AET","role":"target"}}}'
 AET_DELTA_METADATA='{"modules":{"funding_report":{"variable":"AET","role":"delta"}}}'
 TREATMENT_METADATA='{"modules":{"funding_report":{"variable":"TREATMENT","role":"treatment"}}}'
+BIOMASS_MERCH_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","role":"merchantable"}}}'
+BIOMASS_TOTAL_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","role":"total"}}}'
+BIOMASS_WOOD_TYPE_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","role":"wood_type"}}}'
 
 # "${PYTHON_BIN[@]}" manage.py datalayers create "Baseline 2026 aboveground_total_live" --input-file "$RASTER_DIR/Baseline_2026_aboveground_total_live.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --funding
 # "${PYTHON_BIN[@]}" manage.py datalayers create "Baseline 2026 pot_smoke_sev" --input-file "$RASTER_DIR/Baseline_2026_pot_smoke_sev.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --funding
@@ -50,3 +53,6 @@ TREATMENT_METADATA='{"modules":{"funding_report":{"variable":"TREATMENT","role":
 # TREATMENT_STYLE_ID=$(echo "$TREATMENT_STYLE_OUTPUT" | sed -E 's/\x1b\[[0-9;]*m//g' | grep -oE "'id': [0-9]+" | head -n 1 | grep -oE '[0-9]+')
 
 "${PYTHON_BIN[@]}" manage.py datalayers create "Treatments" --input-file "$RASTER_DIR/treatments.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$TREATMENT_METADATA"
+# "${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Merchantable" --input-file "$RASTER_DIR/merchantable_biomass.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_MERCH_METADATA"
+# "${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Total" --input-file "$RASTER_DIR/total_biomass.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_TOTAL_METADATA"
+# "${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Wood Type" --input-file "$RASTER_DIR/wood_type.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_WOOD_TYPE_METADATA"


### PR DESCRIPTION
## Summary
- Adds per-project and planning-area biomass volume calculation to the funding report
- Outputs 6 values (merchantable bf/ac and non-merchantable cuft/ac for softwood, hardwood, and mixed) derived from three new rasters: merchantable biomass, total biomass, and wood type
- Wires the calculation into the existing Celery task chord alongside AET; results land in `results.summary.BIOMASS_VOLUMES` and `results.projects.BIOMASS_VOLUMES`
- Adds commented-out upload commands in `upload_funding_report_datalayers.sh` for the three new rasters

## Test plan
- [ ] Run `make docker-test` targeting `funding_report/tests/test_services.py::BiomassVolumesCalculationTest`
- [ ] Upload the three biomass rasters and trigger a funding report; confirm `BIOMASS_VOLUMES` is present in the response
- [ ] Confirm `MERCHANTABLE_CF_TO_BF_FACTOR` value with data team before merging