### PR TITLE
Poll for GeoPackage readiness on funding report

### DIFF
--- a/src/interface/src/app/funding/full-report-view/full-report-view.component.spec.ts
+++ b/src/interface/src/app/funding/full-report-view/full-report-view.component.spec.ts
@@ -69,6 +69,8 @@ describe('FullReportViewComponent recalculations', () => {
 
   const baseReport: FundingReport = {
     status: 'SUCCESS',
+    geopackage_status: null,
+    geopackage_url: null,
     created_at: '2026-01-01T00:00:00Z',
     created_by: 1,
     updated_at: '2026-01-01T00:00:00Z',

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.spec.ts
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.spec.ts
@@ -1,17 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { FundingDashboardComponent } from '@app/funding/funding-dashboard/funding-dashboard.component';
 import { MockProvider } from 'ng-mocks';
 import { BreadcrumbService } from '@services/breadcrumb.service';
 import { ScenarioState } from '@scenario/scenario.state';
-import { Capabilities, Scenario } from '@types';
+import { Capabilities, FundingReport, Scenario } from '@types';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { FundingReportService } from '@app/services/funding-report.service';
+import { POLLING_INTERVAL } from '@app/plan/plan-helpers';
 
 describe('FundingDashboardComponent', () => {
   let component: FundingDashboardComponent;
@@ -20,6 +27,7 @@ describe('FundingDashboardComponent', () => {
   let currentScenario$: BehaviorSubject<Scenario>;
   let currentScenarioId$: BehaviorSubject<number | null>;
   let activatedRoute: ActivatedRoute;
+  let fundingReportService: FundingReportService;
 
   function makeScenario(id: number, capabilities: Capabilities[]): Scenario {
     return {
@@ -116,4 +124,86 @@ describe('FundingDashboardComponent', () => {
       relativeTo: activatedRoute,
     });
   });
+
+  it('should continue polling while report is RUNNING even if geopackage is SUCCEEDED', fakeAsync(async () => {
+    await setup(makeScenario(123, ['FUNDING_REPORT']));
+    fundingReportService = TestBed.inject(FundingReportService);
+
+    const report1 = {
+      status: 'RUNNING',
+      geopackage_status: 'SUCCEEDED',
+    } as FundingReport;
+    const report2 = {
+      status: 'SUCCESS',
+      geopackage_status: 'SUCCEEDED',
+      results: {},
+    } as FundingReport;
+
+    const reportSpy = spyOn(fundingReportService, 'getReport').and.returnValues(
+      of(report1),
+      of(report2)
+    );
+
+    component.reload$.next();
+    tick(0); // First immediate poll (timer delay 0)
+
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+
+    tick(POLLING_INTERVAL);
+    expect(reportSpy).toHaveBeenCalledTimes(2);
+
+    // it should have stopped because report2 is a terminal state
+    tick(POLLING_INTERVAL);
+    expect(reportSpy).toHaveBeenCalledTimes(2);
+  }));
+
+  it('should continue polling while geopackage is PROCESSING even if report is SUCCESS', fakeAsync(async () => {
+    await setup(makeScenario(123, ['FUNDING_REPORT']));
+    fundingReportService = TestBed.inject(FundingReportService);
+
+    const report1 = {
+      status: 'SUCCESS',
+      geopackage_status: 'PROCESSING',
+    } as FundingReport;
+    const report2 = {
+      status: 'SUCCESS',
+      geopackage_status: 'SUCCEEDED',
+      results: {},
+    } as FundingReport;
+
+    const reportSpy = spyOn(fundingReportService, 'getReport').and.returnValues(
+      of(report1),
+      of(report2)
+    );
+
+    component.reload$.next();
+    tick(0); // Call 1
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+
+    tick(POLLING_INTERVAL); // Call 2
+    expect(reportSpy).toHaveBeenCalledTimes(2);
+
+    tick(POLLING_INTERVAL); // Stream should be complete, no Call 3
+    expect(reportSpy).toHaveBeenCalledTimes(2);
+  }));
+
+  it('should stop polling immediately if the report status fails', fakeAsync(async () => {
+    await setup(makeScenario(123, ['FUNDING_REPORT']));
+    fundingReportService = TestBed.inject(FundingReportService);
+    const report1 = {
+      status: 'FAILED',
+      geopackage_status: 'PENDING',
+    } as FundingReport;
+    const reportSpy = spyOn(fundingReportService, 'getReport').and.returnValue(
+      of(report1)
+    );
+
+    component.reload$.next();
+    tick(0);
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+
+    // Even though geopackage was PENDING, report FAILED is an immediate dealbreaker
+    tick(POLLING_INTERVAL);
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+  }));
 });

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
@@ -88,7 +88,8 @@ export class FundingDashboardComponent implements OnInit {
   isGenerating$ = combineLatest([this.report$, this.generationRequested$]).pipe(
     map(([report, requested]) => {
       // A finished report always wins over a pending click.
-      if (report?.status === 'SUCCESS' || report?.status === 'FAILED') {
+      if (!this.isStillProcessing(report)) {
+        console.log('we are not still processing anymore!');
         return false;
       }
       return requested || this.isGenerating(report);
@@ -102,13 +103,6 @@ export class FundingDashboardComponent implements OnInit {
     map((r) => r?.status === 'SUCCESS' && !this.hasResults(r))
   );
   hasError$ = this.report$.pipe(map((r) => r?.status === 'FAILED'));
-
-  geopackageReady$ = this.report$.pipe(
-    map(
-      (report) =>
-        report?.geopackage_status === 'SUCCEEDED' && report?.geopackage_url
-    )
-  );
 
   /** Empty state shows only before a report exists and before the user asks. */
   showEmptyState$ = combineLatest([
@@ -145,6 +139,7 @@ export class FundingDashboardComponent implements OnInit {
     const geoPackagePending =
       report.geopackage_status === 'PENDING' ||
       report.geopackage_status === 'PROCESSING';
+
     console.log(
       'report status:',
       report.status,

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
@@ -89,7 +89,6 @@ export class FundingDashboardComponent implements OnInit {
     map(([report, requested]) => {
       // A finished report always wins over a pending click.
       if (!this.isStillProcessing(report)) {
-        console.log('we are not still processing anymore!');
         return false;
       }
       return requested || this.isGenerating(report);
@@ -119,7 +118,6 @@ export class FundingDashboardComponent implements OnInit {
       exhaustMap(() => this.fundingReportService.getReport(scenarioId)),
       takeWhile((report) => {
         const processingResult = this.isStillProcessing(report);
-        console.log('processing status:', processingResult, report);
         return processingResult;
       }, true)
     );
@@ -139,13 +137,6 @@ export class FundingDashboardComponent implements OnInit {
     const geoPackagePending =
       report.geopackage_status === 'PENDING' ||
       report.geopackage_status === 'PROCESSING';
-
-    console.log(
-      'report status:',
-      report.status,
-      '- geopackage status:',
-      report.geopackage_status
-    );
 
     return reportIsGenerating || geoPackagePending;
   }

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
@@ -103,6 +103,13 @@ export class FundingDashboardComponent implements OnInit {
   );
   hasError$ = this.report$.pipe(map((r) => r?.status === 'FAILED'));
 
+  geopackageReady$ = this.report$.pipe(
+    map(
+      (report) =>
+        report?.geopackage_status === 'SUCCEEDED' && report?.geopackage_url
+    )
+  );
+
   /** Empty state shows only before a report exists and before the user asks. */
   showEmptyState$ = combineLatest([
     this.report$,
@@ -116,12 +123,36 @@ export class FundingDashboardComponent implements OnInit {
   private pollReport(scenarioId: number) {
     return timer(0, POLLING_INTERVAL).pipe(
       exhaustMap(() => this.fundingReportService.getReport(scenarioId)),
-      takeWhile((report) => this.isGenerating(report), true)
+      takeWhile((report) => {
+        const processingResult = this.isStillProcessing(report);
+        console.log('processing status:', processingResult, report);
+        return processingResult;
+      }, true)
     );
   }
 
   private isGenerating(report: FundingReport | null): boolean {
     return report?.status === 'PENDING' || report?.status === 'RUNNING';
+  }
+
+  private isStillProcessing(report: FundingReport | null): boolean {
+    if (!report) return false;
+    if (report.status === 'FAILED') return false;
+
+    const reportIsGenerating =
+      report.status === 'PENDING' || report.status === 'RUNNING';
+
+    const geoPackagePending =
+      report.geopackage_status === 'PENDING' ||
+      report.geopackage_status === 'PROCESSING';
+    console.log(
+      'report status:',
+      report.status,
+      '- geopackage status:',
+      report.geopackage_status
+    );
+
+    return reportIsGenerating || geoPackagePending;
   }
 
   /** Whether a (successful) report actually carries results to display. */

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
@@ -68,7 +68,7 @@ export class FundingDashboardComponent implements OnInit {
   );
 
   /** Fires on init and after `generateReport()` to (re)start polling. */
-  private reload$ = new BehaviorSubject<void>(undefined);
+  reload$ = new BehaviorSubject<void>(undefined);
 
   /** Set the moment the user clicks generate, so the view switches instantly. */
   private generationRequested$ = new BehaviorSubject<boolean>(false);

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.html
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.html
@@ -10,15 +10,9 @@
   icon="download"
   [matMenuTriggerFor]="menu"
   #trigger="matMenuTrigger"
-  [disabled]="generatingPdf || buttonDisabled"
+  [disabled]="generatingPdf || downloadingGeopackage || buttonDisabled"
   [variant]="isFullView ? 'primary' : 'ghost'">
-  {{
-    generatingPdf
-      ? 'Generating PDF…'
-      : isFullView
-        ? 'Download Options'
-        : 'Download'
-  }}
+  {{ buttonLabel }}
   <mat-icon
     class="material-symbols-outlined download-options-down"
     [ngClass]="{ full: isFullView }"
@@ -26,8 +20,8 @@
   </mat-icon>
 </button>
 <mat-menu #menu="matMenu">
-  <button mat-menu-item (click)="downloadGeopackage()">Geopackage</button>
-  <button mat-menu-item (click)="downloadPDF()">PDF</button>
+  <button mat-menu-item (click)="handleGeopackageDownload()">Geopackage</button>
+  <button mat-menu-item (click)="handleDownloadPdf()">PDF</button>
 </mat-menu>
 <button
   sg-button

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.html
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.html
@@ -26,7 +26,12 @@
   </mat-icon>
 </button>
 <mat-menu #menu="matMenu">
-  <button mat-menu-item (click)="downloadGeopackage()">Geopackage</button>
+  <button
+    mat-menu-item
+    (click)="downloadGeopackage()"
+    [disabled]="!geoPackageUrl">
+    Geopackage
+  </button>
   <button mat-menu-item (click)="downloadPDF()">PDF</button>
 </mat-menu>
 <button

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.html
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.html
@@ -26,12 +26,7 @@
   </mat-icon>
 </button>
 <mat-menu #menu="matMenu">
-  <button
-    mat-menu-item
-    (click)="downloadGeopackage()"
-    [disabled]="!geoPackageUrl">
-    Geopackage
-  </button>
+  <button mat-menu-item (click)="downloadGeopackage()">Geopackage</button>
   <button mat-menu-item (click)="downloadPDF()">PDF</button>
 </mat-menu>
 <button

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.spec.ts
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FundingReportFooterComponent } from './funding-report-footer.component';
 import { ActivatedRoute } from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 describe('FundingReportFooterComponent', () => {
   let component: FundingReportFooterComponent;
@@ -9,7 +11,11 @@ describe('FundingReportFooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FundingReportFooterComponent],
+      imports: [
+        HttpClientTestingModule,
+        FundingReportFooterComponent,
+        MatSnackBarModule,
+      ],
       providers: [{ provide: ActivatedRoute, useValue: { snapshot: {} } }],
     }).compileComponents();
 

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
@@ -41,7 +41,6 @@ export class FundingReportFooterComponent {
 
   downloadingGeopackage = false;
 
-  //TODO: or just emit this to the parent?
   downloadGeopackage() {
     this.downloadingGeopackage = true;
 

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
@@ -5,9 +5,6 @@ import { MatMenuModule } from '@angular/material/menu';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonComponent } from '@styleguide';
 import { FeaturesModule } from '@features/features.module';
-import { FileSaverService } from '@app/services';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { SNACK_ERROR_CONFIG, SUPPORT_URL } from '@app/shared';
 
 @Component({
   selector: 'app-funding-report-footer',
@@ -26,70 +23,33 @@ import { SNACK_ERROR_CONFIG, SUPPORT_URL } from '@app/shared';
 export class FundingReportFooterComponent {
   constructor(
     private router: Router,
-    private route: ActivatedRoute,
-    private fileSaverService: FileSaverService,
-    private snackbar: MatSnackBar
+    private route: ActivatedRoute
   ) {}
   // allow for arbitrary disabling, such as when the map is still loading
   @Input() buttonDisabled = false;
   @Input() footerType: 'preview' | 'full' = 'preview';
   @Input() generatingPdf = false;
+  @Input() downloadingGeopackage = false;
 
   @Output() downloadPdf = new EventEmitter<void>();
+  @Output() downloadGeopackage = new EventEmitter<void>();
 
-  @Input() geoPackageUrl: string | null = null;
-  @Input() geoPackageStatus: string | null = null;
-
-  downloadingGeopackage = false;
-
-  displayDownloadErrorSnackbar() {
-    const snackBarConfig = {
-      ...SNACK_ERROR_CONFIG,
-      verticalPosition: 'bottom' as const,
-    };
-
-    const downloadErrorSnackbar = this.snackbar.open(
-      'Unable to download GeoPackage.',
-      'Submit Feedback',
-      snackBarConfig
-    );
-
-    downloadErrorSnackbar.onAction().subscribe(() => {
-      window.open(SUPPORT_URL, '_blank');
-    });
+  get buttonLabel() {
+    if (this.generatingPdf) {
+      return 'Generating PDF...';
+    } else if (this.downloadingGeopackage) {
+      return 'Downloading GeoPackage...';
+    } else if (this.isFullView) {
+      return 'Download Options';
+    }
+    return 'Download';
   }
 
-  downloadGeopackage() {
-    // if we presume it's failed before the click
-    if (!this.geoPackageStatus || this.geoPackageStatus === 'FAILED') {
-      this.displayDownloadErrorSnackbar();
-    }
-
-    this.downloadingGeopackage = true;
-
-    //TODO: grab this from ... generated file or...compose it?
-    const filename = 'geopackage.gpkg';
-
-    if (this.geoPackageUrl) {
-      this.fileSaverService.downloadGeopackage(this.geoPackageUrl).subscribe({
-        next: (data) => {
-          this.downloadingGeopackage = false;
-          const blob = new Blob([data], {
-            type: 'application/zip',
-          });
-          this.fileSaverService.saveAs(blob, filename);
-        },
-        error: (e) => {
-          this.downloadingGeopackage = false;
-          console.error('Error downloading: ', e);
-          // if it's failed for some other reason, after the click
-          this.displayDownloadErrorSnackbar();
-        },
-      });
-    }
+  handleGeopackageDownload() {
+    this.downloadGeopackage.emit();
   }
 
-  downloadPDF() {
+  handleDownloadPdf() {
     this.downloadPdf.emit();
   }
 

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@styleguide';
 import { FeaturesModule } from '@features/features.module';
 import { FileSaverService } from '@app/services';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { SNACK_ERROR_CONFIG } from '@app/shared';
+import { SNACK_ERROR_CONFIG, SUPPORT_URL } from '@app/shared';
 
 @Component({
   selector: 'app-funding-report-footer',
@@ -38,10 +38,33 @@ export class FundingReportFooterComponent {
   @Output() downloadPdf = new EventEmitter<void>();
 
   @Input() geoPackageUrl: string | null = null;
+  @Input() geoPackageStatus: string | null = null;
 
   downloadingGeopackage = false;
 
+  displayDownloadErrorSnackbar() {
+    const snackBarConfig = {
+      ...SNACK_ERROR_CONFIG,
+      verticalPosition: 'bottom' as const,
+    };
+
+    const downloadErrorSnackbar = this.snackbar.open(
+      'Unable to download GeoPackage.',
+      'Submit Feedback',
+      snackBarConfig
+    );
+
+    downloadErrorSnackbar.onAction().subscribe(() => {
+      window.open(SUPPORT_URL, '_blank');
+    });
+  }
+
   downloadGeopackage() {
+    // if we presume it's failed before the click
+    if (!this.geoPackageStatus || this.geoPackageStatus === 'FAILED') {
+      this.displayDownloadErrorSnackbar();
+    }
+
     this.downloadingGeopackage = true;
 
     //TODO: grab this from ... generated file or...compose it?
@@ -59,11 +82,8 @@ export class FundingReportFooterComponent {
         error: (e) => {
           this.downloadingGeopackage = false;
           console.error('Error downloading: ', e);
-          this.snackbar.open(
-            `Error: Could not generate a GeoPackage.`,
-            'Dismiss',
-            SNACK_ERROR_CONFIG
-          );
+          // if it's failed for some other reason, after the click
+          this.displayDownloadErrorSnackbar();
         },
       });
     }

--- a/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
+++ b/src/interface/src/app/funding/funding-report-footer/funding-report-footer.component.ts
@@ -5,6 +5,9 @@ import { MatMenuModule } from '@angular/material/menu';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonComponent } from '@styleguide';
 import { FeaturesModule } from '@features/features.module';
+import { FileSaverService } from '@app/services';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SNACK_ERROR_CONFIG } from '@app/shared';
 
 @Component({
   selector: 'app-funding-report-footer',
@@ -23,7 +26,9 @@ import { FeaturesModule } from '@features/features.module';
 export class FundingReportFooterComponent {
   constructor(
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private fileSaverService: FileSaverService,
+    private snackbar: MatSnackBar
   ) {}
   // allow for arbitrary disabling, such as when the map is still loading
   @Input() buttonDisabled = false;
@@ -32,8 +37,37 @@ export class FundingReportFooterComponent {
 
   @Output() downloadPdf = new EventEmitter<void>();
 
+  @Input() geoPackageUrl: string | null = null;
+
+  downloadingGeopackage = false;
+
+  //TODO: or just emit this to the parent?
   downloadGeopackage() {
-    // TODO
+    this.downloadingGeopackage = true;
+
+    //TODO: grab this from ... generated file or...compose it?
+    const filename = 'geopackage.gpkg';
+
+    if (this.geoPackageUrl) {
+      this.fileSaverService.downloadGeopackage(this.geoPackageUrl).subscribe({
+        next: (data) => {
+          this.downloadingGeopackage = false;
+          const blob = new Blob([data], {
+            type: 'application/zip',
+          });
+          this.fileSaverService.saveAs(blob, filename);
+        },
+        error: (e) => {
+          this.downloadingGeopackage = false;
+          console.error('Error downloading: ', e);
+          this.snackbar.open(
+            `Error: Could not generate a GeoPackage.`,
+            'Dismiss',
+            SNACK_ERROR_CONFIG
+          );
+        },
+      });
+    }
   }
 
   downloadPDF() {

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -298,5 +298,5 @@
   [footerType]="reportType"
   [buttonDisabled]="(mapLoading$ | async) === true"
   [generatingPdf]="generatingPdf"
-  [geoPackageUrl]="report.geopackage_url ?? null"
+  [geoPackageUrl]="report?.geopackage_url ?? null"
   (downloadPdf)="exportPdf()"></app-funding-report-footer>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -299,4 +299,5 @@
   [buttonDisabled]="(mapLoading$ | async) === true"
   [generatingPdf]="generatingPdf"
   [geoPackageUrl]="report?.geopackage_url ?? null"
+  [geoPackageStatus]="report?.geopackage_status ?? null"
   (downloadPdf)="exportPdf()"></app-funding-report-footer>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -298,5 +298,5 @@
   [footerType]="reportType"
   [buttonDisabled]="(mapLoading$ | async) === true"
   [generatingPdf]="generatingPdf"
-  [geoPackageUrl]="report.geopackage_url"
+  [geoPackageUrl]="report.geopackage_url ?? null"
   (downloadPdf)="exportPdf()"></app-funding-report-footer>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -297,7 +297,7 @@
 <app-funding-report-footer
   [footerType]="reportType"
   [buttonDisabled]="(mapLoading$ | async) === true"
-  [generatingPdf]="generatingPdf"
-  [geoPackageUrl]="report?.geopackage_url ?? null"
-  [geoPackageStatus]="report?.geopackage_status ?? null"
-  (downloadPdf)="exportPdf()"></app-funding-report-footer>
+  [generatingPdf]="(generatingPdf$ | async) || false"
+  [downloadingGeopackage]="(downloadingGeopackage$ | async) || false"
+  (downloadPdf)="exportPdf()"
+  (downloadGeopackage)="downloadGeopackage()"></app-funding-report-footer>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -298,4 +298,5 @@
   [footerType]="reportType"
   [buttonDisabled]="(mapLoading$ | async) === true"
   [generatingPdf]="generatingPdf"
+  [geoPackageUrl]="report.geopackage_url"
   (downloadPdf)="exportPdf()"></app-funding-report-footer>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -66,6 +66,7 @@ import { FundingMapConfigState } from '../funding-map-config-state';
 import { FundingReportToPdfService } from '../funding-report-to-pdf.service';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
+  BehaviorSubject,
   combineLatest,
   debounceTime,
   distinctUntilChanged,
@@ -74,6 +75,7 @@ import {
 } from 'rxjs';
 import { SNACK_ERROR_CONFIG, SUPPORT_URL } from '@app/shared';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { FileSaverService } from '@app/services';
 
 /** Pause after the last keystroke before recalculating water availability. */
 const WATER_DEBOUNCE_MS = 300;
@@ -125,7 +127,8 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
     private fundingModuleService: FundingModuleService,
     private dataLayersStateService: DataLayersStateService,
     private baseLayersStateService: BaseLayersStateService,
-    private snackbar: MatSnackBar
+    private snackbar: MatSnackBar,
+    private fileSaverService: FileSaverService
   ) {}
 
   /** The scrollable container holding the map + report sections. */
@@ -134,7 +137,10 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
   mapLoading$ = this.fundingMapConfigState.mapLoading$;
 
   /** True while a PDF is being generated, to disable the download control. */
-  generatingPdf = false;
+  generatingPdf$ = new BehaviorSubject<boolean>(false);
+
+  /** True while a Geopackage is being downloadeed, to disable the download control. */
+  downloadingGeopackage$ = new BehaviorSubject<boolean>(false);
 
   sections: ReportSection[] = [];
   /** Section ids in document order, handed to the scrollspy directive. */
@@ -493,10 +499,10 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
 
   /** Export the report (map + sections) as a PDF. */
   async exportPdf(): Promise<void> {
-    if (this.generatingPdf) {
+    if (this.generatingPdf$.value === true) {
       return;
     }
-    this.generatingPdf = true;
+    this.generatingPdf$.next(true);
     try {
       // In the dashboard preview the map is inside the captured sections. In the
       // full view it lives in a sibling pane, so grab its canvas to draw on top.
@@ -509,20 +515,58 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
         mapCanvas
       );
     } catch (error) {
-      const snackBarConfig = {
-        ...SNACK_ERROR_CONFIG,
-        verticalPosition: 'bottom' as const,
-      };
-      const downloadErrorSnackbar = this.snackbar.open(
-        'Unable to download PDF.',
-        'Submit Feedback',
-        snackBarConfig
-      );
-      downloadErrorSnackbar.onAction().subscribe(() => {
-        window.open(SUPPORT_URL, '_blank');
-      });
+      this.displayDownloadErrorSnackbar;
     } finally {
-      this.generatingPdf = false;
+      this.generatingPdf$.next(false);
+    }
+  }
+
+  displayDownloadErrorSnackbar() {
+    const snackBarConfig = {
+      ...SNACK_ERROR_CONFIG,
+      verticalPosition: 'bottom' as const,
+    };
+
+    const downloadErrorSnackbar = this.snackbar.open(
+      'Unable to download.',
+      'Submit Feedback',
+      snackBarConfig
+    );
+
+    downloadErrorSnackbar.onAction().subscribe(() => {
+      window.open(SUPPORT_URL, '_blank');
+    });
+  }
+
+  downloadGeopackage() {
+    // if we presume it's failed before the click
+    if (
+      !this.report.geopackage_status ||
+      this.report.geopackage_status === 'FAILED'
+    ) {
+      this.displayDownloadErrorSnackbar();
+    }
+    this.downloadingGeopackage$.next(true);
+    const filename = `geopackage-${this.report.scenario.toString()}.gpkg`;
+
+    if (this.report.geopackage_url) {
+      this.fileSaverService
+        .downloadGeopackage(this.report.geopackage_url)
+        .subscribe({
+          next: (data) => {
+            this.downloadingGeopackage$.next(false);
+            const blob = new Blob([data], {
+              type: 'application/zip',
+            });
+            this.fileSaverService.saveAs(blob, filename);
+          },
+          error: (e) => {
+            this.downloadingGeopackage$.next(false);
+            console.error('Error downloading: ', e);
+            // if it's failed for some other reason, after the click
+            this.displayDownloadErrorSnackbar();
+          },
+        });
     }
   }
 

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -72,6 +72,8 @@ import {
   filter,
   map,
 } from 'rxjs';
+import { SNACK_ERROR_CONFIG, SUPPORT_URL } from '@app/shared';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 /** Pause after the last keystroke before recalculating water availability. */
 const WATER_DEBOUNCE_MS = 300;
@@ -122,7 +124,8 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
     private fundingMapConfigState: FundingMapConfigState,
     private fundingModuleService: FundingModuleService,
     private dataLayersStateService: DataLayersStateService,
-    private baseLayersStateService: BaseLayersStateService
+    private baseLayersStateService: BaseLayersStateService,
+    private snackbar: MatSnackBar
   ) {}
 
   /** The scrollable container holding the map + report sections. */
@@ -505,6 +508,19 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
         `planscape-funding-report-${this.report.scenario}`,
         mapCanvas
       );
+    } catch (error) {
+      const snackBarConfig = {
+        ...SNACK_ERROR_CONFIG,
+        verticalPosition: 'bottom' as const,
+      };
+      const downloadErrorSnackbar = this.snackbar.open(
+        'Unable to download PDF.',
+        'Submit Feedback',
+        snackBarConfig
+      );
+      downloadErrorSnackbar.onAction().subscribe(() => {
+        window.open(SUPPORT_URL, '_blank');
+      });
     } finally {
       this.generatingPdf = false;
     }

--- a/src/interface/src/app/scenario/scenario-dashboard-footer/scenario-dashboard-footer.component.spec.ts
+++ b/src/interface/src/app/scenario/scenario-dashboard-footer/scenario-dashboard-footer.component.spec.ts
@@ -10,6 +10,7 @@ import { ButtonComponent } from '@styleguide';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { MOCK_SCENARIO } from '@app/services/mocks';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ScenarioDashboardFooterComponent', () => {
   let component: ScenarioDashboardFooterComponent;
@@ -17,7 +18,7 @@ describe('ScenarioDashboardFooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ScenarioDashboardFooterComponent],
+      imports: [HttpClientTestingModule, ScenarioDashboardFooterComponent],
       declarations: [
         MockDeclarations(
           ScenarioConfigOverlayComponent,

--- a/src/interface/src/app/scenario/scenario-dashboard-footer/scenario-dashboard-footer.component.ts
+++ b/src/interface/src/app/scenario/scenario-dashboard-footer/scenario-dashboard-footer.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { FileSaverService, ScenarioService } from '@app/services';
+import { FileSaverService } from '@app/services';
 import { Scenario } from '@app/types';
 import { ButtonComponent } from '@styleguide';
 import { ScenarioState } from '../scenario.state';
@@ -38,9 +38,8 @@ export class ScenarioDashboardFooterComponent {
   buttonLabels = GEO_PACKAGE_LABELS;
 
   constructor(
-    private scenarioService: ScenarioService,
     private scenarioState: ScenarioState,
-    private fileServerService: FileSaverService,
+    private fileSaverService: FileSaverService,
     private snackbar: MatSnackBar,
     private dialog: MatDialog,
     private router: Router,
@@ -61,7 +60,7 @@ export class ScenarioDashboardFooterComponent {
 
     if (this.scenario?.geopackage_url && this.scenario?.name) {
       const filename = getSafeFileName(this.scenario.name) + '.zip';
-      this.scenarioService
+      this.fileSaverService
         .downloadGeopackage(this.scenario.geopackage_url)
         .subscribe({
           next: (data) => {
@@ -69,7 +68,7 @@ export class ScenarioDashboardFooterComponent {
             const blob = new Blob([data], {
               type: 'application/zip',
             });
-            this.fileServerService.saveAs(blob, filename);
+            this.fileSaverService.saveAs(blob, filename);
           },
           error: (e) => {
             this.downloadingScenario = false;

--- a/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.ts
+++ b/src/interface/src/app/scenario/scenario-download-footer/scenario-download-footer.component.ts
@@ -2,7 +2,6 @@ import { Component, Input } from '@angular/core';
 import { AsyncPipe, NgIf } from '@angular/common';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { ButtonComponent } from '@styleguide';
-import { ScenarioService } from '@services';
 import { FileSaverService } from '@services';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { getSafeFileName } from '@shared/files';
@@ -34,9 +33,8 @@ import { GEO_PACKAGE_LABELS } from '../scenario.constants';
 })
 export class ScenarioDownloadFooterComponent {
   constructor(
-    private scenarioService: ScenarioService,
     private scenarioState: ScenarioState,
-    private fileServerService: FileSaverService,
+    private fileSaverService: FileSaverService,
     private snackbar: MatSnackBar,
     private dialog: MatDialog
   ) {}
@@ -66,13 +64,13 @@ export class ScenarioDownloadFooterComponent {
 
     if (this.geoPackageURL && this.scenarioName) {
       const filename = getSafeFileName(this.scenarioName) + '.zip';
-      this.scenarioService.downloadGeopackage(this.geoPackageURL).subscribe({
+      this.fileSaverService.downloadGeopackage(this.geoPackageURL).subscribe({
         next: (data) => {
           this.downloadingScenario = false;
           const blob = new Blob([data], {
             type: 'application/zip',
           });
-          this.fileServerService.saveAs(blob, filename);
+          this.fileSaverService.saveAs(blob, filename);
         },
         error: (e) => {
           this.downloadingScenario = false;

--- a/src/interface/src/app/scenario/scenario-results/scenario-results.component.ts
+++ b/src/interface/src/app/scenario/scenario-results/scenario-results.component.ts
@@ -50,7 +50,7 @@ export class ScenarioResultsComponent implements OnChanges, OnInit {
 
   constructor(
     private scenarioService: ScenarioService,
-    private fileServerService: FileSaverService,
+    private fileSaverService: FileSaverService,
     private chartService: ScenarioResultsChartsService,
     private baseLayersStateService: BaseLayersStateService
   ) {
@@ -84,7 +84,7 @@ export class ScenarioResultsComponent implements OnChanges, OnInit {
           const blob = new Blob([data], {
             type: 'application/zip',
           });
-          this.fileServerService.saveAs(blob, filename);
+          this.fileSaverService.saveAs(blob, filename);
         });
     }
   }
@@ -98,7 +98,7 @@ export class ScenarioResultsComponent implements OnChanges, OnInit {
           const blob = new Blob([data], {
             type: 'application/zip',
           });
-          this.fileServerService.saveAs(blob, filename);
+          this.fileSaverService.saveAs(blob, filename);
         });
     }
   }

--- a/src/interface/src/app/services/file-saver.service.spec.ts
+++ b/src/interface/src/app/services/file-saver.service.spec.ts
@@ -1,11 +1,14 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FileSaverService } from './file-saver.service';
 
 describe('FileSaverService', () => {
   let service: FileSaverService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(FileSaverService);
   });
 

--- a/src/interface/src/app/services/file-saver.service.ts
+++ b/src/interface/src/app/services/file-saver.service.ts
@@ -1,9 +1,13 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FileSaverService {
+  constructor(private http: HttpClient) {}
+
   async loadFileSaver() {
     const { default: saveAs } = await import('file-saver');
     return saveAs;
@@ -12,5 +16,11 @@ export class FileSaverService {
   async saveAs(data: Blob | string, filename?: string) {
     const saveAs = await this.loadFileSaver();
     saveAs(data, filename);
+  }
+
+  downloadGeopackage(geoPackageUrl: string): Observable<any> {
+    return this.http.get(geoPackageUrl, {
+      responseType: 'arraybuffer',
+    });
   }
 }

--- a/src/interface/src/app/services/funding-report.service.spec.ts
+++ b/src/interface/src/app/services/funding-report.service.spec.ts
@@ -37,6 +37,8 @@ describe('FundingReportService', () => {
       scenario: 123,
       results: null,
       treatment_datalayer: null,
+      geopackage_status: null,
+      geopackage_url: null,
     };
     let result: FundingReport | null | undefined;
     service.getReport(123).subscribe((r) => (result = r));

--- a/src/interface/src/app/services/scenario.service.ts
+++ b/src/interface/src/app/services/scenario.service.ts
@@ -143,12 +143,6 @@ export class ScenarioService {
     );
   }
 
-  downloadGeopackage(geoPackageUrl: string): Observable<any> {
-    return this.http.get(geoPackageUrl, {
-      responseType: 'arraybuffer',
-    });
-  }
-
   downloadShapeFiles(scenarioId: number): Observable<any> {
     return this.http.get(
       environment.backend_endpoint +

--- a/src/interface/src/app/types/funding-report.ts
+++ b/src/interface/src/app/types/funding-report.ts
@@ -117,6 +117,8 @@ export interface FundingReport {
   scenario: number;
   results: FundingReportResults | null;
   treatment_datalayer: number | null;
+  geopackage_status: 'SUCCEEDED' | 'PROCESSING' | 'PENDING' | 'FAILED';
+  geopackage_url: string;
 }
 
 /**

--- a/src/interface/src/app/types/funding-report.ts
+++ b/src/interface/src/app/types/funding-report.ts
@@ -117,8 +117,8 @@ export interface FundingReport {
   scenario: number;
   results: FundingReportResults | null;
   treatment_datalayer: number | null;
-  geopackage_status: 'SUCCEEDED' | 'PROCESSING' | 'PENDING' | 'FAILED';
-  geopackage_url: string;
+  geopackage_status: null | 'SUCCEEDED' | 'PROCESSING' | 'PENDING' | 'FAILED';
+  geopackage_url: null | string;
 }
 
 /**


### PR DESCRIPTION
This PR:
- adds types in FundingReport to match the geopackage_status types
- changes the conditions on isGenerating$ to check for terminal states of _both_ report status and geopackage_status 
- displays standard snackbar on failures

Some not-totally-related changes:
- moved the `downloadGeopackage()` service function to FileSaverService, since it's not just for scenario reports anymore™
- renamed some component refs from`fileServerService` to `fileSaverService`, for consistency
