### PR TITLE
feat: Project Areas endpoint of FoR public page

### DIFF
--- a/src/planscape/funding_report/serializers.py
+++ b/src/planscape/funding_report/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from funding_report.models import FundingOpportunityReport
 from funding_report.services import calculate_aet_improvement
+from planning.serializers import ProjectAreaSerializer
 
 
 class FundingOpportunityReportSerializer(serializers.ModelSerializer):
@@ -92,6 +93,22 @@ class FundingOpportunityReportPublicSerializer(serializers.ModelSerializer):
 
     def get_shared_configuration(self, instance: FundingOpportunityReport) -> Optional[Dict]:
         return self.context
+
+
+class FundingOpportunityReportPublicProjectAreaSerializer(ProjectAreaSerializer):
+    treatment_rank = serializers.SerializerMethodField()
+
+    class Meta(ProjectAreaSerializer.Meta):
+        fields = (
+            "name",
+            "data",
+            "geometry",
+            "treatment_rank",
+        )
+
+    def get_treatment_rank(self, instance) -> Optional[int]:
+        return (instance.data or {}).get("treatment_rank")
+
 
 class FundingReportAETImprovementRequestSerializer(serializers.Serializer):
     percentage = serializers.FloatField(min_value=0)

--- a/src/planscape/funding_report/tests/test_views.py
+++ b/src/planscape/funding_report/tests/test_views.py
@@ -4,7 +4,11 @@ from uuid import uuid4
 from collaboration.models import Permissions, Role
 from collaboration.tests.factories import UserObjectRoleFactory
 from django.urls import reverse
-from planning.tests.factories import PlanningAreaFactory, ScenarioFactory
+from planning.tests.factories import (
+    PlanningAreaFactory,
+    ProjectAreaFactory,
+    ScenarioFactory,
+)
 from planscape.tests.factories import UserFactory
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -585,6 +589,64 @@ class PublicFundingOpportunityReportTest(APITestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class PublicFundingOpportunityReportProjectAreasTest(APITestCase):
+    def setUp(self):
+        self.report = FundingOpportunityReportFactory()
+        self.shared_link = FundingOpportunityReportSharedLinkFactory(
+            report=self.report,
+            configuration={"aet": 10, "total_flame_severity": "high"},
+        )
+        self.url = reverse(
+            "api:funding_report:public-funding-opportunity-report-project-areas",
+            args=[self.shared_link.uuid],
+        )
+
+    def test_public_get_returns_project_areas_without_authentication(self):
+        project_area = ProjectAreaFactory(
+            scenario=self.report.scenario,
+            name="Shared project area",
+            data={"treatment_rank": 1},
+        )
+        ProjectAreaFactory(scenario=self.report.scenario, data={"treatment_rank": 2})
+        ProjectAreaFactory()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertIn(project_area.name, [item["name"] for item in data])
+        serialized_project_area = next(
+            item for item in data if item["name"] == project_area.name
+        )
+        self.assertEqual(serialized_project_area["data"], project_area.data)
+        self.assertEqual(serialized_project_area["treatment_rank"], 1)
+        for item in data:
+            self.assertIn("geometry", item)
+            self.assertIn("treatment_rank", item)
+            self.assertNotIn("id", item)
+            self.assertNotIn("scenario", item)
+            self.assertNotIn("created_by", item)
+
+    def test_returns_404_for_unknown_uuid(self):
+        url = reverse(
+            "api:funding_report:public-funding-opportunity-report-project-areas",
+            args=[uuid4()],
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_returns_404_for_deleted_shared_link(self):
+        self.shared_link.delete()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 class CreateFundingOpportunityReportInvitesTest(APITestCase):
     def setUp(self):

--- a/src/planscape/funding_report/urls.py
+++ b/src/planscape/funding_report/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from funding_report.views import public_funding_opportunity_report
+from funding_report.views import (
+    public_funding_opportunity_report,
+    public_funding_opportunity_report_project_areas,
+)
 
 app_name = "funding_report"
 
@@ -9,5 +12,10 @@ urlpatterns = [
         "<uuid:shared_link_uuid>/",
         public_funding_opportunity_report,
         name="public-funding-opportunity-report",
+    ),
+    path(
+        "<uuid:shared_link_uuid>/project_areas/",
+        public_funding_opportunity_report_project_areas,
+        name="public-funding-opportunity-report-project-areas",
     ),
 ]

--- a/src/planscape/funding_report/views.py
+++ b/src/planscape/funding_report/views.py
@@ -6,7 +6,10 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from funding_report.models import FundingOpportunityReportSharedLink
-from funding_report.serializers import FundingOpportunityReportPublicSerializer
+from funding_report.serializers import (
+    FundingOpportunityReportPublicProjectAreaSerializer,
+    FundingOpportunityReportPublicSerializer,
+)
 
 
 @extend_schema_view(
@@ -27,4 +30,21 @@ def public_funding_opportunity_report(request, shared_link_uuid):
         instance=shared_link.report, 
         context=shared_link.configuration
     )
+    return Response(serializer.data)
+
+
+@extend_schema(
+    description="Project Areas for a shared Funding Opportunity Report.",
+    responses={200: FundingOpportunityReportPublicProjectAreaSerializer(many=True)},
+)
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def public_funding_opportunity_report_project_areas(request, shared_link_uuid):
+    shared_link = get_object_or_404(
+        FundingOpportunityReportSharedLink.objects.select_related("report__scenario"),
+        uuid=shared_link_uuid,
+        deleted_at__isnull=True,
+    )
+    queryset = shared_link.report.scenario.project_areas.all()
+    serializer = FundingOpportunityReportPublicProjectAreaSerializer(queryset, many=True)
     return Response(serializer.data)


### PR DESCRIPTION
* Returning the Scenario's Project Areas linked to a Funding Opportunity Report that was shared to the public.
* New endpoint /v2/funding_report/<uuid:shared_link_uuid>/project_areas/
* Response hides sensitive data like, id, scenario id, created_by id.