### PR TITLE
plan-3598-send-email-of-user-FOR-generation

### DIFF
--- a/src/planscape/funding_report/migrations/0004_fundingopportunityreportrun.py
+++ b/src/planscape/funding_report/migrations/0004_fundingopportunityreportrun.py
@@ -1,0 +1,55 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("funding_report", "0003_fundingopportunityreport_treatment_datalayer"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="FundingOpportunityReportRun",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, null=True)),
+                ("email", models.EmailField(blank=True, max_length=254)),
+                (
+                    "report",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="runs",
+                        to="funding_report.fundingopportunityreport",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="funding_opportunity_report_runs",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(
+                        fields=["created_at"], name="funding_rep_created_fa8374_idx"
+                    )
+                ],
+            },
+        ),
+    ]

--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -93,7 +93,9 @@ class FundingReportLayerCategory(models.TextChoices):
     WILDFIRE_RISK_REDUCTION = "wildfire_risk_reduction", "Wildfire Risk Reduction"
 
 
-FUNDING_REPORT_LAYER_CATEGORIES: Dict[FundingReportLayerKey, FundingReportLayerCategory] = {
+FUNDING_REPORT_LAYER_CATEGORIES: Dict[
+    FundingReportLayerKey, FundingReportLayerCategory
+] = {
     FundingReportLayerKey.BASELINE_ABOVEGROUND_CARBON_2026: FundingReportLayerCategory.CARBON,
     FundingReportLayerKey.BASELINE_SMOKE_PRODUCTION_2026: FundingReportLayerCategory.CARBON,
     FundingReportLayerKey.BASELINE_FLAME_LENGTH_2026: FundingReportLayerCategory.WILDFIRE_RISK_REDUCTION,
@@ -182,3 +184,31 @@ class FundingOpportunityReport(CreatedAtMixin, UpdatedAtMixin, models.Model):
 
     class Meta(TypedModelMeta):
         ordering = ["scenario", "-created_at"]
+
+
+class FundingOpportunityReportRun(CreatedAtMixin, models.Model):
+    id: int
+
+    report_id: int
+    report = models.ForeignKey(
+        FundingOpportunityReport,
+        related_name="runs",
+        on_delete=models.CASCADE,
+    )
+
+    user_id: Optional[int]
+    user = models.ForeignKey(
+        User,
+        related_name="funding_opportunity_report_runs",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+
+    email = models.EmailField(blank=True)
+
+    class Meta(TypedModelMeta):
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["created_at"]),
+        ]

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -1,10 +1,17 @@
 import logging
+from collections import Counter
 from datetime import timedelta
 
 from celery import chord
-from django.db import transaction
-from django.utils import timezone
 from datasets.models import DataLayer
+from django.conf import settings
+from django.core.mail import send_mail
+from django.db import transaction
+from django.template.loader import render_to_string
+from django.utils import timezone
+from planning.models import ProjectArea
+from planscape.celery import app
+
 from funding_report.models import (
     AET_IMPROVEMENT_DEFAULT_PERCENTAGE,
     FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
@@ -12,6 +19,7 @@ from funding_report.models import (
     FLAME_LENGTH_REDUCTION_INTERVALS,
     FUNDING_REPORT_YEARS,
     FundingOpportunityReport,
+    FundingOpportunityReportRun,
     FundingOpportunityReportStatus,
     FundingReportMetric,
 )
@@ -26,8 +34,6 @@ from funding_report.services import (
     generate_treatment_clip_datalayer,
     get_treatment_datalayer,
 )
-from planning.models import ProjectArea
-from planscape.celery import app
 
 log = logging.getLogger(__name__)
 
@@ -106,9 +112,7 @@ def async_generate_treatment_datalayer(
         return None
 
     try:
-        report = FundingOpportunityReport.objects.get(
-            pk=funding_opportunity_report_id
-        )
+        report = FundingOpportunityReport.objects.get(pk=funding_opportunity_report_id)
         datalayer = generate_treatment_clip_datalayer(report=report)
         return {"kind": "treatment_datalayer", "datalayer_id": datalayer.pk}
     except Exception as exc:
@@ -132,9 +136,7 @@ def async_calculate_treatment_areas(
         return None
 
     try:
-        report = FundingOpportunityReport.objects.get(
-            pk=funding_opportunity_report_id
-        )
+        report = FundingOpportunityReport.objects.get(pk=funding_opportunity_report_id)
         result = calculate_treatment_pixel_areas(report=report)
         return {"kind": "treatment_areas", **result}
     except Exception as exc:
@@ -202,7 +204,10 @@ def async_finalize_funding_report_results(
             case "treatment_datalayer":
                 treatment_datalayer_id = result["datalayer_id"]
             case "treatment_areas":
-                treatment_areas = {"projects": result["projects"], "total": result["total"]}
+                treatment_areas = {
+                    "projects": result["projects"],
+                    "total": result["total"],
+                }
             case "aet_improvement":
                 aet_improvement = result
             case "biomass_volumes":
@@ -276,7 +281,9 @@ def run_funding_opportunity_report(funding_opportunity_report_id: int) -> None:
             return
         report.status = FundingOpportunityReportStatus.RUNNING
         report.save(update_fields=["status", "updated_at"])
-        project_area_ids = list(report.scenario.project_areas.values_list("id", flat=True))
+        project_area_ids = list(
+            report.scenario.project_areas.values_list("id", flat=True)
+        )
 
     try:
         if not project_area_ids:
@@ -355,3 +362,54 @@ def run_funding_opportunity_report(funding_opportunity_report_id: int) -> None:
             pk=funding_opportunity_report_id
         ).update(status=FundingOpportunityReportStatus.FAILED)
         raise
+
+
+@app.task()
+def send_weekly_funding_report_users_report() -> None:
+    recipient_email = settings.WEEKLY_FUNDING_REPORT_USERS_REPORT_EMAIL
+    if not recipient_email:
+        log.warning("No recipient configured for weekly funding report users report.")
+        return
+
+    end = timezone.now()
+    start = end - timedelta(days=7)
+
+    emails = FundingOpportunityReportRun.objects.filter(
+        created_at__gte=start,
+        created_at__lt=end,
+    ).values_list("email", flat=True)
+
+    email_counts = Counter(
+        email.strip().lower() for email in emails if email and email.strip()
+    )
+
+    rows = [
+        {"email": email, "count": count}
+        for email, count in sorted(email_counts.items())
+    ]
+
+    context = {
+        "start": start,
+        "end": end,
+        "rows": rows,
+        "total_runs": sum(email_counts.values()),
+        "unique_users": len(rows),
+    }
+
+    subject = "Weekly Planscape Funding Report Users"
+    txt = render_to_string(
+        "email/funding_report/weekly_report_users.txt",
+        context,
+    )
+    html = render_to_string(
+        "email/funding_report/weekly_report_users.html",
+        context,
+    )
+
+    send_mail(
+        subject=subject,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[recipient_email],
+        message=txt,
+        html_message=html,
+    )

--- a/src/planscape/funding_report/tests/test_tasks.py
+++ b/src/planscape/funding_report/tests/test_tasks.py
@@ -3,7 +3,8 @@ from unittest import mock
 
 from datasets.models import DataLayerType
 from datasets.tests.factories import DataLayerFactory
-from django.test import TestCase
+from django.conf import settings
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from planning.tests.factories import (
     PlanningAreaFactory,
@@ -18,6 +19,7 @@ from funding_report.models import (
     FLAME_LENGTH_REDUCTION_INTERVALS,
     FUNDING_REPORT_YEARS,
     FundingOpportunityReport,
+    FundingOpportunityReportRun,
     FundingOpportunityReportStatus,
     FundingReportMetric,
 )
@@ -26,6 +28,7 @@ from funding_report.tasks import (
     async_calculate_funding_report_delta,
     async_finalize_funding_report_results,
     run_funding_opportunity_report,
+    send_weekly_funding_report_users_report,
 )
 
 
@@ -96,7 +99,11 @@ class FundingOpportunityReportTaskTest(TestCase):
             metric=FundingReportMetric.ABOVEGROUND_TOTAL.value,
             year=2026,
             datalayer_lookup={
-                (FundingReportMetric.ABOVEGROUND_TOTAL.value, 2026, True): baseline_layer,
+                (
+                    FundingReportMetric.ABOVEGROUND_TOTAL.value,
+                    2026,
+                    True,
+                ): baseline_layer,
                 (FundingReportMetric.ABOVEGROUND_TOTAL.value, 2026, False): value_layer,
             },
             from_ft=FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT,
@@ -137,8 +144,16 @@ class FundingOpportunityReportTaskTest(TestCase):
             metric=FundingReportMetric.TOTAL_FLAME_SEVERITY.value,
             year=2026,
             datalayer_lookup={
-                (FundingReportMetric.TOTAL_FLAME_SEVERITY.value, 2026, True): baseline_layer,
-                (FundingReportMetric.TOTAL_FLAME_SEVERITY.value, 2026, False): value_layer,
+                (
+                    FundingReportMetric.TOTAL_FLAME_SEVERITY.value,
+                    2026,
+                    True,
+                ): baseline_layer,
+                (
+                    FundingReportMetric.TOTAL_FLAME_SEVERITY.value,
+                    2026,
+                    False,
+                ): value_layer,
             },
             from_ft=6.0,
             to_ft=4.0,
@@ -255,7 +270,9 @@ class FundingOpportunityReportTaskTest(TestCase):
             results["summary"][FundingReportMetric.ABOVEGROUND_TOTAL],
             [{"year": 2026, "value": 10, "baseline": 8, "delta": 25.0}],
         )
-        self.assertNotIn("raw_value", results["summary"][FundingReportMetric.ABOVEGROUND_TOTAL][0])
+        self.assertNotIn(
+            "raw_value", results["summary"][FundingReportMetric.ABOVEGROUND_TOTAL][0]
+        )
 
         flame_summary = results["summary"]["TOTAL_FLAME_SEVERITY"]
         flame_projects = results["projects"]["TOTAL_FLAME_SEVERITY"]
@@ -266,12 +283,16 @@ class FundingOpportunityReportTaskTest(TestCase):
         self.assertEqual(seven_four_summary["value"], 10)
         self.assertEqual(seven_four_summary["baseline"], 40)
         self.assertEqual(seven_four_summary["raw_value"], seven_four_summary["value"])
-        self.assertEqual(seven_four_summary["total_area"], seven_four_summary["baseline"])
+        self.assertEqual(
+            seven_four_summary["total_area"], seven_four_summary["baseline"]
+        )
 
         seven_four_project = flame_projects["7_4"][0]
         self.assertEqual(seven_four_project["project_id"], self.project_area.pk)
         self.assertEqual(seven_four_project["raw_value"], seven_four_project["value"])
-        self.assertEqual(seven_four_project["total_area"], seven_four_project["baseline"])
+        self.assertEqual(
+            seven_four_project["total_area"], seven_four_project["baseline"]
+        )
 
         six_four_summary = flame_summary["6_4"][0]
         self.assertEqual(six_four_summary["value"], 5)
@@ -341,19 +362,28 @@ class FundingOpportunityReportTaskTest(TestCase):
         flame_tasks = [
             task
             for task in tasks
-            if task.kwargs.get("metric") == FundingReportMetric.TOTAL_FLAME_SEVERITY.value
+            if task.kwargs.get("metric")
+            == FundingReportMetric.TOTAL_FLAME_SEVERITY.value
         ]
-        self.assertEqual(len(flame_tasks), len(FUNDING_REPORT_YEARS) * len(FLAME_LENGTH_REDUCTION_INTERVALS))
-        intervals_used = {(task.kwargs["from_ft"], task.kwargs["to_ft"]) for task in flame_tasks}
+        self.assertEqual(
+            len(flame_tasks),
+            len(FUNDING_REPORT_YEARS) * len(FLAME_LENGTH_REDUCTION_INTERVALS),
+        )
+        intervals_used = {
+            (task.kwargs["from_ft"], task.kwargs["to_ft"]) for task in flame_tasks
+        }
         self.assertEqual(intervals_used, set(FLAME_LENGTH_REDUCTION_INTERVALS))
 
         non_flame_tasks = [
             task
             for task in tasks
-            if task.kwargs.get("metric") not in (None, FundingReportMetric.TOTAL_FLAME_SEVERITY.value)
+            if task.kwargs.get("metric")
+            not in (None, FundingReportMetric.TOTAL_FLAME_SEVERITY.value)
         ]
         for task in non_flame_tasks:
-            self.assertEqual(task.kwargs["from_ft"], FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT)
+            self.assertEqual(
+                task.kwargs["from_ft"], FLAME_LENGTH_REDUCTION_DEFAULT_FROM_FT
+            )
             self.assertEqual(task.kwargs["to_ft"], FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT)
 
     @mock.patch("funding_report.tasks.chord")
@@ -399,3 +429,54 @@ class FundingOpportunityReportTaskTest(TestCase):
         chord_mock.assert_called_once()
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, FundingOpportunityReportStatus.RUNNING)
+
+    @override_settings(
+        WEEKLY_FUNDING_REPORT_USERS_REPORT_EMAIL="signups@planscape.org",
+    )
+    @mock.patch("funding_report.tasks.send_mail")
+    def test_send_weekly_funding_report_users_report(self, send_mail_mock):
+        FundingOpportunityReportRun.objects.create(
+            report=self.report,
+            user=self.user,
+            email="planner@example.com",
+        )
+        FundingOpportunityReportRun.objects.create(
+            report=self.report,
+            user=self.user,
+            email="planner@example.com",
+        )
+        FundingOpportunityReportRun.objects.create(
+            report=self.report,
+            user=self.user,
+            email="other@example.com",
+        )
+
+        send_weekly_funding_report_users_report()
+
+        send_mail_mock.assert_called_once()
+        kwargs = send_mail_mock.call_args.kwargs
+
+        self.assertEqual(kwargs["recipient_list"], ["signups@planscape.org"])
+        self.assertEqual(kwargs["from_email"], settings.DEFAULT_FROM_EMAIL)
+        self.assertIn("Weekly Planscape Funding Report Users", kwargs["subject"])
+        self.assertIn("planner@example.com", kwargs["message"])
+        self.assertIn("other@example.com", kwargs["message"])
+        self.assertIn("(2 reports)", kwargs["message"])
+        self.assertIn("planner@example.com", kwargs["html_message"])
+        self.assertIn("other@example.com", kwargs["html_message"])
+
+    @override_settings(WEEKLY_FUNDING_REPORT_USERS_REPORT_EMAIL="")
+    @mock.patch("funding_report.tasks.send_mail")
+    def test_send_weekly_funding_report_users_report_skips_without_recipient(
+        self,
+        send_mail_mock,
+    ):
+        FundingOpportunityReportRun.objects.create(
+            report=self.report,
+            user=self.user,
+            email="planner@example.com",
+        )
+
+        send_weekly_funding_report_users_report()
+
+        send_mail_mock.assert_not_called()

--- a/src/planscape/funding_report/tests/test_views.py
+++ b/src/planscape/funding_report/tests/test_views.py
@@ -10,6 +10,7 @@ from rest_framework.test import APITestCase
 
 from funding_report.models import (
     FundingOpportunityReport,
+    FundingOpportunityReportRun,
     FundingOpportunityReportStatus,
 )
 
@@ -59,10 +60,38 @@ class RunReportTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(FundingOpportunityReport.objects.count(), 1)
+
         report = FundingOpportunityReport.objects.get()
         self.assertEqual(report.scenario, self.scenario)
         self.assertEqual(report.created_by, self.user)
+
+        report_run = FundingOpportunityReportRun.objects.get()
+        self.assertEqual(report_run.report, report)
+        self.assertEqual(report_run.user, self.user)
+        self.assertEqual(report_run.email, self.user.email)
+
         task_mock.delay.assert_called_once_with(report.pk)
+
+    @mock.patch("planning.views_v2.run_funding_opportunity_report")
+    def test_run_report_reuses_existing_report_and_tracks_new_run(self, task_mock):
+        existing = FundingOpportunityReport.objects.create(
+            scenario=self.scenario,
+            created_by=self.user,
+        )
+
+        self.client.force_authenticate(self.user)
+        response = self.client.post(self.url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(FundingOpportunityReport.objects.count(), 1)
+        self.assertEqual(FundingOpportunityReportRun.objects.count(), 1)
+
+        report_run = FundingOpportunityReportRun.objects.get()
+        self.assertEqual(report_run.report, existing)
+        self.assertEqual(report_run.user, self.user)
+        self.assertEqual(report_run.email, self.user.email)
+
+        task_mock.delay.assert_called_once_with(existing.pk)
 
     @mock.patch("planning.views_v2.run_funding_opportunity_report")
     def test_run_report_reuses_existing_report(self, task_mock):

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -3,12 +3,34 @@ import logging
 from core.serializers import MultiSerializerMixin
 from datasets.models import DataLayer
 from django.contrib.auth import get_user_model
-from django.shortcuts import get_object_or_404
 from django.db.models import Q
 from django.db.models.expressions import RawSQL
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from funding_report.models import (
+    FundingOpportunityReport,
+    FundingOpportunityReportRun,
+    FundingOpportunityReportStatus,
+)
+from funding_report.openapi_examples import (
+    FLAME_LENGTH_REDUCTION_RESPONSE_EXAMPLE,
+    FUNDING_OPPORTUNITY_REPORT_RESPONSE_EXAMPLE,
+)
+from funding_report.serializers import (
+    FundingOpportunityReportSerializer,
+    FundingReportAETImprovementRequestSerializer,
+    FundingReportAETImprovementResponseSerializer,
+    FundingReportFlameLengthReductionRequestSerializer,
+    FundingReportFlameLengthReductionResponseSerializer,
+)
+from funding_report.services import (
+    calculate_aet_improvement,
+    calculate_funding_report_flame_length_reduction,
+)
+from funding_report.tasks import run_funding_opportunity_report
+from modules.base import compute_scenario_capabilities
 from planscape.serializers import BaseErrorMessageSerializer
 from rest_framework import mixins, pagination, permissions, status, viewsets
 from rest_framework.decorators import action
@@ -55,27 +77,6 @@ from planning.serializers import (
     UpsertConfigurationV2Serializer,
     UpsertScenarioV3Serializer,
 )
-from funding_report.models import (
-    FundingOpportunityReport,
-    FundingOpportunityReportStatus,
-)
-from funding_report.openapi_examples import (
-    FLAME_LENGTH_REDUCTION_RESPONSE_EXAMPLE,
-    FUNDING_OPPORTUNITY_REPORT_RESPONSE_EXAMPLE,
-)
-from funding_report.serializers import (
-    FundingOpportunityReportSerializer,
-    FundingReportAETImprovementRequestSerializer,
-    FundingReportAETImprovementResponseSerializer,
-    FundingReportFlameLengthReductionRequestSerializer,
-    FundingReportFlameLengthReductionResponseSerializer,
-)
-from funding_report.services import (
-    calculate_aet_improvement,
-    calculate_funding_report_flame_length_reduction,
-)
-from funding_report.tasks import run_funding_opportunity_report
-from modules.base import compute_scenario_capabilities
 from planning.services import (
     create_config,
     create_planning_area,
@@ -431,6 +432,13 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             scenario=scenario,
             defaults={"created_by": request.user},
         )
+
+        FundingOpportunityReportRun.objects.create(
+            report=report,
+            user=request.user,
+            email=request.user.email or "",
+        )
+
         run_funding_opportunity_report.delay(report.pk)
         serializer = FundingOpportunityReportSerializer(instance=report)
         return Response(serializer.data, status=status.HTTP_202_ACCEPTED)

--- a/src/planscape/planscape/celery.py
+++ b/src/planscape/planscape/celery.py
@@ -80,6 +80,12 @@ if settings.WEEKLY_NEW_USERS_REPORT_ENABLED:
         "schedule": crontab(day_of_week="monday", hour=13, minute=0),
     }
 
+if settings.WEEKLY_FUNDING_REPORT_USERS_REPORT_ENABLED:
+    beat_schedule["send-weekly-funding-report-users-report"] = {
+        "task": "funding_report.tasks.send_weekly_funding_report_users_report",
+        "schedule": crontab(day_of_week="monday", hour=13, minute=0),
+    }
+
 beat_schedule.update(get_catalog_backup_schedule())
 beat_schedule.update(get_catalog_restore_schedule())
 beat_schedule.update(get_forisk_mills_schedule())

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -535,6 +535,17 @@ WEEKLY_NEW_USERS_REPORT_EMAIL = config(
     default="signups@planscape.org",
 )
 
+WEEKLY_FUNDING_REPORT_USERS_REPORT_ENABLED = config(
+    "WEEKLY_FUNDING_REPORT_USERS_REPORT_ENABLED",
+    default=False,
+    cast=bool,
+)
+
+WEEKLY_FUNDING_REPORT_USERS_REPORT_EMAIL = config(
+    "WEEKLY_FUNDING_REPORT_USERS_REPORT_EMAIL",
+    default="signups@planscape.org",
+)
+
 AREA_SRID = 5070
 # Global hex grid origin (EPSG:5070) used to align ALL dynamic stands
 HEX_GRID_ORIGIN_X = config("HEX_GRID_ORIGIN_X", default=-2356881.4306262177, cast=float)

--- a/src/planscape/templates/email/funding_report/weekly_report_users.html
+++ b/src/planscape/templates/email/funding_report/weekly_report_users.html
@@ -1,0 +1,26 @@
+<p>Weekly Planscape Funding Report Users</p>
+
+<p>
+  <strong>Date range:</strong><br />
+  {{ start }} to {{ end }}
+</p>
+
+<p>
+  <strong>Total report generations:</strong> {{ total_runs }}<br />
+  <strong>Unique users:</strong> {{ unique_users }}
+</p>
+
+{% if rows %}
+<ul>
+  {% for row in rows %}
+    <li>
+      {{ row.email }}
+      {% if row.count > 1 %}
+        ({{ row.count }} reports)
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No users generated funding reports this week.</p>
+{% endif %}

--- a/src/planscape/templates/email/funding_report/weekly_report_users.txt
+++ b/src/planscape/templates/email/funding_report/weekly_report_users.txt
@@ -1,0 +1,16 @@
+Weekly Planscape Funding Report Users
+
+Date range:
+{{ start }} to {{ end }}
+
+Total report generations: {{ total_runs }}
+Unique users: {{ unique_users }}
+
+{% if rows %}
+Users:
+{% for row in rows %}
+- {{ row.email }}{% if row.count > 1 %} ({{ row.count }} reports){% endif %}
+{% endfor %}
+{% else %}
+No users generated funding reports this week.
+{% endif %}


### PR DESCRIPTION
@george-silva @roquebetioljr, Track emails of users that generate report and send weekly email to Rob/Abby, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3598:

1. `src/planscape/funding_report/models.py`: added `FundingOpportunityReportRun` to track each report generation email.
2. `src/planscape/funding_report/migrations/0004_fundingopportunityreportrun.py`: added migration for the new report-run tracking table.
3. `src/planscape/planning/views_v2.py`: created a tracking row whenever a user generates a funding report.
4. `src/planscape/funding_report/tasks.py`: added weekly email task for funding report generator emails.
5. `src/planscape/planscape/settings.py`: added weekly funding report email recipient and enabled flag settings.
6. `src/planscape/planscape/celery.py`: scheduled the weekly funding report users email task.
7. `src/planscape/templates/email/funding_report/weekly_report_users.txt`: added plain-text weekly email template.
8. `src/planscape/templates/email/funding_report/weekly_report_users.html`: added HTML weekly email template.
9. `src/planscape/funding_report/tests/test_views.py`: added test coverage for tracking report generation emails.
10. `src/planscape/funding_report/tests/test_tasks.py`: added test coverage for the weekly funding report users email task.

---------------------

I made a new model in funding_report to track whenever a user generates a funding opportunity report, and a task to send those users to the signups@planscape.org e-mail every week.
