### PR TITLE
Update flame length card label

### DIFF
--- a/src/interface/src/app/funding/funding-report/funding-report.component.html
+++ b/src/interface/src/app/funding/funding-report/funding-report.component.html
@@ -128,7 +128,7 @@
         </h5>
         <div class="summary-card" *ngIf="!isPreview">
           <label class="flame-length-label" for="flame-length-interval">
-            (%) Percentage of area with flame length reduced from
+            Percentage of project area(s) with flame length reduced from:
           </label>
           <mat-form-field
             appearance="outline"


### PR DESCRIPTION
This PR just changes the text above the dropdown:
<img width="521" height="173" alt="Screenshot 2026-07-21 at 2 18 43 PM" src="https://github.com/user-attachments/assets/a9eefb88-032a-427b-896e-6195e90e93b6" />
