### PR TITLE
plan-3709-automated-welcome-email-to-new-users

### DIFF
--- a/src/planscape/templates/email/new_users/welcome.html
+++ b/src/planscape/templates/email/new_users/welcome.html
@@ -1,0 +1,39 @@
+<p>Hello {{ user_first_name }},</p>
+
+<p>
+  I’d like to welcome you to the Planscape community! We are thrilled to have you
+  on board.
+</p>
+
+<p>
+  We are committed to making your experience as smooth as possible. To help you
+  get started, here are a couple tips:
+</p>
+
+<ul>
+  <li>
+    <strong>Explore:</strong>
+    Check out our
+    <a href="https://support.planscape.org/support/solutions" target="_blank">
+      Knowledge Base
+    </a>
+    to review Planscape’s core features and workflows.
+  </li>
+  <li>
+    <strong>Support:</strong>
+    Reach out anytime with questions or
+    <a href="https://support.planscape.org/support/tickets/new" target="_blank">
+      feedback
+    </a>.
+    We are always happy to jump on a call to walk through things together.
+  </li>
+</ul>
+
+<p>
+  Thank you so much for signing up. We look forward to hearing from you.
+</p>
+
+<p>
+  Best regards,<br>
+  Planscape Team
+</p>

--- a/src/planscape/templates/email/new_users/welcome.txt
+++ b/src/planscape/templates/email/new_users/welcome.txt
@@ -1,0 +1,18 @@
+Hello {{ user_first_name }},
+
+I’d like to welcome you to the Planscape community! We are thrilled to have you on board.
+
+We are committed to making your experience as smooth as possible. To help you get started, here are a couple tips:
+
+Explore: Check out our Knowledge Base to review Planscape’s core features and workflows:
+https://support.planscape.org/support/solutions
+
+Support: Reach out anytime with questions or feedback:
+https://support.planscape.org/support/tickets/new
+
+We are always happy to jump on a call to walk through things together.
+
+Thank you so much for signing up. We look forward to hearing from you.
+
+Best regards,
+Planscape Team

--- a/src/planscape/users/apps.py
+++ b/src/planscape/users/apps.py
@@ -67,6 +67,14 @@ def create_user_profile(sender, instance, created, **kwargs):
         pass
 
 
+def handle_user_signed_up(sender, request, user, **kwargs):
+    from django.db import transaction
+
+    from users.tasks import send_welcome_email
+
+    transaction.on_commit(lambda: send_welcome_email.delay(user.pk))
+
+
 class UsersConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "users"
@@ -82,7 +90,7 @@ class UsersConfig(AppConfig):
             registry.register(model)
 
     def ready(self):
-        from allauth.account.signals import email_confirmed
+        from allauth.account.signals import email_confirmed, user_signed_up
 
         self.register_actstream()
         user_login_failed.connect(
@@ -98,4 +106,8 @@ class UsersConfig(AppConfig):
         )
         email_confirmed.connect(
             handle_email_confirmed, dispatch_uid="users.handle_email_confirmed"
+        )
+        user_signed_up.connect(
+            handle_user_signed_up,
+            dispatch_uid="users.handle_user_signed_up",
         )

--- a/src/planscape/users/apps.py
+++ b/src/planscape/users/apps.py
@@ -3,6 +3,7 @@ import logging
 from django.apps import AppConfig
 from django.contrib.auth import get_user_model
 from django.contrib.auth.signals import user_logged_in, user_login_failed
+from django.db import transaction
 from django.db.models.signals import post_save
 
 log = logging.getLogger(__name__)
@@ -68,8 +69,6 @@ def create_user_profile(sender, instance, created, **kwargs):
 
 
 def handle_user_signed_up(sender, request, user, **kwargs):
-    from django.db import transaction
-
     from users.tasks import send_welcome_email
 
     transaction.on_commit(lambda: send_welcome_email.delay(user.pk))

--- a/src/planscape/users/tasks.py
+++ b/src/planscape/users/tasks.py
@@ -1,0 +1,43 @@
+import logging
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from planscape.celery import app
+
+log = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+@app.task()
+def send_welcome_email(user_id: int) -> None:
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        log.warning("User %s does not exist; cannot send welcome email.", user_id)
+        return
+
+    email = (user.email or "").strip()
+    if not email:
+        log.info("User %s has no email; skipping welcome email.", user_id)
+        return
+
+    context = {
+        "user_first_name": user.first_name or "there",
+    }
+
+    subject = "[Planscape] Welcome to Planscape"
+    txt = render_to_string("email/new_users/welcome.txt", context)
+    html = render_to_string("email/new_users/welcome.html", context)
+
+    send_mail(
+        subject=subject,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[email],
+        message=txt,
+        html_message=html,
+    )
+
+    log.info("Sent welcome email to user %s.", user_id)

--- a/src/planscape/users/tests.py
+++ b/src/planscape/users/tests.py
@@ -18,6 +18,7 @@ from planning.tests.factories import (
 )
 from planscape.tests.factories import UserFactory
 from rest_framework.test import APITestCase
+
 from users.models import UserProfile
 
 
@@ -46,6 +47,30 @@ class CreateUserTest(APITestCase):
             mail.outbox[0].subject, "[Planscape] Please Confirm Your Email Address"
         )
         self.assertIn("Team Planscape", mail.outbox[0].body)
+
+    @patch("users.tasks.send_welcome_email.delay")
+    def test_create_user_queues_welcome_email(self, mock_send_welcome_email):
+        payload = json.dumps(
+            {
+                "email": "welcome@test.com",
+                "password1": "ComplexPassword123",
+                "password2": "ComplexPassword123",
+                "first_name": "Welcome",
+                "last_name": "User",
+            }
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("rest_register"),
+                payload,
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 201)
+
+        user = User.objects.get(email="welcome@test.com")
+        mock_send_welcome_email.assert_called_once_with(user.pk)
 
 
 class DeactivateUserTest(APITestCase):
@@ -877,3 +902,24 @@ class ReturningUserTrackingTest(TestCase):
         )
         user.profile.refresh_from_db()
         self.assertEqual(user.profile.last_returning_user_bucket, 3)
+
+
+class WelcomeEmailTest(TestCase):
+    def test_send_welcome_email(self):
+        from users.tasks import send_welcome_email
+
+        user = UserFactory.create(
+            email="welcome@test.com",
+            first_name="Welcome",
+            last_name="User",
+        )
+
+        send_welcome_email(user.pk)
+
+        self.assertEqual(len(mail.outbox), 1)
+
+        email = mail.outbox[0]
+        self.assertEqual(email.subject, "[Planscape] Welcome to Planscape")
+        self.assertEqual(email.to, ["welcome@test.com"])
+        self.assertIn("Hello Welcome", email.body)
+        self.assertIn("Planscape community", email.body)


### PR DESCRIPTION
@george-silva @roquebetioljr @lastminutediorama, PLAN-3709 Send automated welcome email to new users, [https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3709](https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3709)

1. `src/planscape/users/tasks.py`: added a Celery task (in a new tasks.py) that sends the new user a personalized welcome email.

2. `src/planscape/users/apps.py`: added a `user_signed_up` signal handler that queues the welcome email after the new user is saved in the db.

3. `src/planscape/templates/email/new_users/welcome.html`: added the HTML welcome email with updated Knowledge Base and support/feedback links.

4. `src/planscape/templates/email/new_users/welcome.txt`: added the plain-text version of the welcome email.

5. `src/planscape/users/tests.py`: added tests that verify signup queues the welcome email task and that the email is generated with the expected recipient/content.

------------------

I got the templates and links from the JIRA ticket.