### PR TITLE
plan-3760-3761-scen-receive-parent-pre-forsys-send-PAs

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -278,9 +278,23 @@ def create_scenario(user: User, **kwargs) -> Scenario:
     from planning.tasks import prepare_scenarios_for_forsys_and_run
 
     planning_area = kwargs.get("planning_area")
+    parent = kwargs.get("parent")
+
+    if isinstance(parent, int):
+        parent = Scenario.objects.get(pk=parent)
+        kwargs["parent"] = parent
+
+    if parent:
+        if parent.type != ScenarioType.PROJECT_AREAS:
+            raise ValueError("Parent scenario must be a Project Areas scenario.")
+
+        planning_area = parent.planning_area
+        kwargs["planning_area"] = planning_area
+
     if isinstance(planning_area, int):
         planning_area = PlanningArea.objects.get(pk=planning_area)
         kwargs["planning_area"] = planning_area
+
     if planning_area and planning_area.map_status == PlanningAreaMapStatus.OVERSIZE:
         raise ValueError(
             f"Planning area is oversize (>{settings.OVERSIZE_PLANNING_AREA_ACRES:,} acres); scenarios are disabled."
@@ -527,8 +541,53 @@ def zip_directory(file_obj, source_dir):
                 )
 
 
+def is_project_areas_child(scenario: Scenario) -> bool:
+    return (
+        scenario.parent_id is not None
+        and scenario.parent is not None
+        and scenario.parent.type == ScenarioType.PROJECT_AREAS
+    )
+
+
+def get_project_areas_stands_lookup_table(
+    scenario: Scenario,
+) -> dict[str, List[int]]:
+    parent = scenario.parent
+    if not parent:
+        return {}
+
+    lookup_table = {}
+    stand_size = scenario.get_stand_size()
+
+    for project_area in parent.project_areas.all():
+        stand_ids = project_area.get_stands(stand_size=stand_size).values_list(
+            "id", flat=True
+        )
+
+        lookup_table[str(project_area.pk)] = list(stand_ids)
+
+    return lookup_table
+
+
+def get_project_areas_child_stand_ids(
+    scenario: Scenario,
+    stand_size: str,
+) -> List[int]:
+    parent = scenario.parent
+    if not parent:
+        return []
+
+    stand_ids = set()
+
+    for project_area in parent.project_areas.all():
+        stand_ids.update(
+            project_area.get_stands(stand_size=stand_size).values_list("id", flat=True)
+        )
+
+    return list(stand_ids)
+
+
 def build_run_configuration(scenario: "Scenario") -> Dict[str, Any]:
-    # treatment goal datalayers
     tx_goal = scenario.treatment_goal
     datalayers = []
 
@@ -627,10 +686,16 @@ def build_run_configuration(scenario: "Scenario") -> Dict[str, Any]:
         )
 
     sub_units_stand_lookup_table = {}
-    if scenario.planning_approach == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS:
+
+    if is_project_areas_child(scenario):
+        sub_units_stand_lookup_table = get_project_areas_stands_lookup_table(
+            scenario=scenario
+        )
+    elif scenario.planning_approach == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS:
         sub_units_datalayer = DataLayer.objects.get(pk=sub_units_layer_id)
         sub_units_stand_lookup_table = get_sub_units_stands_lookup_table(
-            scenario=scenario, datalayer=sub_units_datalayer
+            scenario=scenario,
+            datalayer=sub_units_datalayer,
         )
 
     targets = cfg.get("targets", {})
@@ -688,6 +753,7 @@ def validate_scenario_configuration(scenario: "Scenario") -> List[str]:
 
     cfg = dict(getattr(scenario, "configuration", {}) or {})
     targets = cfg.get("targets") or {}
+    project_areas_child = is_project_areas_child(scenario)
 
     stand_size = cfg.get("stand_size")
     excluded_areas_ids = cfg.get("excluded_areas_ids", [])
@@ -717,72 +783,107 @@ def validate_scenario_configuration(scenario: "Scenario") -> List[str]:
         if not scenario.treatment_goal:
             errors.append("Scenario has no Treatment Goal assigned.")
 
-    else:  # Scenario.type == ScenarioType.CUSTOM
+    elif scenario.type == ScenarioType.CUSTOM:
         if not cfg.get("priorities"):
             errors.append(
                 "Configuration field `priorities` is required for Custom Scenarios."
             )
 
-    # Scenario checks by its `planning_apporach`
+    elif scenario.type == ScenarioType.PROJECT_AREAS:
+        errors.append("Project Areas parent scenarios cannot be run directly.")
+
+    # Scenario checks by its `planning_approach`
     if scenario.planning_approach == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS:
         sub_units_layer_id = cfg.get("sub_units_layer")
         sub_units_fixed_target = targets.get("sub_units_fixed_target")
         sub_units_target_value = targets.get("sub_units_target_value")
 
-        if not sub_units_layer_id:
-            errors.append(
-                "Configuration field `sub_units_layer` is required for this Scenario."
-            )
+        if project_areas_child:
+            if not scenario.parent.project_areas.exists():
+                errors.append("Parent Project Areas scenario has no project areas.")
 
-        elif (
-            not DataLayer.objects.all()
-            .by_meta_module(PrioritizeSubUnitsModule.name)
-            .filter(pk=sub_units_layer_id)
-            .exists()
-        ):
-            errors.append("Invalid `sub_units_layer`.")
-
-        elif sub_units_fixed_target is None or sub_units_target_value is None:
-            errors.append(
-                "It is necessary to set `sub_units_fixed_target` and `sub_units_target_value` fields in Targets for this Scenario."
-            )
-
-        elif sub_units_fixed_target is False and (
-            sub_units_target_value <= 0 or sub_units_target_value > 100
-        ):
-            errors.append(
-                "Field `sub_units_target_value` fields in Targets needs to be greater than zero and lower or equals to 100."
-            )
-
-        elif sub_units_fixed_target is True:
-            sub_units_layer = DataLayer.objects.get(pk=sub_units_layer_id)
-            min_area = get_min_project_area(scenario=scenario)
-            max_area = get_sub_units_details(
-                scenario=scenario,
-                stand_size=scenario.get_stand_size(),
-                datalayer=sub_units_layer,
-            ).get("max")
-            if sub_units_target_value < min_area:
+            if sub_units_fixed_target is None or sub_units_target_value is None:
                 errors.append(
-                    "`sub_units_target_value` cannot be smaller than 1 Stand."
+                    "It is necessary to set `sub_units_fixed_target` and "
+                    "`sub_units_target_value` fields in Targets for this Scenario."
                 )
-            elif sub_units_target_value > max_area:
+
+            elif sub_units_fixed_target is False and (
+                sub_units_target_value <= 0 or sub_units_target_value > 100
+            ):
                 errors.append(
-                    f"`sub_units_target_value` cannot be larger than {max_area}."
+                    "Field `sub_units_target_value` fields in Targets needs to be "
+                    "greater than zero and lower or equals to 100."
                 )
+
+            elif sub_units_fixed_target is True:
+                min_area = get_min_project_area(scenario=scenario)
+
+                if sub_units_target_value < min_area:
+                    errors.append(
+                        "`sub_units_target_value` cannot be smaller than 1 Stand."
+                    )
+        else:
+            if not sub_units_layer_id:
+                errors.append(
+                    "Configuration field `sub_units_layer` is required for this Scenario."
+                )
+
+            elif (
+                not DataLayer.objects.all()
+                .by_meta_module(PrioritizeSubUnitsModule.name)
+                .filter(pk=sub_units_layer_id)
+                .exists()
+            ):
+                errors.append("Invalid `sub_units_layer`.")
+
+            elif sub_units_fixed_target is None or sub_units_target_value is None:
+                errors.append(
+                    "It is necessary to set `sub_units_fixed_target` and "
+                    "`sub_units_target_value` fields in Targets for this Scenario."
+                )
+
+            elif sub_units_fixed_target is False and (
+                sub_units_target_value <= 0 or sub_units_target_value > 100
+            ):
+                errors.append(
+                    "Field `sub_units_target_value` fields in Targets needs to be "
+                    "greater than zero and lower or equals to 100."
+                )
+
+            elif sub_units_fixed_target is True:
+                sub_units_layer = DataLayer.objects.get(pk=sub_units_layer_id)
+                min_area = get_min_project_area(scenario=scenario)
+                max_area = get_sub_units_details(
+                    scenario=scenario,
+                    stand_size=scenario.get_stand_size(),
+                    datalayer=sub_units_layer,
+                ).get("max")
+
+                if sub_units_target_value < min_area:
+                    errors.append(
+                        "`sub_units_target_value` cannot be smaller than 1 Stand."
+                    )
+                elif sub_units_target_value > max_area:
+                    errors.append(
+                        f"`sub_units_target_value` cannot be larger than {max_area}."
+                    )
 
     else:  # scenario.planning_approach == ScenarioPlanningApproach.OPTIMIZE_PROJECT_AREAS
         max_area = targets.get("max_area")
         max_project_count = targets.get("max_project_count")
+
         if max_area is None:
             errors.append(
                 "Configuration target `max_area` (number of acres) is required."
             )
+
         if max_area is not None:
             min_area_project = get_min_project_area(scenario)
             if max_area < min_area_project:
                 errors.append(
-                    f"Target `max_area` must be at least {min_area_project} acres for stand size `{stand_size}`."
+                    f"Target `max_area` must be at least {min_area_project} acres "
+                    f"for stand size `{stand_size}`."
                 )
 
         if max_project_count is None:
@@ -790,7 +891,8 @@ def validate_scenario_configuration(scenario: "Scenario") -> List[str]:
 
         elif max_project_count > available_count:
             errors.append(
-                f"Not enough stands are available: {available_count} stand(s) available for {max_project_count} requested project(s)."
+                f"Not enough stands are available: {available_count} stand(s) "
+                f"available for {max_project_count} requested project(s)."
             )
 
     return errors
@@ -1810,13 +1912,22 @@ def get_available_stand_ids(
     excludes: Optional[QuerySet[DataLayer]] = None,
 ) -> List[int]:
     planning_area = scenario.planning_area
-    if feature_enabled("ADD_INCLUDES"):
+
+    if is_project_areas_child(scenario):
+        stands = Stand.objects.filter(
+            id__in=get_project_areas_child_stand_ids(
+                scenario=scenario,
+                stand_size=stand_size,
+            )
+        )
+    elif feature_enabled("ADD_INCLUDES"):
         stands = scenario.get_treatable_area_stands(stand_size=stand_size)
     else:
         stands = planning_area.get_stands(stand_size=stand_size)
 
     if (
-        scenario.planning_approach == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
+        not is_project_areas_child(scenario)
+        and scenario.planning_approach == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
         and scenario.configuration.get("sub_units_layer")
     ):
         stands_queryset = stands.all()

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -31,15 +31,16 @@ from planning.models import (
     TreatmentGoalUsageType,
 )
 from planning.services import (
+    build_run_configuration,
     calculate_and_update_scenario_result,
     create_planning_area,
     create_scenario,
     export_planning_area_to_geopackage,
-    export_treatable_area_to_geopackage,
     export_scenario_inputs_to_geopackage,
     export_scenario_stand_outputs_to_geopackage,
     export_to_geopackage,
     export_to_shapefile,
+    export_treatable_area_to_geopackage,
     get_acreage,
     get_available_stand_ids,
     get_constrained_stands,
@@ -413,7 +414,7 @@ class TestExportToGeopackage(TestCase):
             name="s1",
             user=self.user,
             treatment_goal=self.treatment_goal,
-            treatable_area=self.planning.geometry
+            treatable_area=self.planning.geometry,
         )
         self.custom_scenario = ScenarioFactory.create(
             planning_area=self.planning,
@@ -422,7 +423,7 @@ class TestExportToGeopackage(TestCase):
             type=ScenarioType.CUSTOM,
             with_priorities=self.datalayers[:2],
             with_cobenefits=self.datalayers[2:],
-            treatable_area=self.planning.geometry
+            treatable_area=self.planning.geometry,
         )
         data = {
             "foo": "abc",
@@ -622,14 +623,15 @@ class TestExportToGeopackage(TestCase):
             feature = next(iter(src))
             self.assertEqual(feature["properties"]["name"], self.planning.name)
 
-
     def test_export_treatable_area_to_geopackage_preset_scenario(self):
         export_treatable_area_to_geopackage(
             self.preset_scenario, self.preset_scenario_output_path
         )
         layers = fiona.listlayers(self.preset_scenario_output_path)
         self.assertIn("treatable_area", layers)
-        with fiona.open(self.preset_scenario_output_path, layer="treatable_area") as src:
+        with fiona.open(
+            self.preset_scenario_output_path, layer="treatable_area"
+        ) as src:
             self.assertEqual(1, len(src))
             self.assertEqual(
                 to_string(src.crs), to_string(settings.CRS_GEOPACKAGE_EXPORT)
@@ -643,7 +645,9 @@ class TestExportToGeopackage(TestCase):
         )
         layers = fiona.listlayers(self.custom_scenario_output_path)
         self.assertIn("treatable_area", layers)
-        with fiona.open(self.custom_scenario_output_path, layer="treatable_area") as src:
+        with fiona.open(
+            self.custom_scenario_output_path, layer="treatable_area"
+        ) as src:
             self.assertEqual(1, len(src))
             self.assertEqual(
                 to_string(src.crs), to_string(settings.CRS_GEOPACKAGE_EXPORT)
@@ -998,8 +1002,7 @@ class TestRemoveExcludes(TestCase):
         self.planning_area = PlanningAreaFactory.create(geometry=pa_geom)
         self.planning_area.get_stands(StandSizeChoices.LARGE)
         self.scenario = ScenarioFactory.create(
-            planning_area=self.planning_area,
-            treatable_area=self.planning_area.geometry
+            planning_area=self.planning_area, treatable_area=self.planning_area.geometry
         )
         self.metrics = calculate_stand_vector_stats_with_stand_list(
             stand_ids=[stand.id for stand in self.stands],
@@ -1167,11 +1170,9 @@ class ValidateScenarioConfigurationTest(TestCase):
             "targets": {"max_area": 500, "max_project_count": 2},
             "excluded_areas_ids": [],
         }
-        
+
         errors = validate_scenario_configuration(self.scenario)
-        self.assertIn(
-            "No stands are available with the current configuration.", errors
-        )
+        self.assertIn("No stands are available with the current configuration.", errors)
         get_available_stand_ids_mock.assert_called_once()
 
     @mock.patch("planning.services.get_available_stand_ids", return_value=[1, 2])
@@ -1182,9 +1183,8 @@ class ValidateScenarioConfigurationTest(TestCase):
         }
         errors = validate_scenario_configuration(self.scenario)
         self.assertIn("Not enough stands are available", " ".join(errors))
-    @mock.patch(
-        "planning.services.get_available_stand_ids", return_value=[1, 2, 3]
-    )
+
+    @mock.patch("planning.services.get_available_stand_ids", return_value=[1, 2, 3])
     def test_valid_configuration(self, get_available_stand_ids_mock):
         self.scenario.configuration = {
             "stand_size": StandSizeChoices.LARGE,
@@ -1210,15 +1210,13 @@ class ValidateScenarioConfigurationTest(TestCase):
             errors,
         )
 
-    @mock.patch(
-        "planning.services.get_available_stand_ids", return_value=[1, 2, 3]
-    )
+    @mock.patch("planning.services.get_available_stand_ids", return_value=[1, 2, 3])
     def test_valid_configuration_with_priorities(self, get_available_stand_ids):
         self.scenario.configuration = {
             "stand_size": StandSizeChoices.LARGE,
             "targets": {"max_area": 9999, "max_project_count": 2},
-            "priorities": [{"datalayer": self.datalayer.pk, "weight": 1}]
-            }
+            "priorities": [{"datalayer": self.datalayer.pk, "weight": 1}],
+        }
         self.scenario.type = ScenarioType.CUSTOM
         self.scenario.save()
         errors = validate_scenario_configuration(self.scenario)
@@ -1278,10 +1276,10 @@ class ValidateScenarioConfigurationTest(TestCase):
             errors,
         )
 
-    @mock.patch(
-        "planning.services.get_available_stand_ids", return_value=[1, 2, 3]
-    )
-    def test_sub_units_target_value_expected_percentage(self, get_available_stand_ids_mock):
+    @mock.patch("planning.services.get_available_stand_ids", return_value=[1, 2, 3])
+    def test_sub_units_target_value_expected_percentage(
+        self, get_available_stand_ids_mock
+    ):
         self.scenario.planning_approach = ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
         self.scenario.configuration = {
             "stand_size": StandSizeChoices.LARGE,
@@ -1324,9 +1322,7 @@ class ValidateScenarioConfigurationTest(TestCase):
         "planning.services.get_sub_units_details",
         return_value={"avg": 1000, "max": 1500, "min": 500},
     )
-    @mock.patch(
-        "planning.services.get_available_stand_ids", return_value=[1, 2, 3]
-    )
+    @mock.patch("planning.services.get_available_stand_ids", return_value=[1, 2, 3])
     def test_sub_units_target_value_expected_acreage(
         self, mock_sub_units_details, get_available_stand_ids_mock
     ):
@@ -1376,6 +1372,79 @@ class ValidateScenarioConfigurationTest(TestCase):
         errors = validate_scenario_configuration(self.scenario)
         self.assertIn("`sub_units_target_value` cannot be larger than 1500.", errors)
         mock_sub_units_details.assert_called_once()
+
+
+class ProjectAreasChildForSysTest(TestCase):
+    def setUp(self):
+        self.planning_area = PlanningAreaFactory.create(with_stands=True)
+
+        self.parent = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            type=ScenarioType.PROJECT_AREAS,
+            configuration={
+                "stand_size": StandSizeChoices.LARGE,
+            },
+        )
+
+        self.project_area = ProjectAreaFactory.create(
+            scenario=self.parent,
+            geometry=self.planning_area.geometry,
+        )
+
+        self.child = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            parent=self.parent,
+            type=ScenarioType.PRESET,
+            planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+            configuration={
+                "stand_size": StandSizeChoices.LARGE,
+                "targets": {
+                    "sub_units_fixed_target": False,
+                    "sub_units_target_value": 50,
+                },
+            },
+        )
+
+    def test_available_stands_come_from_parent_project_areas(self):
+        expected_stand_ids = list(
+            self.project_area.get_stands(stand_size=StandSizeChoices.LARGE).values_list(
+                "id", flat=True
+            )
+        )
+
+        stand_ids = get_available_stand_ids(
+            self.child,
+            StandSizeChoices.LARGE,
+        )
+
+        self.assertCountEqual(stand_ids, expected_stand_ids)
+
+    def test_build_run_configuration_uses_parent_project_areas(self):
+        expected_stand_ids = list(
+            self.project_area.get_stands(stand_size=StandSizeChoices.LARGE).values_list(
+                "id", flat=True
+            )
+        )
+
+        run_configuration = build_run_configuration(self.child)
+
+        self.assertIn("projects_data", run_configuration)
+        self.assertIn(str(self.project_area.pk), run_configuration["projects_data"])
+        self.assertCountEqual(
+            run_configuration["projects_data"][str(self.project_area.pk)],
+            expected_stand_ids,
+        )
+
+    def test_project_areas_child_does_not_require_sub_units_layer(self):
+        self.assertNotIn("sub_units_layer", self.child.configuration)
+
+        errors = validate_scenario_configuration(self.child)
+
+        self.assertNotIn(
+            "Configuration field `sub_units_layer` is required for this Scenario.",
+            errors,
+        )
+        self.assertEqual(errors, [])
 
 
 class CreateScenarioGuardTest(TestCase):
@@ -1503,7 +1572,14 @@ class TriggerScenarioTest(TestCase):
 
         self.assertEqual(
             self.scenario.capabilities,
-            ["FORSYS", "IMPACTS", "MAP", "CLIMATE_FORESIGHT", "PRIORITIZE_SUB_UNITS", "FUNDING_REPORT"],
+            [
+                "FORSYS",
+                "IMPACTS",
+                "MAP",
+                "CLIMATE_FORESIGHT",
+                "PRIORITIZE_SUB_UNITS",
+                "FUNDING_REPORT",
+            ],
         )
 
     def test_compute_scenario_capability_before_run__prioritize_sub_units(self):
@@ -1515,7 +1591,13 @@ class TriggerScenarioTest(TestCase):
 
         self.assertEqual(
             self.scenario.capabilities,
-            ["FORSYS", "MAP", "CLIMATE_FORESIGHT", "PRIORITIZE_SUB_UNITS", "FUNDING_REPORT"],
+            [
+                "FORSYS",
+                "MAP",
+                "CLIMATE_FORESIGHT",
+                "PRIORITIZE_SUB_UNITS",
+                "FUNDING_REPORT",
+            ],
         )
 
 
@@ -1639,11 +1721,13 @@ class CalculateAndUpdateScenarioResult(TestCase):
         features = result.get("features")
         for feature in features:
             self.assertIsNotNone(feature.get("properties", {}).get("rx_leverage"))
-            self.assertIsNotNone(feature.get("properties", {}).get("pct_treatable_area"))
+            self.assertIsNotNone(
+                feature.get("properties", {}).get("pct_treatable_area")
+            )
 
     def test_scenario_type_custom(self):
         scenario = ScenarioFactory(
-            type=ScenarioType.CUSTOM, 
+            type=ScenarioType.CUSTOM,
             with_priorities=self.datalayers,
             forsys_input={"stand_ids": [1, 2, 3, 4]},
         )
@@ -1659,4 +1743,6 @@ class CalculateAndUpdateScenarioResult(TestCase):
         features = result.get("features")
         for feature in features:
             self.assertIsNotNone(feature.get("properties", {}).get("rx_leverage"))
-            self.assertIsNotNone(feature.get("properties", {}).get("pct_treatable_area"))
+            self.assertIsNotNone(
+                feature.get("properties", {}).get("pct_treatable_area")
+            )

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -1852,6 +1852,25 @@ class PatchScenarioConfigurationTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotIn("FORSYS", response.data.get("capabilities", []))
 
+    def test_patch_draft_with_project_areas_parent(self):
+        parent = ScenarioFactory(
+            user=self.user,
+            planning_area=self.planning_area,
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        payload = {
+            "parent": parent.pk,
+        }
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(self.url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.scenario.refresh_from_db()
+        self.assertEqual(self.scenario.parent, parent)
+        self.assertEqual(
+            self.scenario.planning_approach,
+            ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+        )
+
 
 class ScenarioCapabilitiesViewTest(APITestCase):
     def setUp(self):
@@ -2101,6 +2120,57 @@ class CreateScenarioForDraftsTest(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_with_project_areas_parent(self):
+        parent_planning_area = PlanningAreaFactory(user=self.user)
+        parent = ScenarioFactory(
+            user=self.user,
+            planning_area=parent_planning_area,
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        payload = {
+            "name": "project areas child scenario",
+            "planning_area": self.planning_area.pk,
+            "type": ScenarioType.PRESET,
+            "parent": parent.pk,
+        }
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            reverse("api:planning:scenarios-create-draft"),
+            payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        child = Scenario.objects.get(pk=response.data["id"])
+        self.assertEqual(child.parent, parent)
+        self.assertEqual(child.planning_area, parent_planning_area)
+        self.assertEqual(
+            child.planning_approach,
+            ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+        )
+
+    def test_create_rejects_non_project_areas_parent(self):
+        parent = ScenarioFactory(
+            user=self.user,
+            planning_area=self.planning_area,
+            type=ScenarioType.PRESET,
+        )
+        payload = {
+            "name": "invalid child scenario",
+            "planning_area": self.planning_area.pk,
+            "type": ScenarioType.PRESET,
+            "parent": parent.pk,
+        }
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            reverse("api:planning:scenarios-create-draft"),
+            payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(
+            Scenario.objects.filter(name="invalid child scenario").exists()
+        )
 
 
 class ScenarioCapabilitiesSerializerTest(TestCase):

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -14,8 +14,8 @@ from funding_report.models import (
     FundingOpportunityReport,
     FundingOpportunityReportInvite,
     FundingOpportunityReportRun,
-    FundingOpportunityReportStatus,
     FundingOpportunityReportSharedLink,
+    FundingOpportunityReportStatus,
 )
 from funding_report.openapi_examples import (
     FLAME_LENGTH_REDUCTION_RESPONSE_EXAMPLE,
@@ -44,6 +44,7 @@ from modules.base import compute_scenario_capabilities
 from planscape.serializers import BaseErrorMessageSerializer
 from rest_framework import mixins, pagination, permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -59,6 +60,7 @@ from planning.models import (
     PlanningArea,
     ProjectArea,
     Scenario,
+    ScenarioPlanningApproach,
     ScenarioResultStatus,
     ScenarioType,
     ScenarioVersion,
@@ -292,6 +294,22 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         )
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    def validate_parent_scenario(self, parent):
+        if not parent:
+            return None
+
+        parent = get_object_or_404(
+            self.get_queryset().filter(parent__isnull=True),
+            pk=parent.pk,
+        )
+
+        if parent.type != ScenarioType.PROJECT_AREAS:
+            raise DRFValidationError(
+                {"parent": ["Parent scenario must be a Project Areas scenario."]}
+            )
+
+        return parent
+
     @extend_schema(description="Retrieve a Scenario (auto-detects version).")
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
@@ -321,7 +339,11 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     def create_draft(self, request):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+
+        parent = self.validate_parent_scenario(serializer.validated_data.get("parent"))
+
         scenario_type = serializer.validated_data.get("type") or ScenarioType.PRESET
+
         configuration_data = create_config(
             targets=serializer.validated_data.get("targets") or {},
             constraints=[],
@@ -329,12 +351,24 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             excluded_areas=[],
             priorities=[],
             cobenefits=[],
+            planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
+            if parent
+            else None,
         )
+
         validated_data = {
             **serializer.validated_data,
             "configuration": configuration_data,
             "type": scenario_type,
         }
+
+        if parent:
+            validated_data["parent"] = parent
+            validated_data["planning_area"] = parent.planning_area
+            validated_data["planning_approach"] = (
+                ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
+            )
+
         scenario = create_scenario(**validated_data)
 
         if hasattr(scenario, "result_status"):
@@ -421,6 +455,16 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             instance, data=request.data, partial=True
         )
         serializer.is_valid(raise_exception=True)
+        if "parent" in serializer.validated_data:
+            parent = self.validate_parent_scenario(
+                serializer.validated_data.get("parent")
+            )
+            serializer.validated_data["parent"] = parent
+
+            if parent:
+                serializer.validated_data["planning_approach"] = (
+                    ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
+                )
         configuration_data = serializer.validated_data.get("configuration")
         if configuration_data:
             existing = instance.configuration or {}


### PR DESCRIPTION
@roquebetioljr @george-silva @lastminutediorama, 

**PLAN-3760**. Modify create/patch Scenario to receive parent Scenario, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3760

**PLAN-3761**. Send Project Areas similarly to sub-units during pre-ForSys, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3761

----------------------

1. `src/planscape/planning/services.py`: added parent Scenario handling & validation and Project Areas child logic so parent Project Areas are converted to stand groups and sent to ForSys like sub-units.

2. `src/planscape/planning/views_v2.py`: updated draft create & patch to accept and validate a Project Area's parent Scenario and create child prioritization Scenarios.

3. `src/planscape/planning/tests/test_services.py`: added tests for Project Areas child stand selection, ForSys `projects_data`, and running without a `sub_units_layer`.

4. `src/planscape/planning/tests/test_v2_scenario_views.py`: added tests for creating/patching child Scenarios with a Project Area's parent & rejecting invalid parent types.


------------------

The full ticket list is:

3759 = identify Project Areas scenario
3757 = allow children
3758 = list children
3760 = create children
3761 = run children through ForSys

The first 3 tickets are here: https://github.com/OurPlanscape/Planscape/pull/4130