### PR TITLE
plan-3757-3758-3759-add-project-areas-scenario-type-and-child-scenario-endpoint-support

### DIFF
--- a/src/planscape/planning/migrations/0092_scenario_parent_alter_scenario_type.py
+++ b/src/planscape/planning/migrations/0092_scenario_parent_alter_scenario_type.py
@@ -1,0 +1,60 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def backfill_project_area_scenarios(apps, schema_editor):
+    Scenario = apps.get_model("planning", "Scenario")
+    ProjectArea = apps.get_model("planning", "ProjectArea")
+
+    scenario_ids = (
+        ProjectArea.objects.filter(scenario__origin="USER")
+        .values_list("scenario_id", flat=True)
+        .distinct()
+    )
+
+    Scenario.objects.filter(pk__in=scenario_ids).update(type="PROJECT_AREAS")
+
+
+def reverse_backfill_project_area_scenarios(apps, schema_editor):
+    Scenario = apps.get_model("planning", "Scenario")
+    Scenario.objects.filter(type="PROJECT_AREAS").update(type=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("planning", "0091_scenario_treatable_area"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="scenario",
+            name="parent",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Parent Scenario for child Prioritization Scenarios.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="children",
+                to="planning.scenario",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="scenario",
+            name="type",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("PRESET", "Preset"),
+                    ("CUSTOM", "Custom"),
+                    ("PROJECT_AREAS", "Project Areas"),
+                ],
+                help_text="Scenario type.",
+                max_length=16,
+                null=True,
+            ),
+        ),
+        migrations.RunPython(
+            backfill_project_area_scenarios,
+            reverse_backfill_project_area_scenarios,
+        ),
+    ]

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -235,6 +235,7 @@ class ScenarioOrigin(models.TextChoices):
 class ScenarioType(models.TextChoices):
     PRESET = "PRESET", "Preset"
     CUSTOM = "CUSTOM", "Custom"
+    PROJECT_AREAS = "PROJECT_AREAS", "Project Areas"
 
 
 class ScenarioVersion(models.TextChoices):
@@ -450,6 +451,14 @@ class Scenario(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
         blank=True,
         help_text="User ID that created the Scenario.",
     )
+    parent = models.ForeignKey(
+        "self",
+        related_name="children",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        help_text="Parent Scenario for child Prioritization Scenarios.",
+    )
 
     name = models.CharField(max_length=120, help_text="Name of the Scenario.")
 
@@ -590,7 +599,7 @@ class Scenario(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
         if not project_areas_geometry:
             return Stand.objects.none()
         return Stand.objects.within_polygon(project_areas_geometry, size)
-    
+
     def get_treatable_area_stands(self, stand_size=None) -> QuerySet[Stand]:
         if not self.treatable_area:
             return Stand.objects.none()

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -596,6 +596,7 @@ class TargetsSerializer(serializers.Serializer):
 
         return super().validate(attrs)
 
+
 class WeighedPriorityObjectiveField(serializers.Serializer):
     datalayer = serializers.IntegerField()
     weight = serializers.IntegerField()
@@ -603,7 +604,7 @@ class WeighedPriorityObjectiveField(serializers.Serializer):
     def validate_weight(self, value):
         if value < 0 or value > 100:
             raise serializers.ValidationError("Invalid priority objective weight.")
-        
+
         return value
 
 
@@ -738,24 +739,25 @@ class UpsertConfigurationV3Serializer(ConfigurationV3Serializer):
 
     def validate_sub_units_layer(self, sub_units_layer):
         return sub_units_layer.pk
-    
+
     def validate_included_areas(self, included_areas):
         if included_areas is None:
             return None
-        
+
         if len(included_areas) == 0:
-            raise serializers.ValidationError("Cannot set an empty list of included_areas.")
-               
+            raise serializers.ValidationError(
+                "Cannot set an empty list of included_areas."
+            )
+
         return included_areas
-    
+
     def validate(self, attrs):
 
         included_areas = attrs.get("included_areas_ids")
         if included_areas:
             scenario = self.parent.instance
             treatable_area = calculate_scenario_treatable_area(
-                scenario=scenario,
-                includes=included_areas
+                scenario=scenario, includes=included_areas
             )
 
             if not treatable_area or treatable_area.area == 0:
@@ -772,7 +774,6 @@ class UpsertConfigurationV3Serializer(ConfigurationV3Serializer):
                 )
 
         return super().validate(attrs)
-
 
     def update(self, instance, validated_data):
         instance.configuration = {
@@ -938,6 +939,7 @@ class ListScenarioSerializer(serializers.ModelSerializer):
             "version",
             "capabilities",
             "planning_approach",
+            "parent",
         )
         model = Scenario
 
@@ -979,6 +981,7 @@ class ScenarioV2Serializer(ListScenarioSerializer, serializers.ModelSerializer):
             "geopackage_url",
             "geopackage_status",
             "capabilities",
+            "parent",
         )
         model = Scenario
 
@@ -1003,6 +1006,7 @@ class CreateScenarioV2Serializer(serializers.ModelSerializer):
             "notes",
             "configuration",
             "treatment_goal",
+            "parent",
         )
 
 
@@ -1081,6 +1085,7 @@ class ScenarioV3Serializer(ListScenarioSerializer, serializers.ModelSerializer):
             "geopackage_status",
             "capabilities",
             "planning_approach",
+            "parent",
         )
         model = Scenario
 
@@ -1093,6 +1098,11 @@ class UpsertScenarioV3Serializer(serializers.ModelSerializer):
         required=True,
         write_only=True,
     )
+    parent = serializers.PrimaryKeyRelatedField(
+        queryset=Scenario.objects.all(),
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         model = Scenario
@@ -1102,8 +1112,8 @@ class UpsertScenarioV3Serializer(serializers.ModelSerializer):
             "name",
             "type",
             "origin",
-            "type",
             "notes",
+            "parent",
         )
 
     def update(self, instance, validated_data):
@@ -1126,11 +1136,17 @@ class PatchScenarioV3Serializer(serializers.ModelSerializer):
         help_text="Treatment goal of the scenario.",
     )
 
+    parent = serializers.PrimaryKeyRelatedField(
+        queryset=Scenario.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+
     configuration = UpsertConfigurationV3Serializer()
 
     class Meta:
         model = Scenario
-        fields = ("planning_approach", "treatment_goal", "configuration")
+        fields = ("planning_approach", "treatment_goal", "configuration", "parent")
 
     def update(self, instance: Scenario, validated_data):
         if "treatment_goal" in validated_data:
@@ -1146,20 +1162,26 @@ class PatchScenarioV3Serializer(serializers.ModelSerializer):
             if included_areas_ids:
                 included_areas = DataLayer.objects.filter(pk__in=included_areas_ids)
                 treatable_area = calculate_scenario_treatable_area(
-                    scenario=instance,
-                    includes=included_areas
+                    scenario=instance, includes=included_areas
                 )
                 instance.treatable_area = treatable_area
 
         if "planning_approach" in validated_data:
             instance.planning_approach = validated_data["planning_approach"]
 
+        if "parent" in validated_data:
+            instance.parent = validated_data["parent"]
+            if instance.parent:
+                instance.planning_area = instance.parent.planning_area
+
         instance.save(
             update_fields=[
-                "treatment_goal", 
-                "configuration", 
+                "treatment_goal",
+                "configuration",
                 "planning_approach",
                 "treatable_area",
+                "parent",
+                "planning_area",
             ]
         )
         instance.refresh_from_db()
@@ -1406,7 +1428,10 @@ class GeoJSONSerializer(serializers.Serializer):
 class UploadedScenarioDataSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=100, required=True)
     stand_size = serializers.ChoiceField(
-        choices=["SMALL", "MEDIUM", "LARGE"], required=False, allow_null=True, default=None
+        choices=["SMALL", "MEDIUM", "LARGE"],
+        required=False,
+        allow_null=True,
+        default=None,
     )
     planning_area = serializers.IntegerField(min_value=1, required=True)
     geometry = serializers.JSONField(required=True)
@@ -1432,7 +1457,11 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
 
         if not self._is_inside_planning_area(geometry, planning_area_id, stand_size):
             raise serializers.ValidationError(
-                {"global": ["The uploaded geometry is not within the selected planning area."]}
+                {
+                    "global": [
+                        "The uploaded geometry is not within the selected planning area."
+                    ]
+                }
             )
         return attrs
 
@@ -1498,10 +1527,13 @@ class GetAvailableStandsSerializer(serializers.Serializer):
         required=False,
     )
     sub_unit = serializers.PrimaryKeyRelatedField(
-        queryset=DataLayer.objects.filter(type=DataLayerType.VECTOR, status=DataLayerStatus.READY).all(),
+        queryset=DataLayer.objects.filter(
+            type=DataLayerType.VECTOR, status=DataLayerStatus.READY
+        ).all(),
         required=False,
         help_text="Vector Layer ID that contains Sub Units.",
     )
+
 
 class UnavailableStandsSerializer(serializers.Serializer):
     by_inclusions = serializers.ListField(child=serializers.IntegerField())

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -414,8 +414,13 @@ def create_scenario_from_upload(validated_data, user) -> Scenario:
         name=validated_data["name"],
         planning_area=planning_area,
         user=user,
-        configuration={k: v for k, v in {"stand_size": validated_data.get("stand_size")}.items() if v is not None},
+        configuration={
+            k: v
+            for k, v in {"stand_size": validated_data.get("stand_size")}.items()
+            if v is not None
+        },
         origin=ScenarioOrigin.USER,
+        type=ScenarioType.PROJECT_AREAS,
     )
     scenario.capabilities = compute_scenario_capabilities(scenario)
     scenario.save(update_fields=["capabilities"])
@@ -938,8 +943,8 @@ def map_property_for_numeric_export(key_value_pair):
 
 
 def get_schema(
-    geojson: Union[Collection[Dict[str, Any]], Dict[str, Any]], 
-    extra_properties: Dict[str, Any] = {}
+    geojson: Union[Collection[Dict[str, Any]], Dict[str, Any]],
+    extra_properties: Dict[str, Any] = {},
 ) -> Dict[str, Any]:
     feature = {}
     match geojson:
@@ -950,7 +955,7 @@ def get_schema(
         case list() as features:
             feature = features[0]
 
-    merged_properties = feature.get("properties", {}) | extra_properties 
+    merged_properties = feature.get("properties", {}) | extra_properties
     field_type_pairs = list(map(map_property, merged_properties.items()))
     schema = {
         "geometry": feature.get("geometry", {}).get("type", "MultiPolygon")
@@ -989,9 +994,7 @@ def _get_sub_units_lookup_table(scenario: Scenario) -> Optional[Dict[int, Any]]:
     ret = {}
     for feature in geojson.get("features", []):
         proj_id = feature["properties"].get("proj_id")
-        ret[proj_id] = {
-            **feature
-        }
+        ret[proj_id] = {**feature}
     return ret
 
 
@@ -1027,8 +1030,12 @@ def get_flatten_geojson(scenario: Scenario) -> Dict[str, Any]:
 def get_weighing_from_input(stand_inputs: Dict[int, Dict]):
     weighting_data = {}
     if stand_inputs:
-         sample_stand_data = dict(list(stand_inputs.values())[0])
-         weighting_data = {k: v for k, v in sample_stand_data.items() if k.lower().endswith("_weighting")}
+        sample_stand_data = dict(list(stand_inputs.values())[0])
+        weighting_data = {
+            k: v
+            for k, v in sample_stand_data.items()
+            if k.lower().endswith("_weighting")
+        }
     return weighting_data
 
 
@@ -1093,7 +1100,9 @@ def export_scenario_stand_outputs_to_geopackage(
                         properties[key] = int(value)
                         if sub_units_lookup_table:
                             properties["treatment_rank"] = (
-                                sub_units_lookup_table.get(int(value), {}).get("properties", {}).get("treatment_rank")
+                                sub_units_lookup_table.get(int(value), {})
+                                .get("properties", {})
+                                .get("treatment_rank")
                             )
                     case _:
                         try:
@@ -1124,11 +1133,14 @@ def export_scenario_stand_outputs_to_geopackage(
             properties["WKT"] = geometry
             properties["stand_size"] = stand_size
             fields_from_inputs = [
-                key for key in stand_inputs.get(stand_id, {}) 
+                key
+                for key in stand_inputs.get(stand_id, {})
                 if key.lower().endswith("_pcp") or key.lower().endswith("_weighting")
             ]
             for inputed_field in fields_from_inputs:
-                properties[inputed_field] = stand_inputs.get(stand_id, {}).get(inputed_field)
+                properties[inputed_field] = stand_inputs.get(stand_id, {}).get(
+                    inputed_field
+                )
             scenario_outputs[stand_id] = properties
 
     if scenario_outputs:
@@ -1149,7 +1161,9 @@ def export_scenario_stand_outputs_to_geopackage(
                 )
 
         properties = features[0].get("properties", {})
-        field_type_pairs = list(map(map_property_for_numeric_export, properties.items()))
+        field_type_pairs = list(
+            map(map_property_for_numeric_export, properties.items())
+        )
         schema = {
             "geometry": "MultiPolygon",
             "properties": field_type_pairs,
@@ -1183,7 +1197,9 @@ def export_scenario_inputs_to_geopackage(
     tx_goal = scenario.treatment_goal
     if tx_goal:
         weighted_datalayers = []
-        for usage in tx_goal.datalayer_usages.filter(usage_type=TreatmentGoalUsageType.PRIORITY):
+        for usage in tx_goal.datalayer_usages.filter(
+            usage_type=TreatmentGoalUsageType.PRIORITY
+        ):
             item = {
                 "datalayer": usage.datalayer.id,
                 "name": usage.datalayer.name,
@@ -1250,7 +1266,7 @@ def export_scenario_inputs_to_geopackage(
             properties["stand_size"] = stand_size
             for wd in weighted_datalayers:
                 wd_key = sanitize_shp_field_name(f"{wd.get('name')}_weighting")
-                properties[wd_key] = float(wd.get("weight")) # type: ignore
+                properties[wd_key] = float(wd.get("weight"))  # type: ignore
             stand_id = int(row.get("stand_id"))  # type: ignore
             scenario_inputs[stand_id] = properties
 
@@ -1293,7 +1309,9 @@ def export_scenario_inputs_to_geopackage(
 
 
 def export_scenario_project_areas_outputs_to_geopackage(
-    scenario: Scenario, geopackage_path: Path, stand_inputs: Dict[int, Dict],
+    scenario: Scenario,
+    geopackage_path: Path,
+    stand_inputs: Dict[int, Dict],
 ) -> None:
     geojson = get_flatten_geojson(scenario)
 
@@ -1315,10 +1333,7 @@ def export_scenario_project_areas_outputs_to_geopackage(
                 for feature in geojson.get("features", []):
                     geometry = to_multi(feature.get("geometry"))
                     feature["properties"] = {**feature["properties"], **weighting_data}
-                    feature = {
-                        **feature,
-                        "geometry": geometry
-                    }
+                    feature = {**feature, "geometry": geometry}
                     out.write(feature)
     except Exception as e:
         logger.exception(
@@ -1328,7 +1343,9 @@ def export_scenario_project_areas_outputs_to_geopackage(
 
 
 def export_scenario_sub_units_outputs_to_geopackage(
-    scenario: Scenario, geopackage_path: Path, stand_inputs: Dict[int, Dict],
+    scenario: Scenario,
+    geopackage_path: Path,
+    stand_inputs: Dict[int, Dict],
 ) -> None:
     geojson = get_flatten_geojson(scenario)
 
@@ -1380,6 +1397,7 @@ def export_scenario_sub_units_outputs_to_geopackage(
         )
         raise e
 
+
 def export_treatable_area_to_geopackage(
     scenario: Scenario, geopackage_path: Path
 ) -> None:
@@ -1387,7 +1405,7 @@ def export_treatable_area_to_geopackage(
     if not geometry:
         logger.warning("Scenario has no treatable area (Legacy). Skipping.")
         return
-    
+
     crs = from_epsg(settings.CRS_GEOPACKAGE_EXPORT)
     schema = {
         "geometry": "MultiPolygon",
@@ -1417,7 +1435,9 @@ def export_treatable_area_to_geopackage(
                 out.write(feature)
     except Exception as e:
         logger.exception(
-            "Error exporting Scenario's Treatable Area %s to geopackage: %s", scenario.pk, e
+            "Error exporting Scenario's Treatable Area %s to geopackage: %s",
+            scenario.pk,
+            e,
         )
         raise e
 
@@ -1703,7 +1723,7 @@ def get_available_stands(
         stands = scenario.get_treatable_area_stands(stand_size=stand_size)
     else:
         stands = planning_area.get_stands(stand_size)
-    
+
     stands = stands.annotate(area=area_transform)
     total_area = stands.all().aggregate(total_area_m2=Sum("area"))["total_area_m2"]
 
@@ -1720,7 +1740,9 @@ def get_available_stands(
     ):
         # Exclude stands that is not included to any sub-unit
         stands_queryset = stands.all()
-        sub_units_stands = get_stands_from_sub_units(stands_queryset, planning_area, scenario.get_stand_size(), sub_unit)
+        sub_units_stands = get_stands_from_sub_units(
+            stands_queryset, planning_area, scenario.get_stand_size(), sub_unit
+        )
         sub_units_stands_ids = set(sub_units_stands.values_list("id", flat=True))
         stand_ids = stands_queryset.exclude(id__in=sub_units_stands_ids).values_list(
             "id", flat=True
@@ -1819,7 +1841,7 @@ def get_available_stand_ids(
 
 
 def calculate_scenario_treatable_area(
-    scenario: Scenario, 
+    scenario: Scenario,
     includes: Optional[QuerySet[DataLayer]] = None,
 ) -> Optional[MultiPolygon]:
     planning_area = scenario.planning_area
@@ -1833,12 +1855,12 @@ def calculate_scenario_treatable_area(
                 continue
 
             DynamicModel = model_from_fiona(included)
-            queryset = DynamicModel.objects.filter(geometry__bboverlaps=pa_geometry).filter(
-                geometry__intersects=pa_geometry
-            )
-            layer_geometry = queryset.all().aggregate(
-                geometry=UnionOp("geometry")
-            )["geometry"]
+            queryset = DynamicModel.objects.filter(
+                geometry__bboverlaps=pa_geometry
+            ).filter(geometry__intersects=pa_geometry)
+            layer_geometry = queryset.all().aggregate(geometry=UnionOp("geometry"))[
+                "geometry"
+            ]
             if not layer_geometry:
                 continue
             layer_geometry = layer_geometry.intersection(pa_geometry)
@@ -1847,7 +1869,7 @@ def calculate_scenario_treatable_area(
                 included_geometry = layer_geometry
             else:
                 included_geometry = included_geometry.union(layer_geometry)
-    
+
     return to_multipolygon(included_geometry) if included_geometry else None
 
 
@@ -1961,7 +1983,9 @@ def calculate_and_update_scenario_result(scenario: Scenario):
     features = results.result.get("features")
 
     features = calculate_and_update_rx_leverage(scenario=scenario, features=features)
-    features = calculate_and_update_pct_treatable_area(scenario=scenario, features=features)
+    features = calculate_and_update_pct_treatable_area(
+        scenario=scenario, features=features
+    )
 
     results.result["features"] = features
     results.save(update_fields=["result"])
@@ -1998,7 +2022,9 @@ def calculate_and_update_pct_treatable_area(scenario: Scenario, features: List) 
 
     for feature in features:
         proj_area_acres = feature.get("properties").get("area_acres")
-        pct_treatable_area = proj_area_acres / treatable_area if treatable_area else None
+        pct_treatable_area = (
+            proj_area_acres / treatable_area if treatable_area else None
+        )
         feature["properties"]["pct_treatable_area"] = pct_treatable_area
 
     return features

--- a/src/planscape/planning/tests/test_models.py
+++ b/src/planscape/planning/tests/test_models.py
@@ -111,3 +111,10 @@ class ScenarioModelTest(TestCase):
         )
         datalayers = scenario.get_raster_datalayers()
         self.assertEqual(len(datalayers), 5)
+
+    def test_scenario_can_have_parent(self):
+        parent = ScenarioFactory.create()
+        child = ScenarioFactory.create(parent=parent)
+
+        self.assertEqual(child.parent, parent)
+        self.assertIn(child, parent.children.all())

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -607,6 +607,66 @@ class ListScenariosForPlanningAreaTest(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data.get("version"), ScenarioVersion.V3)
 
+    def test_list_scenario_excludes_child_scenarios(self):
+        child = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.owner_user,
+            parent=self.scenario,
+        )
+        ScenarioResultFactory(scenario=child)
+
+        self.client.force_authenticate(self.owner_user)
+        response = self.client.get(
+            reverse("api:planning:scenarios-list"),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [item["id"] for item in response.json()]
+        self.assertIn(self.scenario.pk, ids)
+        self.assertNotIn(child.pk, ids)
+
+    def test_child_endpoint_returns_only_children_for_parent(self):
+        parent = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.owner_user,
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        child = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.owner_user,
+            parent=parent,
+        )
+
+        other_parent = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.owner_user,
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        other_child = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.owner_user,
+            parent=other_parent,
+        )
+
+        ScenarioResultFactory(scenario=parent)
+        ScenarioResultFactory(scenario=child)
+        ScenarioResultFactory(scenario=other_parent)
+        ScenarioResultFactory(scenario=other_child)
+
+        self.client.force_authenticate(self.owner_user)
+        response = self.client.get(
+            reverse("api:planning:scenarios-child", args=[parent.pk]),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [item["id"] for item in response.json()]
+        self.assertIn(child.pk, ids)
+        self.assertNotIn(other_child.pk, ids)
+        self.assertNotIn(parent.pk, ids)
+        self.assertNotIn(other_parent.pk, ids)
+
 
 class ScenarioDetailTest(APITestCase):
     def setUp(self):
@@ -889,7 +949,9 @@ class ScenarioDetailTest(APITestCase):
         )
 
     def test_detail_scenario_scenario_result_prioritize_sub_units(self):
-        scenario_result = ScenarioResultFactory(scenario=self.scenario, with_multiple_features=20)
+        scenario_result = ScenarioResultFactory(
+            scenario=self.scenario, with_multiple_features=20
+        )
 
         self.scenario.planning_approach = ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
         self.scenario.save()
@@ -910,7 +972,9 @@ class ScenarioDetailTest(APITestCase):
         self.assertEqual(len(scenario_result.result["features"]), 20)
 
     def test_detail_scenario_scenario_result_prioritize_sub_units__query_params(self):
-        scenario_result = ScenarioResultFactory(scenario=self.scenario, with_multiple_features=20)
+        scenario_result = ScenarioResultFactory(
+            scenario=self.scenario, with_multiple_features=20
+        )
 
         self.scenario.planning_approach = ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
         self.scenario.save()
@@ -922,7 +986,8 @@ class ScenarioDetailTest(APITestCase):
                 kwargs={
                     "pk": self.scenario.pk,
                 },
-            ) + "?number_of_features=13",
+            )
+            + "?number_of_features=13",
             content_type="application/json",
         )
         data = response.json()
@@ -930,8 +995,12 @@ class ScenarioDetailTest(APITestCase):
         self.assertEqual(len(data["scenario_result"]["result"]["features"]), 13)
         self.assertEqual(len(scenario_result.result["features"]), 20)
 
-    def test_detail_scenario_scenario_result_prioritize_sub_units__query_params_all(self):
-        scenario_result = ScenarioResultFactory(scenario=self.scenario, with_multiple_features=20)
+    def test_detail_scenario_scenario_result_prioritize_sub_units__query_params_all(
+        self,
+    ):
+        scenario_result = ScenarioResultFactory(
+            scenario=self.scenario, with_multiple_features=20
+        )
         self.scenario.planning_approach = ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
         self.scenario.save()
 
@@ -942,16 +1011,19 @@ class ScenarioDetailTest(APITestCase):
                 kwargs={
                     "pk": self.scenario.pk,
                 },
-            ) + "?number_of_features=all",
+            )
+            + "?number_of_features=all",
             content_type="application/json",
         )
         data = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(data["scenario_result"]["result"]["features"]), 20)
         self.assertEqual(len(scenario_result.result["features"]), 20)
-    
+
     def test_detail_scenario_scenario_result__query_params(self):
-        scenario_result = ScenarioResultFactory(scenario=self.scenario, with_multiple_features=20)
+        scenario_result = ScenarioResultFactory(
+            scenario=self.scenario, with_multiple_features=20
+        )
 
         self.client.force_authenticate(self.owner_user)
         response = self.client.get(
@@ -960,7 +1032,8 @@ class ScenarioDetailTest(APITestCase):
                 kwargs={
                     "pk": self.scenario.pk,
                 },
-            ) + "?number_of_features=13",
+            )
+            + "?number_of_features=13",
             content_type="application/json",
         )
         data = response.json()
@@ -969,7 +1042,9 @@ class ScenarioDetailTest(APITestCase):
         self.assertEqual(len(scenario_result.result["features"]), 20)
 
     def test_detail_scenario_scenario_result__query_params_all(self):
-        scenario_result = ScenarioResultFactory(scenario=self.scenario, with_multiple_features=20)
+        scenario_result = ScenarioResultFactory(
+            scenario=self.scenario, with_multiple_features=20
+        )
 
         self.client.force_authenticate(self.owner_user)
         response = self.client.get(
@@ -978,7 +1053,8 @@ class ScenarioDetailTest(APITestCase):
                 kwargs={
                     "pk": self.scenario.pk,
                 },
-            ) + "?number_of_features=all",
+            )
+            + "?number_of_features=all",
             content_type="application/json",
         )
         data = response.json()
@@ -1162,8 +1238,8 @@ class PatchScenarioConfigurationTest(APITestCase):
 
     # Test sequential patches, ensure we retain values as expected
     @mock.patch(
-        "planning.serializers.calculate_scenario_treatable_area", 
-        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1))))
+        "planning.serializers.calculate_scenario_treatable_area",
+        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1)))),
     )
     def test_patch_scenario_incremental_updates(self, treatable_area_mock):
         # create valid excluded_areas and included_areas with real PKs
@@ -1323,12 +1399,11 @@ class PatchScenarioConfigurationTest(APITestCase):
         self.assertEqual(response8.data["treatment_goal"]["name"], new_goal.name)
 
     @mock.patch(
-        "planning.serializers.calculate_scenario_treatable_area", 
-        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1))))
+        "planning.serializers.calculate_scenario_treatable_area",
+        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1)))),
     )
     def test_patch_scenario_with_includes_calculates_treatable_area(
-        self, 
-        calculate_scenario_treatable_area_mock
+        self, calculate_scenario_treatable_area_mock
     ):
         included_layers = DataLayerFactory.create_batch(
             2,
@@ -1355,12 +1430,11 @@ class PatchScenarioConfigurationTest(APITestCase):
         calculate_scenario_treatable_area_mock.assert_called()
 
     @mock.patch(
-        "planning.serializers.calculate_scenario_treatable_area", 
-        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1))))
+        "planning.serializers.calculate_scenario_treatable_area",
+        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1)))),
     )
     def test_patch_scenario_with_includes_invalid_datalayer_ids(
-        self, 
-        calculate_scenario_treatable_area_mock
+        self, calculate_scenario_treatable_area_mock
     ):
         included_layers = DataLayerFactory.create_batch(
             2,
@@ -1384,8 +1458,8 @@ class PatchScenarioConfigurationTest(APITestCase):
         self.assertEqual(calculate_scenario_treatable_area_mock.call_count, 0)
 
     @mock.patch(
-        "planning.serializers.calculate_scenario_treatable_area", 
-        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1))))
+        "planning.serializers.calculate_scenario_treatable_area",
+        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1)))),
     )
     def test_patch_scenario_with_includes_empty_list(
         self, calculate_scenario_treatable_area_mock
@@ -1411,10 +1485,11 @@ class PatchScenarioConfigurationTest(APITestCase):
         self.assertEqual(calculate_scenario_treatable_area_mock.call_count, 0)
 
     @mock.patch(
-        "planning.serializers.calculate_scenario_treatable_area", 
-        return_value=None
+        "planning.serializers.calculate_scenario_treatable_area", return_value=None
     )
-    def test_patch_scenario_with_includes_no_area(self, calculate_scenario_treatable_area_mock):
+    def test_patch_scenario_with_includes_no_area(
+        self, calculate_scenario_treatable_area_mock
+    ):
         included_layers = DataLayerFactory.create_batch(
             2,
             type=DataLayerType.VECTOR,
@@ -1443,10 +1518,12 @@ class PatchScenarioConfigurationTest(APITestCase):
         calculate_scenario_treatable_area_mock.assert_called()
 
     @mock.patch(
-        "planning.serializers.calculate_scenario_treatable_area", 
-        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1))))
+        "planning.serializers.calculate_scenario_treatable_area",
+        return_value=MultiPolygon(Polygon(((1, 1), (1, 2), (2, 2), (1, 1)))),
     )
-    def test_patch_scenario_with_includes_no_stands(self, calculate_scenario_treatable_area_mock):
+    def test_patch_scenario_with_includes_no_stands(
+        self, calculate_scenario_treatable_area_mock
+    ):
         included_layers = DataLayerFactory.create_batch(
             2,
             type=DataLayerType.VECTOR,
@@ -1456,7 +1533,7 @@ class PatchScenarioConfigurationTest(APITestCase):
 
         payload = {
             "configuration": {
-                "stand_size": "SMALL", # no small stands in this test
+                "stand_size": "SMALL",  # no small stands in this test
                 "included_areas": included_ids,
             }
         }
@@ -1558,7 +1635,9 @@ class PatchScenarioConfigurationTest(APITestCase):
             ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS.value,
         )
 
-    def test_patch_scenario_approach_clean_sub_units_layer_when_set_planning_approach(self):
+    def test_patch_scenario_approach_clean_sub_units_layer_when_set_planning_approach(
+        self,
+    ):
         scenario = ScenarioFactory(
             user=self.user,
             planning_area=self.planning_area,
@@ -1579,9 +1658,7 @@ class PatchScenarioConfigurationTest(APITestCase):
             response.data.get("planning_approach"),
             ScenarioPlanningApproach.OPTIMIZE_PROJECT_AREAS.value,
         )
-        self.assertIsNone(
-            response.data.get("sub_units_layer")
-        )
+        self.assertIsNone(response.data.get("sub_units_layer"))
 
     def test_patch_sub_units(self):
         scenario = ScenarioFactory.create(
@@ -1631,17 +1708,26 @@ class PatchScenarioConfigurationTest(APITestCase):
         url = reverse("api:planning:scenarios-patch-draft", args=[scenario.pk])
         payload = {
             "configuration": {
-                "targets" :{"sub_units_fixed_target": True, "sub_units_target_value": 1234.5}
+                "targets": {
+                    "sub_units_fixed_target": True,
+                    "sub_units_target_value": 1234.5,
+                }
             }
         }
 
         self.client.force_authenticate(self.user)
         response = self.client.patch(url, payload, format="json")
         self.assertEqual(
-            response.data.get("configuration", {}).get("targets", {}).get("sub_units_target_value"),
+            response.data.get("configuration", {})
+            .get("targets", {})
+            .get("sub_units_target_value"),
             1234.5,
         )
-        self.assertTrue(response.data.get("configuration", {}).get("targets", {}).get("sub_units_fixed_target"))
+        self.assertTrue(
+            response.data.get("configuration", {})
+            .get("targets", {})
+            .get("sub_units_fixed_target")
+        )
 
     def test_patch_sub_units_relative_target(self):
         scenario = ScenarioFactory.create(
@@ -1655,17 +1741,26 @@ class PatchScenarioConfigurationTest(APITestCase):
         url = reverse("api:planning:scenarios-patch-draft", args=[scenario.pk])
         payload = {
             "configuration": {
-                "targets": {"sub_units_fixed_target": False, "sub_units_target_value": 91.5}
+                "targets": {
+                    "sub_units_fixed_target": False,
+                    "sub_units_target_value": 91.5,
+                }
             }
         }
 
         self.client.force_authenticate(self.user)
         response = self.client.patch(url, payload, format="json")
         self.assertEqual(
-            response.data.get("configuration", {}).get("targets", {}).get("sub_units_target_value"),
+            response.data.get("configuration", {})
+            .get("targets", {})
+            .get("sub_units_target_value"),
             91.5,
         )
-        self.assertFalse(response.data.get("configuration", {}).get("targets", {}).get("sub_units_fixed_target"))
+        self.assertFalse(
+            response.data.get("configuration", {})
+            .get("targets", {})
+            .get("sub_units_fixed_target")
+        )
 
     def test_patch_sub_units_target_value_lower_than_zero(self):
         scenario = ScenarioFactory.create(
@@ -1679,7 +1774,10 @@ class PatchScenarioConfigurationTest(APITestCase):
         url = reverse("api:planning:scenarios-patch-draft", args=[scenario.pk])
         payload = {
             "configuration": {
-                "targets": {"sub_units_fixed_target": True, "sub_units_target_value": -1}
+                "targets": {
+                    "sub_units_fixed_target": True,
+                    "sub_units_target_value": -1,
+                }
             }
         }
 
@@ -1699,14 +1797,16 @@ class PatchScenarioConfigurationTest(APITestCase):
         url = reverse("api:planning:scenarios-patch-draft", args=[scenario.pk])
         payload = {
             "configuration": {
-                "targets" : {"sub_units_fixed_target": False, "sub_units_target_value": 101}
+                "targets": {
+                    "sub_units_fixed_target": False,
+                    "sub_units_target_value": 101,
+                }
             }
         }
 
         self.client.force_authenticate(self.user)
         response = self.client.patch(url, payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
 
     def test_patch_sub_units_target_value_null_with_fixed_target(self):
         scenario = ScenarioFactory.create(
@@ -1718,11 +1818,7 @@ class PatchScenarioConfigurationTest(APITestCase):
         )
 
         url = reverse("api:planning:scenarios-patch-draft", args=[scenario.pk])
-        payload = {
-            "configuration": {
-                "targets": {"sub_units_fixed_target": True}
-            }
-        }
+        payload = {"configuration": {"targets": {"sub_units_fixed_target": True}}}
 
         self.client.force_authenticate(self.user)
         response = self.client.patch(url, payload, format="json")
@@ -1863,7 +1959,16 @@ class ScenarioCapabilitiesViewTest(APITestCase):
 
         caps = resp.data.get("capabilities")
         self.assertIsInstance(caps, list)
-        self.assertSetEqual(set(caps), {"MAP", "FORSYS", "CLIMATE_FORESIGHT", "PRIORITIZE_SUB_UNITS", "FUNDING_REPORT"})
+        self.assertSetEqual(
+            set(caps),
+            {
+                "MAP",
+                "FORSYS",
+                "CLIMATE_FORESIGHT",
+                "PRIORITIZE_SUB_UNITS",
+                "FUNDING_REPORT",
+            },
+        )
 
     def test_capabilities_present_in_detail_inside_california(self):
         self.scenario2.capabilities = compute_scenario_capabilities(self.scenario2)
@@ -1877,7 +1982,15 @@ class ScenarioCapabilitiesViewTest(APITestCase):
         caps = resp.data.get("capabilities")
         self.assertIsInstance(caps, list)
         self.assertSetEqual(
-            set(caps), {"MAP", "FORSYS", "IMPACTS", "CLIMATE_FORESIGHT", "PRIORITIZE_SUB_UNITS", "FUNDING_REPORT"}
+            set(caps),
+            {
+                "MAP",
+                "FORSYS",
+                "IMPACTS",
+                "CLIMATE_FORESIGHT",
+                "PRIORITIZE_SUB_UNITS",
+                "FUNDING_REPORT",
+            },
         )
 
     def test_capabilities_present_in_detail_outside_future_climate(self):
@@ -2212,7 +2325,9 @@ class SubUnitsDetailsTest(APITestCase):
         self.user = UserFactory.create()
         self.other_user = UserFactory.create()
         self.planning_area = PlanningAreaFactory.create(user=self.user)
-        self.scenario = ScenarioFactory.create(planning_area=self.planning_area, user=self.user)
+        self.scenario = ScenarioFactory.create(
+            planning_area=self.planning_area, user=self.user
+        )
         self.sub_units_layer = DataLayerFactory.create(
             type=DataLayerType.VECTOR, geometry_type=GeometryType.POLYGON
         )
@@ -2225,7 +2340,9 @@ class SubUnitsDetailsTest(APITestCase):
         return_value={"avg": 1, "max": 2, "min": 0},
     )
     def test_get_sub_units_details(self, mock):
-        url = reverse("api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk])
+        url = reverse(
+            "api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk]
+        )
         self.client.force_authenticate(self.user)
 
         response = self.client.get(url)
@@ -2236,7 +2353,9 @@ class SubUnitsDetailsTest(APITestCase):
         self.scenario.configuration = {}
         self.scenario.save()
 
-        url = reverse("api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk])
+        url = reverse(
+            "api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk]
+        )
         self.client.force_authenticate(self.user)
 
         response = self.client.get(url)
@@ -2248,7 +2367,9 @@ class SubUnitsDetailsTest(APITestCase):
         return_value=None,
     )
     def test_get_sub_units_details__no_result(self, mock):
-        url = reverse("api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk])
+        url = reverse(
+            "api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk]
+        )
         self.client.force_authenticate(self.user)
 
         response = self.client.get(url)
@@ -2259,11 +2380,15 @@ class SubUnitsDetailsTest(APITestCase):
         "planning.views_v2.get_sub_units_details",
         return_value={"avg": 1, "max": 2, "min": 0, "sum": 10, "targeted_value": None},
     )
-    def test_get_sub_units_details__query_param_overrides_scenario_config(self, mock_service):
+    def test_get_sub_units_details__query_param_overrides_scenario_config(
+        self, mock_service
+    ):
         override_layer = DataLayerFactory.create(
             type=DataLayerType.VECTOR, geometry_type=GeometryType.POLYGON
         )
-        url = reverse("api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk])
+        url = reverse(
+            "api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk]
+        )
         self.client.force_authenticate(self.user)
 
         response = self.client.get(url, {"sub_units_layer": override_layer.pk})
@@ -2276,20 +2401,26 @@ class SubUnitsDetailsTest(APITestCase):
         "planning.views_v2.get_sub_units_details",
         return_value={"avg": 1, "max": 2, "min": 0, "sum": 10, "targeted_value": None},
     )
-    def test_get_sub_units_details__query_param_works_without_scenario_config(self, mock_service):
+    def test_get_sub_units_details__query_param_works_without_scenario_config(
+        self, mock_service
+    ):
         self.scenario.configuration = {}
         self.scenario.save()
 
         override_layer = DataLayerFactory.create(
             type=DataLayerType.VECTOR, geometry_type=GeometryType.POLYGON
         )
-        url = reverse("api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk])
+        url = reverse(
+            "api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk]
+        )
         self.client.force_authenticate(self.user)
 
         response = self.client.get(url, {"sub_units_layer": override_layer.pk})
 
         self.assertEqual(response.status_code, 200)
-        mock_service.assert_called_once_with(self.scenario, self.scenario.get_stand_size(), override_layer, None, None)
+        mock_service.assert_called_once_with(
+            self.scenario, self.scenario.get_stand_size(), override_layer, None, None
+        )
 
     @mock.patch(
         "planning.views_v2.get_sub_units_details",
@@ -2302,18 +2433,21 @@ class SubUnitsDetailsTest(APITestCase):
         override_layer = DataLayerFactory.create(
             type=DataLayerType.VECTOR, geometry_type=GeometryType.POLYGON
         )
-        url = reverse("api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk])
+        url = reverse(
+            "api:planning:scenarios-get-sub-units-details", args=[self.scenario.pk]
+        )
         self.client.force_authenticate(self.user)
 
         response = self.client.get(
-            url, 
+            url,
             {
                 "sub_units_layer": override_layer.pk,
                 "sub_units_fixed_target": False,
                 "sub_units_target_value": 80,
-            }
+            },
         )
 
         self.assertEqual(response.status_code, 200)
-        mock_service.assert_called_once_with(self.scenario, self.scenario.get_stand_size(), override_layer, False, 80)
-
+        mock_service.assert_called_once_with(
+            self.scenario, self.scenario.get_stand_size(), override_layer, False, 80
+        )

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -19,6 +19,7 @@ from planning.models import (
     RegionChoices,
     ScenarioResult,
     ScenarioResultStatus,
+    ScenarioType,
     TreatmentGoal,
     TreatmentGoalCategory,
     TreatmentGoalGroup,
@@ -1160,6 +1161,7 @@ class CreateScenariosFromUpload(APITestCase):
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()["origin"], "USER")
+        self.assertEqual(response.json()["type"], ScenarioType.PROJECT_AREAS)
 
     @mock.patch("planning.views_v2.create_scenario_from_upload")
     def test_invalid_geometry_returns_400_with_global_error(self, mock_create):
@@ -1333,7 +1335,6 @@ class TreatmentGoalViewSetTest(APITestCase):
         treatment_goals = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(treatment_goals), 12)
-
 
     def test_detail_treatment_goal(self):
         self.client.force_authenticate(self.user)

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -260,7 +260,27 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             )
             .prefetch_related("project_areas")
         )
+        if self.action == "list":
+            qs = qs.filter(parent__isnull=True)
         return qs
+
+    @action(methods=["get"], detail=True, url_path="child")
+    def child(self, request, pk=None):
+        parent = self.get_object()
+
+        children = (
+            self.get_queryset()
+            .filter(parent=parent)
+            .select_related("planning_area", "user", "results")
+            .prefetch_related("project_areas")
+        )
+
+        serializer = ListScenarioSerializer(
+            children,
+            many=True,
+            context={"request": request},
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(description="Retrieve a Scenario (auto-detects version).")
     def retrieve(self, request, *args, **kwargs):


### PR DESCRIPTION
@george-silva @roquebetioljr @lastminutediorama, tickets 3757, 3758, and 3759:

**PLAN-3757.** Add option "Project Areas" for Scenario.type field + backfill, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3757; 

**PLAN-3758.** Add "parent" field on Scenario Model,  https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3758; 

**PLAN-3759.** Endpoint to list child Scenarios (Project Areas Scenarios) https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3759

-------------------------------

1. `src/planscape/planning/models.py`: added `PROJECT_AREAS` to `Scenario.type` and added nullable `parent` field on `Scenario`
2. `src/planscape/planning/migrations/0092_scenario_parent_alter_scenario_type.py`: added migration for `parent`, `PROJECT_AREAS`, and backfilled existing uploaded Project Area scenarios

4. `src/planscape/planning/services.py`: updated uploaded Project Area scenario creation to set `type=PROJECT_AREAS`
5. `src/planscape/planning/serializers.py`: exposed `parent` on scenario serializers
6. `src/planscape/planning/views_v2.py`: hid child scenarios from the normal scenario list and added endpoint to list child scenarios

7. `src/planscape/planning/tests/test_models.py`: added test for Scenario parent/child relationship
8. `src/planscape/planning/tests/test_v2_scenario_views.py`: added tests for uploaded Project Area scenario type, child list filtering, and child endpoint
9. `src/planscape/planning/tests/test_v2_views.py`: updated existing expectations for the new Project Areas scenario type

-------------------------------

I ran the unit tests for the updated model and v2 scenario view coverage, and they passed. 

The next two tickets -- 3760, Modify create/patch Scenario to receive parent Scenario, and 3761, Modify pre-forsys process to send Project Areas similarly to sub-units -- look a bit more involved. I'm gonna put them in a separate PR.