### PR TITLE
Use geodesic pixel area for biomass wood volume calc

### DIFF
--- a/src/planscape/funding_report/services.py
+++ b/src/planscape/funding_report/services.py
@@ -316,6 +316,34 @@ def _selected_pixel_area_acres(
     )
 
 
+def _row_weighted_biomass_total(
+    selected: np.ndarray,
+    values: np.ndarray,
+    src: rasterio.DatasetReader,
+    transform,
+) -> float:
+    """
+    Sums `values` over `selected` pixels, weighting each row's contribution
+    by that row's true geodesic pixel area (see `_pixel_area_acres`) instead
+    of a nominal per-pixel acreage constant - the same approach used for
+    treatment pixel areas via `_selected_pixel_area_acres`, but weighting by
+    each row's summed value rather than its pixel count.
+    """
+    if not selected.any():
+        return 0.0
+    to_lonlat = (
+        None
+        if src.crs and src.crs.is_geographic
+        else Transformer.from_crs(src.crs, "EPSG:4326", always_xy=True)
+    )
+    total = 0.0
+    for row in np.unique(np.where(selected)[0]):
+        row = int(row)
+        row_sum = float(values[row][selected[row]].sum())
+        total += row_sum * _pixel_area_acres(transform, row, to_lonlat)
+    return total
+
+
 def _fractional_pixel_contributions(
     pixels: np.ma.MaskedArray,
     touched_by_geometry: np.ndarray,
@@ -1068,11 +1096,6 @@ _BIOMASS_WOOD_TYPES: Dict[int, str] = {
     WOOD_TYPE_MIXED: "mixed",
 }
 
-# Acres represented by one biomass raster pixel (~30 m x 30 m). The merch/
-# non-merch rasters store per-acre values, so summed pixel values must be
-# multiplied by this to turn a per-acre rate into a total.
-_BIOMASS_PIXEL_AREA_ACRES = 0.2224
-
 
 def get_biomass_datalayer(role: str) -> DataLayer:
     datalayers = list(
@@ -1099,28 +1122,30 @@ def get_biomass_datalayer(role: str) -> DataLayer:
     return datalayers[0]
 
 
-def _extract_raw_biomass_volumes(
+def _extract_biomass_volumes(
     geometry: Dict[str, Any],
     merch_src: rasterio.DatasetReader,
     non_merch_src: rasterio.DatasetReader,
     wood_type_src: rasterio.DatasetReader,
 ) -> Dict[str, float]:
     """
-    Sums raster pixel values per wood type for one project area geometry.
-    Keys: merch_{softwood,hardwood,mixed}_bf_ac and nm_{softwood,hardwood,mixed}_cuft_ac.
+    Computes merch/non-merch wood volume totals per wood type for one
+    project area geometry. Keys: merchantable_{softwood,hardwood,mixed}_bf
+    and non_merchantable_{softwood,hardwood,mixed}_cuft.
 
-    Raster pixels are already in per-acre output units (merch in bf/ac,
-    non-merch in cuft/ac), so values are summed directly here with no area
-    conversion. The per-acre sums are converted to totals downstream in
-    `_biomass_volumes_to_output()`.
+    Raster pixels store per-acre rates (merch in bf/ac, non-merch in
+    cuft/ac), so each pixel's value is weighted by that pixel's true
+    geodesic ground area (see `_row_weighted_biomass_total`) to produce a
+    total - the same geodesic-area approach used for treatment pixel areas,
+    rather than a nominal per-pixel acreage constant.
     """
     empty: Dict[str, float] = {}
     for name in _BIOMASS_WOOD_TYPES.values():
-        empty[f"merch_{name}_bf_ac"] = 0.0
-        empty[f"nm_{name}_cuft_ac"] = 0.0
+        empty[f"merchantable_{name}_bf"] = 0.0
+        empty[f"non_merchantable_{name}_cuft"] = 0.0
 
     try:
-        merch_data, _ = mask(merch_src, [geometry], crop=True, filled=False)
+        merch_data, transform = mask(merch_src, [geometry], crop=True, filled=False)
         non_merch_data, _ = mask(non_merch_src, [geometry], crop=True, filled=False)
         wt_data, _ = mask(wood_type_src, [geometry], crop=True, filled=False)
     except ValueError:
@@ -1142,23 +1167,13 @@ def _extract_raw_biomass_volumes(
     result: Dict[str, float] = {}
     for wt_value, wt_name in _BIOMASS_WOOD_TYPES.items():
         wt_match = ~wt_nodata & (wt_raw == wt_value)
-        result[f"merch_{wt_name}_bf_ac"] = float(merch_vals[wt_match & merch_ok].sum())
-        result[f"nm_{wt_name}_cuft_ac"] = float(nm_vals[wt_match & nm_ok].sum())
+        result[f"merchantable_{wt_name}_bf"] = _row_weighted_biomass_total(
+            wt_match & merch_ok, merch_vals, merch_src, transform
+        )
+        result[f"non_merchantable_{wt_name}_cuft"] = _row_weighted_biomass_total(
+            wt_match & nm_ok, nm_vals, merch_src, transform
+        )
 
-    return result
-
-
-def _biomass_volumes_to_output(raw: Dict[str, float]) -> Dict[str, float]:
-    """
-    Converts raw per-acre pixel sums into totals by multiplying by the
-    per-pixel acreage, and maps them to their output field names.
-    """
-    result: Dict[str, float] = {}
-    for wt_name in _BIOMASS_WOOD_TYPES.values():
-        merch_bf_ac = raw.get(f"merch_{wt_name}_bf_ac", 0.0)
-        nm_cuft_ac = raw.get(f"nm_{wt_name}_cuft_ac", 0.0)
-        result[f"merchantable_{wt_name}_bf"] = merch_bf_ac * _BIOMASS_PIXEL_AREA_ACRES
-        result[f"non_merchantable_{wt_name}_cuft"] = nm_cuft_ac * _BIOMASS_PIXEL_AREA_ACRES
     return result
 
 
@@ -1184,9 +1199,11 @@ def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any
             )
 
         accumulated: Dict[str, float] = {
-            f"merch_{wt_name}_bf_ac": 0.0 for wt_name in _BIOMASS_WOOD_TYPES.values()
+            f"merchantable_{wt_name}_bf": 0.0
+            for wt_name in _BIOMASS_WOOD_TYPES.values()
         } | {
-            f"nm_{wt_name}_cuft_ac": 0.0 for wt_name in _BIOMASS_WOOD_TYPES.values()
+            f"non_merchantable_{wt_name}_cuft": 0.0
+            for wt_name in _BIOMASS_WOOD_TYPES.values()
         }
 
         project_area_results = []
@@ -1194,21 +1211,23 @@ def calculate_biomass_volumes(report: FundingOpportunityReport) -> Dict[str, Any
             geometry = json.loads(
                 maybe_transform(project_area.geometry, raster_srid).geojson
             )
-            raw = _extract_raw_biomass_volumes(geometry, merch_src, non_merch_src, wt_src)
+            volumes = _extract_biomass_volumes(
+                geometry, merch_src, non_merch_src, wt_src
+            )
 
             project_area_results.append(
                 {
                     "project_id": project_area.pk,
                     "proj_id": (project_area.data or {}).get("proj_id"),
-                    **_biomass_volumes_to_output(raw),
+                    **volumes,
                 }
             )
 
             for key in accumulated:
-                accumulated[key] += raw.get(key, 0.0)
+                accumulated[key] += volumes.get(key, 0.0)
 
     return {
-        "summary": _biomass_volumes_to_output(accumulated),
+        "summary": accumulated,
         "project_areas": project_area_results,
     }
 

--- a/src/planscape/funding_report/tests/test_services.py
+++ b/src/planscape/funding_report/tests/test_services.py
@@ -31,7 +31,6 @@ from funding_report.models import (
     FundingReportMetric,
 )
 from funding_report.services import (
-    _BIOMASS_PIXEL_AREA_ACRES,
     _filter_by_project_id,
     aggregate_delta_pixels,
     build_datalayer_lookup,
@@ -1189,41 +1188,43 @@ class BiomassVolumesCalculationTest(TestCase):
         results = calculate_biomass_volumes(self.report)
 
         # Pixel values are in per-acre output units (merch bf/ac, non-merch
-        # cuft/ac); they're summed per wood type, then multiplied by the
-        # per-pixel acreage to produce totals.
+        # cuft/ac); each pixel's value is weighted by that pixel's true
+        # geodesic ground area (row-dependent, not column-dependent) to
+        # produce totals - see `geodesic_pixel_area_acres`.
         #
-        # Softwood pixels: (0,0) merch=100, nm=50; (1,1) merch=400, nm=100
-        # Hardwood pixels: (0,1) merch=200, nm=80
-        # Mixed pixels:    (1,0) merch=300, nm=80
+        # Row 0: (0,0) softwood merch=100, nm=50; (0,1) hardwood merch=200, nm=80
+        # Row 1: (1,0) mixed merch=300, nm=80;     (1,1) softwood merch=400, nm=100
+        row0_acres = geodesic_pixel_area_acres(self.merch_path, row=0)
+        row1_acres = geodesic_pixel_area_acres(self.merch_path, row=1)
         summary = results["summary"]
         self.assertAlmostEqual(
             summary["merchantable_softwood_bf"],
-            (100 + 400) * _BIOMASS_PIXEL_AREA_ACRES,
+            100 * row0_acres + 400 * row1_acres,
             places=4,
         )
         self.assertAlmostEqual(
             summary["merchantable_hardwood_bf"],
-            200 * _BIOMASS_PIXEL_AREA_ACRES,
+            200 * row0_acres,
             places=4,
         )
         self.assertAlmostEqual(
             summary["merchantable_mixed_bf"],
-            300 * _BIOMASS_PIXEL_AREA_ACRES,
+            300 * row1_acres,
             places=4,
         )
         self.assertAlmostEqual(
             summary["non_merchantable_softwood_cuft"],
-            (50 + 100) * _BIOMASS_PIXEL_AREA_ACRES,
+            50 * row0_acres + 100 * row1_acres,
             places=4,
         )
         self.assertAlmostEqual(
             summary["non_merchantable_hardwood_cuft"],
-            80 * _BIOMASS_PIXEL_AREA_ACRES,
+            80 * row0_acres,
             places=4,
         )
         self.assertAlmostEqual(
             summary["non_merchantable_mixed_cuft"],
-            80 * _BIOMASS_PIXEL_AREA_ACRES,
+            80 * row1_acres,
             places=4,
         )
 


### PR DESCRIPTION
Biomass wood volumes (merch bf, non-merch cuft) were converted from
per-acre raster rates to totals using a hardcoded 0.2224 acres/pixel
constant (nominal 30m x 30m). All funding-report rasters are EPSG:3857
(Web Mercator), which isn't equal-area, so this silently mis-stated
volumes by latitude - the same bug already fixed for treatment/AET
metrics in this file.

Replaces the constant with true per-row geodesic pixel area, reusing
the same approach (`_pixel_area_acres`) treatment pixel calculations
already use.

## Test plan
- [x] `make docker-test TEST=funding_report.tests.test_services.BiomassVolumesCalculationTest`
- [x] `make docker-test TEST=funding_report` (128 tests, all pass)