### PR TITLE
Fix to_cog_streaming not applying VSI prefix for GCS output

### DIFF
--- a/src/planscape/gis/rasters.py
+++ b/src/planscape/gis/rasters.py
@@ -204,14 +204,8 @@ def to_cog_streaming(
 
     config = get_gdal_env()
 
-    # Convert S3 URLs to VSI prefixes for proper MinIO/S3 endpoint handling (e.g. /vsis3/ prefix)
-    output_path = output_file
-    if is_s3_file(output_file):
-        output_path = with_vsi_prefix(output_file)
-
-    input_path = input_file
-    if is_s3_file(input_file):
-        input_path = with_vsi_prefix(input_file)
+    output_path = with_vsi_prefix(output_file)
+    input_path = with_vsi_prefix(input_file)
 
     cog_translate(
         input_path,


### PR DESCRIPTION
`to_cog_streaming` converted S3 URLs to `/vsis3/` prefixes but passed raw `gs://` URLs directly to `cog_translate`. GDAL requires `/vsigs/` prefix for GCS paths, causing treatment datalayer clipping to fail with "No such file or directory".

Fix: replace the S3-only conditional with a single `with_vsi_prefix` call for both input and output, which already handles S3, GCS, and local paths.