### PR TITLE
Set funding report status to EMPTY when treatment layer has no valid data

### DIFF
--- a/src/planscape/funding_report/migrations/0009_alter_fundingopportunityreport_status.py
+++ b/src/planscape/funding_report/migrations/0009_alter_fundingopportunityreport_status.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("funding_report", "0008_fundingopportunityreport_aet_datalayer"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="fundingopportunityreport",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("PENDING", "Pending"),
+                    ("RUNNING", "Running"),
+                    ("SUCCESS", "Success"),
+                    ("FAILED", "Failed"),
+                    ("EMPTY", "Empty"),
+                ],
+                default="PENDING",
+                help_text="Status of the Funding Opportunity Report.",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/src/planscape/funding_report/models.py
+++ b/src/planscape/funding_report/models.py
@@ -23,6 +23,7 @@ class FundingOpportunityReportStatus(models.TextChoices):
     RUNNING = "RUNNING", "Running"
     SUCCESS = "SUCCESS", "Success"
     FAILED = "FAILED", "Failed"
+    EMPTY = "EMPTY", "Empty"
 
 
 FUNDING_REPORT_YEARS = (2026, 2031, 2036, 2041, 2046)

--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -219,6 +219,34 @@ def get_project_areas_union(scenario: Scenario) -> GEOSGeometry:
     return geometry
 
 
+def treatment_layer_has_valid_data(scenario: Scenario) -> bool:
+    """
+    True if the treatment layer has any valid (non-nodata) pixel within the
+    union of `scenario`'s project areas. Returns True (i.e. "don't block")
+    when no treatment datalayer is configured at all - that's an existing,
+    separate soft-skip case (see async_generate_treatment_datalayer), not a
+    "no data for this scenario" case.
+    """
+    source = get_treatment_datalayer()
+    if source is None:
+        return True
+
+    geometry = get_project_areas_union(scenario)
+
+    with rasterio.open(_datalayer_path(source)) as src:
+        raster_srid = src.crs.to_epsg() if src.crs else None
+        if raster_srid is None:
+            raise ValueError(f"Raster CRS {src.crs} does not resolve to an EPSG SRID.")
+        clip_geometry = json.loads(maybe_transform(geometry, raster_srid).geojson)
+        try:
+            data, _ = mask(src, [clip_geometry], crop=True, filled=False)
+        except ValueError:
+            # Union geometry doesn't overlap the raster extent at all.
+            return False
+
+    return bool((~np.ma.getmaskarray(data[0])).any())
+
+
 def _get_datalayer(
     datalayer_lookup: Dict[Tuple[str, int, bool], DataLayer],
     metric: str,

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -38,6 +38,7 @@ from funding_report.services import (
     generate_treatment_clip_datalayer,
     get_aet_percentual_datalayer,
     get_treatment_datalayer,
+    treatment_layer_has_valid_data,
 )
 
 log = logging.getLogger(__name__)
@@ -456,11 +457,12 @@ def run_funding_opportunity_report(funding_opportunity_report_id: int) -> None:
         )
 
     try:
-        if not project_area_ids:
-            async_finalize_funding_report_results(
-                project_results=[],
-                funding_opportunity_report_id=funding_opportunity_report_id,
-            )
+        if not project_area_ids or not treatment_layer_has_valid_data(
+            report.scenario
+        ):
+            FundingOpportunityReport.objects.filter(
+                pk=funding_opportunity_report_id
+            ).update(status=FundingOpportunityReportStatus.EMPTY)
             return
 
         datalayer_lookup = build_datalayer_lookup()

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -50,6 +50,7 @@ from funding_report.services import (
     get_aet_delta_datalayer,
     get_biomass_datalayer,
     get_funding_report_layers_of_interest,
+    treatment_layer_has_valid_data,
 )
 
 TEST_DATA = Path("funding_report/tests/test_data")
@@ -642,6 +643,109 @@ class TreatmentPixelAreaTest(TestCase):
             expected_half_pixel_acres,
             places=4,
         )
+
+
+class TreatmentLayerHasValidDataTest(TestCase):
+    def setUp(self):
+        self.planning_area = PlanningAreaFactory.create(with_stands=False)
+        self.scenario = ScenarioFactory.create(planning_area=self.planning_area)
+
+    def create_treatment_datalayer(self, raster_path):
+        return DataLayerFactory.create(
+            name="Treatment",
+            type=DataLayerType.RASTER,
+            url=str(raster_path),
+            metadata={
+                "modules": {
+                    "funding_report": {
+                        "variable": TREATMENT_VARIABLE,
+                        "role": TREATMENT_ROLE,
+                    }
+                }
+            },
+        )
+
+    def test_no_treatment_datalayer_configured_returns_true(self):
+        self.assertTrue(treatment_layer_has_valid_data(self.scenario))
+
+    def test_all_nodata_under_project_areas_returns_false(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        raster_path = Path(tmp_dir.name) / "treatment_all_nodata.tif"
+        values = np.zeros((10, 10), dtype=np.uint8)
+        write_treatment_raster(
+            raster_path,
+            values,
+            origin_x=-121.0,
+            origin_y=39.0,
+            px=0.001,
+            py=0.001,
+            nodata=0,
+        )
+        self.create_treatment_datalayer(raster_path)
+        ProjectAreaFactory.create(
+            scenario=self.scenario,
+            geometry=raster_bounds_geometry(raster_path),
+        )
+
+        self.assertFalse(treatment_layer_has_valid_data(self.scenario))
+
+    def test_some_valid_pixels_under_project_areas_returns_true(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        raster_path = Path(tmp_dir.name) / "treatment_partial.tif"
+        values = np.zeros((10, 10), dtype=np.uint8)
+        values[0, 0] = 1
+        write_treatment_raster(
+            raster_path,
+            values,
+            origin_x=-121.0,
+            origin_y=39.0,
+            px=0.001,
+            py=0.001,
+            nodata=0,
+        )
+        self.create_treatment_datalayer(raster_path)
+        ProjectAreaFactory.create(
+            scenario=self.scenario,
+            geometry=raster_bounds_geometry(raster_path),
+        )
+
+        self.assertTrue(treatment_layer_has_valid_data(self.scenario))
+
+    def test_project_areas_outside_raster_extent_returns_false(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        raster_path = Path(tmp_dir.name) / "treatment_offset.tif"
+        values = np.ones((10, 10), dtype=np.uint8)
+        write_treatment_raster(
+            raster_path,
+            values,
+            origin_x=-121.0,
+            origin_y=39.0,
+            px=0.001,
+            py=0.001,
+            nodata=0,
+        )
+        self.create_treatment_datalayer(raster_path)
+        # Far away from the raster's extent entirely.
+        ProjectAreaFactory.create(
+            scenario=self.scenario,
+            geometry=MultiPolygon(
+                Polygon(
+                    (
+                        (-100.0, 10.0),
+                        (-100.0, 10.001),
+                        (-99.999, 10.001),
+                        (-99.999, 10.0),
+                        (-100.0, 10.0),
+                    )
+                ),
+                srid=4269,
+            ),
+        )
+
+        self.assertFalse(treatment_layer_has_valid_data(self.scenario))
 
 
 class BuildFlameLengthReductionResultsTest(TestCase):

--- a/src/planscape/funding_report/tests/test_tasks.py
+++ b/src/planscape/funding_report/tests/test_tasks.py
@@ -483,6 +483,31 @@ class FundingOpportunityReportTaskTest(TestCase):
             self.assertEqual(task.kwargs["to_ft"], FLAME_LENGTH_REDUCTION_DEFAULT_TO_FT)
 
     @mock.patch("funding_report.tasks.chord")
+    def test_run_task_sets_empty_status_when_no_project_areas(self, chord_mock):
+        self.project_area.delete()
+
+        run_funding_opportunity_report(self.report.pk)
+
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, FundingOpportunityReportStatus.EMPTY)
+        chord_mock.assert_not_called()
+
+    @mock.patch("funding_report.tasks.treatment_layer_has_valid_data")
+    @mock.patch("funding_report.tasks.chord")
+    def test_run_task_sets_empty_status_when_treatment_layer_has_no_valid_data(
+        self, chord_mock, has_valid_data_mock
+    ):
+        self.create_all_datalayers()
+        has_valid_data_mock.return_value = False
+
+        run_funding_opportunity_report(self.report.pk)
+
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, FundingOpportunityReportStatus.EMPTY)
+        chord_mock.assert_not_called()
+        has_valid_data_mock.assert_called_once_with(self.scenario)
+
+    @mock.patch("funding_report.tasks.chord")
     def test_run_task_sets_failed_on_exception(self, chord_mock):
         self.create_all_datalayers()
         chord_mock.side_effect = ValueError("bad data")


### PR DESCRIPTION
Adds a pre-check before the funding report chord runs: if the treatment raster has no valid pixels under the union of a scenario's project areas (or the scenario has no project areas), the report short-circuits to a new EMPTY status instead of running the full pipeline.