### PR TITLE
plan-3712-export-selected-project-area-to-geopackage

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -1492,13 +1492,17 @@ def export_to_geopackage(scenario: Scenario, regenerate=False) -> Optional[str]:
         stand_inputs = export_scenario_inputs_to_geopackage(scenario, temp_file)
 
         if scenario.result_status == ScenarioResultStatus.SUCCESS:
+            export_scenario_project_areas_outputs_to_geopackage(
+                scenario, temp_file, stand_inputs
+            )
+
             if (
                 scenario.planning_approach
                 == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
             ):
-                export_scenario_sub_units_outputs_to_geopackage(scenario, temp_file, stand_inputs)
-            else:
-                export_scenario_project_areas_outputs_to_geopackage(scenario, temp_file, stand_inputs)
+                export_scenario_sub_units_outputs_to_geopackage(
+                    scenario, temp_file, stand_inputs
+                )
 
             export_scenario_stand_outputs_to_geopackage(
                 scenario, temp_file, stand_inputs


### PR DESCRIPTION
@george-silva @roquebetioljr @lastminutediorama, Export selected project area to geopackage, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3712:

1. `src/planscape/planning/services.py`: ALWAYS export project_areas_outputs for ANY successful scenario GeoPackages, regular or sub_unit scenarios. ONLY export sub_unit_outputs for sub_unit scenarios.

----------------------

This is the alternative code, not sure if I should use it instead:

```
if scenario.result_status == ScenarioResultStatus.SUCCESS:
    export_scenario_project_areas_outputs_to_geopackage(
        scenario, temp_file, stand_inputs
    )

    export_scenario_stand_outputs_to_geopackage(
        scenario, temp_file, stand_inputs
    )
```

^ ALWAYS exporting `project_areas_outputs` for ANY successful scenario geopackages, and no more `sub_unit_outputs` in sub_unit scenarios.