### PR TITLE
Fix NaN/Infinity JSON storage error for clipped funding report layers

### DIFF
--- a/src/planscape/gis/info.py
+++ b/src/planscape/gis/info.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 from typing import Any, Dict, Optional
 
 import fiona
@@ -57,6 +58,21 @@ def get_gdal_env(
     return gdal_env
 
 
+def _sanitize_non_finite(value: Any) -> Any:
+    """Replaces NaN/Infinity floats with None.
+
+    Python's json module happily emits the non-standard NaN/Infinity tokens,
+    but PostgreSQL's json/jsonb columns reject them as invalid JSON.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: _sanitize_non_finite(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_non_finite(val) for val in value]
+    return value
+
+
 def info_raster(input_file: str) -> Dict[str, Any]:
     """z
     This copies the original rasterio info CLI util with some changes, so we can call this
@@ -108,7 +124,7 @@ def info_raster(input_file: str) -> Dict[str, Any]:
             info["stats"] = stats
             info["checksum"] = [src.checksum(i) for i in src.indexes]
 
-            return json.loads(json.dumps(info))
+            return _sanitize_non_finite(json.loads(json.dumps(info)))
 
 
 def info_vector_layer(input_file: str, layer: Optional[str] = None) -> Dict[str, Any]:
@@ -133,7 +149,7 @@ def info_vector_layer(input_file: str, layer: Optional[str] = None) -> Dict[str,
             )
 
         info["crs"] = src.crs.to_string()
-        return json.loads(json.dumps(info))
+        return _sanitize_non_finite(json.loads(json.dumps(info)))
 
 
 def info_vector(input_file: str) -> Dict[str, Any]:

--- a/src/planscape/gis/tests/test_info.py
+++ b/src/planscape/gis/tests/test_info.py
@@ -1,0 +1,55 @@
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from django.test import SimpleTestCase
+from rasterio.transform import from_origin
+
+from gis.info import info_raster
+
+
+def write_test_raster(path: Path, nodata: float) -> None:
+    transform = from_origin(0, 10, 10, 10)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        dtype=np.float32,
+        crs="EPSG:3857",
+        transform=transform,
+        nodata=nodata,
+    ) as dst:
+        # Real data values, unrelated to the nodata value itself - mirrors a
+        # clipped raster whose nodata happens to be set to NaN in its profile.
+        dst.write(np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32), 1)
+
+
+class InfoRasterNonFiniteValuesTests(SimpleTestCase):
+    def setUp(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.tmp_dir = Path(tmp_dir.name)
+
+    def test_nan_nodata_is_sanitized_to_none(self):
+        path = self.tmp_dir / "nan_nodata.tif"
+        write_test_raster(path, float("nan"))
+
+        info = info_raster(str(path))
+
+        self.assertIsNone(info["nodata"])
+        # PostgreSQL's json/jsonb columns reject the NaN token; allow_nan=False
+        # mirrors that strictness, so this proves the result is storable.
+        json.dumps(info, allow_nan=False)
+
+    def test_finite_nodata_is_preserved(self):
+        path = self.tmp_dir / "finite_nodata.tif"
+        write_test_raster(path, -9999.0)
+
+        info = info_raster(str(path))
+
+        self.assertEqual(info["nodata"], -9999.0)


### PR DESCRIPTION
## Summary
- Postgres rejects the `NaN` token in JSON, but Python's `json.dumps` allows it by default, so a float32 raster with `nodata: NaN` failed to save as a `DataLayer` (e.g. for clipped funding report treatment layers).
- `gis/info.py` now sanitizes non-finite floats (`NaN`/`Infinity`/`-Infinity`) to `None` in `info_raster`/`info_vector_layer`, fixing this for all `DataLayer` creation paths that use them.

## Test plan
- [x] Added `gis/tests/test_info.py` covering NaN-nodata sanitization and finite-nodata preservation
- [x] `make docker-test TEST=gis.tests.test_info` passes
- [x] `make docker-test TEST=gis` passes (13 tests)
- [x] `make docker-test TEST=funding_report` passes (57 tests)