### PR TITLE
fix ExpressionChangedAfterItHasBeenCheckedError on funding report

### DIFF
--- a/src/interface/src/app/funding/funding-map-config-state.ts
+++ b/src/interface/src/app/funding/funding-map-config-state.ts
@@ -7,14 +7,14 @@ export class FundingMapConfigState extends MapConfigState {
   private _selectedProjectAreas$ = new BehaviorSubject<number[]>([]);
   public selectedProjectAreas$ = this._selectedProjectAreas$.asObservable();
 
-  private _mapLoading$ = new BehaviorSubject<boolean>(false);
-  public mapLoading$ = this._mapLoading$.asObservable();
+  private _mapLoaded$ = new BehaviorSubject<boolean>(false);
+  public mapLoaded$ = this._mapLoaded$.asObservable();
 
   private _showFundingLegend$ = new BehaviorSubject(true);
   public showFundingLegend$ = this._showFundingLegend$.asObservable();
 
-  isMapLoading(loaded: boolean) {
-    this._mapLoading$.next(loaded);
+  setMapLoaded(loaded: boolean) {
+    this._mapLoaded$.next(loaded);
   }
 
   setFundingLegendVisibility(value: boolean) {

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.html
@@ -104,9 +104,7 @@
 
 <div
   class="loader"
-  [class.visible]="mapLoading$ | async"
-  [attr.aria-hidden]="
-    (mapLoading$ | async) === false || (mapLoading$ | async) === null
-  ">
+  [class.visible]="(mapLoaded$ | async) === false"
+  [attr.aria-hidden]="(mapLoaded$ | async) !== false">
   <mat-spinner diameter="32"></mat-spinner>
 </div>

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.scss
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.scss
@@ -69,7 +69,7 @@ mgl-map {
   position: absolute;
   height: 100%;
   width: 100%;
-  background-color: rgba($color-black, 0.4);
+  background-color: rgba($color-black, 0.2);
   z-index: 10;
   display: flex;
   align-items: center;

--- a/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
+++ b/src/interface/src/app/funding/funding-report-map/funding-report-map.component.ts
@@ -82,7 +82,6 @@ export class FundingReportMapComponent implements OnInit {
     private matSnackBar: MatSnackBar
   ) {
     this.mapConfigService.initialize();
-    this.fundingMapConfigState.isMapLoading(true);
   }
 
   readonly BASE_COLORS = BASE_COLORS;
@@ -94,7 +93,7 @@ export class FundingReportMapComponent implements OnInit {
   /** Id of the report's treatment datalayer to display on the map. */
   @Input() treatmentDataLayerId!: number;
 
-  mapLoading$ = this.fundingMapConfigState.mapLoading$;
+  mapLoaded$ = this.fundingMapConfigState.mapLoaded$;
 
   mapLibreMap!: MapLibreMap;
   /**
@@ -143,7 +142,7 @@ export class FundingReportMapComponent implements OnInit {
 
   mapLoaded(loadedMap: MapLibreMap) {
     this.mapLibreMap = loadedMap;
-    this.fundingMapConfigState.isMapLoading(false);
+    this.fundingMapConfigState.setMapLoaded(true);
   }
 
   handleOpacityChange(opacity: number) {

--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -296,6 +296,6 @@
 
 <app-funding-report-footer
   [footerType]="reportType"
-  [buttonDisabled]="(mapLoading$ | async) === true"
+  [buttonDisabled]="willShowMap && (mapLoaded$ | async) === false"
   [generatingPdf]="generatingPdf"
   (downloadPdf)="exportPdf()"></app-funding-report-footer>

--- a/src/interface/src/app/funding/funding-report/funding-report.component.scss
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.scss
@@ -52,7 +52,7 @@
   position: relative;
   height: 330px;
   border-radius: 8px;
-  background-color: $color-soft-gray;
+  background-color: $color-white;
   border: 1px solid $color-light-purple;
   overflow: hidden;
 }

--- a/src/interface/src/app/funding/funding-report/funding-report.component.ts
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.ts
@@ -128,7 +128,7 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
   /** The scrollable container holding the map + report sections. */
   @ViewChild('scrollContainer') scrollContainer!: ElementRef<HTMLElement>;
 
-  mapLoading$ = this.fundingMapConfigState.mapLoading$;
+  mapLoaded$ = this.fundingMapConfigState.mapLoaded$;
 
   /** True while a PDF is being generated, to disable the download control. */
   generatingPdf = false;
@@ -486,6 +486,16 @@ export class FundingReportComponent implements OnInit, OnChanges, OnDestroy {
 
   get isPreview() {
     return this.reportType === 'preview';
+  }
+
+  /**
+   * Whether the preview map will render. When it does, the download control
+   * stays disabled until the map reports it has loaded (the export captures the
+   * map canvas). Derived from stable state so the footer's disabled binding
+   * never changes mid-change-detection.
+   */
+  get willShowMap(): boolean {
+    return this.isPreview && !!this.report?.treatment_datalayer;
   }
 
   /** Export the report (map + sections) as a PDF. */


### PR DESCRIPTION
Fixes a `ExpressionChangedAfterItHasBeenCheckedError` between the map state  and the funding footer.