### PR TITLE
Models to support Funding Opportunity Report Sharing

### DIFF
--- a/src/planscape/funding_report/migrations/0006_fundingopportunitreportsharedlink_and_more.py
+++ b/src/planscape/funding_report/migrations/0006_fundingopportunitreportsharedlink_and_more.py
@@ -1,0 +1,103 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("funding_report", "0005_fundingopportunityreport_geopackage_status_and_more"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="FundingOpportunitReportSharedLink",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("uuid", models.UUIDField(auto_created=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True, null=True)),
+                (
+                    "deleted_at",
+                    models.DateTimeField(
+                        help_text="Define if the entity has been deleted or not and when",
+                        null=True,
+                        verbose_name="Deleted at",
+                    ),
+                ),
+                ("configuration", models.JSONField()),
+                (
+                    "report",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="funding_opportunity_report_shared_links",
+                        to="funding_report.fundingopportunityreport",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        migrations.CreateModel(
+            name="FundingOpportunityReportInvite",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, null=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "deleted_at",
+                    models.DateTimeField(
+                        help_text="Define if the entity has been deleted or not and when",
+                        null=True,
+                        verbose_name="Deleted at",
+                    ),
+                ),
+                ("invitee_email", models.EmailField(max_length=254)),
+                (
+                    "invitee",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="funding_opportunity_report_invitees",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "inviter",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="funding_opportunity_report_inviters",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "report",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="funding_opportunity_report_invites",
+                        to="funding_report.fundingopportunityreport",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+    ]

--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -13,7 +13,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django_stubs_ext.db.models import TypedModelMeta
 from planning.models import GeoPackageStatus, Scenario
-from utils.frontend import get_base_url, get_domain
+from utils.frontend import get_base_url
 from django.conf import settings
 
 

--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -289,9 +289,11 @@ class FundingOpportunitReportSharedLink(CreatedAtMixin, DeletedAtMixin):
         on_delete=models.CASCADE,
     )
 
+    # set of selected key/values to be shared (e.g. AET, TOTAL_FLAME_SEVERITY)
     configuration = models.JSONField()
     
     def get_public_url(self):
+        #TODO: Update the public URL once the path is defined
         base_url = get_base_url(settings.ENV)
         return f"{base_url}/for/{self.uuid}"
 

--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -257,21 +257,21 @@ class FundingOpportunityReportInvite(CreatedAtMixin, UpdatedAtMixin, DeletedAtMi
     report_id: int
     report = models.ForeignKey(
         FundingOpportunityReport,
-        related_name="invites",
+        related_name="funding_opportunity_report_invites",
         on_delete=models.CASCADE,
     )
 
     inviter_id: int
     inviter = models.ForeignKey(
         User,
-        related_name="funding_opportunity_report_invites",
+        related_name="funding_opportunity_report_inviters",
         on_delete=models.CASCADE,
     )
 
     invitee_email = models.EmailField()
     invitee = models.ForeignKey(
         User,
-        related_name="funding_opportunity_report_invites",
+        related_name="funding_opportunity_report_invitees",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -285,7 +285,7 @@ class FundingOpportunitReportSharedLink(CreatedAtMixin, DeletedAtMixin):
     report_id: int
     report = models.ForeignKey(
         FundingOpportunityReport,
-        related_name="invites",
+        related_name="funding_opportunity_report_shared_links",
         on_delete=models.CASCADE,
     )
 

--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 from core.gcs import create_download_url as create_gcs_download_url
 from core.gcs import get_bucket_and_key as get_gcs_bucket_and_key
 from core.gcs import is_gcs_file
-from core.models import CreatedAtMixin, UpdatedAtMixin
+from core.models import CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin
 from core.s3 import create_download_url as create_s3_download_url
 from core.s3 import get_bucket_and_key as get_s3_bucket_and_key
 from core.s3 import is_s3_file
@@ -13,6 +13,8 @@ from django.contrib.auth.models import User
 from django.db import models
 from django_stubs_ext.db.models import TypedModelMeta
 from planning.models import GeoPackageStatus, Scenario
+from utils.frontend import get_base_url, get_domain
+from django.conf import settings
 
 
 class FundingOpportunityReportStatus(models.TextChoices):
@@ -247,3 +249,49 @@ class FundingOpportunityReportRun(CreatedAtMixin, models.Model):
         indexes = [
             models.Index(fields=["created_at"]),
         ]
+
+
+class FundingOpportunityReportInvite(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin):
+    id: int
+
+    report_id: int
+    report = models.ForeignKey(
+        FundingOpportunityReport,
+        related_name="invites",
+        on_delete=models.CASCADE,
+    )
+
+    inviter_id: int
+    inviter = models.ForeignKey(
+        User,
+        related_name="funding_opportunity_report_invites",
+        on_delete=models.CASCADE,
+    )
+
+    invitee_email = models.EmailField()
+    invitee = models.ForeignKey(
+        User,
+        related_name="funding_opportunity_report_invites",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+
+
+class FundingOpportunitReportSharedLink(CreatedAtMixin, DeletedAtMixin):
+    id: int
+    uuid = models.UUIDField(auto_created=True)
+
+    report_id: int
+    report = models.ForeignKey(
+        FundingOpportunityReport,
+        related_name="invites",
+        on_delete=models.CASCADE,
+    )
+
+    configuration = models.JSONField()
+    
+    def get_public_url(self):
+        base_url = get_base_url(settings.ENV)
+        return f"{base_url}/for/{self.uuid}"
+


### PR DESCRIPTION
The model `FundingOpportunityReportInvite` is to keep the emails which a reporta were shared with.
The model `FundingOpportunitReportSharedLink` keeps a unique id (UUID) which will keep the selected AET and TOTAL_FLAME_SEVERITY variables to be shared.