### PR TITLE
fix double scrollbar

### DIFF
--- a/src/interface/src/app/funding/full-report-view/full-report-view.component.scss
+++ b/src/interface/src/app/funding/full-report-view/full-report-view.component.scss
@@ -112,11 +112,28 @@
 .data-layers-view {
   background-color: $color-white;
   width: $funding-sidebar-width;
-  overflow: auto;
+  // Don't scroll here — let the tab content's own scroll container handle it.
+  overflow: hidden;
   flex: 1;
-  
-    @include on-small() {
+  min-height: 0;
+
+  @include on-small() {
     width: 100%;
+  }
+}
+
+// Make the tab group fill the sidebar height so the tab content (and its
+// own internal scroll container) is properly constrained. Otherwise the
+// tab body wrapper grows to fit its content and the inner scrollbar gutter
+// is painted with nothing to scroll, adding phantom spacing.
+.map-layers-tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  ::ng-deep .mat-mdc-tab-body-wrapper {
+    flex: 1;
+    min-height: 0;
   }
 }
 


### PR DESCRIPTION
removes the extra space inside the tabs for the scroll element

<img width="552" height="709" alt="Screenshot 2026-06-23 at 3 32 38 PM" src="https://github.com/user-attachments/assets/c976b6ed-5f34-4820-9002-246694e6f8b7" />
