### PR TITLE
fix: funding_report datalayers accessible via urls action

### DIFF
--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -569,6 +569,16 @@ class TestPublicAccess(APITestCase):
                 resp = self.client.get(url)
                 self.assertEqual(resp.status_code, 404)
 
+    def test_funding_report_datalayer_urls_are_accessible(self):
+        dataset = DatasetFactory.create(
+            visibility=VisibilityOptions.PRIVATE,
+            modules=["funding_report"],
+        )
+        datalayer = DataLayerFactory.create(dataset=dataset)
+        url = reverse("api:datasets:datalayers-urls", kwargs={"pk": datalayer.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
     def test_write_still_requires_authentication(self):
         url = reverse("api:datasets:datasets-list")
         resp = self.client.post(url, {})

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -144,7 +144,7 @@ class DataLayerViewSet(RetrieveModelMixin, ListModelMixin, MultiSerializerMixin,
         user = self.request.user if self.request else None
 
         if self.action == "urls":
-            return DataLayer.objects.all().accessible_by(user).filter(
+            return DataLayer.objects.filter(
                 Q(dataset__visibility=VisibilityOptions.PUBLIC)
                 | Q(dataset_id=settings.CLIMATE_FORESIGHT_DATASET_ID)
                 | Q(dataset__modules__contains=["funding_report"])


### PR DESCRIPTION
`accessible_by(user)` was excluding private funding_report datasets before the module filter could apply, causing 404s on the `urls` action.