### PR TITLE
Show only AET percentual change layer in funding report

### DIFF
--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -80,6 +80,7 @@ class FundingReportLayerKey(models.TextChoices):
     )
     AET_BASELINE = "aet_baseline", "AET Baseline"
     AET_TARGET = "aet_target", "AET Target"
+    AET_PERCENTUAL_CHANGE = "aet_percentual_change", "AET Percentual Change"
     MILLS_AND_OTHER_BIOMASS_FACILITIES = (
         "mills_and_other_biomass_facilities",
         "Mills & Other Biomass Facilities",
@@ -101,6 +102,7 @@ FUNDING_REPORT_LAYER_CATEGORIES: Dict[
     FundingReportLayerKey.BASELINE_FLAME_LENGTH_2026: FundingReportLayerCategory.WILDFIRE_RISK_REDUCTION,
     FundingReportLayerKey.AET_BASELINE: FundingReportLayerCategory.WATER,
     FundingReportLayerKey.AET_TARGET: FundingReportLayerCategory.WATER,
+    FundingReportLayerKey.AET_PERCENTUAL_CHANGE: FundingReportLayerCategory.WATER,
     FundingReportLayerKey.MILLS_AND_OTHER_BIOMASS_FACILITIES: FundingReportLayerCategory.BIOMASS,
 }
 

--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -58,6 +58,7 @@ AET_VARIABLE = "AET"
 AET_DELTA_ROLE = "delta"
 AET_BASELINE_ROLE = "baseline"
 AET_TARGET_ROLE = "target"
+AET_PERCENTUAL_ROLE = "percentual"
 
 
 def build_datalayer_lookup() -> Dict[Tuple[str, int, bool], DataLayer]:
@@ -135,6 +136,10 @@ def get_aet_target_datalayer() -> DataLayer | None:
     return _get_aet_role_datalayer(AET_TARGET_ROLE)
 
 
+def get_aet_percentual_datalayer() -> DataLayer | None:
+    return _get_aet_role_datalayer(AET_PERCENTUAL_ROLE)
+
+
 def get_mills_datalayers() -> List[DataLayer]:
     return list(
         DataLayer.objects.filter(dataset__name=settings.FORISK_MILLS_DATASET_NAME)
@@ -157,8 +162,9 @@ def get_funding_report_layers_of_interest() -> Dict[str, List[DataLayer]]:
         FundingReportLayerKey.BASELINE_FLAME_LENGTH_2026: _as_list(
             lookup.get((FundingReportMetric.TOTAL_FLAME_SEVERITY.value, 2026, True))
         ),
-        FundingReportLayerKey.AET_BASELINE: _as_list(get_aet_baseline_datalayer()),
-        FundingReportLayerKey.AET_TARGET: _as_list(get_aet_target_datalayer()),
+        FundingReportLayerKey.AET_PERCENTUAL_CHANGE: _as_list(
+            get_aet_percentual_datalayer()
+        ),
         FundingReportLayerKey.MILLS_AND_OTHER_BIOMASS_FACILITIES: get_mills_datalayers(),
     }
 

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -892,8 +892,7 @@ class FundingReportLayersOfInterestTest(TestCase):
         flame = self.create_funding_report_datalayer(
             FundingReportMetric.TOTAL_FLAME_SEVERITY, 2026, True
         )
-        aet_baseline = self.create_aet_datalayer("baseline")
-        aet_target = self.create_aet_datalayer("target")
+        aet_percentual = self.create_aet_datalayer("percentual")
 
         mills_dataset = DatasetFactory.create(name=settings.FORISK_MILLS_DATASET_NAME)
         mill_layer_1 = DataLayerFactory.create(dataset=mills_dataset)
@@ -907,7 +906,7 @@ class FundingReportLayersOfInterestTest(TestCase):
         )
         self.assertCountEqual(
             result[FundingReportLayerCategory.WATER],
-            [aet_baseline, aet_target],
+            [aet_percentual],
         )
         self.assertEqual(
             result[FundingReportLayerCategory.WILDFIRE_RISK_REDUCTION], [flame]

--- a/src/planscape/modules/tests/test_modules.py
+++ b/src/planscape/modules/tests/test_modules.py
@@ -450,8 +450,7 @@ class FundingReportModuleTest(TestCase):
         flame = self.create_funding_report_datalayer(
             FundingReportMetric.TOTAL_FLAME_SEVERITY, 2026, True
         )
-        aet_baseline = self.create_aet_datalayer("baseline")
-        aet_target = self.create_aet_datalayer("target")
+        aet_percentual = self.create_aet_datalayer("percentual")
 
         mills_dataset = DatasetFactory.create(name=settings.FORISK_MILLS_DATASET_NAME)
         mill_layer = DataLayerFactory.create(dataset=mills_dataset)
@@ -473,7 +472,7 @@ class FundingReportModuleTest(TestCase):
             datalayers[FundingReportLayerCategory.WILDFIRE_RISK_REDUCTION], [flame]
         )
         self.assertCountEqual(
-            datalayers[FundingReportLayerCategory.WATER], [aet_baseline, aet_target]
+            datalayers[FundingReportLayerCategory.WATER], [aet_percentual]
         )
         self.assertEqual(
             datalayers[FundingReportLayerCategory.BIOMASS],


### PR DESCRIPTION
Funding report was showing two AET water layers (baseline + target). Now shows one: AET percentual change.