### PR TITLE
Calculate flame length reduction for 7-4, 6-4, and 4-2 ft intervals

### DIFF
--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from core.models import CreatedAtMixin, UpdatedAtMixin
 from django.contrib.auth.models import User
@@ -20,6 +20,14 @@ FUNDING_REPORT_YEARS = (2026, 2031, 2036, 2041, 2046)
 
 FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT = 7.0
 FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT = 4.0
+
+# (from_ft, to_ft) intervals calculated and stored for every funding report run.
+FLAME_LENGTH_REDUCTION_INTERVALS: Tuple[Tuple[float, float], ...] = (
+    (7.0, 4.0),
+    (6.0, 4.0),
+    (4.0, 2.0),
+)
+
 AET_IMPROVEMENT_DEFAULT_PERCENTAGE = 25.0
 
 

--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -741,6 +741,81 @@ def build_funding_report_results(
     }
 
 
+def build_flame_length_reduction_results(
+    project_results: Iterable[Dict[str, Any]],
+) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    """
+    Like build_funding_report_results, but buckets entries by their flame
+    length "interval" (e.g. "7_4") instead of by metric, since a single
+    funding report run now calculates flame length reduction for multiple
+    intervals. Each result must carry an "interval": {"from": ..., "to": ...}
+    key, as produced by aggregate_flame_length_reduction.
+    """
+    projects: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    summary_values: Dict[Tuple[str, int], Dict[str, Any]] = {}
+
+    for result in project_results:
+        interval = result["interval"]
+        interval_key = f"{int(interval['from'])}_{int(interval['to'])}"
+        year = result["year"]
+        project_result = {
+            "project_id": result["project_id"],
+            "proj_id": result.get("proj_id"),
+            "year": year,
+            "value": result["value"],
+            "baseline": result["baseline"],
+            "delta": result["delta"],
+            "raw_value": result["value"],
+            "total_area": result["baseline"],
+        }
+        projects[interval_key].append(project_result)
+
+        summary = summary_values.setdefault(
+            (interval_key, year),
+            {
+                "year": year,
+                "value": None,
+                "baseline": None,
+                "delta": None,
+                "raw_value": None,
+                "total_area": None,
+            },
+        )
+        for field in ("value", "baseline"):
+            if result[field] is None:
+                continue
+            summary[field] = (summary[field] or 0) + result[field]
+
+    for (_interval_key, _year), summary in summary_values.items():
+        if summary["value"] is None or summary["baseline"] is None:
+            continue
+        summary["delta"] = (
+            summary["value"] / summary["baseline"] * 100
+            if summary["baseline"]
+            else 0.0
+        )
+        summary["raw_value"] = summary["value"]
+        summary["total_area"] = summary["baseline"]
+
+    summary_by_interval: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for (interval_key, _year), summary in summary_values.items():
+        summary_by_interval[interval_key].append(summary)
+
+    return {
+        "summary": {
+            interval_key: sorted(values, key=lambda item: item["year"])
+            for interval_key, values in summary_by_interval.items()
+        },
+        "projects": {
+            interval_key: sorted(
+                values,
+                key=lambda item: (item["year"], item["project_id"]),
+            )
+            for interval_key, values in projects.items()
+        },
+    }
+
+
 def calculate_funding_report_flame_length_reduction(
     report: FundingOpportunityReport,
     from_ft: float,

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -7,6 +7,9 @@ from django.utils import timezone
 from datasets.models import DataLayer
 from funding_report.models import (
     AET_IMPROVEMENT_DEFAULT_PERCENTAGE,
+    FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
+    FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT,
+    FLAME_LENGTH_REDUCTION_INTERVALS,
     FUNDING_REPORT_YEARS,
     FundingOpportunityReport,
     FundingOpportunityReportStatus,
@@ -14,6 +17,7 @@ from funding_report.models import (
 )
 from funding_report.services import (
     build_datalayer_lookup,
+    build_flame_length_reduction_results,
     build_funding_report_results,
     calculate_aet_improvement,
     calculate_biomass_volumes,
@@ -47,6 +51,8 @@ def async_calculate_funding_report_delta(
     value_layer_id: int,
     year: int,
     metric: str,
+    from_ft: float = FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
+    to_ft: float = FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT,
 ) -> dict | None:
     try:
         project_area = ProjectArea.objects.get(pk=project_area_id)
@@ -67,6 +73,8 @@ def async_calculate_funding_report_delta(
             metric=metric,
             year=year,
             datalayer_lookup=datalayer_lookup,
+            from_ft=from_ft,
+            to_ft=to_ft,
         )
     except Exception as exc:
         log.exception(
@@ -202,7 +210,14 @@ def async_finalize_funding_report_results(
             case _:
                 successes.append(result)
 
-    results = build_funding_report_results(successes)
+    flame_successes = [r for r in successes if "interval" in r]
+    non_flame_successes = [r for r in successes if "interval" not in r]
+
+    results = build_funding_report_results(non_flame_successes)
+    flame_results = build_flame_length_reduction_results(flame_successes)
+    if flame_results["summary"] or flame_results["projects"]:
+        results["summary"]["TOTAL_FLAME_SEVERITY"] = flame_results["summary"]
+        results["projects"]["TOTAL_FLAME_SEVERITY"] = flame_results["projects"]
     if aet_improvement is not None:
         results["summary"]["AET"] = {
             "percentage": aet_improvement["percentage"],
@@ -283,16 +298,29 @@ def run_funding_opportunity_report(funding_opportunity_report_id: int) -> None:
                         "Missing funding report datalayer for variable="
                         f"{metric.value!r}, year={year}."
                     )
-                tasks.extend(
-                    async_calculate_funding_report_delta.si(
-                        project_area_id=project_area_id,
-                        baseline_layer_id=baseline_layer.pk,
-                        value_layer_id=value_layer.pk,
-                        year=year,
-                        metric=metric.value,
+                intervals = (
+                    FLAME_LENGTH_REDUCTION_INTERVALS
+                    if metric == FundingReportMetric.TOTAL_FLAME_SEVERITY
+                    else (
+                        (
+                            FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
+                            FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT,
+                        ),
                     )
-                    for project_area_id in project_area_ids
                 )
+                for from_ft, to_ft in intervals:
+                    tasks.extend(
+                        async_calculate_funding_report_delta.si(
+                            project_area_id=project_area_id,
+                            baseline_layer_id=baseline_layer.pk,
+                            value_layer_id=value_layer.pk,
+                            year=year,
+                            metric=metric.value,
+                            from_ft=from_ft,
+                            to_ft=to_ft,
+                        )
+                        for project_area_id in project_area_ids
+                    )
         tasks.append(
             async_generate_treatment_datalayer.si(
                 funding_opportunity_report_id=funding_opportunity_report_id,

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -31,6 +31,7 @@ from funding_report.services import (
     aggregate_delta_pixels,
     calculate_aet_improvement,
     build_datalayer_lookup,
+    build_flame_length_reduction_results,
     build_funding_report_results,
     calculate_biomass_volumes,
     calculate_funding_report_flame_length_reduction,
@@ -424,6 +425,143 @@ class FundingReportRasterCalculationTest(TestCase):
                     "delta": 3,
                 },
             ],
+        )
+
+
+class BuildFlameLengthReductionResultsTest(TestCase):
+    def test_buckets_results_by_interval_key(self):
+        results = build_flame_length_reduction_results(
+            [
+                {
+                    "project_id": 1,
+                    "year": 2026,
+                    "value": 10,
+                    "baseline": 40,
+                    "delta": 25.0,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+                {
+                    "project_id": 2,
+                    "year": 2026,
+                    "value": 5,
+                    "baseline": 20,
+                    "delta": 25.0,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+                {
+                    "project_id": 1,
+                    "year": 2026,
+                    "value": 2,
+                    "baseline": 40,
+                    "delta": 5.0,
+                    "interval": {"from": 6.0, "to": 4.0},
+                },
+                {
+                    "project_id": 1,
+                    "year": 2026,
+                    "value": 1,
+                    "baseline": 40,
+                    "delta": 2.5,
+                    "interval": {"from": 4.0, "to": 2.0},
+                },
+            ]
+        )
+
+        self.assertEqual(set(results["summary"].keys()), {"7_4", "6_4", "4_2"})
+        self.assertEqual(set(results["projects"].keys()), {"7_4", "6_4", "4_2"})
+
+        seven_four_summary = results["summary"]["7_4"][0]
+        self.assertEqual(seven_four_summary["value"], 15)
+        self.assertEqual(seven_four_summary["baseline"], 60)
+        self.assertAlmostEqual(seven_four_summary["delta"], 15 / 60 * 100)
+        self.assertEqual(len(results["projects"]["7_4"]), 2)
+
+    def test_summary_includes_raw_value_and_total_area_aliases(self):
+        results = build_flame_length_reduction_results(
+            [
+                {
+                    "project_id": 1,
+                    "year": 2026,
+                    "value": 10,
+                    "baseline": 40,
+                    "delta": 25.0,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+            ]
+        )
+
+        summary = results["summary"]["7_4"][0]
+        self.assertEqual(summary["raw_value"], summary["value"])
+        self.assertEqual(summary["total_area"], summary["baseline"])
+
+    def test_project_entries_include_raw_value_and_total_area_aliases(self):
+        results = build_flame_length_reduction_results(
+            [
+                {
+                    "project_id": 1,
+                    "proj_id": "abc",
+                    "year": 2026,
+                    "value": 10,
+                    "baseline": 40,
+                    "delta": 25.0,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+            ]
+        )
+
+        project_result = results["projects"]["7_4"][0]
+        self.assertEqual(project_result["raw_value"], project_result["value"])
+        self.assertEqual(project_result["total_area"], project_result["baseline"])
+        self.assertEqual(project_result["proj_id"], "abc")
+
+    def test_interval_key_formatting_truncates_to_int(self):
+        results = build_flame_length_reduction_results(
+            [
+                {
+                    "project_id": 1,
+                    "year": 2026,
+                    "value": 10,
+                    "baseline": 40,
+                    "delta": 25.0,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+            ]
+        )
+
+        self.assertIn("7_4", results["summary"])
+        self.assertNotIn("7.0_4.0", results["summary"])
+
+    def test_empty_input_returns_empty_dicts(self):
+        self.assertEqual(
+            build_flame_length_reduction_results([]),
+            {"summary": {}, "projects": {}},
+        )
+
+    def test_sorts_by_year_and_project_id_within_bucket(self):
+        results = build_flame_length_reduction_results(
+            [
+                {
+                    "project_id": 2,
+                    "year": 2026,
+                    "value": 20,
+                    "baseline": 10,
+                    "delta": 3,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+                {
+                    "project_id": 1,
+                    "year": 2026,
+                    "value": 5,
+                    "baseline": 2,
+                    "delta": 1,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+            ]
+        )
+
+        self.assertEqual(
+            [item["project_id"] for item in results["projects"]["7_4"]],
+            [1, 2],
         )
 
 

--- a/src/planscape/funding_report/tests/test_tasks.py
+++ b/src/planscape/funding_report/tests/test_tasks.py
@@ -13,6 +13,9 @@ from planning.tests.factories import (
 from planscape.tests.factories import UserFactory
 
 from funding_report.models import (
+    FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
+    FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT,
+    FLAME_LENGTH_REDUCTION_INTERVALS,
     FUNDING_REPORT_YEARS,
     FundingOpportunityReport,
     FundingOpportunityReportStatus,
@@ -96,6 +99,49 @@ class FundingOpportunityReportTaskTest(TestCase):
                 (FundingReportMetric.ABOVEGROUND_TOTAL.value, 2026, True): baseline_layer,
                 (FundingReportMetric.ABOVEGROUND_TOTAL.value, 2026, False): value_layer,
             },
+            from_ft=FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
+            to_ft=FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT,
+        )
+
+    @mock.patch("funding_report.tasks.calculate_project_area_delta")
+    def test_delta_task_threads_custom_interval_through(self, calculate_mock):
+        baseline_layer = self.create_datalayer(
+            FundingReportMetric.TOTAL_FLAME_SEVERITY, 2026, baseline=True
+        )
+        value_layer = self.create_datalayer(
+            FundingReportMetric.TOTAL_FLAME_SEVERITY, 2026, baseline=False
+        )
+        calculate_mock.return_value = {
+            "variable": FundingReportMetric.TOTAL_FLAME_SEVERITY,
+            "project_id": self.project_area.pk,
+            "year": 2026,
+            "value": 10,
+            "baseline": 8,
+            "delta": 1.2,
+            "interval": {"from": 6.0, "to": 4.0},
+        }
+
+        result = async_calculate_funding_report_delta(
+            project_area_id=self.project_area.pk,
+            baseline_layer_id=baseline_layer.pk,
+            value_layer_id=value_layer.pk,
+            year=2026,
+            metric=FundingReportMetric.TOTAL_FLAME_SEVERITY.value,
+            from_ft=6.0,
+            to_ft=4.0,
+        )
+
+        self.assertEqual(result, calculate_mock.return_value)
+        calculate_mock.assert_called_once_with(
+            project_area=self.project_area,
+            metric=FundingReportMetric.TOTAL_FLAME_SEVERITY.value,
+            year=2026,
+            datalayer_lookup={
+                (FundingReportMetric.TOTAL_FLAME_SEVERITY.value, 2026, True): baseline_layer,
+                (FundingReportMetric.TOTAL_FLAME_SEVERITY.value, 2026, False): value_layer,
+            },
+            from_ft=6.0,
+            to_ft=4.0,
         )
 
     @mock.patch("funding_report.tasks.calculate_project_area_delta")
@@ -167,6 +213,70 @@ class FundingOpportunityReportTaskTest(TestCase):
             },
         )
 
+    def test_finalize_task_buckets_flame_severity_by_interval(self):
+        async_finalize_funding_report_results(
+            project_results=[
+                {
+                    "variable": FundingReportMetric.TOTAL_FLAME_SEVERITY,
+                    "project_id": self.project_area.pk,
+                    "year": 2026,
+                    "value": 10,
+                    "baseline": 40,
+                    "delta": 25.0,
+                    "interval": {"from": 7.0, "to": 4.0},
+                },
+                {
+                    "variable": FundingReportMetric.TOTAL_FLAME_SEVERITY,
+                    "project_id": self.project_area.pk,
+                    "year": 2026,
+                    "value": 5,
+                    "baseline": 40,
+                    "delta": 12.5,
+                    "interval": {"from": 6.0, "to": 4.0},
+                },
+                {
+                    "variable": FundingReportMetric.ABOVEGROUND_TOTAL,
+                    "project_id": self.project_area.pk,
+                    "year": 2026,
+                    "value": 10,
+                    "baseline": 8,
+                    "delta": 1.2,
+                },
+            ],
+            funding_opportunity_report_id=self.report.pk,
+        )
+
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, FundingOpportunityReportStatus.SUCCESS)
+        results = self.report.results
+
+        # Non-flame metrics keep their existing flat shape, untouched.
+        self.assertEqual(
+            results["summary"][FundingReportMetric.ABOVEGROUND_TOTAL],
+            [{"year": 2026, "value": 10, "baseline": 8, "delta": 25.0}],
+        )
+        self.assertNotIn("raw_value", results["summary"][FundingReportMetric.ABOVEGROUND_TOTAL][0])
+
+        flame_summary = results["summary"]["TOTAL_FLAME_SEVERITY"]
+        flame_projects = results["projects"]["TOTAL_FLAME_SEVERITY"]
+        self.assertEqual(set(flame_summary.keys()), {"7_4", "6_4"})
+        self.assertEqual(set(flame_projects.keys()), {"7_4", "6_4"})
+
+        seven_four_summary = flame_summary["7_4"][0]
+        self.assertEqual(seven_four_summary["value"], 10)
+        self.assertEqual(seven_four_summary["baseline"], 40)
+        self.assertEqual(seven_four_summary["raw_value"], seven_four_summary["value"])
+        self.assertEqual(seven_four_summary["total_area"], seven_four_summary["baseline"])
+
+        seven_four_project = flame_projects["7_4"][0]
+        self.assertEqual(seven_four_project["project_id"], self.project_area.pk)
+        self.assertEqual(seven_four_project["raw_value"], seven_four_project["value"])
+        self.assertEqual(seven_four_project["total_area"], seven_four_project["baseline"])
+
+        six_four_summary = flame_summary["6_4"][0]
+        self.assertEqual(six_four_summary["value"], 5)
+        self.assertEqual(six_four_summary["raw_value"], 5)
+
     def test_finalize_task_sets_failed_status_with_errors(self):
         async_finalize_funding_report_results(
             project_results=[
@@ -213,10 +323,38 @@ class FundingOpportunityReportTaskTest(TestCase):
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.RUNNING)
         chord_mock.assert_called_once()
         tasks = chord_mock.call_args.args[0]
+        non_flame_metric_count = len(FundingReportMetric) - 1
         self.assertEqual(
             len(tasks),
-            1 * len(FundingReportMetric) * len(FUNDING_REPORT_YEARS) + 4,
+            1 * non_flame_metric_count * len(FUNDING_REPORT_YEARS)
+            + 1 * len(FUNDING_REPORT_YEARS) * len(FLAME_LENGTH_REDUCTION_INTERVALS)
+            + 4,
         )
+
+    @mock.patch("funding_report.tasks.chord")
+    def test_run_task_dispatches_three_intervals_for_flame_severity(self, chord_mock):
+        self.create_all_datalayers()
+
+        run_funding_opportunity_report(self.report.pk)
+
+        tasks = chord_mock.call_args.args[0]
+        flame_tasks = [
+            task
+            for task in tasks
+            if task.kwargs.get("metric") == FundingReportMetric.TOTAL_FLAME_SEVERITY.value
+        ]
+        self.assertEqual(len(flame_tasks), len(FUNDING_REPORT_YEARS) * len(FLAME_LENGTH_REDUCTION_INTERVALS))
+        intervals_used = {(task.kwargs["from_ft"], task.kwargs["to_ft"]) for task in flame_tasks}
+        self.assertEqual(intervals_used, set(FLAME_LENGTH_REDUCTION_INTERVALS))
+
+        non_flame_tasks = [
+            task
+            for task in tasks
+            if task.kwargs.get("metric") not in (None, FundingReportMetric.TOTAL_FLAME_SEVERITY.value)
+        ]
+        for task in non_flame_tasks:
+            self.assertEqual(task.kwargs["from_ft"], FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT)
+            self.assertEqual(task.kwargs["to_ft"], FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT)
 
     @mock.patch("funding_report.tasks.chord")
     def test_run_task_sets_failed_on_exception(self, chord_mock):


### PR DESCRIPTION
## Summary
- Funding reports now compute and persist flame length reduction for three intervals (7→4ft, 6→4ft, 4→2ft) instead of just the 7→4ft default, nested under `results["summary"]["TOTAL_FLAME_SEVERITY"]` / `results["projects"]["TOTAL_FLAME_SEVERITY"]` by interval key (`"7_4"`, `"6_4"`, `"4_2"`).
- Each entry now also carries `raw_value`/`total_area` (aliases of the existing `value`/`baseline`) so the frontend can recombine results across an arbitrary subset of project areas without backend recalculation.
- The on-demand `/scenarios/{id}/flame-length-reduction/` endpoint and every other metric's result shape are unchanged.

## Test plan
- [x] `make docker-test TEST=funding_report` — 66/66 passing
- [x] `ruff check` on changed files — clean
- [ ] Manually trigger a funding report run and inspect `results["summary"]["TOTAL_FLAME_SEVERITY"]`/`results["projects"]["TOTAL_FLAME_SEVERITY"]` for the three interval buckets