### PR TITLE
Public Project Areas from Shared Link endpoint update

### DIFF
--- a/src/planscape/funding_report/serializers.py
+++ b/src/planscape/funding_report/serializers.py
@@ -94,12 +94,16 @@ class FundingOpportunityReportPublicSerializer(serializers.ModelSerializer):
     def get_shared_configuration(self, instance: FundingOpportunityReport) -> Optional[Dict]:
         return self.context
 
+class FundingOpportunityReportPublicProjectAreaQueryParamsSerializer(serializers.Serializer):
+    number_of_features = serializers.IntegerField(min_value=1, required=False)
+
 
 class FundingOpportunityReportPublicProjectAreaSerializer(ProjectAreaSerializer):
     treatment_rank = serializers.SerializerMethodField()
 
     class Meta(ProjectAreaSerializer.Meta):
         fields = (
+            "id",
             "name",
             "data",
             "geometry",

--- a/src/planscape/funding_report/tests/test_views.py
+++ b/src/planscape/funding_report/tests/test_views.py
@@ -3,7 +3,9 @@ from uuid import uuid4
 
 from collaboration.models import Permissions, Role
 from collaboration.tests.factories import UserObjectRoleFactory
+from django.conf import settings
 from django.urls import reverse
+from planning.models import ScenarioPlanningApproach
 from planning.tests.factories import (
     PlanningAreaFactory,
     ProjectAreaFactory,
@@ -609,6 +611,7 @@ class PublicFundingOpportunityReportProjectAreasTest(APITestCase):
             name="Shared project area",
             data={"treatment_rank": 1},
         )
+        ProjectAreaFactory(scenario=self.report.scenario, data={"treatment_rank": 3})
         ProjectAreaFactory(scenario=self.report.scenario, data={"treatment_rank": 2})
         ProjectAreaFactory()
 
@@ -616,19 +619,56 @@ class PublicFundingOpportunityReportProjectAreasTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertEqual(len(data), 2)
+        self.assertEqual(len(data), 3)
+        self.assertEqual([item["treatment_rank"] for item in data], [1, 2, 3])
         self.assertIn(project_area.name, [item["name"] for item in data])
         serialized_project_area = next(
             item for item in data if item["name"] == project_area.name
         )
         self.assertEqual(serialized_project_area["data"], project_area.data)
         self.assertEqual(serialized_project_area["treatment_rank"], 1)
+        self.assertEqual(serialized_project_area["id"], project_area.id)
         for item in data:
             self.assertIn("geometry", item)
             self.assertIn("treatment_rank", item)
-            self.assertNotIn("id", item)
+            self.assertIn("id", item)
             self.assertNotIn("scenario", item)
             self.assertNotIn("created_by", item)
+
+    def test_public_get_limits_project_areas_by_number_of_features(self):
+        ProjectAreaFactory(scenario=self.report.scenario, data={"treatment_rank": 1})
+        ProjectAreaFactory(scenario=self.report.scenario, data={"treatment_rank": 2})
+
+        response = self.client.get(self.url, {"number_of_features": 1})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+
+    def test_public_get_validates_number_of_features(self):
+        response = self.client.get(self.url, {"number_of_features": 0})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("number_of_features", response.json()["errors"])
+
+    def test_public_get_defaults_to_feature_limit_for_prioritize_sub_units(self):
+        self.report.scenario.planning_approach = (
+            ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
+        )
+        self.report.scenario.save(update_fields=["planning_approach"])
+        total_project_areas = settings.DEFAULT_NUMBER_OF_FEATURES_PRIORITIZE_SUB_UNITS + 1
+        for rank in range(total_project_areas):
+            ProjectAreaFactory(
+                scenario=self.report.scenario,
+                data={"treatment_rank": rank},
+            )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            len(response.json()),
+            settings.DEFAULT_NUMBER_OF_FEATURES_PRIORITIZE_SUB_UNITS,
+        )
 
     def test_returns_404_for_unknown_uuid(self):
         url = reverse(

--- a/src/planscape/funding_report/views.py
+++ b/src/planscape/funding_report/views.py
@@ -1,4 +1,6 @@
 
+from django.conf import settings
+from django.db.models.expressions import RawSQL
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.decorators import api_view, permission_classes
@@ -8,8 +10,10 @@ from rest_framework.response import Response
 from funding_report.models import FundingOpportunityReportSharedLink
 from funding_report.serializers import (
     FundingOpportunityReportPublicProjectAreaSerializer,
+    FundingOpportunityReportPublicProjectAreaQueryParamsSerializer,
     FundingOpportunityReportPublicSerializer,
 )
+from planning.models import ScenarioPlanningApproach
 
 
 @extend_schema_view(
@@ -35,6 +39,7 @@ def public_funding_opportunity_report(request, shared_link_uuid):
 
 @extend_schema(
     description="Project Areas for a shared Funding Opportunity Report.",
+    parameters=[FundingOpportunityReportPublicProjectAreaQueryParamsSerializer],
     responses={200: FundingOpportunityReportPublicProjectAreaSerializer(many=True)},
 )
 @api_view(["GET"])
@@ -45,6 +50,24 @@ def public_funding_opportunity_report_project_areas(request, shared_link_uuid):
         uuid=shared_link_uuid,
         deleted_at__isnull=True,
     )
-    queryset = shared_link.report.scenario.project_areas.all()
+    queryset = shared_link.report.scenario.project_areas.annotate(
+        treatment_rank=RawSQL("COALESCE((data->>'treatment_rank')::int, 1)", [])
+    ).order_by("treatment_rank")
+    scenario = shared_link.report.scenario
+    params_serializer = FundingOpportunityReportPublicProjectAreaQueryParamsSerializer(
+        data=request.query_params
+    )
+    params_serializer.is_valid(raise_exception=True)
+    number_of_features = params_serializer.data.get("number_of_features")
+
+    if number_of_features:
+        queryset = queryset[:number_of_features]
+    if (
+        not number_of_features
+        and scenario.planning_approach
+        == ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
+    ):
+        queryset = queryset[:settings.DEFAULT_NUMBER_OF_FEATURES_PRIORITIZE_SUB_UNITS]
+
     serializer = FundingOpportunityReportPublicProjectAreaSerializer(queryset, many=True)
     return Response(serializer.data)


### PR DESCRIPTION
* Returning id field
* Support of query parameter 'number_of_features' to limit the number of project areas to be returned
* In case 'number_of_features' is not defined, it will return a default value for scenarios which planning_approach is PRIORITIZE_SUB_UNITS.