### PR TITLE
Update biomass funding report rasters to merch/non-merch units

### DIFF
--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -49,14 +49,10 @@ WOOD_TYPE_SOFTWOOD = 1
 WOOD_TYPE_HARDWOOD = 2
 WOOD_TYPE_MIXED = 3
 
-# Conversion factor from cubic feet to board feet (Scribner scale).
-# Confirm with data team before changing.
-MERCHANTABLE_CF_TO_BF_FACTOR = 5.5
-
 
 class BiomassRole(models.TextChoices):
     MERCHANTABLE = "merchantable", "Merchantable"
-    TOTAL = "total", "Total"
+    NON_MERCHANTABLE = "non_merchantable", "Non-Merchantable"
     WOOD_TYPE = "wood_type", "Wood Type"
 
 # Label for pixels that are nodata in the treatments raster.

--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -36,7 +36,6 @@ from funding_report.models import (
     FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
     FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT,
     FUNDING_REPORT_YEARS,
-    MERCHANTABLE_CF_TO_BF_FACTOR,
     TREATMENT_NO_TREATMENT_LABEL,
     TREATMENT_PIXEL_VALUE_LABELS,
     TREATMENT_ROLE,
@@ -741,31 +740,30 @@ def get_biomass_datalayer(role: str) -> DataLayer:
 def _extract_raw_biomass_volumes(
     geometry: Dict[str, Any],
     merch_src: rasterio.DatasetReader,
-    total_src: rasterio.DatasetReader,
+    non_merch_src: rasterio.DatasetReader,
     wood_type_src: rasterio.DatasetReader,
 ) -> Dict[str, float]:
     """
     Sums raster pixel values per wood type for one project area geometry.
-    Keys: merch_{softwood,hardwood,mixed}_cuft_ac and nm_{softwood,hardwood,mixed}_cuft_ac.
+    Keys: merch_{softwood,hardwood,mixed}_bf_ac and nm_{softwood,hardwood,mixed}_cuft_ac.
 
-    Raster pixels are already in output units (cuft/ac), so values are summed
-    directly with no area conversion.
+    Raster pixels are already in output units (merch in bf/ac, non-merch in
+    cuft/ac), so values are summed directly with no unit conversion.
     """
     empty: Dict[str, float] = {}
     for name in _BIOMASS_WOOD_TYPES.values():
-        empty[f"merch_{name}_cuft_ac"] = 0.0
+        empty[f"merch_{name}_bf_ac"] = 0.0
         empty[f"nm_{name}_cuft_ac"] = 0.0
 
     try:
         merch_data, _ = mask(merch_src, [geometry], crop=True, filled=False)
-        total_data, _ = mask(total_src, [geometry], crop=True, filled=False)
+        non_merch_data, _ = mask(non_merch_src, [geometry], crop=True, filled=False)
         wt_data, _ = mask(wood_type_src, [geometry], crop=True, filled=False)
     except ValueError:
         return empty
 
     merch_arr = np.ma.array(merch_data[0], dtype=float)
-    total_arr = np.ma.array(total_data[0], dtype=float)
-    non_merch_arr = total_arr - merch_arr
+    non_merch_arr = np.ma.array(non_merch_data[0], dtype=float)
     wt_arr = np.ma.array(wt_data[0])
 
     wt_nodata = np.ma.getmaskarray(wt_arr)
@@ -780,7 +778,7 @@ def _extract_raw_biomass_volumes(
     result: Dict[str, float] = {}
     for wt_value, wt_name in _BIOMASS_WOOD_TYPES.items():
         wt_match = ~wt_nodata & (wt_raw == wt_value)
-        result[f"merch_{wt_name}_cuft_ac"] = float(merch_vals[wt_match & merch_ok].sum())
+        result[f"merch_{wt_name}_bf_ac"] = float(merch_vals[wt_match & merch_ok].sum())
         result[f"nm_{wt_name}_cuft_ac"] = float(nm_vals[wt_match & nm_ok].sum())
 
     return result
@@ -789,10 +787,8 @@ def _extract_raw_biomass_volumes(
 def _biomass_volumes_to_output(raw: Dict[str, float]) -> Dict[str, float]:
     result: Dict[str, float] = {}
     for wt_name in _BIOMASS_WOOD_TYPES.values():
-        merch_cuft_ac = raw.get(f"merch_{wt_name}_cuft_ac", 0.0)
-        nm_cuft_ac = raw.get(f"nm_{wt_name}_cuft_ac", 0.0)
-        result[f"merchantable_{wt_name}_bf_ac"] = merch_cuft_ac * MERCHANTABLE_CF_TO_BF_FACTOR
-        result[f"non_merchantable_{wt_name}_cuft_ac"] = nm_cuft_ac
+        result[f"merchantable_{wt_name}_bf_ac"] = raw.get(f"merch_{wt_name}_bf_ac", 0.0)
+        result[f"non_merchantable_{wt_name}_cuft_ac"] = raw.get(f"nm_{wt_name}_cuft_ac", 0.0)
     return result
 
 
@@ -803,12 +799,12 @@ def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any
     project_areas = list(report.scenario.project_areas.all())
 
     merch_layer = get_biomass_datalayer(BiomassRole.MERCHANTABLE)
-    total_layer = get_biomass_datalayer(BiomassRole.TOTAL)
+    non_merch_layer = get_biomass_datalayer(BiomassRole.NON_MERCHANTABLE)
     wt_layer = get_biomass_datalayer(BiomassRole.WOOD_TYPE)
 
     with (
         rasterio.open(_datalayer_path(merch_layer)) as merch_src,
-        rasterio.open(_datalayer_path(total_layer)) as total_src,
+        rasterio.open(_datalayer_path(non_merch_layer)) as non_merch_src,
         rasterio.open(_datalayer_path(wt_layer)) as wt_src,
     ):
         raster_srid = merch_src.crs.to_epsg() if merch_src.crs else None
@@ -818,7 +814,7 @@ def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any
             )
 
         accumulated: Dict[str, float] = {
-            f"merch_{wt_name}_cuft_ac": 0.0 for wt_name in _BIOMASS_WOOD_TYPES.values()
+            f"merch_{wt_name}_bf_ac": 0.0 for wt_name in _BIOMASS_WOOD_TYPES.values()
         } | {
             f"nm_{wt_name}_cuft_ac": 0.0 for wt_name in _BIOMASS_WOOD_TYPES.values()
         }
@@ -828,7 +824,7 @@ def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any
             geometry = json.loads(
                 maybe_transform(project_area.geometry, raster_srid).geojson
             )
-            raw = _extract_raw_biomass_volumes(geometry, merch_src, total_src, wt_src)
+            raw = _extract_raw_biomass_volumes(geometry, merch_src, non_merch_src, wt_src)
 
             project_area_results.append(
                 {

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -20,7 +20,6 @@ from rasterio.mask import mask
 
 from funding_report.models import (
     FUNDING_REPORT_YEARS,
-    MERCHANTABLE_CF_TO_BF_FACTOR,
     BiomassRole,
     FundingOpportunityReport,
     FundingOpportunityReportStatus,
@@ -556,10 +555,10 @@ def write_biomass_rasters(tmp_dir: str):
     Write three aligned 2x2 rasters (10 m pixels, EPSG:3857) for biomass tests.
 
     Layout (row, col):
-      (0,0) softwood  merch=100  total=150  → nm=50
-      (0,1) hardwood  merch=200  total=280  → nm=80
-      (1,0) mixed     merch=300  total=380  → nm=80
-      (1,1) softwood  merch=400  total=500  → nm=100
+      (0,0) softwood  merch=100 bf/ac  non_merch=50 cuft/ac
+      (0,1) hardwood  merch=200 bf/ac  non_merch=80 cuft/ac
+      (1,0) mixed     merch=300 bf/ac  non_merch=80 cuft/ac
+      (1,1) softwood  merch=400 bf/ac  non_merch=100 cuft/ac
     """
     transform = from_origin(0, 20, 10, 10)
     profile = dict(
@@ -571,25 +570,25 @@ def write_biomass_rasters(tmp_dir: str):
         transform=transform,
         nodata=-9999,
     )
-    merch_path = Path(tmp_dir) / "merchantable_biomass.tif"
-    total_path = Path(tmp_dir) / "total_biomass.tif"
-    wt_path = Path(tmp_dir) / "wood_type.tif"
+    merch_path = Path(tmp_dir) / "merch-2026.tif"
+    non_merch_path = Path(tmp_dir) / "non-merch-2026.tif"
+    wt_path = Path(tmp_dir) / "softwood_hardwood_mixed.tif"
 
     with rasterio.open(merch_path, "w", dtype=np.float32, **profile) as dst:
         dst.write(np.array([[100, 200], [300, 400]], dtype=np.float32), 1)
-    with rasterio.open(total_path, "w", dtype=np.float32, **profile) as dst:
-        dst.write(np.array([[150, 280], [380, 500]], dtype=np.float32), 1)
+    with rasterio.open(non_merch_path, "w", dtype=np.float32, **profile) as dst:
+        dst.write(np.array([[50, 80], [80, 100]], dtype=np.float32), 1)
     with rasterio.open(wt_path, "w", dtype=np.uint8, **{**profile, "nodata": 0}) as dst:
         dst.write(np.array([[1, 2], [3, 1]], dtype=np.uint8), 1)
 
-    return merch_path, total_path, wt_path
+    return merch_path, non_merch_path, wt_path
 
 
 class BiomassVolumesCalculationTest(TestCase):
     def setUp(self):
         tmp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(tmp_dir.cleanup)
-        self.merch_path, self.total_path, self.wt_path = write_biomass_rasters(
+        self.merch_path, self.non_merch_path, self.wt_path = write_biomass_rasters(
             tmp_dir.name
         )
 
@@ -617,7 +616,7 @@ class BiomassVolumesCalculationTest(TestCase):
 
     def _create_all_biomass_datalayers(self):
         self._create_biomass_datalayer(BiomassRole.MERCHANTABLE, self.merch_path)
-        self._create_biomass_datalayer(BiomassRole.TOTAL, self.total_path)
+        self._create_biomass_datalayer(BiomassRole.NON_MERCHANTABLE, self.non_merch_path)
         self._create_biomass_datalayer(BiomassRole.WOOD_TYPE, self.wt_path)
 
     def test_get_biomass_datalayer_returns_correct_layer(self):
@@ -658,17 +657,17 @@ class BiomassVolumesCalculationTest(TestCase):
 
         results = calculate_biomass_volumes(self.report)
 
-        # Pixel values are already in output units (cuft/ac). Values are summed
-        # directly per wood type, then merchantable is converted cuft/ac → bf/ac.
+        # Pixel values are already in output units (merch bf/ac, non-merch
+        # cuft/ac), so values are summed directly per wood type with no
+        # unit conversion.
         #
         # Softwood pixels: (0,0) merch=100, nm=50; (1,1) merch=400, nm=100
         # Hardwood pixels: (0,1) merch=200, nm=80
         # Mixed pixels:    (1,0) merch=300, nm=80
-        cf_to_bf = MERCHANTABLE_CF_TO_BF_FACTOR
         summary = results["summary"]
-        self.assertAlmostEqual(summary["merchantable_softwood_bf_ac"], (100 + 400) * cf_to_bf, places=4)
-        self.assertAlmostEqual(summary["merchantable_hardwood_bf_ac"], 200 * cf_to_bf, places=4)
-        self.assertAlmostEqual(summary["merchantable_mixed_bf_ac"], 300 * cf_to_bf, places=4)
+        self.assertAlmostEqual(summary["merchantable_softwood_bf_ac"], 100 + 400, places=4)
+        self.assertAlmostEqual(summary["merchantable_hardwood_bf_ac"], 200, places=4)
+        self.assertAlmostEqual(summary["merchantable_mixed_bf_ac"], 300, places=4)
         self.assertAlmostEqual(summary["non_merchantable_softwood_cuft_ac"], 50 + 100, places=4)
         self.assertAlmostEqual(summary["non_merchantable_hardwood_cuft_ac"], 80, places=4)
         self.assertAlmostEqual(summary["non_merchantable_mixed_cuft_ac"], 80, places=4)

--- a/upload_funding_report_datalayers.sh
+++ b/upload_funding_report_datalayers.sh
@@ -12,7 +12,7 @@ AET_TARGET_METADATA='{"modules":{"funding_report":{"variable":"AET","role":"targ
 AET_DELTA_METADATA='{"modules":{"funding_report":{"variable":"AET","role":"delta"}}}'
 TREATMENT_METADATA='{"modules":{"funding_report":{"variable":"TREATMENT","role":"treatment"}}}'
 BIOMASS_MERCH_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","role":"merchantable"}}}'
-BIOMASS_TOTAL_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","role":"total"}}}'
+BIOMASS_NON_MERCH_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","role":"non_merchantable"}}}'
 BIOMASS_WOOD_TYPE_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","role":"wood_type"}}}'
 
 # "${PYTHON_BIN[@]}" manage.py datalayers create "Baseline 2026 aboveground_total_live" --input-file "$RASTER_DIR/Baseline_2026_aboveground_total_live.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --funding
@@ -53,6 +53,6 @@ BIOMASS_WOOD_TYPE_METADATA='{"modules":{"funding_report":{"variable":"BIOMASS","
 # TREATMENT_STYLE_ID=$(echo "$TREATMENT_STYLE_OUTPUT" | sed -E 's/\x1b\[[0-9;]*m//g' | grep -oE "'id': [0-9]+" | head -n 1 | grep -oE '[0-9]+')
 
 "${PYTHON_BIN[@]}" manage.py datalayers create "Treatments" --input-file "$RASTER_DIR/treatments.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$TREATMENT_METADATA"
-# "${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Merchantable" --input-file "$RASTER_DIR/merchantable_biomass.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_MERCH_METADATA"
-# "${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Total" --input-file "$RASTER_DIR/total_biomass.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_TOTAL_METADATA"
-# "${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Wood Type" --input-file "$RASTER_DIR/wood_type.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_WOOD_TYPE_METADATA"
+"${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Merchantable" --input-file "$RASTER_DIR/merch-2026.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_MERCH_METADATA"
+"${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Non-Merchantable" --input-file "$RASTER_DIR/non-merch-2026.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_NON_MERCH_METADATA"
+"${PYTHON_BIN[@]}" manage.py datalayers create "Biomass Wood Type" --input-file "$RASTER_DIR/softwood_hardwood_mixed.tif" --dataset "$DATASET_ID" --map-service-type "$MAP_SERVICE_TYPE" --metadata "$BIOMASS_WOOD_TYPE_METADATA"


### PR DESCRIPTION
## Summary
- Upload script now points at the new raster filenames (`merch-2026.tif`, `non-merch-2026.tif`, `softwood_hardwood_mixed.tif`) and uses a `non_merchantable` role instead of `total`.
- `services.py` reads merch (bf/ac) and non-merch (cuft/ac) rasters directly instead of subtracting merch from a total raster and converting cuft to bf.
- `BiomassRole.TOTAL` replaced with `BiomassRole.NON_MERCHANTABLE`; removed the now-unused cuft→bf conversion factor.

## Test plan
- [x] `make docker-test TEST=funding_report` — 57 tests pass