### PR TITLE
plan-3693-remove-restore-from-latest-catalog-button

### DIFF
--- a/src/planscape/core/tests/test_admin_backup.py
+++ b/src/planscape/core/tests/test_admin_backup.py
@@ -3,6 +3,7 @@ from unittest import mock
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from planscape.tests.factories import UserFactory
 
 from core.backup_state import (
     BACKUP_STATE_FAILED,
@@ -21,8 +22,6 @@ from core.backup_state import (
     set_restore_status,
 )
 from core.tasks import generate_backup_data_task, load_latest_catalog_backup_task
-from planscape.tests.factories import UserFactory
-
 
 TEST_CACHES = {
     "default": {
@@ -42,6 +41,7 @@ class TestAdminBackupTrigger(TestCase):
         self.trigger_url = reverse("admin:trigger_backup_data")
         self.restore_url = reverse("admin:trigger_restore_data")
 
+    @override_settings(ENV="staging")
     def test_index_shows_enabled_button_when_backup_not_running(self):
         self.client.force_login(self.superuser)
 
@@ -49,17 +49,20 @@ class TestAdminBackupTrigger(TestCase):
 
         self.assertContains(response, "Run backup")
         self.assertNotContains(response, "Backup in progress")
-        self.assertContains(response, "Restore from latest catalog")
+        self.assertContains(response, "Restore from prod")
+        self.assertNotContains(response, "Restore from latest catalog")
         self.assertNotContains(response, "Restore in progress")
 
-    @override_settings(ENV="catalog")
-    def test_index_hides_restore_box_in_catalog_environment(self):
+    @override_settings(ENV="production")
+    def test_index_hides_restore_box_in_production_environment(self):
         self.client.force_login(self.superuser)
 
         response = self.client.get(self.index_url)
 
         self.assertContains(response, "Run backup")
+        self.assertNotContains(response, "Restore from prod")
         self.assertNotContains(response, "Restore from latest catalog")
+        self.assertNotContains(response, "Restore in progress")
 
     def test_index_shows_disabled_button_when_backup_running(self):
         self.client.force_login(self.superuser)
@@ -111,6 +114,7 @@ class TestAdminBackupTrigger(TestCase):
         delay_mock.assert_not_called()
         self.assertContains(response, "A backup is already queued or running.")
 
+    @override_settings(ENV="staging")
     def test_index_shows_disabled_restore_button_when_restore_running(self):
         self.client.force_login(self.superuser)
         acquire_restore_lock()

--- a/src/planscape/core/tests/test_admin_backup.py
+++ b/src/planscape/core/tests/test_admin_backup.py
@@ -50,7 +50,6 @@ class TestAdminBackupTrigger(TestCase):
         self.assertContains(response, "Run backup")
         self.assertNotContains(response, "Backup in progress")
         self.assertContains(response, "Restore from prod")
-        self.assertNotContains(response, "Restore from latest catalog")
         self.assertNotContains(response, "Restore in progress")
 
     @override_settings(ENV="production")
@@ -61,7 +60,6 @@ class TestAdminBackupTrigger(TestCase):
 
         self.assertContains(response, "Run backup")
         self.assertNotContains(response, "Restore from prod")
-        self.assertNotContains(response, "Restore from latest catalog")
         self.assertNotContains(response, "Restore in progress")
 
     def test_index_shows_disabled_button_when_backup_running(self):

--- a/src/planscape/templates/admin/base_site.html
+++ b/src/planscape/templates/admin/base_site.html
@@ -146,20 +146,20 @@
         </form>
       </div>
     </div>
-    {% if ENV != "catalog" %}
+    {% if ENV != "production" %}
       <div class="admin-backup-trigger-wrap">
         <div class="admin-backup-trigger">
           <div>
-            <div class="admin-backup-trigger__title">Restore from latest catalog</div>
+            <div class="admin-backup-trigger__title">Restore from Latest Prod</div>
             <p class="admin-backup-trigger__text">
-              Trigger the `load_backup_data` management command with the default latest catalog backup.
+              Trigger the `load_backup_data` management command with the default latest production backup.
               Current status: {{ restore_status.state }}.
             </p>
           </div>
-          <form action="{{ trigger_restore_data_url }}" method="post" onsubmit="return confirm('Restore data from the latest catalog backup?');">
+          <form action="{{ trigger_restore_data_url }}" method="post" onsubmit="return confirm('Restore data from the latest production backup?');">
             {% csrf_token %}
             <button class="admin-backup-trigger__button" type="submit" {% if restore_in_progress %}disabled{% endif %}>
-              {% if restore_in_progress %}Restore in progress{% else %}Restore from latest catalog{% endif %}
+              {% if restore_in_progress %}Restore in progress{% else %}Restore from prod{% endif %}
             </button>
           </form>
         </div>

--- a/src/planscape/templates/admin/base_site.html
+++ b/src/planscape/templates/admin/base_site.html
@@ -150,7 +150,7 @@
       <div class="admin-backup-trigger-wrap">
         <div class="admin-backup-trigger">
           <div>
-            <div class="admin-backup-trigger__title">Restore from Latest Prod</div>
+            <div class="admin-backup-trigger__title">Restore from latest prod</div>
             <p class="admin-backup-trigger__text">
               Trigger the `load_backup_data` management command with the default latest production backup.
               Current status: {{ restore_status.state }}.


### PR DESCRIPTION
@george-silva @roquebetioljr, Remove "Restore from Latest Catalog" Button from prod site, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3693.

1. `src/planscape/core/tests/test_admin_backup.py`: made restore button env be != prod (so staging & dev), and say prod instead of catalog.
2. `src/planscape/core/tests/test_admin_backup.py`: changed the tests to match prod instead of catalog, and the text to say prod instead of catalog too.