### PR TITLE
Fix funding dashboard map border-radius 

### DIFF
--- a/src/interface/src/app/funding/funding-report/funding-report.component.scss
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.scss
@@ -34,10 +34,6 @@
   padding: 16px;
   overflow-y: auto;
 
-  ::ng-deep #map .maplibregl-map{
-    border-radius: 8px;
-  }
-
   &.fullview {
     background-color: $color-soft-purple;
 
@@ -58,6 +54,7 @@
   border-radius: 8px;
   background-color: $color-soft-gray;
   border: 1px solid $color-light-purple;
+  overflow: hidden;
 }
 
 .report-footer {

--- a/src/interface/src/app/funding/funding-report/funding-report.component.scss
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.scss
@@ -34,6 +34,10 @@
   padding: 16px;
   overflow-y: auto;
 
+  ::ng-deep #map .maplibregl-map{
+    border-radius: 4px;
+  }
+
   &.fullview {
     background-color: $color-soft-purple;
 

--- a/src/interface/src/app/funding/funding-report/funding-report.component.scss
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.scss
@@ -35,7 +35,7 @@
   overflow-y: auto;
 
   ::ng-deep #map .maplibregl-map{
-    border-radius: 4px;
+    border-radius: 8px;
   }
 
   &.fullview {


### PR DESCRIPTION
Just a small change to this border. 
Note: it's 8px in Figma, but now wondering if it should be 4px to match the other report sections.

Before: <img width="82" height="50" alt="Screenshot 2026-07-08 at 10 59 38 AM" src="https://github.com/user-attachments/assets/312a7ede-4bec-45ba-8984-712830520a52" />

After: <img width="83" height="120" alt="Screenshot 2026-07-08 at 10 59 24 AM" src="https://github.com/user-attachments/assets/08af4a65-1a96-4e23-9865-abd354a6657c" />
