### PR TITLE
Funding legend w new endpoint

### DIFF
--- a/src/interface/src/app/funding/full-report-view/full-report-view.component.html
+++ b/src/interface/src/app/funding/full-report-view/full-report-view.component.html
@@ -24,7 +24,7 @@
             <div>Viewing outcomes for:</div>
             <sg-filter-dropdown
               class="outcome-areas-dropdown"
-              size="large"
+              size="medium"
               (confirmedSelection)="handleFilterSelection($event)"
               [styleType]="'white'"
               [hasSearch]="false"
@@ -32,7 +32,7 @@
               shortLabel="shortName"
               noSelectionsLabel="All Project Areas"
               [selectedItems]="(filteredProjectAreas$ | async) ?? []"
-              [menuItems]="(availableProjectAreas$ | async) ?? []"
+              [menuItems]="(filterOptions$ | async) ?? []"
               [showCountChip]="false"
               menuLabel="Project Areas">
             </sg-filter-dropdown>
@@ -83,6 +83,7 @@
     </app-map-nav-bar>
     <app-funding-report-map
       *ngIf="treatmentDataLayerId$ | async as treatmentDataLayerId"
-      [treatmentDataLayerId]="treatmentDataLayerId"></app-funding-report-map>
+      [treatmentDataLayerId]="treatmentDataLayerId"
+      [legendData]="legendData$ | async"></app-funding-report-map>
   </div>
 </section>

--- a/src/interface/src/app/funding/full-report-view/full-report-view.component.html
+++ b/src/interface/src/app/funding/full-report-view/full-report-view.component.html
@@ -43,7 +43,6 @@
             *ngIf="report.status === 'SUCCESS'; else loadingReport"
             [report]="report"
             [projectAreas]="(selectedProjectAreas$ | async) ?? []"
-            [origin]="(currentScenario$ | async)?.origin ?? 'USER'"
             [scrollElement]="reportScroll"
             reportType="full"
             [updatingWaterAvailability]="updatingWaterAvailability"

--- a/src/interface/src/app/funding/full-report-view/full-report-view.component.ts
+++ b/src/interface/src/app/funding/full-report-view/full-report-view.component.ts
@@ -13,7 +13,7 @@ import { MapNavbarComponent } from '@app/maplibre-map/map-nav-bar/map-nav-bar.co
 import { ScenarioState } from '@app/scenario/scenario.state';
 import { BreadcrumbService } from '@app/services/breadcrumb.service';
 import { NavBarComponent } from '@app/standalone/nav-bar/nav-bar.component';
-import { ScenarioResult } from '@app/types';
+import { ProjectArea } from '@app/types';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { FundingReportService } from '@services/funding-report.service';
 import { FilterDropdownComponent, OpacitySliderComponent } from '@styleguide';
@@ -29,6 +29,7 @@ import {
   finalize,
   map,
   Observable,
+  of,
   shareReplay,
   Subject,
   switchMap,
@@ -39,9 +40,12 @@ import {
 import { FundingReportMapComponent } from '../funding-report-map/funding-report-map.component';
 import { FundingReportComponent } from '../funding-report/funding-report.component';
 import { FundingMapConfigState } from '../funding-map-config-state';
+import { generateLegendFromReport } from '../funding-report/funding-report.helper';
 import { MapConfigState } from '@app/maplibre-map/map-config.state';
+import { ScenarioService } from '@app/services';
+import { isPlanningApproachSubUnits } from '@app/scenario/scenario-helper';
 
-interface FilterProjectFormat {
+export interface FilterProjectFormat {
   id: number;
   name: string;
   shortName: string;
@@ -89,20 +93,44 @@ export class FullReportViewComponent implements OnInit {
   currentScenario$ = this.scenarioState.currentScenario$;
   selectedProjectAreas$ = this.fundingMapConfigState.selectedProjectAreas$;
   opacity$ = this.fundingMapConfigState.opacity$;
-  availableProjectAreas$: Observable<FilterProjectFormat[]> =
+
+  allAvailableProjectAreas$: Observable<ProjectArea[]> =
     this.currentScenario$.pipe(
-      map((scenario) => {
-        if (!scenario?.origin || !scenario?.scenario_result) return [];
-        return this.resultsToSelectionMenu(
-          scenario.origin,
-          scenario.scenario_result
-        );
+      switchMap((scenario) => {
+        if (!scenario?.id) {
+          return of([]);
+        }
+        return this.scenarioService.getProjectAreas(scenario.id);
       }),
       shareReplay(1)
     );
 
+  filterOptions$: Observable<FilterProjectFormat[]> = combineLatest([
+    this.allAvailableProjectAreas$,
+    this.currentScenario$,
+  ]).pipe(
+    map(([projectAreas, scenario]) => {
+      if (!projectAreas.length) {
+        return [];
+      }
+
+      // filter the top 10 for subunit approaches
+      if (
+        scenario?.planning_approach &&
+        isPlanningApproachSubUnits(scenario?.planning_approach)
+      ) {
+        projectAreas = projectAreas.filter(
+          (pa) => pa.data.treatment_rank <= 10
+        );
+      }
+
+      return this.projectAreasToSelectionMenu(projectAreas);
+    }),
+    shareReplay(1)
+  );
+
   readonly filteredProjectAreas$: Observable<FilterProjectFormat[]> =
-    combineLatest(this.availableProjectAreas$, this.selectedProjectAreas$).pipe(
+    combineLatest(this.filterOptions$, this.selectedProjectAreas$).pipe(
       map(([available, selectedIds]) => {
         if (!selectedIds?.length) return [];
         return available.filter((area) => selectedIds.includes(area.id));
@@ -150,6 +178,7 @@ export class FullReportViewComponent implements OnInit {
   constructor(
     private breadcrumbService: BreadcrumbService,
     private scenarioState: ScenarioState,
+    private scenarioService: ScenarioService,
     private fundingReportService: FundingReportService,
     private fundingMapConfigState: FundingMapConfigState,
     private router: Router,
@@ -204,18 +233,21 @@ export class FullReportViewComponent implements OnInit {
       .subscribe((water) => this.water$.next(water));
   }
 
-  resultsToSelectionMenu(
-    origin: string,
-    results: ScenarioResult
+  projectAreasToSelectionMenu(
+    projectAreas: ProjectArea[]
   ): FilterProjectFormat[] {
-    return results.result.features.map((featureCollection) => {
-      const props = featureCollection.properties;
-      return {
-        id: origin === 'USER' ? props.project_id : props.treatment_rank,
-        shortName: props.treatment_rank,
-        name: `Project Area ${props.treatment_rank}`,
-      };
-    });
+    return projectAreas
+      .map((projectArea) => {
+        const filterOption: FilterProjectFormat = {
+          id: projectArea.id,
+          shortName: projectArea.data.treatment_rank.toString(),
+          name: `Project Area ${projectArea.data.treatment_rank}`,
+        };
+        return filterOption; // sort the resulting array so 'Project 10' is after 'Project 2'
+      })
+      .sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { numeric: true })
+      );
   }
 
   redirectToFunding() {
@@ -253,4 +285,15 @@ export class FullReportViewComponent implements OnInit {
     }
     return { ...report, results };
   }
+
+  legendData$ = combineLatest([
+    this.fetchedReport$,
+    this.selectedProjectAreas$,
+    this.allAvailableProjectAreas$,
+  ]).pipe(
+    map(([report, areas, projAreas]) =>
+      generateLegendFromReport(report?.results ?? null, areas, projAreas)
+    ),
+    shareReplay(1)
+  );
 }

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.html
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.html
@@ -1,0 +1,73 @@
+<div
+  class="treatment-acres-legend"
+  #tooltip="matTooltip"
+  matTooltip="All results reflect modeled changes compared to baseline (no-treatment) conditions."
+  [matTooltipDisabled]="true"
+  #tooltipRef="matTooltip"
+  matTooltipPosition="left"
+  matTooltipClass="tx-legend-tooltip"
+  matTooltipTrigger="manual">
+  <div class="title-header">
+    <div class="title">Legend</div>
+    <button
+      sg-button
+      variant="icon-only"
+      class="close-button"
+      (click)="close()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+  <div class="acres-section">
+    <div class="static-section">
+      <div class="static-row">
+        <div class="legend-line">
+          <div
+            class="swatch-box"
+            [ngStyle]="{ 'background-color': '#064BBA' }"></div>
+          <div class="swatch-label">Total Planning Area Acres</div>
+        </div>
+        <div *ngIf="currentPlan$ | async as plan" class="acres-line">
+          {{ plan.area_acres | number: '1.0-0' }} acres
+        </div>
+      </div>
+      <div class="static-row">
+        <div class="legend-line">
+          <div
+            class="swatch-box"
+            [ngStyle]="{ 'background-color': '#344F42' }"></div>
+          <div class="swatch-label">Selected Project Area Acres</div>
+        </div>
+        <div class="acres-line">
+          {{ legendData.selectedAcres | number: '1.0-0' }} acres
+        </div>
+      </div>
+    </div>
+    <div class="treatment-title-line" *ngIf="legendData.treatmentAcresTotals">
+      <div class="title">Treatment Type</div>
+      <button
+        sg-button
+        variant="icon-only"
+        icon="info"
+        class="info-icon"
+        [outlined]="true"
+        (click)="toggleTooltip(tooltip, $event)"></button>
+    </div>
+    <div class="dynamic-section" *ngIf="legendData.treatmentAcresTotals">
+      <div
+        class="dynamic-acres-row"
+        *ngFor="let acreageDetail of legendData.treatmentAcresTotals">
+        <div class="legend-line">
+          <div
+            class="swatch-box"
+            [ngStyle]="{
+              'background-color': treatmentColors[acreageDetail.treatment],
+            }"></div>
+          <div class="swatch-label">{{ acreageDetail.treatment }}</div>
+        </div>
+        <div class="acres-line">
+          {{ acreageDetail.acres | number: '1.0-0' }} acres
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.scss
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.scss
@@ -1,0 +1,166 @@
+@import 'colors';
+@import 'mixins';
+@import 'variables';
+
+:host {
+  box-sizing: border-box;
+  pointer-events: all;
+  /* specifying font family here, since the control defaults to helvetica */
+  font-family: 'Public Sans';
+}
+
+.treatment-acres-legend {
+  border-radius: 4px;
+  border: 1px solid #000;
+  background: rgba(42, 42, 42, 0.9);
+  backdrop-filter: blur(10px);
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(2px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  height: auto;
+  max-height: calc(100% - $map-nav-bar-height);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  transition:
+    width 0.8s ease,
+    height 0.8s ease;
+  white-space: nowrap;
+
+  padding: 0;
+  width: 240px;
+  position: relative;
+}
+
+.title-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 16px;
+  flex: 1;
+  justify-content: space-between;
+  border-bottom: 1px #ffffff19 solid;
+}
+
+.treatment-title-line {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  flex: 1;
+  justify-content: space-between;
+  border-top: 1px #ffffff19 solid;
+  padding: 12px 0;
+}
+
+.acres-section {
+  padding: 16px;
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  @include standard-label();
+  font-size: 14px;
+  font-weight: 600;
+  color: $color-white;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.close-button,
+.info-icon {
+  color: $color-white;
+}
+
+.legend-line {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  color: $color-white;
+}
+
+.acres-line {
+  @include small-input-label();
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  color: $color-white;
+  padding: 0 20px;
+}
+
+.swatch-box {
+  height: 14px;
+  width: 14px;
+  flex-shrink: 0;
+  border-radius: 4px;
+}
+
+.swatch-label {
+  @include small-input-label();
+  font-family: 'Public Sans';
+  line-height: 14px;
+  color: $color-white;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.static-row,
+.dynamic-acres-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+}
+
+.static-section,
+.dynamic-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+}
+
+.swatch-gradient {
+  width: 14px;
+  min-height: 160px;
+  flex-shrink: 0;
+}
+
+::ng-deep .tx-legend-tooltip {
+  color:$color-white;
+  border-radius: 6px;
+  position: relative;
+  top: 20px;
+
+  .mdc-tooltip__surface {
+    background-color: $color-black !important;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    transform: translateY(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent transparent transparent $color-black;
+  }
+}

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.spec.ts
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import {
+  FundingAcreageLegendComponent,
+  FundingLegendData,
+} from './funding-acreage-legend.component';
+import { MockProvider } from 'ng-mocks';
+import { FundingMapConfigState } from '../funding-map-config-state';
+import { of } from 'rxjs';
+
+describe('FundingAcreageLegendComponent', () => {
+  let component: FundingAcreageLegendComponent;
+  let fixture: ComponentFixture<FundingAcreageLegendComponent>;
+
+  let testLegendData: FundingLegendData = {
+    selectedAcres: 100,
+    treatmentAcresTotals: [],
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, FundingAcreageLegendComponent],
+      providers: [
+        MockProvider(FundingMapConfigState, { selectedProjectAreas$: of([]) }),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FundingAcreageLegendComponent);
+    component = fixture.componentInstance;
+    component.legendData = testLegendData;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.ts
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.ts
@@ -1,0 +1,85 @@
+import { AsyncPipe, DecimalPipe, NgFor, NgIf, NgStyle } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { ButtonComponent } from '@styleguide';
+import { FundingMapConfigState } from '../funding-map-config-state';
+import { MatTooltip, MatTooltipModule } from '@angular/material/tooltip';
+import { PlanState } from '@app/plan/plan.state';
+
+export const TREATMENT_ORDER = [
+  'No Treatment',
+  'Rx Burn',
+  'Thinning Only',
+  'Thin and Rx Burn',
+] as const;
+
+// derive the order as a type, using TS magic
+export type LegendTreatmentType = (typeof TREATMENT_ORDER)[number];
+
+export interface FundingLegendData {
+  selectedAcres: number;
+  treatmentAcresTotals?: Array<{
+    treatment: LegendTreatmentType;
+    acres: number;
+  }>;
+}
+
+@Component({
+  selector: 'app-funding-acreage-legend',
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    ButtonComponent,
+    DecimalPipe,
+    MatIconModule,
+    MatMenuModule,
+    MatTooltipModule,
+    NgFor,
+    NgIf,
+    NgStyle,
+  ],
+  templateUrl: './funding-acreage-legend.component.html',
+  styleUrl: './funding-acreage-legend.component.scss',
+})
+export class FundingAcreageLegendComponent {
+  constructor(
+    private fundingMapConfig: FundingMapConfigState,
+    private planState: PlanState
+  ) {}
+
+  @Input() legendData!: FundingLegendData;
+
+  currentPlan$ = this.planState.currentPlan$;
+
+  selectedAcres = this.legendData?.selectedAcres ?? 0;
+
+  // TODO: these are different than the assignments in PRESCRIPTION_COLORS,
+  //  so confirm that these are what we want
+  treatmentColors: Record<LegendTreatmentType, string> = {
+    'No Treatment': '#fff',
+    'Rx Burn': '#FB6F92',
+    'Thinning Only': '#90BE6D',
+    'Thin and Rx Burn': '#2A9D8F',
+  };
+
+  toggleTooltip(tooltip: MatTooltip, event: MouseEvent): void {
+    event.stopPropagation();
+
+    if (tooltip.disabled) {
+      tooltip.disabled = false;
+      tooltip.show();
+    } else {
+      tooltip.hide();
+
+      // Re-disable tooltip so it doesn't instantly re-appear on hover
+      setTimeout(() => {
+        tooltip.disabled = true;
+      }, 100);
+    }
+  }
+
+  close() {
+    this.fundingMapConfig.setFundingLegendVisibility(false);
+  }
+}

--- a/src/interface/src/app/funding/funding-map-config-state.ts
+++ b/src/interface/src/app/funding/funding-map-config-state.ts
@@ -7,16 +7,17 @@ export class FundingMapConfigState extends MapConfigState {
   private _selectedProjectAreas$ = new BehaviorSubject<number[]>([]);
   public selectedProjectAreas$ = this._selectedProjectAreas$.asObservable();
 
-  /**  note that 'ids' here is either based on:
-  /*  the project_id for USER origin or the rank for SYSTEM origin
-  */
+  private _showFundingLegend$ = new BehaviorSubject(false);
+  public showFundingLegend$ = this._showFundingLegend$.asObservable();
+
+  setFundingLegendVisibility(value: boolean) {
+    this._showFundingLegend$.next(value);
+  }
+
   updateSelectedProjectAreas(ids: number[]) {
     this._selectedProjectAreas$.next(ids);
   }
 
-  /**  note that 'id' here is either based on:
-  /*  the project_id for USER origin or the rank for SYSTEM origin
-  */
   toggleSelectedProjectArea(id: any) {
     const currentSelection = this._selectedProjectAreas$.getValue();
     // if the id is already selected, we remove it.

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
@@ -59,8 +59,16 @@
     >Click project area to select</app-map-tooltip
   >
 
-  <mgl-control position="top-right">
-    <!-- TODO: add the funding legend -->
+  <mgl-control position="top-right" *ngIf="allowInteraction">
+    <app-action-button
+      *ngIf="(showFundingLegend$ | async) === false"
+      (clickedActionButton)="openFundingLegend()"
+      tooltipContent="Funding Report Legend"
+      icon="legend-toggle">
+    </app-action-button>
+    <app-funding-acreage-legend
+      *ngIf="(showFundingLegend$ | async) && legendData"
+      [legendData]="legendData"></app-funding-acreage-legend>
   </mgl-control>
 
   <mgl-control

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.scss
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.scss
@@ -22,6 +22,12 @@ mgl-map {
   min-width: 0;
 }
 
+:host ::ng-deep .maplibregl-ctrl-top-right .maplibregl-ctrl {
+ top: 60px;
+ position: relative;
+}
+
+
 .selected-layer-control {
   border-top-right-radius: 8px;
 }

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
@@ -36,6 +36,11 @@ import { ButtonComponent } from '@styleguide';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SNACK_ERROR_CONFIG } from '@app/shared';
 import { FundingMapConfigState } from '../funding-map-config-state';
+import {
+  FundingAcreageLegendComponent,
+  FundingLegendData,
+} from '../funding-acreage-legend/funding-acreage-legend.component';
+import { MapActionButtonComponent } from '@app/treatments/map-action-button/map-action-button.component';
 
 @Component({
   selector: 'app-funding-report-map',
@@ -44,8 +49,10 @@ import { FundingMapConfigState } from '../funding-map-config-state';
     AsyncPipe,
     ButtonComponent,
     ControlComponent,
+    FundingAcreageLegendComponent,
     FundingDataLayerComponent,
     LayerComponent,
+    MapActionButtonComponent,
     MapBaseLayersComponent,
     MapDataLayerComponent,
     MapComponent,
@@ -77,6 +84,8 @@ export class FundingReportMapComponent implements OnInit {
 
   @Input() allowInteraction = true;
 
+  @Input() legendData: FundingLegendData | null = null;
+
   /** Id of the report's treatment datalayer to display on the map. */
   @Input() treatmentDataLayerId!: number;
 
@@ -88,6 +97,7 @@ export class FundingReportMapComponent implements OnInit {
   maxZoom = FrontendConstants.MAPLIBRE_MAP_MAX_ZOOM;
 
   baseLayerUrl$ = this.fundingMapConfigState.baseMapUrl$;
+  showFundingLegend$ = this.fundingMapConfigState.showFundingLegend$;
 
   opacity$ = this.fundingMapConfigState.opacity$;
 
@@ -152,6 +162,10 @@ export class FundingReportMapComponent implements OnInit {
         panelClass: ['snackbar-error', 'snackbar-error-multiline'],
       }
     );
+  }
+
+  openFundingLegend() {
+    this.fundingMapConfigState.setFundingLegendVisibility(true);
   }
 
   setHoveredProjectAreaId(value: number | null) {

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -353,7 +353,7 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
 
     const results = this.report?.results;
     this.biomass = results
-      ? aggregateBiomassVolumes(results, this.projectAreas, this.origin)
+      ? aggregateBiomassVolumes(results, this.projectAreas)
       : undefined;
   }
 
@@ -367,12 +367,9 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
     const interval = this.flameLengthInterval.value;
     // delta can be null when an interval had no valid pixels; treat it as 0.
     const deltas = results
-      ? aggregateFlameLengthSummary(
-          results,
-          interval,
-          this.projectAreas,
-          this.origin
-        ).map((point) => point.delta ?? 0)
+      ? aggregateFlameLengthSummary(results, interval, this.projectAreas).map(
+          (point) => point.delta ?? 0
+        )
       : [];
     this.flameLengthChart = {
       data: buildPercentageBarData(this.labels, deltas, 'orange'),
@@ -382,17 +379,13 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
       )!,
     };
     this.flameLengthHasData =
-      !!results &&
-      hasFlameLengthData(results, interval, this.projectAreas, this.origin);
+      !!results && hasFlameLengthData(results, interval, this.projectAreas);
   }
 
   /** True when the metric has any non-null data over the current selection. */
   private metricHasData(metric: FundingReportTimeSeriesMetric): boolean {
     const results = this.report?.results;
-    return (
-      !!results &&
-      hasMetricData(results, metric, this.projectAreas, this.origin)
-    );
+    return !!results && hasMetricData(results, metric, this.projectAreas);
   }
 
   /** Build a bar chart from a report metric: one bar per year, value = % delta. */
@@ -417,12 +410,9 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
       return [];
     }
     // delta can be null when a metric had no valid pixels; treat it as 0.
-    return aggregateMetricSummary(
-      results,
-      metric,
-      this.projectAreas,
-      this.origin
-    ).map((point) => point.delta ?? 0);
+    return aggregateMetricSummary(results, metric, this.projectAreas).map(
+      (point) => point.delta ?? 0
+    );
   }
 
   onLayerSelected(layer: MapLayer): void {

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -43,7 +43,6 @@ import {
   FundingReportBiomassVolumes,
   FundingReportDataLayers,
   FundingReportTimeSeriesMetric,
-  ORIGIN_TYPE,
 } from '@types';
 import { FundingModuleService } from '@services/funding-module.service';
 import { DataLayersStateService } from '@data-layers/data-layers.state.service';
@@ -195,12 +194,6 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
   @Input() report!: FundingReport;
   /** Selected project area ids; empty means show the whole-scenario summary. */
   @Input() projectAreas: number[] = [];
-  /**
-   * Scenario origin. Decides which per-project field the selected
-   * `projectAreas` ids are matched against: `project_id` for USER scenarios,
-   * `proj_id` (treatment rank) for SYSTEM ones.
-   */
-  @Input() origin: ORIGIN_TYPE = 'USER';
   /**
    * The element that actually scrolls the report. When the report is embedded
    * in a host that owns the scroll (e.g. full-report-view), the host passes its

--- a/src/interface/src/app/funding/funding-report/funding-report.helper.spec.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.helper.spec.ts
@@ -3,6 +3,7 @@ import {
   FundingReportBiomassVolumesProject,
   FundingReportProjectDataPoint,
   FundingReportResults,
+  ProjectArea,
 } from '@types';
 import {
   aggregateBiomassVolumes,
@@ -10,7 +11,10 @@ import {
   aggregateMetricSummary,
   hasFlameLengthData,
   percentDelta,
+  generateLegendFromReport,
+  calculateTreatmentAcreSums,
 } from './funding-report.helper';
+import { MOCK_GEOMETRY } from '@app/services/mocks';
 
 const METRIC = 'POTENTIAL_SMOKE';
 
@@ -82,32 +86,27 @@ describe('funding-report helper', () => {
 
     it('returns the whole-scenario summary when no areas are selected', () => {
       // passthrough — same reference, not a recompute
-      expect(aggregateMetricSummary(results, METRIC, [], 'USER')).toBe(
+      expect(aggregateMetricSummary(results, METRIC, [])).toBe(
         results.summary[METRIC]
       );
     });
 
     it('aggregates a single selected project, year-sorted', () => {
-      expect(aggregateMetricSummary(results, METRIC, [1], 'USER')).toEqual([
+      expect(aggregateMetricSummary(results, METRIC, [1])).toEqual([
         { year: 0, value: 120, baseline: 100, delta: 20 },
         { year: 5, value: 90, baseline: 100, delta: -10 },
       ]);
     });
 
     it('sums value and baseline across selected projects, recomputing delta', () => {
-      expect(aggregateMetricSummary(results, METRIC, [1, 2], 'USER')).toEqual([
+      expect(aggregateMetricSummary(results, METRIC, [1, 2])).toEqual([
         { year: 0, value: 200, baseline: 200, delta: 0 },
         { year: 5, value: 240, baseline: 200, delta: 20 },
       ]);
     });
 
     it('excludes projects that are not selected', () => {
-      const onlyProjectTwo = aggregateMetricSummary(
-        results,
-        METRIC,
-        [2],
-        'USER'
-      );
+      const onlyProjectTwo = aggregateMetricSummary(results, METRIC, [2]);
       expect(onlyProjectTwo).toEqual([
         { year: 0, value: 80, baseline: 100, delta: -20 },
         { year: 5, value: 150, baseline: 100, delta: 50 },
@@ -115,44 +114,14 @@ describe('funding-report helper', () => {
     });
 
     it('returns an empty list when no selected ids match the report', () => {
-      expect(aggregateMetricSummary(results, METRIC, [99], 'USER')).toEqual([]);
+      expect(aggregateMetricSummary(results, METRIC, [99])).toEqual([]);
     });
 
     it('yields a 0 delta when the aggregated baseline is 0', () => {
       const zeroBaseline = makeResults([project(1, 0, 50, 0)]);
-      expect(aggregateMetricSummary(zeroBaseline, METRIC, [1], 'USER')).toEqual(
-        [{ year: 0, value: 50, baseline: 0, delta: 0 }]
-      );
-    });
-
-    it('matches SYSTEM-origin selections against proj_id, not project_id', () => {
-      // project_id and proj_id diverge: selecting by proj_id picks a different
-      // point than the same id would under USER origin.
-      const systemResults = makeResults([
-        {
-          project_id: 10,
-          proj_id: 1,
-          year: 0,
-          value: 120,
-          baseline: 100,
-          delta: 20,
-        },
-        {
-          project_id: 20,
-          proj_id: 2,
-          year: 0,
-          value: 80,
-          baseline: 100,
-          delta: -20,
-        },
+      expect(aggregateMetricSummary(zeroBaseline, METRIC, [1])).toEqual([
+        { year: 0, value: 50, baseline: 0, delta: 0 },
       ]);
-      expect(
-        aggregateMetricSummary(systemResults, METRIC, [1], 'SYSTEM')
-      ).toEqual([{ year: 0, value: 120, baseline: 100, delta: 20 }]);
-      // The same id under USER origin matches nothing (no project_id === 1).
-      expect(
-        aggregateMetricSummary(systemResults, METRIC, [1], 'USER')
-      ).toEqual([]);
     });
   });
 
@@ -207,10 +176,10 @@ describe('funding-report helper', () => {
     };
 
     it('returns the selected interval summary when no areas are selected', () => {
-      expect(aggregateFlameLengthSummary(results, '7_4', [], 'USER')).toEqual([
+      expect(aggregateFlameLengthSummary(results, '7_4', [])).toEqual([
         { year: 0, value: 70, baseline: 100, delta: 70 },
       ]);
-      expect(aggregateFlameLengthSummary(results, '4_2', [], 'USER')).toEqual([
+      expect(aggregateFlameLengthSummary(results, '4_2', [])).toEqual([
         { year: 0, value: 40, baseline: 100, delta: 40 },
       ]);
     });
@@ -219,29 +188,25 @@ describe('funding-report helper', () => {
       // Filtering by project area sums value/baseline and recomputes the delta
       // as the share of total area reduced: 70 / 100 * 100 = 70 (not the
       // time-series percent-change formula).
-      expect(aggregateFlameLengthSummary(results, '7_4', [1], 'USER')).toEqual([
+      expect(aggregateFlameLengthSummary(results, '7_4', [1])).toEqual([
         { year: 0, value: 70, baseline: 100, delta: 70 },
       ]);
     });
 
     it('sums value and baseline across selected project areas before the delta', () => {
       // value = 70 + 30 = 100, baseline = 100 + 200 = 300, delta = 100/300*100.
-      expect(
-        aggregateFlameLengthSummary(results, '7_4', [1, 2], 'USER')
-      ).toEqual([
+      expect(aggregateFlameLengthSummary(results, '7_4', [1, 2])).toEqual([
         { year: 0, value: 100, baseline: 300, delta: (100 / 300) * 100 },
       ]);
     });
 
     it('returns an empty list for an interval the report has no data for', () => {
-      expect(aggregateFlameLengthSummary(results, '6_4', [], 'USER')).toEqual(
-        []
-      );
+      expect(aggregateFlameLengthSummary(results, '6_4', [])).toEqual([]);
     });
 
     it('reports whether the selected interval has data', () => {
-      expect(hasFlameLengthData(results, '7_4', [], 'USER')).toBeTrue();
-      expect(hasFlameLengthData(results, '6_4', [], 'USER')).toBeFalse();
+      expect(hasFlameLengthData(results, '7_4', [])).toBeTrue();
+      expect(hasFlameLengthData(results, '6_4', [])).toBeFalse();
     });
   });
 
@@ -264,21 +229,19 @@ describe('funding-report helper', () => {
 
     it('returns the whole-scenario summary when no areas are selected', () => {
       // passthrough — same reference, not a recompute
-      expect(aggregateBiomassVolumes(results, [], 'USER')).toBe(summary);
+      expect(aggregateBiomassVolumes(results, [])).toBe(summary);
     });
 
     it('sums each volume field across the selected project areas', () => {
-      expect(aggregateBiomassVolumes(results, [1, 2], 'USER')).toEqual(
-        biomass(13)
-      );
+      expect(aggregateBiomassVolumes(results, [1, 2])).toEqual(biomass(13));
     });
 
     it('sums only the selected project areas', () => {
-      expect(aggregateBiomassVolumes(results, [2], 'USER')).toEqual(biomass(3));
+      expect(aggregateBiomassVolumes(results, [2])).toEqual(biomass(3));
     });
 
     it('returns undefined when no selected ids match', () => {
-      expect(aggregateBiomassVolumes(results, [99], 'USER')).toBeUndefined();
+      expect(aggregateBiomassVolumes(results, [99])).toBeUndefined();
     });
 
     it('returns undefined when the report carries no biomass data', () => {
@@ -286,28 +249,227 @@ describe('funding-report helper', () => {
         summary: { ...empty },
         projects: { ...empty },
       };
-      expect(aggregateBiomassVolumes(noBiomass, [], 'USER')).toBeUndefined();
-      expect(aggregateBiomassVolumes(noBiomass, [1], 'USER')).toBeUndefined();
+      expect(aggregateBiomassVolumes(noBiomass, [])).toBeUndefined();
+      expect(aggregateBiomassVolumes(noBiomass, [1])).toBeUndefined();
     });
+  });
+});
 
-    it('matches SYSTEM-origin selections against proj_id, not project_id', () => {
-      const systemResults: FundingReportResults = {
-        summary: { ...empty, BIOMASS_VOLUMES: summary },
-        projects: {
-          ...empty,
-          BIOMASS_VOLUMES: [
-            { project_id: 10, proj_id: 1, ...biomass(10) },
-            { project_id: 20, proj_id: 2, ...biomass(3) },
-          ],
-        },
-      };
-      expect(aggregateBiomassVolumes(systemResults, [1], 'SYSTEM')).toEqual(
-        biomass(10)
-      );
-      // The same id under USER origin matches nothing (no project_id === 1).
-      expect(
-        aggregateBiomassVolumes(systemResults, [1], 'USER')
-      ).toBeUndefined();
+describe('calculateTreatmentAcreSums', () => {
+  it('should return empty array for empty input', () => {
+    const result = calculateTreatmentAcreSums([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should aggregate treatment acres from realistic input', () => {
+    const input = [
+      { 'No Treatment': 101, 'Thin and Rx Burn': 654 },
+      { 'Rx Burn': 444, 'No Treatment': 105, 'Thin and Rx Burn': 101 },
+      { 'Rx Burn': 555, 'No Treatment': 200, 'Thin and Rx Burn': 333 },
+    ] as Record<string, number>[];
+    const result = calculateTreatmentAcreSums(input);
+    expect(result).toEqual([
+      { treatment: 'No Treatment', acres: 406 },
+      { treatment: 'Rx Burn', acres: 999 },
+      { treatment: 'Thin and Rx Burn', acres: 1088 },
+    ]);
+  });
+});
+
+describe('generateLegendFromReport', () => {
+  const mockProjectAreas: ProjectArea[] = [
+    {
+      id: 1,
+      scenario: 666666,
+      name: 'Proj Area 1',
+      data: {
+        YR: 2026,
+        proj_id: 20001,
+        pct_area: 10,
+        area_acres: 500,
+        total_cost: 27000,
+        stand_count: 15,
+        pct_excluded: 1,
+        cost_per_acre: 2700,
+        treatment_rank: 1,
+        weightedPriority: 1,
+      },
+      geometry: MOCK_GEOMETRY,
+    },
+    {
+      id: 2,
+      scenario: 666666,
+      name: 'Proj Area 2',
+      data: {
+        YR: 2026,
+        proj_id: 20002,
+        pct_area: 20,
+        area_acres: 1000,
+        total_cost: 54000,
+        stand_count: 30,
+        pct_excluded: 2,
+        cost_per_acre: 2700,
+        treatment_rank: 2,
+        weightedPriority: 2,
+      },
+      geometry: MOCK_GEOMETRY,
+    },
+    {
+      id: 3,
+      scenario: 666666,
+      name: 'Proj Area 3',
+      data: {
+        YR: 2026,
+        proj_id: 20003,
+        pct_area: 15,
+        area_acres: 750,
+        total_cost: 40500,
+        stand_count: 22,
+        pct_excluded: 1.5,
+        cost_per_acre: 2700,
+        treatment_rank: 3,
+        weightedPriority: 1.5,
+      },
+      geometry: MOCK_GEOMETRY,
+    },
+    {
+      id: 4,
+      scenario: 777777,
+      name: 'Proj Area 4',
+      data: {
+        YR: 2027,
+        proj_id: 30001,
+        pct_area: 25,
+        area_acres: 1250,
+        total_cost: 67500,
+        stand_count: 35,
+        pct_excluded: 3,
+        cost_per_acre: 2700,
+        treatment_rank: 1,
+        weightedPriority: 3,
+      },
+      geometry: MOCK_GEOMETRY,
+    },
+  ];
+
+  // Mock treatment areas matching the project area IDs
+  const mockTreatmentAreas = {
+    total: {},
+    projects: {
+      '1': {
+        'Rx Burn': 157,
+        'No Treatment': 250,
+        'Thin and Rx Burn': 250,
+      },
+      '2': {
+        'No Treatment': 400,
+        'Rx Burn': 600,
+        'Thin and Rx Burn': 0,
+      },
+      '3': {
+        'No Treatment': 300,
+        'Rx Burn': 300,
+        'Thin and Rx Burn': 150,
+      },
+      '4': {
+        'Rx Burn': 21,
+        'No Treatment': 450,
+        'Thin and Rx Burn': 800,
+      },
+    },
+  };
+
+  const empty = {
+    POTENTIAL_SMOKE: [],
+    ABOVEGROUND_TOTAL: [],
+  };
+  const mockResults: FundingReportResults = {
+    summary: {
+      ...empty,
+      POTENTIAL_SMOKE: [{ year: 0, value: 999, baseline: 999, delta: 42 }],
+    },
+    projects: {
+      ...empty,
+      TOTAL_FLAME_SEVERITY: {
+        '7_4': [
+          {
+            project_id: 1,
+            proj_id: 1,
+            year: 0,
+            value: 70,
+            baseline: 100,
+            delta: 70,
+          },
+          {
+            project_id: 2,
+            proj_id: 2,
+            year: 0,
+            value: 30,
+            baseline: 200,
+            delta: 15,
+          },
+        ],
+        '4_2': [
+          {
+            project_id: 1,
+            proj_id: 1,
+            year: 0,
+            value: 40,
+            baseline: 100,
+            delta: 40,
+          },
+        ],
+      },
+    },
+    treatment_areas: mockTreatmentAreas,
+  };
+
+  it('should return zeros when results is null', () => {
+    const result = generateLegendFromReport(null, [1, 2], mockProjectAreas);
+    expect(result).toEqual({ selectedAcres: 0 });
+  });
+
+  it('should calculate selectedAcres from selected areas (ids 1 and 3: 500 + 750 = 1250)', () => {
+    const result = generateLegendFromReport(
+      mockResults,
+      [1, 3],
+      mockProjectAreas
+    );
+    expect(result.selectedAcres).toBe(1250);
+  });
+
+  it('should calculate treatment totals using mock treatment areas', () => {
+    const result = generateLegendFromReport(
+      mockResults,
+      [1, 2, 3, 4],
+      mockProjectAreas
+    );
+    expect(result).toEqual({
+      selectedAcres: 3500,
+      treatmentAcresTotals: [
+        { treatment: 'No Treatment', acres: 1400 },
+        { treatment: 'Rx Burn', acres: 1078 },
+        { treatment: 'Thin and Rx Burn', acres: 1200 },
+      ],
     });
+  });
+
+  it('should filter treatment results by selectedAreas (only ids 1 and 3)', () => {
+    const result = generateLegendFromReport(
+      mockResults,
+      [1, 3],
+      mockProjectAreas
+    );
+    expect(result.selectedAcres).toBe(1250);
+    expect(result.treatmentAcresTotals).toEqual([
+      { treatment: 'No Treatment', acres: 550 },
+      { treatment: 'Rx Burn', acres: 457 },
+      { treatment: 'Thin and Rx Burn', acres: 400 },
+    ]);
+  });
+
+  it('should select all areas when selectedAreas is empty', () => {
+    const result = generateLegendFromReport(mockResults, [], mockProjectAreas);
+    expect(result.selectedAcres).toBe(3500);
   });
 });

--- a/src/interface/src/app/funding/funding-report/funding-report.helper.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.helper.ts
@@ -5,19 +5,13 @@ import {
   FundingReportProjectDataPoint,
   FundingReportResults,
   FundingReportTimeSeriesMetric,
-  ORIGIN_TYPE,
+  ProjectArea,
 } from '@types';
-
-/**
- * The per-project field that selection ids are matched against. USER scenarios
- * select by project area id (`project_id`); SYSTEM scenarios select by the
- * 1-based project index / treatment rank (`proj_id`).
- */
-function projectIdKey(
-  origin: ORIGIN_TYPE
-): keyof Pick<FundingReportProjectDataPoint, 'project_id' | 'proj_id'> {
-  return origin === 'SYSTEM' ? 'proj_id' : 'project_id';
-}
+import {
+  FundingLegendData,
+  LegendTreatmentType,
+  TREATMENT_ORDER,
+} from '../funding-acreage-legend/funding-acreage-legend.component';
 
 /**
  * Percentage change after treatment for a year, mirroring the backend's
@@ -50,15 +44,13 @@ export function percentOfArea(value: number, baseline: number): number {
 function pointsHaveData(
   summary: FundingReportDataPoint[],
   projects: FundingReportProjectDataPoint[],
-  projectAreas: number[],
-  origin: ORIGIN_TYPE
+  projectAreas: number[]
 ): boolean {
-  const idKey = projectIdKey(origin);
   const points =
     projectAreas.length === 0
       ? summary
       : projects.filter((point) =>
-          projectAreas.includes(point[idKey] as number)
+          projectAreas.includes(point['project_id'] as number)
         );
   return points.some((point) => point.value !== null);
 }
@@ -76,13 +68,12 @@ function aggregateSummary(
   summary: FundingReportDataPoint[],
   projects: FundingReportProjectDataPoint[],
   projectAreas: number[],
-  origin: ORIGIN_TYPE,
   computeDelta: (value: number, baseline: number) => number = percentDelta
 ): FundingReportDataPoint[] {
   if (projectAreas.length === 0) {
     return summary;
   }
-  const idKey = projectIdKey(origin);
+  const idKey = 'project_id';
   const selected = new Set(projectAreas);
   const byYear = new Map<number, { value: number; baseline: number }>();
   for (const point of projects) {
@@ -108,14 +99,12 @@ function aggregateSummary(
 export function hasMetricData(
   results: FundingReportResults,
   metric: FundingReportTimeSeriesMetric,
-  projectAreas: number[],
-  origin: ORIGIN_TYPE
+  projectAreas: number[]
 ): boolean {
   return pointsHaveData(
     results.summary[metric],
     results.projects[metric],
-    projectAreas,
-    origin
+    projectAreas
   );
 }
 
@@ -123,14 +112,12 @@ export function hasMetricData(
 export function aggregateMetricSummary(
   results: FundingReportResults,
   metric: FundingReportTimeSeriesMetric,
-  projectAreas: number[],
-  origin: ORIGIN_TYPE
+  projectAreas: number[]
 ): FundingReportDataPoint[] {
   return aggregateSummary(
     results.summary[metric],
     results.projects[metric],
-    projectAreas,
-    origin
+    projectAreas
   );
 }
 
@@ -166,14 +153,12 @@ function flameProjectPoints(
 export function hasFlameLengthData(
   results: FundingReportResults,
   interval: FlameLengthInterval,
-  projectAreas: number[],
-  origin: ORIGIN_TYPE
+  projectAreas: number[]
 ): boolean {
   return pointsHaveData(
     flameSummaryPoints(results, interval),
     flameProjectPoints(results, interval),
-    projectAreas,
-    origin
+    projectAreas
   );
 }
 
@@ -186,14 +171,12 @@ export function hasFlameLengthData(
 export function aggregateFlameLengthSummary(
   results: FundingReportResults,
   interval: FlameLengthInterval,
-  projectAreas: number[],
-  origin: ORIGIN_TYPE
+  projectAreas: number[]
 ): FundingReportDataPoint[] {
   return aggregateSummary(
     flameSummaryPoints(results, interval),
     flameProjectPoints(results, interval),
     projectAreas,
-    origin,
     percentOfArea
   );
 }
@@ -212,8 +195,7 @@ export function aggregateFlameLengthSummary(
  */
 export function aggregateBiomassVolumes(
   results: FundingReportResults,
-  projectAreas: number[],
-  origin: ORIGIN_TYPE
+  projectAreas: number[]
 ): FundingReportBiomassVolumes | undefined {
   if (projectAreas.length === 0) {
     return results.summary.BIOMASS_VOLUMES;
@@ -222,7 +204,7 @@ export function aggregateBiomassVolumes(
   if (!projects) {
     return undefined;
   }
-  const idKey = projectIdKey(origin);
+  const idKey = 'project_id';
   const selected = new Set(projectAreas);
   const matches = projects.filter((project) =>
     selected.has(project[idKey] as number)
@@ -240,4 +222,72 @@ export function aggregateBiomassVolumes(
     non_merchantable_hardwood_cuft: sum('non_merchantable_hardwood_cuft'),
     non_merchantable_mixed_cuft: sum('non_merchantable_mixed_cuft'),
   };
+}
+
+export function generateLegendFromReport(
+  results: FundingReportResults | null,
+  selectedAreas: number[],
+  projectAreas: ProjectArea[]
+): FundingLegendData {
+  const legendData: FundingLegendData = { selectedAcres: 0 };
+  if (!results) {
+    return { selectedAcres: 0 };
+  }
+  const txAreas = results?.treatment_areas;
+
+  const selectedProjectAreas = projectAreas?.filter((f) => {
+    if (selectedAreas.length === 0) {
+      return f;
+    } else {
+      return selectedAreas.includes(f.id);
+    }
+  });
+
+  legendData.selectedAcres =
+    selectedProjectAreas?.reduce((sum, f) => {
+      return sum + (f.data.area_acres || 0);
+    }, 0) ?? 0;
+
+  // calculate dynamic totals
+  const selectedTreatmentResults = selectedProjectAreas.map(
+    (area) => txAreas?.projects[area.id]
+  );
+  legendData.treatmentAcresTotals = calculateTreatmentAcreSums(
+    selectedTreatmentResults
+  );
+  return legendData;
+}
+
+export function calculateTreatmentAcreSums(
+  selectedTreatmentResults: (Record<string, number | undefined> | undefined)[]
+): { treatment: LegendTreatmentType; acres: number }[] {
+  const totals: Record<string, number> = {};
+
+  selectedTreatmentResults.forEach((obj) => {
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const value = obj[key] || 0;
+        totals[key] = (totals[key] || 0) + value;
+      }
+    }
+  });
+
+  const treatmentAcresSums: {
+    treatment: LegendTreatmentType;
+    acres: number;
+  }[] = [];
+  for (const key in totals) {
+    if (Object.prototype.hasOwnProperty.call(totals, key)) {
+      treatmentAcresSums.push({
+        treatment: key as LegendTreatmentType,
+        acres: totals[key],
+      });
+    }
+  }
+
+  return treatmentAcresSums.sort(
+    (a, b) =>
+      TREATMENT_ORDER.indexOf(a.treatment) -
+      TREATMENT_ORDER.indexOf(b.treatment)
+  );
 }

--- a/src/interface/src/app/funding/funding-report/funding-report.helper.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.helper.ts
@@ -38,8 +38,7 @@ export function percentOfArea(value: number, baseline: number): number {
  * when nothing was computed; if every point is null the chart should be hidden.
  *
  * An empty `projectAreas` checks the whole-scenario summary; a non-empty list
- * checks only the selected project areas. `origin` decides which per-project
- * field the selection ids are matched against.
+ * checks only the selected project areas.
  */
 function pointsHaveData(
   summary: FundingReportDataPoint[],
@@ -61,8 +60,7 @@ function pointsHaveData(
  * An empty `projectAreas` means "all areas" and returns the precomputed
  * whole-scenario summary as-is. A non-empty list aggregates only those projects
  * the same way the backend builds the summary: sum value & baseline per year,
- * then recompute the percentage delta. `origin` decides which per-project field
- * the selection ids are matched against.
+ * then recompute the percentage delta.
  */
 function aggregateSummary(
   summary: FundingReportDataPoint[],
@@ -191,7 +189,6 @@ export function aggregateFlameLengthSummary(
  * already-converted per-area outputs yields the same totals.
  *
  * Returns `undefined` when no biomass data is available for the selection.
- * `origin` decides which per-project field the selection ids are matched against.
  */
 export function aggregateBiomassVolumes(
   results: FundingReportResults,

--- a/src/interface/src/app/funding/map-multi-project-areas/map-multi-project-areas.component.ts
+++ b/src/interface/src/app/funding/map-multi-project-areas/map-multi-project-areas.component.ts
@@ -146,14 +146,10 @@ export class MapMultiProjectAreasComponent implements OnInit {
       return;
 
     const ids = selectedIds || [];
-    let projectKey = 'rank';
-    if (this.scenarioOrigin === 'USER') {
-      projectKey = 'id';
-    }
     this.mapLibreMap.setPaintProperty(
       this.layers.projectAreasOutline.name,
       'line-width',
-      ['case', ['in', ['get', projectKey], ['literal', ids]], 6, 2]
+      ['case', ['in', ['get', 'id'], ['literal', ids]], 6, 2]
     );
   }
 
@@ -162,11 +158,7 @@ export class MapMultiProjectAreasComponent implements OnInit {
       return;
     }
     const proj = this.getProjectAreaFromFeatures(event.point);
-    let project_identifier = proj.properties['rank'];
-    if (this.scenarioOrigin === 'USER') {
-      project_identifier = proj.properties['id'];
-    }
-    this.fundingMapConfigState.toggleSelectedProjectArea(project_identifier);
+    this.fundingMapConfigState.toggleSelectedProjectArea(proj.properties['id']);
   }
 
   setCursor() {

--- a/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
+++ b/src/interface/src/app/treatments/direct-impacts-map/direct-impacts-map.component.html
@@ -54,6 +54,7 @@
 
   <app-action-button
     *ngIf="(showLegend$ | async) === false"
-    (clickedActionButton)="openTreatmentLegend()">
+    (clickedActionButton)="openTreatmentLegend()"
+    tooltipContent="Treatment Legend">
   </app-action-button>
 </mgl-map>

--- a/src/interface/src/app/treatments/map-action-button/map-action-button.component.html
+++ b/src/interface/src/app/treatments/map-action-button/map-action-button.component.html
@@ -4,9 +4,15 @@
       mat-icon-button
       type="button"
       (click)="handleClick()"
-      matTooltip="Treatment Legend"
+      [matTooltip]="tooltipContent"
       matTooltipPosition="below">
-      <mat-icon class="material-symbols-outlined">layers</mat-icon>
+      <mat-icon *ngIf="icon === 'layers'" class="material-symbols-outlined">{{
+        icon
+      }}</mat-icon>
+      <div
+        *ngIf="icon === 'legend-toggle'"
+        [style.mask-image]="'url(/assets/svg/icons/actions/legend_toggle.svg)'"
+        class="svg-icon icon"></div>
     </button>
   </div>
 </mgl-control>

--- a/src/interface/src/app/treatments/map-action-button/map-action-button.component.scss
+++ b/src/interface/src/app/treatments/map-action-button/map-action-button.component.scss
@@ -30,3 +30,17 @@ button {
     }
   }
 }
+
+.svg-icon {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  background-color: black;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}
+

--- a/src/interface/src/app/treatments/map-action-button/map-action-button.component.ts
+++ b/src/interface/src/app/treatments/map-action-button/map-action-button.component.ts
@@ -1,18 +1,21 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ControlComponent } from '@maplibre/ngx-maplibre-gl';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-action-button',
   standalone: true,
-  imports: [ControlComponent, MatIconModule, MatTooltipModule],
+  imports: [ControlComponent, MatIconModule, MatTooltipModule, NgIf],
   templateUrl: './map-action-button.component.html',
   styleUrl: './map-action-button.component.scss',
 })
 export class MapActionButtonComponent {
   constructor() {}
 
+  @Input() tooltipContent: string = '';
+  @Input() icon: 'layers' | 'legend-toggle' = 'layers';
   @Output() clickedActionButton = new EventEmitter();
 
   handleClick() {

--- a/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
+++ b/src/interface/src/app/treatments/treatment-map/treatment-map.component.html
@@ -52,7 +52,8 @@
       (standSelectionEnabled$ | async) === false &&
       (showLegend$ | async) === false
     "
-    (clickedActionButton)="openTreatmentLegend()">
+    (clickedActionButton)="openTreatmentLegend()"
+    tooltipContent="Treatment Legend">
   </app-action-button>
 
   <mgl-layer

--- a/src/interface/src/app/types/funding-report.ts
+++ b/src/interface/src/app/types/funding-report.ts
@@ -100,6 +100,11 @@ export interface FundingReportResults {
     TOTAL_FLAME_SEVERITY?: FlameLengthIntervalProjects;
     BIOMASS_VOLUMES?: FundingReportBiomassVolumesProject[];
   };
+
+  treatment_areas?: {
+    total: Record<string, Record<string, number>>;
+    projects: Record<string, Record<string, number>>;
+  };
 }
 
 // TODO full interface

--- a/src/interface/src/assets/svg/icons/actions/legend_toggle.svg
+++ b/src/interface/src/assets/svg/icons/actions/legend_toggle.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_2856_9036" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<rect width="24" height="24" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_2856_9036)">
+<path d="M4 19V17H20V19H4ZM4 15V13H20V15H4ZM4 11V8.65L10 5L15 8.55L20 5V7.45L15 11L9.925 7.4L4 11Z" fill="black"/>
+</g>
+</svg>


### PR DESCRIPTION
Adds a legend on the funding map and incorporates the latest endpoint.

(Note: a lot of the file changes here are specifically just to remove the proj_id vs project_id differences, which are obviated by the new data.)

I also realize the legend looks disproportionately large on this video, because I made the screen tiny, to keep the interactive elements all on one view.
https://github.com/user-attachments/assets/040e5bec-5be9-4451-858b-81d8a4f4a50e

