### PR TITLE
Allow different Planning Area line color on funding map

### DIFF
--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
@@ -19,7 +19,9 @@
     controlsPosition="bottom-right"></app-map-zoom-control>
 
   <!-- This *ngIf="true" is a hack to fix the issue where the planning area was displayed on top of the project areas when moving back and forward. -->
-  <app-planning-area-layer *ngIf="true"></app-planning-area-layer>
+  <app-planning-area-layer
+    [lineColor]="BASE_COLORS.standard_blue"
+    *ngIf="true"></app-planning-area-layer>
   <app-funding-data-layer
     *ngIf="mapLibreMap && (fundingDataLayer$ | async) as fundingDataLayer"
     [mapLibreMap]="mapLibreMap"

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
@@ -42,6 +42,7 @@ import {
 } from '../funding-acreage-legend/funding-acreage-legend.component';
 import { MapActionButtonComponent } from '@app/treatments/map-action-button/map-action-button.component';
 import { MapLayerColorLegendComponent } from '@app/maplibre-map/map-layer-color-legend/map-layer-color-legend.component';
+import { BASE_COLORS } from '@app/treatments/map.styles';
 
 @Component({
   selector: 'app-funding-report-map',
@@ -83,6 +84,8 @@ export class FundingReportMapComponent implements OnInit {
     this.mapConfigService.initialize();
     this.loading$.next(true);
   }
+
+  readonly BASE_COLORS = BASE_COLORS;
 
   @Input() allowInteraction = true;
 

--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import {
   FeatureComponent,
   GeoJSONSourceComponent,
@@ -24,10 +24,10 @@ import { MARTIN_SOURCES } from '@treatments/map.sources';
   ],
   templateUrl: './planning-area-layer.component.html',
 })
-export class PlanningAreaLayerComponent {
+export class PlanningAreaLayerComponent implements OnInit {
   @Input() before = '';
 
-  readonly lineColor = BASE_COLORS.blue;
+  @Input() lineColor: string = BASE_COLORS.blue;
 
   linePaint = {
     'line-color': this.lineColor,
@@ -36,6 +36,10 @@ export class PlanningAreaLayerComponent {
   } as any;
 
   constructor(private planState: PlanState) {}
+
+  ngOnInit() {
+    this.linePaint['line-color'] = this.lineColor;
+  }
 
   tilesUrl$ = this.planState.currentPlanId$.pipe(
     map((id) => {

--- a/src/interface/src/app/treatments/map.styles.ts
+++ b/src/interface/src/app/treatments/map.styles.ts
@@ -22,6 +22,7 @@ export const BASE_COLORS = {
   dark_gray: '#646464',
   light_gray: '#909090',
   dark_green: '#344F42',
+  standard_blue: '#064BBA',
 } as const;
 
 export const SELECTED_STANDS_PAINT = {


### PR DESCRIPTION
The Planning Area line color is different on the funding view, so this PR allows us to set a color from a parent component:

<img width="488" height="239" alt="Screenshot 2026-07-08 at 11 38 43 AM" src="https://github.com/user-attachments/assets/c1cf4165-ec26-435a-842c-ca55d75f92e4" />