### PR TITLE
Fix raster pixel area to use geodesic calculation, not nominal CRS units

### DIFF
--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -31,7 +31,7 @@ from gis.io import detect_mimetype
 from gis.rasters import to_cog_streaming
 from planning.models import GeoPackageStatus, ProjectArea, Scenario
 from planning.services import get_acreage, map_property_for_numeric_export
-from pyproj import Geod
+from pyproj import Geod, Transformer
 from rasterio.features import geometry_mask
 from rasterio.mask import mask
 from utils.geometry import to_multi
@@ -238,27 +238,31 @@ def _datalayer_path(datalayer: DataLayer) -> str:
     return with_vsi_prefix(datalayer.url)
 
 
-def _projected_pixel_area_acres(src: rasterio.DatasetReader) -> float:
-    transform = src.transform
-    unit_factor = 1.0
-    if src.crs and src.crs.is_projected:
-        linear_units_factor = src.crs.linear_units_factor
-        if isinstance(linear_units_factor, tuple):
-            unit_factor = float(linear_units_factor[-1])
-    pixel_area = abs(transform.a * transform.e) * unit_factor * unit_factor
-    return pixel_area / settings.CONVERSION_SQM_ACRES
-
-
-def _geographic_pixel_area_acres(transform, row: int) -> float:
-    geod = Geod(ellps="WGS84")
+def _pixel_area_acres(
+    transform,
+    row: int,
+    to_lonlat: Transformer | None,
+) -> float:
+    """
+    Geodesic ground area (in acres) of one raster pixel in row `row`. Pixel
+    corners are read straight from the raster's own transform - whatever its
+    native resolution actually is - then converted to lon/lat (if not already
+    geographic) so the area reflects true ground distance. This matters for
+    CRSs like EPSG:3857 (Web Mercator), which is conformal but not
+    equal-area: its scale factor grows with latitude, so treating its
+    "meters" as ground meters silently inflates area away from the equator.
+    """
     corners = [
         transform * (0, row),
         transform * (1, row),
         transform * (1, row + 1),
         transform * (0, row + 1),
     ]
+    if to_lonlat is not None:
+        corners = [to_lonlat.transform(x, y) for x, y in corners]
     lons = [corner[0] for corner in corners]
     lats = [corner[1] for corner in corners]
+    geod = Geod(ellps="WGS84")
     area_sq_meters, _perimeter = geod.polygon_area_perimeter(lons, lats)
     return abs(area_sq_meters) / settings.CONVERSION_SQM_ACRES
 
@@ -270,15 +274,16 @@ def _selected_pixel_area_acres(
 ) -> float:
     if not selected_pixels.any():
         return 0.0
-    if src.crs and src.crs.is_projected:
-        return float(selected_pixels.sum()) * _projected_pixel_area_acres(src)
-    if src.crs and src.crs.is_geographic:
-        rows, counts = np.unique(np.where(selected_pixels)[0], return_counts=True)
-        return sum(
-            int(count) * _geographic_pixel_area_acres(transform, int(row))
-            for row, count in zip(rows, counts)
-        )
-    raise ValueError("AET delta raster must use a projected or geographic CRS.")
+    to_lonlat = (
+        None
+        if src.crs and src.crs.is_geographic
+        else Transformer.from_crs(src.crs, "EPSG:4326", always_xy=True)
+    )
+    rows, counts = np.unique(np.where(selected_pixels)[0], return_counts=True)
+    return sum(
+        int(count) * _pixel_area_acres(transform, int(row), to_lonlat)
+        for row, count in zip(rows, counts)
+    )
 
 
 def _valid_pixel_mask(

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -16,8 +16,8 @@ from planning.tests.factories import (
     ScenarioFactory,
 )
 from pyproj import Geod, Transformer
-from rasterio.transform import from_origin
 from rasterio.mask import mask
+from rasterio.transform import from_origin
 
 from funding_report.models import (
     FUNDING_REPORT_YEARS,
@@ -31,12 +31,12 @@ from funding_report.services import (
     _BIOMASS_PIXEL_AREA_ACRES,
     _filter_by_project_id,
     aggregate_delta_pixels,
-    calculate_aet_improvement,
     build_datalayer_lookup,
     build_flame_length_reduction_results,
     build_funding_report_results,
     build_planning_area_feature,
     build_project_area_features,
+    calculate_aet_improvement,
     calculate_biomass_volumes,
     calculate_funding_report_flame_length_reduction,
     calculate_pixel_deltas,
@@ -47,7 +47,6 @@ from funding_report.services import (
     get_biomass_datalayer,
     get_funding_report_layers_of_interest,
 )
-
 
 TEST_DATA = Path("funding_report/tests/test_data")
 BASELINE_RASTER = TEST_DATA / "Baseline_2026_aboveground_total_live.tif"
@@ -121,9 +120,7 @@ def expected_raster_aggregate(geometry: MultiPolygon) -> dict:
     value_values = np.ma.array(value, mask=~valid, dtype=float)
     baseline_sum = float(baseline_values.sum())
     value_sum = float(value_values.sum())
-    delta = (
-        (value_sum - baseline_sum) / baseline_sum * 100 if baseline_sum else 0.0
-    )
+    delta = (value_sum - baseline_sum) / baseline_sum * 100 if baseline_sum else 0.0
     return {
         "baseline": baseline_sum,
         "value": value_sum,
@@ -784,16 +781,22 @@ class BiomassVolumesCalculationTest(TestCase):
             name=f"Biomass {role}",
             type=DataLayerType.RASTER,
             url=str(path),
-            metadata={"modules": {"funding_report": {"variable": "BIOMASS", "role": role}}},
+            metadata={
+                "modules": {"funding_report": {"variable": "BIOMASS", "role": role}}
+            },
         )
 
     def _create_all_biomass_datalayers(self):
         self._create_biomass_datalayer(BiomassRole.MERCHANTABLE, self.merch_path)
-        self._create_biomass_datalayer(BiomassRole.NON_MERCHANTABLE, self.non_merch_path)
+        self._create_biomass_datalayer(
+            BiomassRole.NON_MERCHANTABLE, self.non_merch_path
+        )
         self._create_biomass_datalayer(BiomassRole.WOOD_TYPE, self.wt_path)
 
     def test_get_biomass_datalayer_returns_correct_layer(self):
-        layer = self._create_biomass_datalayer(BiomassRole.MERCHANTABLE, self.merch_path)
+        layer = self._create_biomass_datalayer(
+            BiomassRole.MERCHANTABLE, self.merch_path
+        )
 
         self.assertEqual(get_biomass_datalayer(BiomassRole.MERCHANTABLE), layer)
 
@@ -823,7 +826,9 @@ class BiomassVolumesCalculationTest(TestCase):
         self.assertEqual(len(results["project_areas"]), 1)
         project_result = results["project_areas"][0]
         self.assertEqual(project_result["project_id"], self.project_area.pk)
-        self.assertEqual(set(project_result.keys()), expected_keys | {"project_id", "proj_id"})
+        self.assertEqual(
+            set(project_result.keys()), expected_keys | {"project_id", "proj_id"}
+        )
 
     def test_calculate_biomass_volumes_correct_values(self):
         self._create_all_biomass_datalayers()
@@ -882,7 +887,9 @@ class BiomassVolumesCalculationTest(TestCase):
 
         summary = results["summary"]
         for key in summary:
-            self.assertEqual(summary[key], 0.0, msg=f"{key} should be 0 for non-overlapping area")
+            self.assertEqual(
+                summary[key], 0.0, msg=f"{key} should be 0 for non-overlapping area"
+            )
 
 
 class FundingReportLayersOfInterestTest(TestCase):
@@ -1042,8 +1049,17 @@ class FlattenReportMetricsTest(TestCase):
             "",
             {
                 "TOTAL_FLAME_SEVERITY": {
-                    "7_4": [{"year": 2026, "value": 320.5, "baseline": 5000.0, "delta": 6.41}],
-                    "6_4": [{"year": 2026, "value": 100.0, "baseline": 5000.0, "delta": 2.0}],
+                    "7_4": [
+                        {
+                            "year": 2026,
+                            "value": 320.5,
+                            "baseline": 5000.0,
+                            "delta": 6.41,
+                        }
+                    ],
+                    "6_4": [
+                        {"year": 2026, "value": 100.0, "baseline": 5000.0, "delta": 2.0}
+                    ],
                 }
             },
             out,

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -15,6 +15,7 @@ from planning.tests.factories import (
     ProjectAreaFactory,
     ScenarioFactory,
 )
+from pyproj import Geod, Transformer
 from rasterio.transform import from_origin
 from rasterio.mask import mask
 
@@ -67,6 +68,28 @@ def raster_bounds_geometry(raster_path: Path) -> MultiPolygon:
             srid=src.crs.to_epsg(),
         )
     return MultiPolygon(polygon.transform(4269, clone=True), srid=4269)
+
+
+def geodesic_pixel_area_acres(raster_path: Path, row: int = 0) -> float:
+    """
+    Independently-computed (not reusing the implementation under test) true
+    ground area of one pixel in `row`, used as the expected value for tests
+    against rasters in a projected CRS like EPSG:3857, where a pixel's area
+    isn't simply its nominal resolution squared.
+    """
+    with rasterio.open(raster_path) as src:
+        transform = src.transform
+        to_lonlat = Transformer.from_crs(src.crs, "EPSG:4326", always_xy=True)
+        corners = [
+            transform * (0, row),
+            transform * (1, row),
+            transform * (1, row + 1),
+            transform * (0, row + 1),
+        ]
+        lons, lats = zip(*(to_lonlat.transform(x, y) for x, y in corners))
+        geod = Geod(ellps="WGS84")
+        area_sq_meters, _perimeter = geod.polygon_area_perimeter(lons, lats)
+    return abs(area_sq_meters) / settings.CONVERSION_SQM_ACRES
 
 
 def expected_raster_aggregate(geometry: MultiPolygon) -> dict:
@@ -270,18 +293,21 @@ class FundingReportRasterCalculationTest(TestCase):
                 raster_srid=raster_srid,
             )
 
-        self.assertAlmostEqual(
-            improved_acres,
-            300 / settings.CONVERSION_SQM_ACRES,
-            places=6,
-        )
+        # Threshold 15 selects (row 0, col 1)=15, (row 1, col 0)=20, (row 1, col 1)=30.
+        expected_acres = geodesic_pixel_area_acres(
+            delta_layer.url, row=0
+        ) + 2 * geodesic_pixel_area_acres(delta_layer.url, row=1)
+        self.assertAlmostEqual(improved_acres, expected_acres, places=6)
 
     def test_calculate_aet_improvement_returns_acres_and_percent(self):
-        self.create_aet_datalayer(role="percentual")
+        percentual_layer = self.create_aet_datalayer(role="percentual")
 
         results = calculate_aet_improvement(self.report, percentage=15)
 
-        expected_acres = 300 / settings.CONVERSION_SQM_ACRES
+        # Threshold 15 selects (row 0, col 1)=15, (row 1, col 0)=20, (row 1, col 1)=30.
+        expected_acres = geodesic_pixel_area_acres(
+            percentual_layer.url, row=0
+        ) + 2 * geodesic_pixel_area_acres(percentual_layer.url, row=1)
         expected_total = get_acreage(self.project_area.geometry)
         self.assertEqual(results["percentage"], 15)
         self.assertAlmostEqual(results["improved_acres"], expected_acres, places=6)
@@ -598,7 +624,8 @@ class FlameLengthReductionCalculationTest(TestCase):
             self.create_flame_datalayer(year=year, baseline=False)
 
         self.datalayer_lookup = build_datalayer_lookup()
-        self.pixel_area_acres = 100 / settings.CONVERSION_SQM_ACRES
+        self.row0_pixel_acres = geodesic_pixel_area_acres(self.baseline_path, row=0)
+        self.row1_pixel_acres = geodesic_pixel_area_acres(self.baseline_path, row=1)
 
     def create_flame_datalayer(self, year, baseline):
         return DataLayerFactory.create(
@@ -625,7 +652,8 @@ class FlameLengthReductionCalculationTest(TestCase):
         )
 
         expected_project_area_acres = get_acreage(self.project_area.geometry)
-        expected_reduced_acres = 2 * self.pixel_area_acres
+        # (row 0, col 0)=8/3 and (row 1, col 1)=8/3 satisfy from_ft=7, to_ft=4.
+        expected_reduced_acres = self.row0_pixel_acres + self.row1_pixel_acres
 
         self.assertEqual(result["interval"], {"from": 7.0, "to": 4.0})
         self.assertAlmostEqual(result["value"], expected_reduced_acres, places=6)
@@ -648,7 +676,8 @@ class FlameLengthReductionCalculationTest(TestCase):
             to_ft=3.0,
         )
 
-        expected_reduced_acres = 3 * self.pixel_area_acres
+        # (row 0, col 0), (row 1, col 0), (row 1, col 1) satisfy from_ft=2, to_ft=3.
+        expected_reduced_acres = self.row0_pixel_acres + 2 * self.row1_pixel_acres
 
         self.assertEqual(result["interval"], {"from": 2.0, "to": 3.0})
         self.assertAlmostEqual(result["value"], expected_reduced_acres, places=6)
@@ -668,7 +697,7 @@ class FlameLengthReductionCalculationTest(TestCase):
         )
 
         # Pixels (0,0) and (1,1) have baseline==8 >= 8 and value<=4 → selected.
-        expected_reduced_acres = 2 * self.pixel_area_acres
+        expected_reduced_acres = self.row0_pixel_acres + self.row1_pixel_acres
         self.assertEqual(result["interval"], {"from": 8.0, "to": 4.0})
         self.assertAlmostEqual(result["value"], expected_reduced_acres, places=6)
 


### PR DESCRIPTION
## Summary
Follow-up to #4151. Fixing the AET datalayer bug there exposed a second, pre-existing bug: `_selected_pixel_area_acres` treated a raster's projected-CRS transform units as literal ground meters. All funding-report rasters are stored in EPSG:3857 (Web Mercator), which is conformal but not equal-area - its scale factor grows with latitude - so acreage was silently inflated 10-60%+ depending on latitude. This affects AET improvement, flame length reduction, and treatment area acres alike.

Now pixel corners are always reprojected to lon/lat and area is computed geodesically, regardless of the raster's native CRS/resolution, instead of assuming a fixed pixel size.

## Test plan
- [x] `funding_report` test suite passes (98 tests)
- [x] Verified against live dev data (scenario 5083): before this fix, AET improvement reported 110%-131% of a project area (impossible); after, 70%-83%.