### PR TITLE
fix: allow funding_report datalayers in urls action queryset

### DIFF
--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -147,6 +147,7 @@ class DataLayerViewSet(RetrieveModelMixin, ListModelMixin, MultiSerializerMixin,
             return DataLayer.objects.all().accessible_by(user).filter(
                 Q(dataset__visibility=VisibilityOptions.PUBLIC)
                 | Q(dataset_id=settings.CLIMATE_FORESIGHT_DATASET_ID)
+                | Q(dataset__modules__contains=["funding_report"])
             )
 
         queryset = DataLayer.objects.all().accessible_by(user)


### PR DESCRIPTION
The `urls` action queryset was missing a condition for datasets with the `funding_report` module, causing a 404 when fetching map URLs for those datalayers.