### PR TITLE
Persist AET cutoff results and trigger geopackage regeneration

### DIFF
--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -618,6 +618,28 @@ def calculate_aet_improvement(
     }
 
 
+def merge_aet_improvement_into_results(
+    results: Optional[Dict[str, Any]], aet_result: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Shapes a `calculate_aet_improvement()` result into the
+    `results["summary"]["AET"]` / `results["projects"]["AET"]` structure
+    stored on `FundingOpportunityReport.results` (used by both the full
+    report run and the on-demand aet-improvement endpoint). Returns a new
+    dict; does not mutate `results` in place.
+    """
+    merged = deepcopy(results) if results else {}
+    merged.setdefault("summary", {})["AET"] = {
+        "percentage": aet_result["percentage"],
+        "improved_acres": aet_result["improved_acres"],
+        "total_project_area_acres": aet_result["total_project_area_acres"],
+        "planning_area_acres": aet_result["planning_area_acres"],
+        "improved_area_percent": aet_result["improved_area_percent"],
+    }
+    merged.setdefault("projects", {})["AET"] = aet_result["project_areas"]
+    return merged
+
+
 def _clip_metadata(source_metadata: dict | None, role: str) -> dict:
     metadata = deepcopy(source_metadata) or {}
     try:

--- a/src/planscape/funding_report/tasks.py
+++ b/src/planscape/funding_report/tasks.py
@@ -38,6 +38,7 @@ from funding_report.services import (
     generate_treatment_clip_datalayer,
     get_aet_percentual_datalayer,
     get_treatment_datalayer,
+    merge_aet_improvement_into_results,
     treatment_layer_has_valid_data,
 )
 
@@ -392,14 +393,7 @@ def async_finalize_funding_report_results(
         results["summary"]["TOTAL_FLAME_SEVERITY"] = flame_results["summary"]
         results["projects"]["TOTAL_FLAME_SEVERITY"] = flame_results["projects"]
     if aet_improvement is not None:
-        results["summary"]["AET"] = {
-            "percentage": aet_improvement["percentage"],
-            "improved_acres": aet_improvement["improved_acres"],
-            "total_project_area_acres": aet_improvement["total_project_area_acres"],
-            "planning_area_acres": aet_improvement["planning_area_acres"],
-            "improved_area_percent": aet_improvement["improved_area_percent"],
-        }
-        results["projects"]["AET"] = aet_improvement["project_areas"]
+        results = merge_aet_improvement_into_results(results, aet_improvement)
     if biomass_volumes is not None:
         results["summary"]["BIOMASS_VOLUMES"] = biomass_volumes["summary"]
         results["projects"]["BIOMASS_VOLUMES"] = biomass_volumes["project_areas"]

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -50,6 +50,7 @@ from funding_report.services import (
     get_aet_delta_datalayer,
     get_biomass_datalayer,
     get_funding_report_layers_of_interest,
+    merge_aet_improvement_into_results,
     treatment_layer_has_valid_data,
 )
 
@@ -943,6 +944,64 @@ class BuildFlameLengthReductionResultsTest(TestCase):
             [item["project_id"] for item in results["projects"]["7_4"]],
             [1, 2],
         )
+
+
+class MergeAETImprovementIntoResultsTest(TestCase):
+    def setUp(self):
+        self.aet_result = {
+            "percentage": 15,
+            "improved_acres": 12.5,
+            "total_project_area_acres": 100,
+            "planning_area_acres": 500,
+            "improved_area_percent": 2.5,
+            "project_areas": [
+                {
+                    "project_id": 1,
+                    "improved_acres": 12.5,
+                    "total_acres": 100,
+                    "improved_area_percent": 12.5,
+                }
+            ],
+        }
+
+    def test_merges_into_none_results(self):
+        merged = merge_aet_improvement_into_results(None, self.aet_result)
+
+        self.assertEqual(merged["summary"]["AET"]["percentage"], 15)
+        self.assertEqual(merged["projects"]["AET"], self.aet_result["project_areas"])
+
+    def test_preserves_unrelated_existing_keys(self):
+        existing = {
+            "summary": {"ABOVEGROUND_TOTAL": [{"year": 2026, "value": 1}]},
+            "projects": {"ABOVEGROUND_TOTAL": [{"project_id": 1, "value": 1}]},
+            "treatment_areas": {"total": {}},
+        }
+
+        merged = merge_aet_improvement_into_results(existing, self.aet_result)
+
+        self.assertEqual(
+            merged["summary"]["ABOVEGROUND_TOTAL"], existing["summary"]["ABOVEGROUND_TOTAL"]
+        )
+        self.assertEqual(merged["treatment_areas"], existing["treatment_areas"])
+        self.assertEqual(merged["summary"]["AET"]["improved_acres"], 12.5)
+
+    def test_overwrites_previous_aet_result(self):
+        existing = {
+            "summary": {"AET": {"percentage": 10, "improved_acres": 1}},
+            "projects": {"AET": []},
+        }
+
+        merged = merge_aet_improvement_into_results(existing, self.aet_result)
+
+        self.assertEqual(merged["summary"]["AET"]["percentage"], 15)
+        self.assertEqual(merged["projects"]["AET"], self.aet_result["project_areas"])
+
+    def test_does_not_mutate_input(self):
+        existing = {"summary": {}, "projects": {}}
+
+        merge_aet_improvement_into_results(existing, self.aet_result)
+
+        self.assertEqual(existing, {"summary": {}, "projects": {}})
 
 
 class FlameLengthReductionCalculationTest(TestCase):

--- a/src/planscape/funding_report/tests/test_views.py
+++ b/src/planscape/funding_report/tests/test_views.py
@@ -939,29 +939,32 @@ class AETImprovementTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
 
+    @mock.patch("planning.views_v2.async_generate_funding_report_geopackage")
     @mock.patch("planning.views_v2.calculate_aet_improvement")
     def test_aet_improvement_returns_results_after_successful_report(
-        self, calculate_mock
+        self, calculate_mock, geopackage_task_mock
     ):
         report = FundingOpportunityReport.objects.create(
             scenario=self.scenario,
             created_by=self.user,
             status=FundingOpportunityReportStatus.SUCCESS,
+            results={"summary": {"ABOVEGROUND_TOTAL": []}, "projects": {}},
         )
+        project_areas = [
+            {
+                "project_id": 1,
+                "improved_acres": 12.5,
+                "total_acres": 100,
+                "improved_area_percent": 12.5,
+            }
+        ]
         calculate_mock.return_value = {
             "percentage": 15,
             "improved_acres": 12.5,
             "total_project_area_acres": 100,
             "planning_area_acres": 500,
             "improved_area_percent": 2.5,
-            "project_areas": [
-                {
-                    "project_id": 1,
-                    "improved_acres": 12.5,
-                    "total_acres": 100,
-                    "improved_area_percent": 12.5,
-                }
-            ],
+            "project_areas": project_areas,
         }
         self.client.force_authenticate(self.user)
 
@@ -972,6 +975,14 @@ class AETImprovementTest(APITestCase):
         self.assertEqual(response.json()["planning_area_acres"], 500)
         self.assertEqual(len(response.json()["project_areas"]), 1)
         calculate_mock.assert_called_once_with(report=report, percentage=15.0)
+
+        report.refresh_from_db()
+        self.assertEqual(report.results["summary"]["AET"]["percentage"], 15)
+        self.assertEqual(report.results["summary"]["AET"]["improved_acres"], 12.5)
+        self.assertEqual(report.results["projects"]["AET"], project_areas)
+        # unrelated results are preserved
+        self.assertEqual(report.results["summary"]["ABOVEGROUND_TOTAL"], [])
+        geopackage_task_mock.delay.assert_called_once_with(report.pk)
 
     def test_aet_improvement_validates_percentage(self):
         FundingOpportunityReport.objects.create(
@@ -985,9 +996,12 @@ class AETImprovementTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @mock.patch("planning.views_v2.async_generate_funding_report_geopackage")
     @mock.patch("planning.views_v2.calculate_aet_improvement")
-    def test_aet_improvement_returns_400_on_value_error(self, calculate_mock):
-        FundingOpportunityReport.objects.create(
+    def test_aet_improvement_returns_400_on_value_error(
+        self, calculate_mock, geopackage_task_mock
+    ):
+        report = FundingOpportunityReport.objects.create(
             scenario=self.scenario,
             created_by=self.user,
             status=FundingOpportunityReportStatus.SUCCESS,
@@ -1001,6 +1015,43 @@ class AETImprovementTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.json())
+        report.refresh_from_db()
+        self.assertIsNone(report.results)
+        geopackage_task_mock.delay.assert_not_called()
+
+    @mock.patch("planning.views_v2.async_generate_funding_report_geopackage")
+    @mock.patch("planning.views_v2.calculate_aet_improvement")
+    def test_aet_improvement_skips_persistence_when_report_no_longer_successful(
+        self, calculate_mock, geopackage_task_mock
+    ):
+        report = FundingOpportunityReport.objects.create(
+            scenario=self.scenario,
+            created_by=self.user,
+            status=FundingOpportunityReportStatus.SUCCESS,
+        )
+
+        def _flip_status_and_return(*args, **kwargs):
+            FundingOpportunityReport.objects.filter(pk=report.pk).update(
+                status=FundingOpportunityReportStatus.RUNNING
+            )
+            return {
+                "percentage": 15,
+                "improved_acres": 12.5,
+                "total_project_area_acres": 100,
+                "planning_area_acres": 500,
+                "improved_area_percent": 2.5,
+                "project_areas": [],
+            }
+
+        calculate_mock.side_effect = _flip_status_and_return
+        self.client.force_authenticate(self.user)
+
+        response = self.client.post(self.url, {"percentage": 15}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        report.refresh_from_db()
+        self.assertIsNone(report.results)
+        geopackage_task_mock.delay.assert_not_called()
 
 
 class FlameLengthReductionTest(APITestCase):

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -35,8 +35,10 @@ from funding_report.serializers import (
 from funding_report.services import (
     calculate_aet_improvement,
     calculate_funding_report_flame_length_reduction,
+    merge_aet_improvement_into_results,
 )
 from funding_report.tasks import (
+    async_generate_funding_report_geopackage,
     run_funding_opportunity_report,
     send_funding_opportunity_report_shared_link,
 )
@@ -559,13 +561,29 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             )
 
         try:
-            results = calculate_aet_improvement(
+            aet_result = calculate_aet_improvement(
                 report=report,
                 percentage=serializer.validated_data["percentage"],
             )
         except ValueError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
-        return Response(results)
+
+        should_regenerate_geopackage = False
+        with transaction.atomic():
+            locked_report = FundingOpportunityReport.objects.select_for_update().get(
+                pk=report.pk
+            )
+            if locked_report.status == FundingOpportunityReportStatus.SUCCESS:
+                locked_report.results = merge_aet_improvement_into_results(
+                    locked_report.results, aet_result
+                )
+                locked_report.save(update_fields=["results", "updated_at"])
+                should_regenerate_geopackage = True
+
+        if should_regenerate_geopackage:
+            async_generate_funding_report_geopackage.delay(report.pk)
+
+        return Response(aet_result)
 
     @extend_schema(
         description=(


### PR DESCRIPTION
## Summary
- `aet-improvement` now persists the new AET result (including the requested cutoff percentage) into `report.results`, so `GET get-report` and the exported GeoPackage reflect the latest cutoff.
- Triggers geopackage regeneration after a successful update, guarded with `select_for_update` against a concurrent `run-report` overwriting results mid-calculation.
- Extracted the `results["summary"/"projects"]["AET"]` shaping into a shared `merge_aet_improvement_into_results` helper, reused by the full report-run pipeline.

## Test plan
- [x] `make docker-test TEST=funding_report` (133 tests, incl. new persistence/geopackage/race-guard tests)
- [x] `make docker-test TEST=planning` (291 tests)