### PR TITLE
 plan-3494-give-pa-owners-option-to-delete-completed-scenarios

### DIFF
--- a/src/planscape/collaboration/permissions.py
+++ b/src/planscape/collaboration/permissions.py
@@ -181,12 +181,11 @@ class ScenarioPermission(CheckPermissionMixin):
     @staticmethod
     def can_remove(user: AbstractUser, scenario: Scenario):
         planning_creator = is_creator(user, scenario.planning_area)
-        scenario_creator = is_creator(user, scenario)
         has_permission = check_for_permission(
             user.pk, scenario.planning_area, "remove_scenario"
         )
 
-        return any([planning_creator, scenario_creator, has_permission])
+        return any([planning_creator, has_permission])
 
 
 class ClimateForesightPermission(CheckPermissionMixin):

--- a/src/planscape/collaboration/tests/test_permissions.py
+++ b/src/planscape/collaboration/tests/test_permissions.py
@@ -202,6 +202,15 @@ class PermissionsTest(TestCase):
         self.create_collaborator_record(Role.COLLABORATOR)
         self.assertFalse(ScenarioPermission.can_remove(self.invitee, self.scenario))
 
+    def test_collaborator_cannot_delete_own_scenario(self):
+        self.create_collaborator_record(Role.COLLABORATOR)
+        scenario = Scenario.objects.create(
+            user=self.invitee,
+            planning_area=self.planning_area,
+            name="collaborator owned scenario",
+        )
+        self.assertFalse(ScenarioPermission.can_remove(self.invitee, scenario))
+
     def test_owner_can_delete_scenarios(self):
         self.create_collaborator_record(Role.OWNER)
         self.assertTrue(ScenarioPermission.can_remove(self.invitee, self.scenario))

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -16,6 +16,7 @@ from planning.models import (
     ScenarioCapability,
     ScenarioPlanningApproach,
     ScenarioResult,
+    ScenarioResultStatus,
     ScenarioType,
     ScenarioVersion,
     TreatmentGoalGroup,
@@ -2309,7 +2310,7 @@ class DeleteScenarioTest(APITestCase):
 
         response = self.client.delete(url)
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 403)
 
     def test_delete_collab_scenario_as_viewer(self):
         url = reverse("api:planning:scenarios-detail", args=[self.collab_scenario.pk])

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -16,7 +16,6 @@ from planning.models import (
     ScenarioCapability,
     ScenarioPlanningApproach,
     ScenarioResult,
-    ScenarioResultStatus,
     ScenarioType,
     ScenarioVersion,
     TreatmentGoalGroup,


### PR DESCRIPTION
@george-silva @roquebetioljr, 542 - Give PA Owners the option to Delete Completed Scenarios, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3494.

1. `src/planscape/collaboration/permissions.py`: removed the `scenario_creator` line in `can_remove` so only planning area creators/owners with `remove_scenario` can delete scenarios.

2. `src/planscape/collaboration/tests/test_permissions.py`: added a test that collaborators cannot delete scenarios they created.

3. `src/planscape/planning/tests/test_v2_scenario_views.py`: updated scenario test so collaborator deletes are not allowed, but owner/creator deletes are allowed.