### PR TITLE
fix(includes): Using Planning Area geometry to get available stands when Treatable Area is not defined yet.

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -1695,7 +1695,7 @@ def get_available_stands(
         constraints = list()
     planning_area = scenario.planning_area
     area_transform = Area(Transform("geometry", settings.AREA_SRID))
-    if feature_enabled("ADD_INCLUDES"):
+    if feature_enabled("ADD_INCLUDES") and scenario.treatable_area is not None:
         stands = scenario.get_treatable_area_stands(stand_size=stand_size)
     else:
         stands = planning_area.get_stands(stand_size)


### PR DESCRIPTION
The `available_stands` endpoint is returning no stands and area on first step of scenario creation. It is being caused because the Treatable Area is not defined yet.

In this case, the whole planning area will be considered to return the stands and do the maths, AND, whenever treatable_area is defined, it will use it as reference.