### PR TITLE
Add Mixpanel integration: migration script + live tracking

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -38,6 +38,30 @@ REPORT_RECIPIENT_EMAIL=no-reply@planscape.org
 OPENPANEL_URL=https://op.sig-gis.com/api
 OPENPANEL_CLIENT_ID=fakeclientid
 OPENPANEL_CLIENT_SECRET=fakeclientsecret
+
+# Live Mixpanel tracking (track_openpanel/identify_openpanel dual-write to
+# Mixpanel alongside OpenPanel). This is the project token from Project
+# Settings -> Overview, NOT a service account - distinct from the
+# MIXPANEL_*_SA_SECRET credentials below used only by the one-off migration
+# script.
+MIXPANEL_INTEGRATION=False
+MIXPANEL_PROJECT_TOKEN=fakemixpanelprojecttoken
+
+# Used only by scripts/openpanel_to_mixpanel (OpenPanel -> Mixpanel migration).
+# Must be a "read" or "root" scoped client - the ingest credentials above are
+# write-only and will 401 against the export API.
+OPENPANEL_EXPORT_CLIENT_ID=fakeexportclientid
+OPENPANEL_EXPORT_CLIENT_SECRET=fakeexportclientsecret
+OPENPANEL_EXPORT_PROJECT_ID=fakeprojectcuid
+
+MIXPANEL_TEST_PROJECT_ID=faketestprojectid
+MIXPANEL_TEST_SA_USERNAME=fake.test-service-account
+MIXPANEL_TEST_SA_SECRET=faketestsecret
+
+MIXPANEL_PROD_PROJECT_ID=fakeprodprojectid
+MIXPANEL_PROD_SA_USERNAME=fake.prod-service-account
+MIXPANEL_PROD_SA_SECRET=fakeprodsecret
+
 MATTERMOST_WEBHOOK_URL=fake
 MATTERMOST_CHANNEL="#planscape-control-dev"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     "opentelemetry-api>=1.39.1",
     "opentelemetry-sdk>=1.39.1",
     "opentelemetry-instrumentation>=0.60b1",
+    "mixpanel>=5.0.0",
 ]
 
 [tool.isort]

--- a/scripts/openpanel_to_mixpanel/README.md
+++ b/scripts/openpanel_to_mixpanel/README.md
@@ -1,0 +1,166 @@
+# OpenPanel → Mixpanel migration
+
+One-off tool to export Planscape's analytics history from the self-hosted
+OpenPanel instance (`op.sig-gis.com`, project `spatial-informatics-group/planscape`)
+and import it into Mixpanel. Self-contained `uv run --script` — no changes to
+the main app's `pyproject.toml`/`uv.lock`.
+
+## Manual prerequisites (not scriptable)
+
+1. **OpenPanel export credentials.** In the `op.sig-gis.com` dashboard →
+   Settings → Clients, create a new client of type `read` (or `root`) scoped
+   to the Planscape project. This must be separate from the existing
+   ingest-only `OPENPANEL_CLIENT_ID`/`OPENPANEL_CLIENT_SECRET` in `.env` —
+   those are write-scoped and get a 401 against `/export`. Note the client
+   id/secret. If the client isn't scoped to a single project, also grab the
+   project's internal id (a cuid, not the `spatial-informatics-group/planscape`
+   URL slug) via a `root` client against `GET /api/manage/projects`.
+2. **Mixpanel test project.** Mixpanel has no API to create or delete
+   projects — do this by hand: Org Settings → Projects → Create Project, then
+   Project Settings → Service Accounts to create a Service Account scoped to
+   it. Note the project id + service account username/secret.
+3. **Mixpanel production project.** Locate the existing "Planscape
+   Production" project id and create/reuse a Service Account with import
+   permission on it.
+4. After the test run is validated, **manually delete the test project** in
+   the Mixpanel UI — again, no API for this.
+
+## Configuration
+
+Add to the repo root `.env` (see `.sample.env` for placeholders):
+
+```
+OPENPANEL_EXPORT_CLIENT_ID=
+OPENPANEL_EXPORT_CLIENT_SECRET=
+OPENPANEL_EXPORT_PROJECT_ID=
+
+MIXPANEL_TEST_PROJECT_ID=
+MIXPANEL_TEST_SA_USERNAME=
+MIXPANEL_TEST_SA_SECRET=
+
+MIXPANEL_PROD_PROJECT_ID=
+MIXPANEL_PROD_SA_USERNAME=
+MIXPANEL_PROD_SA_SECRET=
+```
+
+`OPENPANEL_URL` is already set in `.env` and is reused as-is.
+
+## Usage
+
+Run from this directory (or pass `--data-dir` to point elsewhere). Each step
+writes/reads plain NDJSON under `data/` (gitignored) so it can be inspected,
+re-run, or re-targeted without redoing earlier steps.
+
+```bash
+# 1. Pull raw events from OpenPanel into data/raw/*.ndjson (resumable: re-run
+#    to pick up where an interrupted export left off).
+uv run migrate.py export --start 2024-01-01 --end 2026-07-29
+
+# 2. Convert data/raw/*.ndjson into data/converted/{events,profiles}.ndjson.
+#    Records that can't be mapped (e.g. no identity at all) go to
+#    data/skipped.ndjson with a reason.
+uv run migrate.py convert
+
+# 3. Upload to Mixpanel. --target is required, no default.
+uv run migrate.py upload --target test
+
+# Or all three in one go:
+uv run migrate.py run --start 2024-01-01 --end 2026-07-29 --target test
+```
+
+`upload --target production` (or `run ... --target production`) prompts for
+a typed confirmation phrase before sending anything, to make an accidental
+production write hard to do by muscle memory. Pass `--yes-really-production`
+to skip the prompt in non-interactive use.
+
+Failed Mixpanel batches (validation errors, non-2xx responses) are written to
+`data/failed/` with both the request batch and Mixpanel's response, rather
+than aborting the whole upload.
+
+## Recommended rollout
+
+1. Small dry run against a single day: `export --start <yesterday> --end
+   <today>`, then `convert`, and eyeball `data/converted/events.ndjson` /
+   `profiles.ndjson`.
+2. `upload --target test` that same small window. Confirm in Mixpanel's Live
+   View that events/profiles land with correct `time`, `distinct_id`, and
+   properties before trusting the field mapping at scale.
+3. Full `run --target test` across the whole history. Compare OpenPanel's
+   reported `meta.totalCount` per window (printed during `export`) against
+   Mixpanel's `num_records_imported` totals (printed during `upload`), and
+   spot-check a handful of events/profiles in the Mixpanel UI.
+4. Manually delete the test Mixpanel project.
+5. Final import to production: `upload --target production` (reusing the
+   already-converted NDJSON from step 3 — export/convert are target-agnostic,
+   no need to re-export), or `run ... --target production` for a fresh pull.
+
+## Field mapping notes (`convert.py`)
+
+- `distinct_id` = OpenPanel `profileId` if present, else `deviceId`
+  (anonymous events still import, just not linked to a named user).
+- `$insert_id` = OpenPanel's event `id` (a UUID, fits Mixpanel's ≤36-byte
+  limit) — makes re-running `upload` safe to retry without creating
+  duplicates.
+- Geo (`$city`/`$region`/`mp_country_code`) and device (`$os`/`$browser`)
+  fields are copied explicitly from OpenPanel rather than left for Mixpanel
+  to derive via GeoIP/user-agent parsing at import time, since Mixpanel's
+  GeoIP-at-import uses today's IP-location tables — a poor match for
+  backdated historical events, and OpenPanel already resolved these at
+  ingest time.
+- Custom `properties.*` pass through as-is (except `__query`, whose
+  `utm_*` keys are flattened to top-level properties).
+- `mp_lib` / `$source` are set to `"openpanel-migration"` on every imported
+  event, so migrated data stays distinguishable from anything tracked
+  natively into Mixpanel later.
+- Profiles are de-duplicated by id across all events before import (the
+  OpenPanel export API attaches a `profile` snapshot per-event via
+  `includes=profile`; there's no standalone "list all profiles" endpoint).
+
+## Gotchas found by testing against the real op.sig-gis.com deployment
+
+Both confirmed empirically against live data/credentials, neither documented
+anywhere:
+
+- **OpenPanel's `includes` param must be sent as repeated query params**
+  (`includes=properties&includes=profile&...`), not one comma-joined value.
+  A comma-joined `includes` is silently ignored — the response falls back to
+  the default (minimal) field set with no error, which would have meant
+  quietly losing `properties`, geo, device, and profile data across the
+  entire export. `openpanel_client.py`'s `INCLUDES` is a list for exactly
+  this reason; do not collapse it back into a string.
+- **Mixpanel's `/engage` batch-update still requires a `$token` field per
+  record**, even when authenticating with a Service Account + `project_id`
+  query param (unlike `/import`, which needs neither). The numeric
+  `project_id` works as the token value. `MixpanelClient.import_profiles`
+  injects `$token = config.project_id` into each record at send time —
+  intentionally not baked into `convert.py`'s output, so the same converted
+  NDJSON can be uploaded to either target without re-converting. Omitting
+  `$token` doesn't error — it returns `200 {"error": "a temporary failure
+  occurred", "status": 0}`, which reads like a transient outage but is
+  actually a rejected/malformed payload.
+- **OpenPanel's own event count metadata (`meta.totalCount`/`meta.pages`) is
+  unreliable and must not be used for pagination termination.** A request
+  that returned 50 events in `data` reported `totalCount: 0, pages: 0` in
+  the same response; a real 30-day window's actual volume (6,377 events,
+  128 pages) was silently truncated to a fixed 300 (6 pages) when trusting
+  that field. `openpanel_client.py`'s `fetch_window` pages until a genuinely
+  empty page comes back instead — slower, but can't be fooled by a wrong
+  counter. Also: page size is hard-clamped to 50 server-side regardless of
+  the `limit` requested (tried up to 1000).
+- **`/import`'s strict-mode 400 responses still partially succeed** — a
+  batch of 2000 that returned `400 "some data points... failed validation"`
+  had `num_records_imported: 1873` and only 127 entries in `failed_records`.
+  Treating any non-2xx status as "whole batch failed" (an easy first
+  instinct) silently discards the successful rows too. `failed_records` is
+  also *omitted entirely* (not present-but-empty) on a clean 200 — the only
+  reliable signal that a response is structured is `num_records_imported`
+  being present at all; branch on that, not on HTTP status.
+- **Mixpanel rejects a specific set of placeholder `distinct_id` values**
+  case-insensitively (`none`, `null`, `undefined`, `anonymous`, the all-zero
+  UUID, etc — see `convert._BAD_DISTINCT_IDS`, taken verbatim from a real
+  `failed_records[].message`). Some OpenPanel events carry a `deviceId` of
+  the literal string `"None"` (not JSON `null`), which passes a naive
+  truthiness check. `convert._distinct_id` filters both `profileId` and
+  `deviceId` against this blocklist before falling back between them,
+  routing anything that fails to `skipped.ndjson` instead of uploading it
+  and having Mixpanel reject it.

--- a/scripts/openpanel_to_mixpanel/convert.py
+++ b/scripts/openpanel_to_mixpanel/convert.py
@@ -1,0 +1,233 @@
+"""OpenPanel -> Mixpanel event/profile field mapping.
+
+Geo (`$city`/`$region`/`mp_country_code`) and device (`$os`/`$browser`) are
+mapped explicitly from OpenPanel's already-resolved fields rather than left
+for Mixpanel to derive at import time - Mixpanel's own GeoIP-at-import only
+has today's IP-to-location tables, which is a poor match for backdated
+historical events.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+SOURCE_LABEL = "openpanel-migration"
+
+# Keys inside an OpenPanel event's `properties` blob that are handled
+# specially elsewhere (e.g. flattened out) rather than passed through as-is.
+_RESERVED_EVENT_PROPERTY_KEYS = {"__query"}
+
+_PROFILE_FIELD_MAP = {
+    "email": "$email",
+    "firstName": "$first_name",
+    "lastName": "$last_name",
+    "createdAt": "openpanel_created_at",
+    "lastSeenAt": "openpanel_last_seen_at",
+    "isExternal": "openpanel_is_external",
+}
+
+
+def _to_millis(created_at: str) -> int:
+    dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    return int(dt.astimezone(timezone.utc).timestamp() * 1000)
+
+
+# Mixpanel's own reserved/placeholder distinct_id blocklist (confirmed via a
+# real 400 response's failed_records[].message). Some OpenPanel events carry
+# a literal deviceId of "None" (the string, not JSON null) - passes a plain
+# truthiness check but Mixpanel rejects it case-insensitively.
+_BAD_DISTINCT_IDS = {
+    "-1",
+    "0",
+    "00000000-0000-0000-0000-000000000000",
+    "<nil>",
+    "[]",
+    "anon",
+    "anonymous",
+    "false",
+    "lmy47d",
+    "n/a",
+    "na",
+    "nil",
+    "none",
+    "null",
+    "true",
+    "undefined",
+    "unknown",
+    "{}",
+}
+
+
+def _is_valid_id(value: Any) -> bool:
+    if not value:
+        return False
+    return str(value).strip().lower() not in _BAD_DISTINCT_IDS
+
+
+def _distinct_id(event: dict) -> str | None:
+    profile_id = event.get("profileId")
+    if _is_valid_id(profile_id):
+        return profile_id
+    device_id = event.get("deviceId")
+    if _is_valid_id(device_id):
+        return device_id
+    return None
+
+
+def _custom_properties(raw_properties: dict) -> dict:
+    return {
+        key: value
+        for key, value in raw_properties.items()
+        if key not in _RESERVED_EVENT_PROPERTY_KEYS
+    }
+
+
+def _utm_properties(raw_properties: dict) -> dict:
+    query = raw_properties.get("__query") or {}
+    return {key: value for key, value in query.items() if key.startswith("utm_")}
+
+
+def openpanel_event_to_mixpanel(event: dict) -> tuple[dict | None, str | None]:
+    """Map one raw OpenPanel event to a Mixpanel /import record.
+
+    Returns (mixpanel_event, None) on success, or (None, reason) if the
+    event can't be mapped (e.g. no usable identity).
+    """
+    distinct_id = _distinct_id(event)
+    if not distinct_id:
+        return None, "missing profileId and deviceId"
+    if not event.get("createdAt"):
+        return None, "missing createdAt"
+    if not event.get("id"):
+        return None, "missing event id"
+    if not event.get("name"):
+        return None, "missing event name"
+
+    raw_properties = event.get("properties") or {}
+    current_url = None
+    if event.get("origin") or event.get("path"):
+        current_url = f"{event.get('origin') or ''}{event.get('path') or ''}"
+
+    properties: dict[str, Any] = {
+        "time": _to_millis(event["createdAt"]),
+        "distinct_id": distinct_id,
+        "$insert_id": event["id"],
+        "$device_id": event.get("deviceId"),
+        "mp_lib": SOURCE_LABEL,
+        "$source": SOURCE_LABEL,
+        **_custom_properties(raw_properties),
+        **_utm_properties(raw_properties),
+    }
+    if event.get("profileId"):
+        properties["$user_id"] = event["profileId"]
+    if event.get("os"):
+        properties["$os"] = event["os"]
+    if event.get("osVersion"):
+        properties["$os_version"] = event["osVersion"]
+    if event.get("browser"):
+        properties["$browser"] = event["browser"]
+    if event.get("browserVersion"):
+        properties["$browser_version"] = event["browserVersion"]
+    if event.get("city"):
+        properties["$city"] = event["city"]
+    if event.get("region"):
+        properties["$region"] = event["region"]
+    if event.get("country"):
+        properties["mp_country_code"] = event["country"]
+    if current_url:
+        properties["$current_url"] = current_url
+    if event.get("referrer"):
+        properties["$referrer"] = event["referrer"]
+    if event.get("referrerName"):
+        properties["$referring_domain"] = event["referrerName"]
+    if event.get("sessionId"):
+        properties["session_id"] = event["sessionId"]
+    if event.get("duration") is not None:
+        properties["duration_ms"] = event["duration"]
+    if event.get("revenue") is not None:
+        properties["revenue"] = event["revenue"]
+
+    properties = {k: v for k, v in properties.items() if v is not None}
+    return {"event": event["name"], "properties": properties}, None
+
+
+def openpanel_profile_to_mixpanel(profile: dict) -> tuple[dict | None, str | None]:
+    """Map one raw OpenPanel profile to a Mixpanel Engage $set record."""
+    distinct_id = profile.get("id")
+    if not distinct_id:
+        return None, "missing profile id"
+
+    set_props: dict[str, Any] = {}
+    for source_key, target_key in _PROFILE_FIELD_MAP.items():
+        value = profile.get(source_key)
+        if value not in (None, ""):
+            set_props[target_key] = value
+    for key, value in (profile.get("properties") or {}).items():
+        set_props.setdefault(key, value)
+
+    if not set_props:
+        return None, "no non-empty profile fields"
+
+    return {"$distinct_id": distinct_id, "$set": set_props}, None
+
+
+def _iter_raw_events(raw_dir: Path) -> Iterator[dict]:
+    for path in sorted(raw_dir.glob("*.ndjson")):
+        with path.open() as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    yield json.loads(line)
+
+
+def convert_all(raw_dir: Path, converted_dir: Path, skipped_path: Path) -> dict[str, int]:
+    """Convert every raw event under raw_dir into Mixpanel events + profiles.
+
+    Profiles are de-duplicated by id across all events (OpenPanel's export
+    attaches a `profile` snapshot per-event, there's no standalone profile
+    list endpoint); files are processed in filename order (which is
+    chronological, per the `<window-start>_<window-end>.ndjson` naming from
+    export_range), so later snapshots overwrite earlier ones.
+    """
+    converted_dir.mkdir(parents=True, exist_ok=True)
+    skipped_path.parent.mkdir(parents=True, exist_ok=True)
+
+    profiles_by_id: dict[str, dict] = {}
+    event_count = skipped_count = 0
+
+    with (converted_dir / "events.ndjson").open("w") as events_out, skipped_path.open(
+        "w"
+    ) as skipped_out:
+        for raw_event in _iter_raw_events(raw_dir):
+            mixpanel_event, reason = openpanel_event_to_mixpanel(raw_event)
+            if mixpanel_event is None:
+                skipped_out.write(
+                    json.dumps({"kind": "event", "reason": reason, "raw": raw_event}) + "\n"
+                )
+                skipped_count += 1
+            else:
+                events_out.write(json.dumps(mixpanel_event) + "\n")
+                event_count += 1
+
+            profile = raw_event.get("profile")
+            if profile and profile.get("id"):
+                profiles_by_id[profile["id"]] = profile
+
+    profile_count = 0
+    with (converted_dir / "profiles.ndjson").open("w") as profiles_out, skipped_path.open(
+        "a"
+    ) as skipped_out:
+        for profile in profiles_by_id.values():
+            mixpanel_profile, reason = openpanel_profile_to_mixpanel(profile)
+            if mixpanel_profile is None:
+                skipped_out.write(
+                    json.dumps({"kind": "profile", "reason": reason, "raw": profile}) + "\n"
+                )
+                skipped_count += 1
+            else:
+                profiles_out.write(json.dumps(mixpanel_profile) + "\n")
+                profile_count += 1
+
+    return {"events": event_count, "profiles": profile_count, "skipped": skipped_count}

--- a/scripts/openpanel_to_mixpanel/migrate.py
+++ b/scripts/openpanel_to_mixpanel/migrate.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "requests>=2.31",
+#     "python-decouple>=3.8",
+# ]
+# ///
+"""OpenPanel -> Mixpanel event & profile migration CLI.
+
+See README.md in this directory for the manual setup prerequisites, required
+.env variables, and the recommended test-then-production rollout sequence.
+
+Examples:
+    uv run migrate.py export --start 2024-01-01 --end 2026-07-29
+    uv run migrate.py convert
+    uv run migrate.py upload --target test
+    uv run migrate.py run --start 2024-01-01 --end 2026-07-29 --target test
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+from decouple import Config, RepositoryEnv
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_DATA_DIR = SCRIPT_DIR / "data"
+REPO_ROOT = SCRIPT_DIR.parents[1]
+
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from convert import convert_all  # noqa: E402
+from mixpanel_client import MixpanelClient, MixpanelConfig  # noqa: E402
+from openpanel_client import OpenPanelClient, OpenPanelConfig, export_range  # noqa: E402
+
+PRODUCTION_CONFIRM_PHRASE = "import to production"
+
+
+def _load_env() -> Config:
+    env_path = REPO_ROOT / ".env"
+    if not env_path.exists():
+        sys.exit(f"No .env found at {env_path} - copy .sample.env and fill in credentials.")
+    return Config(RepositoryEnv(str(env_path)))
+
+
+def _openpanel_config(config: Config) -> OpenPanelConfig:
+    return OpenPanelConfig(
+        base_url=config("OPENPANEL_URL"),
+        client_id=config("OPENPANEL_EXPORT_CLIENT_ID"),
+        client_secret=config("OPENPANEL_EXPORT_CLIENT_SECRET"),
+        project_id=config("OPENPANEL_EXPORT_PROJECT_ID", default=None),
+    )
+
+
+def _mixpanel_config(config: Config, target: str) -> MixpanelConfig:
+    prefix = "MIXPANEL_TEST" if target == "test" else "MIXPANEL_PROD"
+    return MixpanelConfig(
+        project_id=config(f"{prefix}_PROJECT_ID"),
+        service_account_username=config(f"{prefix}_SA_USERNAME"),
+        service_account_secret=config(f"{prefix}_SA_SECRET"),
+    )
+
+
+def _parse_date(value: str) -> date:
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def _confirm_production() -> None:
+    typed = input(
+        f'Type "{PRODUCTION_CONFIRM_PHRASE}" to confirm writing to Mixpanel PRODUCTION: '
+    )
+    if typed.strip() != PRODUCTION_CONFIRM_PHRASE:
+        sys.exit("Confirmation phrase did not match - aborting.")
+
+
+def _read_ndjson(path: Path):
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def cmd_export(args: argparse.Namespace) -> None:
+    config = _load_env()
+    client = OpenPanelClient(_openpanel_config(config))
+    export_range(
+        client,
+        start=args.start,
+        end=args.end,
+        chunk_days=args.chunk_days,
+        raw_dir=args.data_dir / "raw",
+        force=args.force,
+    )
+
+
+def cmd_convert(args: argparse.Namespace) -> None:
+    result = convert_all(
+        raw_dir=args.data_dir / "raw",
+        converted_dir=args.data_dir / "converted",
+        skipped_path=args.data_dir / "skipped.ndjson",
+    )
+    print(
+        f"converted {result['events']} events, {result['profiles']} profiles, "
+        f"skipped {result['skipped']} records"
+    )
+
+
+def cmd_upload(args: argparse.Namespace) -> None:
+    if args.target == "production" and not args.yes_really_production:
+        _confirm_production()
+
+    config = _load_env()
+    client = MixpanelClient(_mixpanel_config(config, args.target))
+    failed_dir = args.data_dir / "failed"
+
+    events_path = args.data_dir / "converted" / "events.ndjson"
+    profiles_path = args.data_dir / "converted" / "profiles.ndjson"
+
+    if args.kind in ("events", "all"):
+        if events_path.exists():
+            result = client.import_events(_read_ndjson(events_path), failed_dir)
+            print(f"events: imported={result['imported']} failed={result['failed']}")
+        else:
+            print(f"no {events_path} - run `convert` first")
+
+    if args.kind in ("profiles", "all"):
+        if profiles_path.exists():
+            result = client.import_profiles(_read_ndjson(profiles_path), failed_dir)
+            print(f"profiles: imported={result['imported']} failed={result['failed']}")
+        else:
+            print(f"no {profiles_path} - run `convert` first")
+
+
+def cmd_run(args: argparse.Namespace) -> None:
+    cmd_export(args)
+    cmd_convert(args)
+    cmd_upload(args)
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DEFAULT_DATA_DIR,
+        help="Directory for raw/converted/failed data (default: scripts/openpanel_to_mixpanel/data)",
+    )
+
+
+def _add_date_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--start", type=_parse_date, required=True, help="YYYY-MM-DD")
+    parser.add_argument("--end", type=_parse_date, required=True, help="YYYY-MM-DD")
+    parser.add_argument(
+        "--chunk-days", type=int, default=30, help="Days per export window (default: 30)"
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Re-fetch windows that already have output on disk"
+    )
+
+
+def _add_target_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--target", choices=["test", "production"], required=True, help="Which Mixpanel project"
+    )
+    parser.add_argument(
+        "--yes-really-production",
+        action="store_true",
+        help="Skip the interactive confirmation prompt for --target production",
+    )
+    parser.add_argument(
+        "--kind", choices=["events", "profiles", "all"], default="all"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    export_p = subparsers.add_parser("export", help="Pull raw events from OpenPanel to disk")
+    _add_common_args(export_p)
+    _add_date_args(export_p)
+    export_p.set_defaults(func=cmd_export)
+
+    convert_p = subparsers.add_parser(
+        "convert", help="Convert raw OpenPanel events/profiles into Mixpanel-ready NDJSON"
+    )
+    _add_common_args(convert_p)
+    convert_p.set_defaults(func=cmd_convert)
+
+    upload_p = subparsers.add_parser("upload", help="Upload converted data to Mixpanel")
+    _add_common_args(upload_p)
+    _add_target_args(upload_p)
+    upload_p.set_defaults(func=cmd_upload)
+
+    run_p = subparsers.add_parser("run", help="export + convert + upload in one go")
+    _add_common_args(run_p)
+    _add_date_args(run_p)
+    _add_target_args(run_p)
+    run_p.set_defaults(func=cmd_run)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/openpanel_to_mixpanel/mixpanel_client.py
+++ b/scripts/openpanel_to_mixpanel/mixpanel_client.py
@@ -1,0 +1,147 @@
+"""Mixpanel Import/Engage API client: batched upload with retry+backoff.
+
+Auth is via a Service Account (Basic auth), with the target project selected
+by the `project_id` query param - this is what lets the same code target a
+disposable test project or the real production project purely via config.
+"""
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import random
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+import requests
+
+IMPORT_URL = "https://api.mixpanel.com/import"
+ENGAGE_URL = "https://api.mixpanel.com/engage"
+
+EVENT_BATCH_SIZE = 2000
+PROFILE_BATCH_SIZE = 2000
+MAX_RETRIES = 5
+INITIAL_BACKOFF_SECONDS = 2.0
+MAX_BACKOFF_SECONDS = 60.0
+
+
+@dataclass
+class MixpanelConfig:
+    project_id: str
+    service_account_username: str
+    service_account_secret: str
+
+
+def _auth_header(config: MixpanelConfig) -> dict:
+    token = base64.b64encode(
+        f"{config.service_account_username}:{config.service_account_secret}".encode()
+    ).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def _batched(items: Iterable[dict], size: int) -> Iterator[list[dict]]:
+    batch: list[dict] = []
+    for item in items:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _safe_json(resp: requests.Response) -> dict:
+    try:
+        return resp.json()
+    except ValueError:
+        return {"raw": resp.text}
+
+
+def _post_with_retry(
+    session: requests.Session, url: str, params: dict, headers: dict, body: bytes
+) -> tuple[int, dict]:
+    delay = INITIAL_BACKOFF_SECONDS
+    resp = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        resp = session.post(url, params=params, headers=headers, data=body, timeout=120)
+        if resp.status_code == 429 and attempt < MAX_RETRIES:
+            sleep_for = min(delay, MAX_BACKOFF_SECONDS) + random.uniform(0, 1.5)
+            print(f"  429, retrying in {sleep_for:.1f}s (attempt {attempt}/{MAX_RETRIES})")
+            time.sleep(sleep_for)
+            delay *= 2
+            continue
+        break
+    assert resp is not None
+    return resp.status_code, _safe_json(resp)
+
+
+def _write_failed(failed_dir: Path, name: str, batch: list[dict], response_body: dict) -> None:
+    failed_dir.mkdir(parents=True, exist_ok=True)
+    with (failed_dir / name).open("w") as f:
+        json.dump({"response": response_body, "batch": batch}, f, indent=2)
+
+
+class MixpanelClient:
+    def __init__(self, config: MixpanelConfig):
+        self.config = config
+        self.session = requests.Session()
+
+    def import_events(self, events: Iterable[dict], failed_dir: Path) -> dict[str, int]:
+        headers = {
+            **_auth_header(self.config),
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        }
+        params = {"strict": "1", "project_id": self.config.project_id}
+        imported = failed = 0
+        for i, batch in enumerate(_batched(events, EVENT_BATCH_SIZE)):
+            body = gzip.compress(json.dumps(batch).encode())
+            status, response = _post_with_retry(self.session, IMPORT_URL, params, headers, body)
+            # Mixpanel's strict-mode 400 responses still carry a structured
+            # num_records_imported/failed_records body, same as a 200 with
+            # partial failures - it's a genuine "some rows rejected", not a
+            # whole-batch failure. Confirmed empirically: a 400 with 2000
+            # events imported 1873 and only 127 were in failed_records.
+            # `failed_records` is omitted entirely (not just empty) on a
+            # clean 200 - only `num_records_imported` is a reliable signal
+            # that this is a real structured response, not a raw 5xx/
+            # network-level error with no such body.
+            n_imported = response.get("num_records_imported")
+            if n_imported is None:
+                failed += len(batch)
+                _write_failed(failed_dir, f"events_batch_{i}.json", batch, response)
+                print(f"  events batch {i}: FAILED status={status} {response}")
+                continue
+            failed_records = response.get("failed_records") or []
+            imported += n_imported
+            if failed_records:
+                failed += len(failed_records)
+                _write_failed(failed_dir, f"events_batch_{i}_partial.json", batch, response)
+            print(f"  events batch {i}: imported={n_imported} failed={len(failed_records)}")
+        return {"imported": imported, "failed": failed}
+
+    def import_profiles(self, profiles: Iterable[dict], failed_dir: Path) -> dict[str, int]:
+        headers = {**_auth_header(self.config), "Content-Type": "application/json"}
+        params: dict[str, Any] = {"project_id": self.config.project_id, "verbose": "1"}
+        imported = failed = 0
+        # Unlike /import, /engage still requires a $token per record even with
+        # Service Account auth - confirmed empirically that the numeric
+        # project_id works here. Injected at upload time (not in convert.py)
+        # so converted NDJSON stays reusable across the test/production targets.
+        tagged_profiles = (
+            {**profile, "$token": self.config.project_id} for profile in profiles
+        )
+        for i, batch in enumerate(_batched(tagged_profiles, PROFILE_BATCH_SIZE)):
+            body = json.dumps(batch).encode()
+            status, response = _post_with_retry(self.session, ENGAGE_URL, params, headers, body)
+            ok = status < 300 and response.get("status") in (1, "1", None)
+            if not ok:
+                failed += len(batch)
+                _write_failed(failed_dir, f"profiles_batch_{i}.json", batch, response)
+                print(f"  profiles batch {i}: FAILED status={status} {response}")
+                continue
+            imported += len(batch)
+            print(f"  profiles batch {i}: imported={len(batch)}")
+        return {"imported": imported, "failed": failed}

--- a/scripts/openpanel_to_mixpanel/openpanel_client.py
+++ b/scripts/openpanel_to_mixpanel/openpanel_client.py
@@ -1,0 +1,187 @@
+"""OpenPanel export API client: window-chunked, paginated event export.
+
+Two undocumented behaviors of the self-hosted export endpoint drive the
+design here (confirmed against apps/api/src/controllers/export.controller.ts
+in the OpenPanel source):
+
+- Omitting `start`/`end` falls back to a ~12 hour default window, so callers
+  must always pass both explicitly.
+- `properties` (and most other fields) are omitted from the response unless
+  requested via `includes=...` - the default column set is minimal.
+"""
+from __future__ import annotations
+
+import json
+import random
+import time
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Iterator
+
+import requests
+
+EXPORT_PATH = "/export/events"
+# Requested as 1000 (docs' stated max) but this deployment silently clamps
+# every response to 50 rows/page regardless of what's requested - confirmed
+# empirically, not a bug in this client. Left at 1000 in case that clamp is
+# raised later; it costs nothing to ask for more than we'll get.
+PAGE_LIMIT = 1000
+MIN_REQUEST_INTERVAL = 0.25  # spacing between requests; retry below is the real safety net
+MAX_RETRIES = 6
+INITIAL_BACKOFF_SECONDS = 1.0
+MAX_BACKOFF_SECONDS = 30.0
+
+# Sent as repeated `includes=` query params, NOT comma-joined: this deployment
+# silently falls back to the default (minimal) field set if `includes` is a
+# single comma-separated value, with no error - confirmed empirically against
+# op.sig-gis.com, and not documented anywhere. `requests` serializes a list
+# value as repeated params, which is what this API actually expects.
+INCLUDES = [
+    "properties",
+    "profile",
+    "region",
+    "longitude",
+    "latitude",
+    "osVersion",
+    "browserVersion",
+    "device",
+    "brand",
+    "model",
+    "origin",
+    "referrer",
+    "referrerName",
+    "referrerType",
+    "sdkName",
+    "sdkVersion",
+    "revenue",
+    "groups",
+]
+
+
+@dataclass
+class OpenPanelConfig:
+    base_url: str
+    client_id: str
+    client_secret: str
+    project_id: str | None = None
+
+
+class OpenPanelClient:
+    def __init__(self, config: OpenPanelConfig):
+        self.config = config
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "openpanel-client-id": config.client_id,
+                "openpanel-client-secret": config.client_secret,
+            }
+        )
+        self._last_request_at = 0.0
+
+    def _throttle(self) -> None:
+        elapsed = time.monotonic() - self._last_request_at
+        if elapsed < MIN_REQUEST_INTERVAL:
+            time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
+    def _get_page(self, start: str, end: str, page: int) -> dict:
+        params = {
+            "start": start,
+            "end": end,
+            "page": page,
+            "limit": PAGE_LIMIT,
+            "includes": INCLUDES,
+        }
+        if self.config.project_id:
+            params["projectId"] = self.config.project_id
+        url = self.config.base_url.rstrip("/") + EXPORT_PATH
+
+        delay = INITIAL_BACKOFF_SECONDS
+        for attempt in range(1, MAX_RETRIES + 1):
+            self._throttle()
+            resp = self.session.get(url, params=params, timeout=60)
+            self._last_request_at = time.monotonic()
+            if resp.status_code == 429 and attempt < MAX_RETRIES:
+                retry_after = resp.headers.get("Retry-After")
+                sleep_for = (
+                    float(retry_after) if retry_after else min(delay, MAX_BACKOFF_SECONDS)
+                )
+                sleep_for += random.uniform(0, 1.0)
+                print(f"  429 from OpenPanel, retrying in {sleep_for:.1f}s (attempt {attempt}/{MAX_RETRIES})")
+                time.sleep(sleep_for)
+                delay *= 2
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_window(self, start: date, end: date) -> Iterator[dict]:
+        """Yield every event in [start, end] (inclusive, day granularity).
+
+        Deliberately ignores `meta.pages`/`meta.totalCount` for pagination
+        termination: confirmed empirically that this deployment's count query
+        is unreliable (a request that returned 50 events in `data` reported
+        `totalCount: 0, pages: 0` in the same response - internally
+        inconsistent). Trusting that field silently truncated every window to
+        a fixed number of pages regardless of actual volume. Paging until a
+        genuinely empty page comes back is slower (one extra confirmation
+        request per window) but can't be fooled by a wrong counter.
+        """
+        start_s, end_s = start.isoformat(), end.isoformat()
+        page = 1
+        while True:
+            payload = self._get_page(start_s, end_s, page)
+            events = payload.get("data", [])
+            if not events:
+                break
+            for event in events:
+                yield event
+            page += 1
+
+
+def iter_windows(
+    start: date, end: date, chunk_days: int
+) -> Iterator[tuple[date, date]]:
+    """Split [start, end] into consecutive, inclusive date windows.
+
+    Chunking (rather than one huge range query) keeps each query's page
+    count low - deep ClickHouse offsets degrade badly per OpenPanel's own
+    event.service.ts.
+    """
+    cursor = start
+    step = timedelta(days=chunk_days)
+    one_day = timedelta(days=1)
+    while cursor <= end:
+        window_end = min(cursor + step - one_day, end)
+        yield cursor, window_end
+        cursor = window_end + one_day
+
+
+def export_range(
+    client: OpenPanelClient,
+    start: date,
+    end: date,
+    chunk_days: int,
+    raw_dir: Path,
+    force: bool = False,
+) -> None:
+    """Fetch every event in [start, end], writing one NDJSON file per window.
+
+    Re-runnable: windows whose output file already exists are skipped unless
+    force=True, so an interrupted export can just be re-invoked.
+    """
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    for window_start, window_end in iter_windows(start, end, chunk_days):
+        out_path = raw_dir / f"{window_start.isoformat()}_{window_end.isoformat()}.ndjson"
+        if out_path.exists() and not force:
+            print(f"skip {out_path.name} (exists)")
+            continue
+        count = 0
+        tmp_path = out_path.with_suffix(".ndjson.tmp")
+        with tmp_path.open("w") as f:
+            for event in client.fetch_window(window_start, window_end):
+                f.write(json.dumps(event) + "\n")
+                count += 1
+        tmp_path.rename(out_path)
+        print(f"{out_path.name}: {count} events")

--- a/src/planscape/core/tasks.py
+++ b/src/planscape/core/tasks.py
@@ -6,6 +6,7 @@ import requests
 from django.conf import settings
 from django.core.management import call_command
 from django.core.serializers.json import DjangoJSONEncoder
+from mixpanel import Mixpanel, MixpanelException
 
 from core.backup_state import (
     BACKUP_STATE_FAILED,
@@ -41,6 +42,28 @@ def track(payload: Dict[str, Any]) -> None:
         return
 
     log.info("Event tracked")
+
+
+@app.task()
+def track_mixpanel(payload: Dict[str, Any]) -> None:
+    if not settings.MIXPANEL_INTEGRATION:
+        return
+
+    mp = Mixpanel(settings.MIXPANEL_PROJECT_TOKEN)
+    kind = payload["type"]
+    data = payload["payload"]
+    try:
+        if kind == "track":
+            mp.track(
+                data["distinct_id"], data["event_name"], data.get("properties") or {}
+            )
+        elif kind == "identify":
+            mp.people_set(data["distinct_id"], data.get("properties") or {})
+    except MixpanelException:
+        log.exception("Something went wrong while posting data to Mixpanel")
+        return
+
+    log.info("Event tracked in Mixpanel")
 
 
 @app.task()

--- a/src/planscape/planscape/openpanel.py
+++ b/src/planscape/planscape/openpanel.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Optional, Union
 
-from core.tasks import track
+from core.tasks import track, track_mixpanel
 from django.conf import settings
 from django.contrib.auth.models import User
 
@@ -11,6 +11,15 @@ log = logging.getLogger(__name__)
 def get_domain(email: str) -> str:
     handle, domain = email.split("@")
     return domain
+
+
+def _dispatch(
+    openpanel_payload: Dict[str, Any], mixpanel_payload: Dict[str, Any]
+) -> None:
+    if settings.TESTING_MODE:
+        return
+    track.delay(payload=openpanel_payload)  # type: ignore
+    track_mixpanel.delay(payload=mixpanel_payload)  # type: ignore
 
 
 def track_openpanel(
@@ -24,34 +33,57 @@ def track_openpanel(
         domain = get_domain(email)
         properties["domain"] = domain
 
-    payload = {
-        "type": "track",
-        "payload": {
-            "name": name,
-            "profileId": str(user_id) if user_id else None,
-            "properties": properties,
-        },
-    }
+    distinct_id = str(user_id) if user_id else "anonymous"
     log.info(f"tracking openpanel event {name}")
-    if not settings.TESTING_MODE:
-        track.delay(payload=payload)  # type: ignore
+    _dispatch(
+        openpanel_payload={
+            "type": "track",
+            "payload": {
+                "name": name,
+                "profileId": str(user_id) if user_id else None,
+                "properties": properties,
+            },
+        },
+        mixpanel_payload={
+            "type": "track",
+            "payload": {
+                "distinct_id": distinct_id,
+                "event_name": name,
+                "properties": properties,
+            },
+        },
+    )
 
 
 def identify_openpanel(user: User) -> None:
-    payload = {
-        "type": "identify",
-        "payload": {
-            "profileId": str(user.pk),
-            "traits": {
-                "firstName": user.first_name,
-                "lastName": user.last_name,
-                "email": user.email,
-            },
-            "properties": {
-                "organization": None,
-                "last_login": user.last_login,
+    distinct_id = str(user.pk)
+    shared_properties = {
+        "organization": None,
+        "last_login": user.last_login,
+    }
+    _dispatch(
+        openpanel_payload={
+            "type": "identify",
+            "payload": {
+                "profileId": distinct_id,
+                "traits": {
+                    "firstName": user.first_name,
+                    "lastName": user.last_name,
+                    "email": user.email,
+                },
+                "properties": shared_properties,
             },
         },
-    }
-    if not settings.TESTING_MODE:
-        track.delay(payload=payload)
+        mixpanel_payload={
+            "type": "identify",
+            "payload": {
+                "distinct_id": distinct_id,
+                "properties": {
+                    "$first_name": user.first_name,
+                    "$last_name": user.last_name,
+                    "$email": user.email,
+                    **shared_properties,
+                },
+            },
+        },
+    )

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -612,6 +612,10 @@ OPENPANEL_CLIENT_SECRET = config(
     "OPENPANEL_CLIENT_SECRET", "fake-openpanel-client-secret"
 )
 
+# MIXPANEL config
+MIXPANEL_INTEGRATION = config("MIXPANEL_INTEGRATION", default=False, cast=bool)
+MIXPANEL_PROJECT_TOKEN = config("MIXPANEL_PROJECT_TOKEN", "fake-mixpanel-project-token")
+
 # MARTOR (ADMIN MARKDOWN EDITOR)
 MARTOR_TOOLBAR_BUTTONS = [
     "bold",

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -624,6 +638,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "factory-boy"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -896,6 +922,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1127,6 +1190,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/88/e1907e1ca3488f2d9507ca8b0ae1add7b1cd5d3ca2bc8e5b329382ea2c7b/memory_profiler-0.61.0.tar.gz", hash = "sha256:4e5b73d7864a1d1292fb76a03e82a3e78ef934d06828a698d9dada76da2067b0", size = 35935, upload-time = "2022-11-15T17:57:28.994Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/26/aaca612a0634ceede20682e692a6c55e35a94c21ba36b807cc40fe910ae1/memory_profiler-0.61.0-py3-none-any.whl", hash = "sha256:400348e61031e3942ad4d4109d18753b2fb08c2f6fb8290671c5513a34182d84", size = 31803, upload-time = "2022-11-15T17:57:27.031Z" },
+]
+
+[[package]]
+name = "mixpanel"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1e/d2a733cb35b380942e0f1791427d23afa1bc1c37b8ce7089b2c691176d0f/mixpanel-5.0.0.tar.gz", hash = "sha256:ef78b7b36150fbf24796972bf44871515c6d1381a69be683eb26a65d44b84bb5", size = 21083, upload-time = "2025-11-04T22:10:23.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/05/248580e987b203c24e4cce53f5e5d60ea749550af5c756c770196d549f96/mixpanel-5.0.0-py3-none-any.whl", hash = "sha256:5c5fee75a304bd2940828a08a31f74fae7f02d5fe81914a851ed87e8884096ec", size = 23848, upload-time = "2025-11-04T22:10:22.233Z" },
 ]
 
 [[package]]
@@ -1551,6 +1629,7 @@ dependencies = [
     { name = "humanize" },
     { name = "jsonschema" },
     { name = "martor" },
+    { name = "mixpanel" },
     { name = "mmh3" },
     { name = "multipledispatch" },
     { name = "numpy" },
@@ -1649,6 +1728,7 @@ requires-dist = [
     { name = "humanize", specifier = "==4.8.0" },
     { name = "jsonschema", specifier = ">=4.21,<5.0" },
     { name = "martor", specifier = ">=1.6.45,<2" },
+    { name = "mixpanel", specifier = ">=5.0.0" },
     { name = "mmh3", specifier = ">=5.1.0,<6" },
     { name = "multipledispatch", specifier = ">=1.0.0,<2" },
     { name = "numpy", specifier = ">=1.26.4,<2" },


### PR DESCRIPTION
## Summary
- New `scripts/openpanel_to_mixpanel/` tool: exports OpenPanel event/profile history and imports it into Mixpanel, with an explicit `--target {test,production}` switch (production gated behind a typed confirmation). Tested end-to-end against the real OpenPanel API and a disposable Mixpanel test project (133,756 events + 9,553 profiles imported cleanly). See the script's README for setup, manual prerequisites, and gotchas found along the way.
- `track_openpanel`/`identify_openpanel` now also dual-write to Mixpanel via a new `track_mixpanel` Celery task, using the official `mixpanel` SDK. Gated behind `MIXPANEL_INTEGRATION` (defaults to `False` until a production project token is configured).

## Test plan
- [x] `users`/`core`/`planscape` Django test suites pass (black/flake8 clean)
- [x] Migration script validated against real OpenPanel data and a disposable Mixpanel test project
- [ ] Set `MIXPANEL_PROJECT_TOKEN` + `MIXPANEL_INTEGRATION=True` in an environment to validate live tracking end-to-end before enabling in production