### PR TITLE
Rearrange legend results per Figma changes

### DIFF
--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.html
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.html
@@ -21,9 +21,7 @@
     <div class="static-section">
       <div class="static-row">
         <div class="legend-line">
-          <div
-            class="swatch-box"
-            [ngStyle]="{ 'background-color': '#064BBA' }"></div>
+          <div class="swatch-box total-acres"></div>
           <div class="swatch-label">Total Planning Area Acres</div>
         </div>
         <div *ngIf="currentPlan$ | async as plan" class="acres-line">
@@ -32,9 +30,7 @@
       </div>
       <div class="static-row">
         <div class="legend-line">
-          <div
-            class="swatch-box"
-            [ngStyle]="{ 'background-color': '#344F42' }"></div>
+          <div class="swatch-box selected-acres"></div>
           <div class="swatch-label">Selected Project Area Acres</div>
         </div>
         <div class="acres-line">
@@ -66,6 +62,14 @@
         </div>
         <div class="acres-line">
           {{ acreageDetail.acres | number: '1.0-0' }} acres
+        </div>
+      </div>
+    </div>
+    <div class="no-treatment">
+      <div class="no-treatment-title">No Treatment</div>
+      <div class="static-row">
+        <div class="acres-line no-treatment-acres">
+          {{ legendData.noTreatments | number: '1.0-0' }} acres
         </div>
       </div>
     </div>

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.html
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.html
@@ -69,7 +69,7 @@
       <div class="no-treatment-title">No Treatment</div>
       <div class="static-row">
         <div class="acres-line no-treatment-acres">
-          {{ legendData.noTreatments | number: '1.0-0' }} acres
+          {{ legendData.noTreatmentAcres | number: '1.0-0' }} acres
         </div>
       </div>
     </div>

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.scss
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.scss
@@ -78,6 +78,18 @@
   text-transform: capitalize;
 }
 
+.no-treatment-title {
+  @include standard-label();
+  font-size: 14px;
+  color: $color-white;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-transform: capitalize;
+  padding: 16px 0 8px;
+  border-top: 1px #ffffff19 solid;
+}
+
 .close-button,
 .info-icon {
   color: $color-white;
@@ -99,6 +111,10 @@
   width: 100%;
   color: $color-white;
   padding: 0 20px;
+
+  &.no-treatment-acres {
+    padding: 0;
+  }
 }
 
 .swatch-box {
@@ -106,6 +122,16 @@
   width: 14px;
   flex-shrink: 0;
   border-radius: 4px;
+
+  &.total-acres {
+    background-color: #064bba;
+    border: 1.5px solid #6b93d4;
+  }
+
+  &.selected-acres {
+    background-color: #344f42;
+    border: 1.5px solid #709482;
+  }
 }
 
 .swatch-label {
@@ -144,7 +170,7 @@
 }
 
 ::ng-deep .tx-legend-tooltip {
-  color:$color-white;
+  color: $color-white;
   border-radius: 6px;
   position: relative;
   top: 20px;
@@ -154,7 +180,7 @@
   }
 
   &::after {
-    content: "";
+    content: '';
     position: absolute;
     top: 50%;
     left: 100%;

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.scss
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.scss
@@ -124,12 +124,12 @@
   border-radius: 4px;
 
   &.total-acres {
-    background-color: #064bba;
+    background-color: $color-standard-blue;
     border: 1.5px solid #6b93d4;
   }
 
   &.selected-acres {
-    background-color: #344f42;
+    background-color: $color-brand-green;
     border: 1.5px solid #709482;
   }
 }

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.spec.ts
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.spec.ts
@@ -15,6 +15,7 @@ describe('FundingAcreageLegendComponent', () => {
   let testLegendData: FundingLegendData = {
     selectedAcres: 100,
     treatmentAcresTotals: [],
+    noTreatmentAcres: 0,
   };
 
   beforeEach(async () => {

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.ts
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.ts
@@ -19,6 +19,7 @@ export type LegendTreatmentType = (typeof TREATMENT_ORDER)[number];
 
 export interface FundingLegendData {
   selectedAcres: number;
+  noTreatments?: number;
   treatmentAcresTotals?: Array<{
     treatment: LegendTreatmentType;
     acres: number;

--- a/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.ts
+++ b/src/interface/src/app/funding/funding-acreage-legend/funding-acreage-legend.component.ts
@@ -19,7 +19,7 @@ export type LegendTreatmentType = (typeof TREATMENT_ORDER)[number];
 
 export interface FundingLegendData {
   selectedAcres: number;
-  noTreatments?: number;
+  noTreatmentAcres: number;
   treatmentAcresTotals?: Array<{
     treatment: LegendTreatmentType;
     acres: number;

--- a/src/interface/src/app/funding/funding-report/funding-report.helper.spec.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.helper.spec.ts
@@ -199,7 +199,7 @@ describe('funding-report helper', () => {
 describe('calculateTreatmentAcreSums', () => {
   it('should return empty array for empty input', () => {
     const result = calculateTreatmentAcreSums([]);
-    expect(result).toEqual([]);
+    expect(result).toEqual({ noTreatmentSum: 0, treatmentSums: [] });
   });
 
   it('should aggregate treatment acres from realistic input', () => {
@@ -209,11 +209,13 @@ describe('calculateTreatmentAcreSums', () => {
       { 'Rx Burn': 555, 'No Treatment': 200, 'Thin and Rx Burn': 333 },
     ] as Record<string, number>[];
     const result = calculateTreatmentAcreSums(input);
-    expect(result).toEqual([
-      { treatment: 'No Treatment', acres: 406 },
-      { treatment: 'Rx Burn', acres: 999 },
-      { treatment: 'Thin and Rx Burn', acres: 1088 },
-    ]);
+    expect(result).toEqual({
+      treatmentSums: [
+        { treatment: 'Rx Burn', acres: 999 },
+        { treatment: 'Thin and Rx Burn', acres: 1088 },
+      ],
+      noTreatmentSum: 406,
+    });
   });
 });
 
@@ -388,10 +390,10 @@ describe('generateLegendFromReport', () => {
     expect(result).toEqual({
       selectedAcres: 3500,
       treatmentAcresTotals: [
-        { treatment: 'No Treatment', acres: 1400 },
         { treatment: 'Rx Burn', acres: 1078 },
         { treatment: 'Thin and Rx Burn', acres: 1200 },
       ],
+      noTreatments: 1400,
     });
   });
 
@@ -403,10 +405,10 @@ describe('generateLegendFromReport', () => {
     );
     expect(result.selectedAcres).toBe(1250);
     expect(result.treatmentAcresTotals).toEqual([
-      { treatment: 'No Treatment', acres: 550 },
       { treatment: 'Rx Burn', acres: 457 },
       { treatment: 'Thin and Rx Burn', acres: 400 },
     ]);
+    expect(result.noTreatments).toBe(550);
   });
 
   it('should select all areas when selectedAreas is empty', () => {

--- a/src/interface/src/app/funding/funding-report/funding-report.helper.spec.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.helper.spec.ts
@@ -369,7 +369,7 @@ describe('generateLegendFromReport', () => {
 
   it('should return zeros when results is null', () => {
     const result = generateLegendFromReport(null, [1, 2], mockProjectAreas);
-    expect(result).toEqual({ selectedAcres: 0 });
+    expect(result).toEqual({ selectedAcres: 0, noTreatmentAcres: 0 });
   });
 
   it('should calculate selectedAcres from selected areas (ids 1 and 3: 500 + 750 = 1250)', () => {
@@ -393,7 +393,7 @@ describe('generateLegendFromReport', () => {
         { treatment: 'Rx Burn', acres: 1078 },
         { treatment: 'Thin and Rx Burn', acres: 1200 },
       ],
-      noTreatments: 1400,
+      noTreatmentAcres: 1400,
     });
   });
 
@@ -408,7 +408,7 @@ describe('generateLegendFromReport', () => {
       { treatment: 'Rx Burn', acres: 457 },
       { treatment: 'Thin and Rx Burn', acres: 400 },
     ]);
-    expect(result.noTreatments).toBe(550);
+    expect(result.noTreatmentAcres).toBe(550);
   });
 
   it('should select all areas when selectedAreas is empty', () => {

--- a/src/interface/src/app/funding/funding-report/funding-report.helper.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.helper.ts
@@ -183,9 +183,12 @@ export function generateLegendFromReport(
   selectedAreas: number[],
   projectAreas: ProjectArea[]
 ): FundingLegendData {
-  const legendData: FundingLegendData = { selectedAcres: 0 };
+  const legendData: FundingLegendData = {
+    selectedAcres: 0,
+    noTreatmentAcres: 0,
+  };
   if (!results) {
-    return { selectedAcres: 0 };
+    return { selectedAcres: 0, noTreatmentAcres: 0 };
   }
   const txAreas = results?.treatment_areas;
 
@@ -209,7 +212,7 @@ export function generateLegendFromReport(
 
   const calculatedSums = calculateTreatmentAcreSums(selectedTreatmentResults);
   legendData.treatmentAcresTotals = calculatedSums.treatmentSums;
-  legendData.noTreatments = calculatedSums.noTreatmentSum;
+  legendData.noTreatmentAcres = calculatedSums.noTreatmentSum;
   return legendData;
 }
 

--- a/src/interface/src/app/funding/funding-report/funding-report.helper.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.helper.ts
@@ -206,22 +206,35 @@ export function generateLegendFromReport(
   const selectedTreatmentResults = selectedProjectAreas.map(
     (area) => txAreas?.projects[area.id]
   );
-  legendData.treatmentAcresTotals = calculateTreatmentAcreSums(
-    selectedTreatmentResults
-  );
+
+  const calculatedSums = calculateTreatmentAcreSums(selectedTreatmentResults);
+  legendData.treatmentAcresTotals = calculatedSums.treatmentSums;
+  legendData.noTreatments = calculatedSums.noTreatmentSum;
   return legendData;
+}
+
+interface TreatmentSumsResult {
+  treatmentSums: { treatment: LegendTreatmentType; acres: number }[];
+  noTreatmentSum: number;
 }
 
 export function calculateTreatmentAcreSums(
   selectedTreatmentResults: (Record<string, number | undefined> | undefined)[]
-): { treatment: LegendTreatmentType; acres: number }[] {
+): TreatmentSumsResult {
   const totals: Record<string, number> = {};
+  let noTreatmentAcres = 0;
 
   selectedTreatmentResults.forEach((obj) => {
     for (const key in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {
         const value = obj[key] || 0;
-        totals[key] = (totals[key] || 0) + value;
+
+        // capture no treatments separately
+        if (key === 'No Treatment') {
+          noTreatmentAcres += value;
+        } else {
+          totals[key] = (totals[key] || 0) + value;
+        }
       }
     }
   });
@@ -239,9 +252,15 @@ export function calculateTreatmentAcreSums(
     }
   }
 
-  return treatmentAcresSums.sort(
+  const sortedTreatments = treatmentAcresSums.sort(
     (a, b) =>
       TREATMENT_ORDER.indexOf(a.treatment) -
       TREATMENT_ORDER.indexOf(b.treatment)
   );
+
+  // Return them in one interface
+  return {
+    treatmentSums: sortedTreatments,
+    noTreatmentSum: noTreatmentAcres,
+  };
 }


### PR DESCRIPTION
This PR:
- moves 'No Treatment' to its own section
- adds borders on top two swatches per Figma
- updates calculation results and legend interface to handle 'No Treatment' data separately.
- adds a few styles, specifically for the no treatment section


<img width="253" height="486" alt="Screenshot 2026-07-10 at 4 44 44 PM" src="https://github.com/user-attachments/assets/9b14dd71-6a3e-4d6d-8a07-9016765ef68b" />
