### PR TITLE
plan-3715-geopackage-regeneration-command

### DIFF
--- a/src/planscape/planning/management/commands/backfill_scenario_result_post_processing.py
+++ b/src/planscape/planning/management/commands/backfill_scenario_result_post_processing.py
@@ -4,17 +4,116 @@ from typing import Any
 from django.core.management.base import BaseCommand
 
 from planning.models import Scenario, ScenarioResultStatus
-from planning.services import calculate_and_update_scenario_result
+from planning.services import (
+    calculate_and_update_scenario_result,
+    export_to_geopackage,
+)
 
 log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    def handle(self, *args: Any, **options: Any) -> str | None:
-        successful_scenarios = Scenario.objects.filter(result_status=ScenarioResultStatus.SUCCESS)
+    help = "Backfill scenario post-processing data, optionally regenerating GeoPackages."
 
-        for scenario in successful_scenarios:
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--scenario-id",
+            type=int,
+            help="Only backfill one scenario by id.",
+        )
+        parser.add_argument(
+            "--regenerate-geopackages",
+            action="store_true",
+            help="Also regenerate GeoPackages after backfilling scenario results.",
+        )
+        parser.add_argument(
+            "--only-existing-geopackages",
+            action="store_true",
+            help=(
+                "Only regenerate GeoPackages for scenarios that already have a "
+                "geopackage_url. Requires --regenerate-geopackages."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print what would happen without saving changes.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> str | None:
+        scenario_id = options.get("scenario_id")
+        regenerate_geopackages = options["regenerate_geopackages"]
+        only_existing_geopackages = options["only_existing_geopackages"]
+        dry_run = options["dry_run"]
+
+        if only_existing_geopackages and not regenerate_geopackages:
+            self.stderr.write(
+                "--only-existing-geopackages requires --regenerate-geopackages."
+            )
+            return
+
+        successful_scenarios = Scenario.objects.filter(
+            result_status=ScenarioResultStatus.SUCCESS
+        ).select_related("results", "treatment_goal")
+
+        if scenario_id:
+            successful_scenarios = successful_scenarios.filter(pk=scenario_id)
+
+        total = successful_scenarios.count()
+
+        self.stdout.write(f"Found {total} successful scenario(s).")
+
+        backfilled_count = 0
+        geopackage_count = 0
+        skipped_geopackage_count = 0
+        failed_count = 0
+
+        for scenario in successful_scenarios.iterator(chunk_size=100):
             try:
-                calculate_and_update_scenario_result(scenario)
+                self.stdout.write(f"Backfilling scenario {scenario.pk}")
+
+                if not dry_run:
+                    calculate_and_update_scenario_result(scenario)
+
+                backfilled_count += 1
+
+                if regenerate_geopackages:
+                    if only_existing_geopackages and not scenario.geopackage_url:
+                        skipped_geopackage_count += 1
+                        self.stdout.write(
+                            f"Skipping GeoPackage for scenario {scenario.pk}: "
+                            "no existing geopackage_url."
+                        )
+                        continue
+
+                    self.stdout.write(
+                        f"Regenerating GeoPackage for scenario {scenario.pk}"
+                    )
+
+                    if not dry_run:
+                        geopackage_url = export_to_geopackage(
+                            scenario,
+                            regenerate=True,
+                        )
+
+                        if not geopackage_url:
+                            raise RuntimeError(
+                                f"GeoPackage regeneration failed for scenario {scenario.pk}"
+                            )
+
+                    geopackage_count += 1
+
             except Exception:
-                logging.exception("Failed to backfill post-processing data.", extra={"scenario": scenario.pk})
+                failed_count += 1
+                log.exception(
+                    "Failed to backfill scenario %s.",
+                    scenario.pk,
+                )
+                self.stderr.write(f"[FAIL] Scenario {scenario.pk}")
+
+        self.stdout.write(
+            f"Done. Backfilled {backfilled_count} scenario result(s). "
+            f"Regenerated {geopackage_count} GeoPackage(s). "
+            f"Skipped {skipped_geopackage_count} GeoPackage(s). "
+            f"Failed {failed_count} scenario(s)."
+        )

--- a/src/planscape/planning/management/commands/backfill_scenario_result_post_processing.py
+++ b/src/planscape/planning/management/commands/backfill_scenario_result_post_processing.py
@@ -4,16 +4,16 @@ from typing import Any
 from django.core.management.base import BaseCommand
 
 from planning.models import Scenario, ScenarioResultStatus
-from planning.services import (
-    calculate_and_update_scenario_result,
-    export_to_geopackage,
-)
+from planning.services import calculate_and_update_scenario_result
+from planning.tasks import async_generate_scenario_geopackage
 
 log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Backfill scenario post-processing data, optionally regenerating GeoPackages."
+    help = (
+        "Backfill scenario post-processing data, optionally regenerating GeoPackages."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -64,7 +64,7 @@ class Command(BaseCommand):
         self.stdout.write(f"Found {total} successful scenario(s).")
 
         backfilled_count = 0
-        geopackage_count = 0
+        geopackage_queued_count = 0
         skipped_geopackage_count = 0
         failed_count = 0
 
@@ -87,21 +87,16 @@ class Command(BaseCommand):
                         continue
 
                     self.stdout.write(
-                        f"Regenerating GeoPackage for scenario {scenario.pk}"
+                        f"Queueing GeoPackage regeneration for scenario {scenario.pk}"
                     )
 
                     if not dry_run:
-                        geopackage_url = export_to_geopackage(
-                            scenario,
+                        async_generate_scenario_geopackage.delay(
+                            scenario_id=scenario.pk,
                             regenerate=True,
                         )
 
-                        if not geopackage_url:
-                            raise RuntimeError(
-                                f"GeoPackage regeneration failed for scenario {scenario.pk}"
-                            )
-
-                    geopackage_count += 1
+                    geopackage_queued_count += 1
 
             except Exception:
                 failed_count += 1
@@ -111,9 +106,13 @@ class Command(BaseCommand):
                 )
                 self.stderr.write(f"[FAIL] Scenario {scenario.pk}")
 
+        backfill_action = "Would backfill" if dry_run else "Backfilled"
+        geopackage_action = "Would queue" if dry_run else "Queued"
+
         self.stdout.write(
-            f"Done. Backfilled {backfilled_count} scenario result(s). "
-            f"Regenerated {geopackage_count} GeoPackage(s). "
+            f"Done. {backfill_action} {backfilled_count} scenario result(s). "
+            f"{geopackage_action} {geopackage_queued_count} "
+            "GeoPackage regeneration task(s). "
             f"Skipped {skipped_geopackage_count} GeoPackage(s). "
             f"Failed {failed_count} scenario(s)."
         )

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -2003,8 +2003,8 @@ def calculate_and_update_rx_leverage(scenario: Scenario, features: List) -> List
     names = [name[0] for name in names]
 
     for feature in features:
-        attainment = feature.get("properties").get("attainment")
-        att_values = [attainment.get(name) for name in names]
+        attainment = feature.get("properties").get("attainment") or {}
+        att_values = [attainment.get(name) or 0 for name in names]
         area_acres = feature.get("properties").get("area_acres")
         rx_leverage = (sum(att_values) / area_acres) * 10000 if area_acres else None
         feature["properties"]["rx_leverage"] = rx_leverage

--- a/src/planscape/planning/tasks.py
+++ b/src/planscape/planning/tasks.py
@@ -428,7 +428,10 @@ def trigger_geopackage_generation():
 
 
 @app.task()
-def async_generate_scenario_geopackage(scenario_id: int) -> None:
+def async_generate_scenario_geopackage(
+    scenario_id: int,
+    regenerate: bool = False,
+) -> None:
     """
     This function is a placeholder for the actual implementation of generating
     a scenario geopackage. It should be implemented in the future.
@@ -444,13 +447,16 @@ def async_generate_scenario_geopackage(scenario_id: int) -> None:
         )
         return
 
-    if scenario.geopackage_status != GeoPackageStatus.PENDING:
+    if not regenerate and scenario.geopackage_status != GeoPackageStatus.PENDING:
         log.warning(
             f"Geopackage status for scenario {scenario_id} is {scenario.geopackage_status}. Will not generate geopackage."
         )
         return
 
-    geopackage_path = export_to_geopackage(scenario)
+    geopackage_path = export_to_geopackage(
+        scenario,
+        regenerate=regenerate,
+    )
     log.info(f"Geopackage generated at {geopackage_path}")
     return
 


### PR DESCRIPTION
@george-silva @roquebetioljr, Multiply by 10,000 instead of 1,000, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3715:

1. `src/planscape/planning/management/commands/backfill_scenario_result_post_processing.py`: added to command to be able to regenerate geopackages for scenarios, including trying regenerating individual scenario's geopackages

2. `src/planscape/planning/services.py`: when I tried running `calculate_and_update_scenario_result`, some of the scenarios go the error `TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'`, so I changed the code to treat `None` as a value Python can actually some in the handful of scenarios where that was the case.