### PR TITLE
Funding link change for email

### DIFF
--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -248,7 +248,7 @@ def async_send_email_funding_report_finished(
         return
 
     funding_report_link = get_frontend_url(
-        f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}"
+        f"plan/{report.scenario.planning_area_id}/scenario/{report.scenario_id}/funding"
     )
 
     context = {


### PR DESCRIPTION
It was great to see this email come through, but on the FE, this would be the direct link to the funding report.