### PR TITLE
add layer legend to funding map

### DIFF
--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
@@ -59,6 +59,10 @@
     >Click project area to select</app-map-tooltip
   >
 
+  <mgl-control position="top-left">
+    <app-map-layer-color-legend></app-map-layer-color-legend>
+  </mgl-control>
+
   <mgl-control position="top-right" *ngIf="allowInteraction">
     <app-action-button
       *ngIf="(showFundingLegend$ | async) === false"

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.scss
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.scss
@@ -22,11 +22,15 @@ mgl-map {
   min-width: 0;
 }
 
-:host ::ng-deep .maplibregl-ctrl-top-right .maplibregl-ctrl {
- top: 60px;
- position: relative;
+:host ::ng-deep {
+  .maplibregl-ctrl-top-right,
+  .maplibregl-ctrl-top-left {
+    .maplibregl-ctrl {
+      top: 60px;
+      position: relative;
+    }
+  }
 }
-
 
 .selected-layer-control {
   border-top-right-radius: 8px;

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
@@ -41,6 +41,7 @@ import {
   FundingLegendData,
 } from '../funding-acreage-legend/funding-acreage-legend.component';
 import { MapActionButtonComponent } from '@app/treatments/map-action-button/map-action-button.component';
+import { MapLayerColorLegendComponent } from '@app/maplibre-map/map-layer-color-legend/map-layer-color-legend.component';
 
 @Component({
   selector: 'app-funding-report-map',
@@ -56,6 +57,7 @@ import { MapActionButtonComponent } from '@app/treatments/map-action-button/map-
     MapBaseLayersComponent,
     MapDataLayerComponent,
     MapComponent,
+    MapLayerColorLegendComponent,
     MapMultiProjectAreasComponent,
     MapTooltipComponent,
     MapZoomControlComponent,

--- a/src/interface/src/app/funding/map-multi-project-areas/map-multi-project-areas.component.ts
+++ b/src/interface/src/app/funding/map-multi-project-areas/map-multi-project-areas.component.ts
@@ -151,6 +151,13 @@ export class MapMultiProjectAreasComponent implements OnInit {
       'line-width',
       ['case', ['in', ['get', 'id'], ['literal', ids]], 6, 2]
     );
+
+    // Set the line color to green
+    this.mapLibreMap.setPaintProperty(
+      this.layers.projectAreasOutline.name,
+      'line-color',
+      BASE_COLORS.dark_green
+    );
   }
 
   handleLayerClick(event: MapMouseEvent) {

--- a/src/interface/src/app/maplibre-map/map-layer-color-legend/map-layer-color-legend.component.scss
+++ b/src/interface/src/app/maplibre-map/map-layer-color-legend/map-layer-color-legend.component.scss
@@ -10,10 +10,9 @@
 .layer-color-legend {
   border-radius: 4px;
   border: 1px solid #000;
-  background: rgba($color-black, 0.55);
-  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
-  backdrop-filter: blur(2px);
-  display: flex;
+  background: rgba(42, 42, 42, 0.9);
+  backdrop-filter: blur(10px);
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);  display: flex;
   padding: 16px;
   flex-direction: column;
   align-items: flex-start;

--- a/src/interface/src/app/treatments/map.styles.ts
+++ b/src/interface/src/app/treatments/map.styles.ts
@@ -21,6 +21,7 @@ export const BASE_COLORS = {
   darker_magenta: '#860747',
   dark_gray: '#646464',
   light_gray: '#909090',
+  dark_green: '#344F42',
 } as const;
 
 export const SELECTED_STANDS_PAINT = {


### PR DESCRIPTION
Adds a layer legend, updated the background treatment to current designs.

<img width="464" height="386" alt="Screenshot 2026-07-08 at 9 11 44 AM" src="https://github.com/user-attachments/assets/8dcde998-0cd4-4898-ad28-621b66090c29" />

Also -- unrelated small edit: the selected border for project areas should actually be a dark green, so I took the liberty to update that here.
