### PR TITLE
Calculate AET improvement percent against planning area

### DIFF
--- a/src/planscape/funding_report/openapi_examples.py
+++ b/src/planscape/funding_report/openapi_examples.py
@@ -48,7 +48,8 @@ FUNDING_OPPORTUNITY_REPORT_RESPONSE_EXAMPLE = OpenApiExample(
                     "percentage": 25.0,
                     "improved_acres": 1234.5,
                     "total_project_area_acres": 5000.0,
-                    "improved_area_percent": 24.69,
+                    "planning_area_acres": 6500.0,
+                    "improved_area_percent": 18.99,
                 },
                 "BIOMASS_VOLUMES": {
                     "merchantable_softwood_bf": 1820.5,

--- a/src/planscape/funding_report/serializers.py
+++ b/src/planscape/funding_report/serializers.py
@@ -57,6 +57,7 @@ class FundingReportAETImprovementResponseSerializer(serializers.Serializer):
     percentage = serializers.FloatField()
     improved_acres = serializers.FloatField()
     total_project_area_acres = serializers.FloatField()
+    planning_area_acres = serializers.FloatField()
     improved_area_percent = serializers.FloatField()
     project_areas = FundingReportAETImprovementProjectAreaSerializer(many=True)
 

--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -563,10 +563,11 @@ def calculate_project_area_aet_improvement(
 def calculate_aet_improvement(
     report: FundingOpportunityReport, percentage: float
 ) -> Dict[str, Any]:
-    report = FundingOpportunityReport.objects.select_related("scenario").get(
-        pk=report.pk
-    )
+    report = FundingOpportunityReport.objects.select_related(
+        "scenario", "scenario__planning_area"
+    ).get(pk=report.pk)
     project_areas = list(report.scenario.project_areas.all())
+    planning_area_acres = get_acreage(report.scenario.planning_area.geometry)
     percentual_layer = get_aet_percentual_datalayer()
     if percentual_layer is None:
         raise ValueError("Missing funding report AET percentual datalayer.")
@@ -604,15 +605,14 @@ def calculate_aet_improvement(
     )
     improved_acres = sum(result["improved_acres"] for result in project_area_results)
     improved_area_percent = (
-        improved_acres / total_project_area_acres * 100
-        if total_project_area_acres
-        else 0.0
+        improved_acres / planning_area_acres * 100 if planning_area_acres else 0.0
     )
 
     return {
         "percentage": percentage,
         "improved_acres": improved_acres,
         "total_project_area_acres": total_project_area_acres,
+        "planning_area_acres": planning_area_acres,
         "improved_area_percent": improved_area_percent,
         "project_areas": project_area_results,
     }

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -391,6 +391,7 @@ def async_finalize_funding_report_results(
             "percentage": aet_improvement["percentage"],
             "improved_acres": aet_improvement["improved_acres"],
             "total_project_area_acres": aet_improvement["total_project_area_acres"],
+            "planning_area_acres": aet_improvement["planning_area_acres"],
             "improved_area_percent": aet_improvement["improved_area_percent"],
         }
         results["projects"]["AET"] = aet_improvement["project_areas"]

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -311,14 +311,24 @@ class FundingReportRasterCalculationTest(TestCase):
             percentual_layer.url, row=0
         ) + 2 * geodesic_pixel_area_acres(percentual_layer.url, row=1)
         expected_total = get_acreage(self.project_area.geometry)
+        expected_planning_area_acres = get_acreage(self.planning_area.geometry)
+        # The planning area (set from BASELINE_RASTER's real-world bounds in
+        # setUp) is vastly larger than the project area (overwritten to the
+        # tiny synthetic AET raster's bounds above), so this also proves the
+        # percentage is computed against the planning area, not the project
+        # area total.
+        self.assertNotAlmostEqual(expected_planning_area_acres, expected_total)
         self.assertEqual(results["percentage"], 15)
         self.assertAlmostEqual(results["improved_acres"], expected_acres, places=6)
         self.assertAlmostEqual(
             results["total_project_area_acres"], expected_total, places=6
         )
         self.assertAlmostEqual(
+            results["planning_area_acres"], expected_planning_area_acres, places=6
+        )
+        self.assertAlmostEqual(
             results["improved_area_percent"],
-            expected_acres / expected_total * 100,
+            expected_acres / expected_planning_area_acres * 100,
             places=6,
         )
 
@@ -335,6 +345,56 @@ class FundingReportRasterCalculationTest(TestCase):
             project_area_result["improved_area_percent"],
             expected_acres / expected_total * 100,
             places=6,
+        )
+
+    def test_calculate_aet_improvement_percent_uses_planning_area_across_projects(
+        self,
+    ):
+        percentual_layer = self.create_aet_datalayer(role="percentual")
+        # Second project area sharing the same tiny synthetic raster bounds as
+        # self.project_area, so its improved/total acres double the first's.
+        second_project_area = ProjectAreaFactory.create(
+            scenario=self.scenario,
+            geometry=self.project_area.geometry,
+        )
+
+        results = calculate_aet_improvement(self.report, percentage=15)
+
+        expected_acres_per_project = geodesic_pixel_area_acres(
+            percentual_layer.url, row=0
+        ) + 2 * geodesic_pixel_area_acres(percentual_layer.url, row=1)
+        expected_total_per_project = get_acreage(self.project_area.geometry)
+        expected_planning_area_acres = get_acreage(self.planning_area.geometry)
+
+        expected_improved_acres = 2 * expected_acres_per_project
+        expected_total_project_area_acres = 2 * expected_total_per_project
+
+        self.assertEqual(len(results["project_areas"]), 2)
+        self.assertAlmostEqual(
+            results["improved_acres"], expected_improved_acres, places=6
+        )
+        self.assertAlmostEqual(
+            results["total_project_area_acres"],
+            expected_total_project_area_acres,
+            places=6,
+        )
+        self.assertAlmostEqual(
+            results["planning_area_acres"], expected_planning_area_acres, places=6
+        )
+        # The percentage must track the constant planning area total, not the
+        # sum of the (here, two) project areas' own acreage.
+        self.assertAlmostEqual(
+            results["improved_area_percent"],
+            expected_improved_acres / expected_planning_area_acres * 100,
+            places=6,
+        )
+        self.assertNotAlmostEqual(
+            results["improved_area_percent"],
+            expected_improved_acres / expected_total_project_area_acres * 100,
+        )
+        self.assertEqual(
+            {r["project_id"] for r in results["project_areas"]},
+            {self.project_area.pk, second_project_area.pk},
         )
 
     def test_calculate_project_area_delta_raises_for_missing_datalayer(self):

--- a/src/planscape/funding_report/tests/test_views.py
+++ b/src/planscape/funding_report/tests/test_views.py
@@ -679,7 +679,8 @@ class AETImprovementTest(APITestCase):
             "percentage": 15,
             "improved_acres": 12.5,
             "total_project_area_acres": 100,
-            "improved_area_percent": 12.5,
+            "planning_area_acres": 500,
+            "improved_area_percent": 2.5,
             "project_areas": [
                 {
                     "project_id": 1,
@@ -695,6 +696,7 @@ class AETImprovementTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["improved_acres"], 12.5)
+        self.assertEqual(response.json()["planning_area_acres"], 500)
         self.assertEqual(len(response.json()["project_areas"]), 1)
         calculate_mock.assert_called_once_with(report=report, percentage=15.0)
 


### PR DESCRIPTION
## Summary
AET improvement's scenario-wide percentage was computed against the sum of the scenario's project areas. It now divides by the planning area's total acreage instead, and exposes that acreage (`planning_area_acres`) so the frontend can compute the percentage for any combination of project areas.

## Test plan
- [x] `make docker-test TEST=funding_report` (119 tests, OK)