### PR TITLE
Fix treatment area overcounting from whole-pixel inclusion

### DIFF
--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -34,6 +34,7 @@ from planning.services import get_acreage, map_property_for_numeric_export
 from pyproj import Geod, Transformer
 from rasterio.features import geometry_mask
 from rasterio.mask import mask
+from shapely.geometry import Polygon, shape
 from utils.geometry import to_multi
 
 from funding_report.models import (
@@ -285,6 +286,64 @@ def _selected_pixel_area_acres(
         int(count) * _pixel_area_acres(transform, int(row), to_lonlat)
         for row, count in zip(rows, counts)
     )
+
+
+def _fractional_pixel_contributions(
+    pixels: np.ma.MaskedArray,
+    touched_by_geometry: np.ndarray,
+    src: rasterio.DatasetReader,
+    transform,
+    project_geometry: Polygon,
+) -> Dict[Optional[int], float]:
+    """
+    Area-weighted acres per raster value for every pixel touched by
+    `project_geometry`, keyed by the pixel's integer value (or None for a
+    touched pixel with no raster data - i.e. "no treatment").
+
+    Whole-pixel inclusion (count each touched pixel's full area) only
+    approximates true polygon area when pixels are small relative to the
+    polygon. When the treatment raster's native pixel size approaches or
+    exceeds the size of a project area, a single pixel that only clips a
+    small corner of the polygon would otherwise still contribute its full
+    area - this instead weights each pixel's contribution by the actual
+    fraction of it that overlaps the polygon.
+    """
+    contributions: Dict[Optional[int], float] = defaultdict(float)
+    if not touched_by_geometry.any():
+        return contributions
+
+    to_lonlat = (
+        None
+        if src.crs and src.crs.is_geographic
+        else Transformer.from_crs(src.crs, "EPSG:4326", always_xy=True)
+    )
+    data_mask = np.ma.getmaskarray(pixels)
+    raw_values = pixels.filled(0)
+    pixel_area_cache: Dict[int, float] = {}
+
+    for row, col in zip(*np.where(touched_by_geometry)):
+        row, col = int(row), int(col)
+        pixel_polygon = Polygon(
+            [
+                transform * (col, row),
+                transform * (col + 1, row),
+                transform * (col + 1, row + 1),
+                transform * (col, row + 1),
+            ]
+        )
+        if pixel_polygon.area <= 0:
+            continue
+        fraction = pixel_polygon.intersection(project_geometry).area / pixel_polygon.area
+        if fraction <= 0:
+            continue
+
+        if row not in pixel_area_cache:
+            pixel_area_cache[row] = _pixel_area_acres(transform, row, to_lonlat)
+
+        key = None if data_mask[row, col] else int(raw_values[row, col])
+        contributions[key] += pixel_area_cache[row] * fraction
+
+    return contributions
 
 
 def _valid_pixel_mask(
@@ -761,44 +820,39 @@ def calculate_treatment_pixel_areas(report: FundingOpportunityReport) -> Dict[st
                 maybe_transform(project_area.geometry, raster_srid).geojson
             )
             try:
-                data, transform = mask(src, [geometry], crop=True, filled=False)
+                data, transform = mask(
+                    src, [geometry], crop=True, filled=False, all_touched=True
+                )
             except ValueError:
                 projects[project_area.pk] = {}
                 continue
 
             pixels = data[0]
-            data_mask = np.ma.getmaskarray(pixels)
-            valid_mask = ~data_mask
-            values = np.ma.array(pixels, mask=~valid_mask).compressed()
-
-            inside_geometry = ~geometry_mask(
+            touched_by_geometry = ~geometry_mask(
                 [geometry],
                 out_shape=pixels.shape,
                 transform=transform,
                 invert=False,
+                all_touched=True,
+            )
+
+            contributions = _fractional_pixel_contributions(
+                pixels=pixels,
+                touched_by_geometry=touched_by_geometry,
+                src=src,
+                transform=transform,
+                project_geometry=shape(geometry),
             )
 
             project_result: Dict[str, float] = {}
-            for value in np.unique(values):
-                selected_pixels = valid_mask & (pixels.filled(np.nan) == value)
-                acres = _selected_pixel_area_acres(
-                    selected_pixels=selected_pixels,
-                    src=src,
-                    transform=transform,
+            for value, acres in contributions.items():
+                label = (
+                    TREATMENT_NO_TREATMENT_LABEL
+                    if value is None
+                    else TREATMENT_PIXEL_VALUE_LABELS.get(value, str(value))
                 )
-                label = TREATMENT_PIXEL_VALUE_LABELS.get(int(value), str(int(value)))
-                project_result[label] = acres
+                project_result[label] = project_result.get(label, 0.0) + acres
                 total[label] += acres
-
-            no_treatment_pixels = inside_geometry & data_mask
-            if no_treatment_pixels.any():
-                acres = _selected_pixel_area_acres(
-                    selected_pixels=no_treatment_pixels,
-                    src=src,
-                    transform=transform,
-                )
-                project_result[TREATMENT_NO_TREATMENT_LABEL] = acres
-                total[TREATMENT_NO_TREATMENT_LABEL] += acres
 
             projects[project_area.pk] = project_result
 

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -50,7 +50,6 @@ from funding_report.services import (
     get_aet_delta_datalayer,
     get_biomass_datalayer,
     get_funding_report_layers_of_interest,
-    get_treatment_datalayer,
 )
 
 TEST_DATA = Path("funding_report/tests/test_data")
@@ -633,9 +632,7 @@ class TreatmentPixelAreaTest(TestCase):
 
         result = calculate_treatment_pixel_areas(self.report)
 
-        expected_half_pixel_acres = (
-            geodesic_pixel_area_acres(str(raster_path), row=0) / 2
-        )
+        expected_half_pixel_acres = geodesic_pixel_area_acres(raster_path, row=0) / 2
         project_result = result["projects"][project_area.pk]
         self.assertAlmostEqual(
             project_result["Rx Burn"], expected_half_pixel_acres, places=4

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -21,6 +21,9 @@ from rasterio.transform import from_origin
 
 from funding_report.models import (
     FUNDING_REPORT_YEARS,
+    TREATMENT_NO_TREATMENT_LABEL,
+    TREATMENT_ROLE,
+    TREATMENT_VARIABLE,
     BiomassRole,
     FundingOpportunityReport,
     FundingOpportunityReportStatus,
@@ -42,10 +45,12 @@ from funding_report.services import (
     calculate_pixel_deltas,
     calculate_project_area_aet_improvement,
     calculate_project_area_delta,
+    calculate_treatment_pixel_areas,
     flatten_report_metrics,
     get_aet_delta_datalayer,
     get_biomass_datalayer,
     get_funding_report_layers_of_interest,
+    get_treatment_datalayer,
 )
 
 TEST_DATA = Path("funding_report/tests/test_data")
@@ -452,6 +457,193 @@ class FundingReportRasterCalculationTest(TestCase):
                     "delta": 3,
                 },
             ],
+        )
+
+
+def write_treatment_raster(
+    path: Path,
+    values: np.ndarray,
+    origin_x: float,
+    origin_y: float,
+    px: float,
+    py: float,
+    crs: str = "EPSG:4269",
+    nodata: int = 0,
+) -> None:
+    transform = from_origin(origin_x, origin_y, px, py)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=values.shape[0],
+        width=values.shape[1],
+        count=1,
+        dtype=values.dtype,
+        crs=crs,
+        transform=transform,
+        nodata=nodata,
+    ) as dst:
+        dst.write(values, 1)
+
+
+class TreatmentPixelAreaTest(TestCase):
+    """
+    Covers calculate_treatment_pixel_areas, which previously had no tests -
+    the whole-pixel-inclusion bug (a touched pixel's full area counted
+    regardless of how much of it actually overlaps the project area) went
+    undetected because nothing asserted raster-derived acres against the
+    project area's true vector acreage.
+    """
+
+    def setUp(self):
+        self.planning_area = PlanningAreaFactory.create(with_stands=False)
+        self.scenario = ScenarioFactory.create(planning_area=self.planning_area)
+        self.report = FundingOpportunityReport.objects.create(
+            scenario=self.scenario,
+            created_by=self.scenario.user,
+        )
+
+    def create_treatment_datalayer(self, raster_path):
+        return DataLayerFactory.create(
+            name="Treatment",
+            type=DataLayerType.RASTER,
+            url=str(raster_path),
+            metadata={
+                "modules": {
+                    "funding_report": {
+                        "variable": TREATMENT_VARIABLE,
+                        "role": TREATMENT_ROLE,
+                    }
+                }
+            },
+        )
+
+    def test_pixel_aligned_project_area_matches_vector_acreage(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        raster_path = Path(tmp_dir.name) / "treatment_aligned.tif"
+        values = np.ones((10, 10), dtype=np.uint8)
+        write_treatment_raster(
+            raster_path, values, origin_x=-121.0, origin_y=39.0, px=0.001, py=0.001
+        )
+        self.create_treatment_datalayer(raster_path)
+
+        project_area = ProjectAreaFactory.create(
+            scenario=self.scenario,
+            geometry=raster_bounds_geometry(raster_path),
+        )
+
+        result = calculate_treatment_pixel_areas(self.report)
+
+        expected_acres = get_acreage(project_area.geometry)
+        self.assertAlmostEqual(
+            result["projects"][project_area.pk]["Rx Burn"], expected_acres, places=4
+        )
+        self.assertAlmostEqual(result["total"]["Rx Burn"], expected_acres, places=4)
+
+    def test_irregular_small_project_area_on_coarse_raster_uses_fractional_coverage(
+        self,
+    ):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        raster_path = Path(tmp_dir.name) / "treatment_coarse.tif"
+        # ~300m pixels, uniform "Rx Burn" (value=1) everywhere.
+        values = np.ones((100, 100), dtype=np.uint8)
+        write_treatment_raster(
+            raster_path,
+            values,
+            origin_x=-121.01,
+            origin_y=39.01,
+            px=0.0027,
+            py=0.0027,
+        )
+        self.create_treatment_datalayer(raster_path)
+
+        # Irregular pentagon (~8.3 true acres), deliberately unaligned to the
+        # pixel grid and small relative to a ~300m pixel. Whole-pixel
+        # inclusion at this resolution can be off by 2x or more (a single
+        # touched pixel contributes its full ~22-acre area); fractional
+        # coverage should track the true polygon area closely.
+        project_area = ProjectAreaFactory.create(
+            scenario=self.scenario,
+            geometry=MultiPolygon(
+                Polygon(
+                    (
+                        (-121.0000, 39.0000),
+                        (-120.9970, 39.0003),
+                        (-120.9975, 39.0012),
+                        (-120.9990, 39.0015),
+                        (-121.0005, 39.0008),
+                        (-121.0000, 39.0000),
+                    )
+                ),
+                srid=4269,
+            ),
+        )
+
+        result = calculate_treatment_pixel_areas(self.report)
+
+        expected_acres = get_acreage(project_area.geometry)
+        actual_acres = result["projects"][project_area.pk]["Rx Burn"]
+        self.assertAlmostEqual(
+            actual_acres, expected_acres, delta=max(expected_acres * 0.02, 0.01)
+        )
+
+    def test_no_treatment_pixels_get_fractional_weighting(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        raster_path = Path(tmp_dir.name) / "treatment_partial_nodata.tif"
+        # 1 row x 2 cols: left pixel = Rx Burn (1), right pixel = nodata (0).
+        values = np.array([[1, 0]], dtype=np.uint8)
+        px = py = 0.01
+        origin_x, origin_y = -121.0, 39.0
+        write_treatment_raster(
+            raster_path,
+            values,
+            origin_x=origin_x,
+            origin_y=origin_y,
+            px=px,
+            py=py,
+            nodata=0,
+        )
+        self.create_treatment_datalayer(raster_path)
+
+        # Spans exactly the right half of pixel 0 and the left half of pixel
+        # 1, full pixel height - each half should contribute exactly half of
+        # one pixel's true geodesic area.
+        minx = origin_x + 0.5 * px
+        maxx = origin_x + 1.5 * px
+        miny = origin_y - py
+        maxy = origin_y
+        project_area = ProjectAreaFactory.create(
+            scenario=self.scenario,
+            geometry=MultiPolygon(
+                Polygon(
+                    (
+                        (minx, miny),
+                        (minx, maxy),
+                        (maxx, maxy),
+                        (maxx, miny),
+                        (minx, miny),
+                    )
+                ),
+                srid=4269,
+            ),
+        )
+
+        result = calculate_treatment_pixel_areas(self.report)
+
+        expected_half_pixel_acres = (
+            geodesic_pixel_area_acres(str(raster_path), row=0) / 2
+        )
+        project_result = result["projects"][project_area.pk]
+        self.assertAlmostEqual(
+            project_result["Rx Burn"], expected_half_pixel_acres, places=4
+        )
+        self.assertAlmostEqual(
+            project_result[TREATMENT_NO_TREATMENT_LABEL],
+            expected_half_pixel_acres,
+            places=4,
         )
 
 


### PR DESCRIPTION
## Summary
- `calculate_treatment_pixel_areas` counted a touched raster pixel's full area regardless of how much actually overlapped the project area, causing large over/undercounting when pixel size approaches project-area scale (confirmed on staging scenario 5598).
- Switched to area-weighted fractional pixel coverage (shapely intersection per pixel) instead of whole-pixel binary inclusion.

## Test plan
- [x] Added `TreatmentPixelAreaTest` (pixel-aligned baseline, irregular polygon on coarse raster, nodata fractional weighting)
- [x] `make docker-test TEST=funding_report` — 112 tests pass