### PR TITLE
migrate events to mixpanel

### DIFF
--- a/src/interface/src/app/app.component.ts
+++ b/src/interface/src/app/app.component.ts
@@ -6,8 +6,7 @@ import { OverlayLoaderService } from '@services/overlay-loader.service';
 import { environment } from '@env/environment';
 import { ForsysService } from '@services/forsys.service';
 import { MapModuleService } from '@services/map-module.service';
-import { MixpanelService } from '@services/mixpanel.service';
-import { OpenPanelService } from '@services/open-panel.service';
+import { ProductAnalyticsService } from '@services/product-analytics.service';
 
 @Component({
   selector: 'app-root',
@@ -26,8 +25,7 @@ export class AppComponent implements OnInit {
     private overlayLoaderService: OverlayLoaderService,
     private forsysService: ForsysService,
     private mapModuleService: MapModuleService,
-    private mixpanelService: MixpanelService,
-    private openPanelService: OpenPanelService
+    private productAnalyticsService: ProductAnalyticsService
   ) {}
 
   isLoading$ = this.overlayLoaderService.isLoading$;
@@ -45,7 +43,6 @@ export class AppComponent implements OnInit {
     this.authService.refreshLoggedInUser().pipe(take(1)).subscribe();
     // We're migrating from OpenPanel to Mixpanel, so both run side by side
     // while the historical data is backfilled. See scripts/openpanel_to_mixpanel.
-    this.openPanelService.init();
-    this.mixpanelService.init();
+    this.productAnalyticsService.init();
   }
 }

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.html
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.html
@@ -20,7 +20,8 @@
       biomass, wildfire risk, and water, making it easier to assess potential impacts
       and share them with conservation finance partners and funders. These insights can
       support project alignment, portfolio development, and informed investment decisions."
-      [partners]="partners"></sg-tool-info-card>
+      [partners]="partners"
+      (clickPartner)="trackPartnerClick($event)"></sg-tool-info-card>
   </div>
   <div right-column class="right-column">
     <mat-spinner
@@ -31,7 +32,7 @@
     <ng-template #loadedView>
       <app-funding-empty-state
         *ngIf="showEmptyState$ | async"
-        (generateReport)="generateReport()">
+        (generateReport)="generateReport('empty_state')">
       </app-funding-empty-state>
       <!-- Generating report-->
       <div class="generating-report" *ngIf="isGenerating$ | async">
@@ -61,7 +62,7 @@
             sg-button
             icon="assignment"
             variant="primary"
-            (click)="generateReport()">
+            (click)="generateReport('retry')">
             Retry Report Generation
           </button>
         </div>

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.spec.ts
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.spec.ts
@@ -13,6 +13,9 @@ import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { BehaviorSubject, NEVER, of } from 'rxjs';
 import { FundingDashboardComponent } from '@app/funding/funding-dashboard/funding-dashboard.component';
 import { MockProvider } from 'ng-mocks';
+import { By } from '@angular/platform-browser';
+import { ToolInfoCardComponent } from '@styleguide/tool-info-card/tool-info-card.component';
+import { ProductAnalyticsService } from '@services/product-analytics.service';
 import { BreadcrumbService } from '@services/breadcrumb.service';
 import { ScenarioState } from '@scenario/scenario.state';
 import { PlanState } from '@plan/plan.state';
@@ -106,6 +109,7 @@ describe('FundingDashboardComponent', () => {
         },
         { provide: PlanState, useValue: { currentPlan$ } },
         { provide: AuthService, useValue: { loggedInUser$ } },
+        MockProvider(ProductAnalyticsService),
       ],
     }).compileComponents();
 
@@ -248,7 +252,7 @@ describe('FundingDashboardComponent', () => {
     const snackSpy = spyOn(snackbar, 'open');
     mockRouter.navigate.calls.reset();
 
-    component.generateReport();
+    component.generateReport('empty_state');
 
     httpMock
       .expectOne((req) => req.url.endsWith('v2/scenarios/123/run-report/'))
@@ -380,7 +384,83 @@ describe('FundingDashboardComponent', () => {
     component.isGenerating$.subscribe((v) => (isGenerating = v));
     expect(isGenerating).toBe(false);
 
-    component.generateReport();
+    component.generateReport('empty_state');
     expect(isGenerating).toBe(true);
   }));
+
+  it('tracks which entry point asked for the report', async () => {
+    await setup(makeScenario(123, ['FUNDING_REPORT']));
+    const analytics = TestBed.inject(ProductAnalyticsService);
+    spyOn(analytics, 'trackEvent');
+
+    component.generateReport('retry');
+
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
+      'funding_report.generation.requested',
+      { source: 'retry' }
+    );
+  });
+
+  it('tracks partner logo clicks', async () => {
+    await setup(makeScenario(123, ['FUNDING_REPORT']));
+    const analytics = TestBed.inject(ProductAnalyticsService);
+    spyOn(analytics, 'trackEvent');
+
+    component.trackPartnerClick({
+      name: 'Partner',
+      url: 'https://partner.example',
+      logo: 'logo.png',
+    });
+
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
+      'funding_report.partner_link.clicked',
+      { name: 'Partner', url: 'https://partner.example' }
+    );
+  });
+
+  it('tracks from the empty state button, wiring included', async () => {
+    await setup(makeScenario(123, ['FUNDING_REPORT']), '123', makePlan(7), {
+      id: 7,
+    } as User);
+    await resolveNoReport();
+    const analytics = TestBed.inject(ProductAnalyticsService);
+    spyOn(analytics, 'trackEvent');
+
+    // Click the real button rather than calling the handler, so a broken
+    // template binding fails here instead of going silently untracked.
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector(
+      'app-funding-empty-state button'
+    );
+    button.click();
+
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
+      'funding_report.generation.requested',
+      { source: 'empty_state' }
+    );
+
+    const httpMock = TestBed.inject(HttpTestingController);
+    httpMock
+      .expectOne((req) => req.url.endsWith('v2/scenarios/123/run-report/'))
+      .flush(null);
+  });
+
+  it('tracks partner clicks emitted by the info card, wiring included', async () => {
+    await setup(makeScenario(123, ['FUNDING_REPORT']), '123', makePlan(7), {
+      id: 7,
+    } as User);
+    await resolveNoReport();
+    const analytics = TestBed.inject(ProductAnalyticsService);
+    spyOn(analytics, 'trackEvent');
+
+    const card = fixture.debugElement.query(
+      By.directive(ToolInfoCardComponent)
+    );
+    const partner = component.partners[0];
+    card.componentInstance.clickPartner.emit(partner);
+
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
+      'funding_report.partner_link.clicked',
+      { name: partner.name, url: partner.url }
+    );
+  });
 });

--- a/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
+++ b/src/interface/src/app/funding/funding-dashboard/funding-dashboard.component.ts
@@ -4,6 +4,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { DashboardLayoutComponent } from '@styleguide/dashboard-layout/dashboard-layout.component';
 import { NavBarComponent } from '@standalone/nav-bar/nav-bar.component';
 import { BreadcrumbService } from '@services/breadcrumb.service';
+import { ProductAnalyticsService } from '@services/product-analytics.service';
+import { ToolInfoCardPartner } from '@styleguide/tool-info-card/tool-info-card.component';
 import { MapConfigState } from '@app/maplibre-map/map-config.state';
 import { FundingMapConfigState } from '../funding-map-config-state';
 import {
@@ -73,7 +75,8 @@ export class FundingDashboardComponent implements OnInit {
     private router: Router,
     private route: ActivatedRoute,
     private fundingReportService: FundingReportService,
-    private snackbar: MatSnackBar
+    private snackbar: MatSnackBar,
+    private productAnalyticsService: ProductAnalyticsService
   ) {}
 
   protected readonly SUPPORT_URL = SUPPORT_URL;
@@ -222,7 +225,21 @@ export class FundingDashboardComponent implements OnInit {
       .subscribe(() => this.router.navigate(['/home']));
   }
 
-  generateReport() {
+  trackPartnerClick(partner: ToolInfoCardPartner) {
+    this.productAnalyticsService.trackEvent(
+      'funding_report.partner_link.clicked',
+      {
+        name: partner.name,
+        url: partner.url,
+      }
+    );
+  }
+
+  generateReport(source: 'empty_state' | 'retry') {
+    this.productAnalyticsService.trackEvent(
+      'funding_report.generation.requested',
+      { source }
+    );
     // Switch to the generating state immediately, before the server responds.
     this.generationRequested$.next(true);
     this.scenarioState.currentScenario$

--- a/src/interface/src/app/funding/funding-empty-state/funding-empty-state.component.html
+++ b/src/interface/src/app/funding/funding-empty-state/funding-empty-state.component.html
@@ -40,7 +40,6 @@
 </div>
 
 <button
-  data-track="generate-funding-report"
   sg-button
   icon="assignment"
   variant="primary"

--- a/src/interface/src/app/funding/share-funding-report-dialog/share-funding-report-dialog.component.spec.ts
+++ b/src/interface/src/app/funding/share-funding-report-dialog/share-funding-report-dialog.component.spec.ts
@@ -7,7 +7,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { FundingReportService } from '@services/funding-report.service';
-import { OpenPanelService } from '@services/open-panel.service';
+import { ProductAnalyticsService } from '@services/product-analytics.service';
 import { ShareDialogComponent } from '@styleguide/share-dialog/share-dialog.component';
 import { ShareFundingReportDialogComponent } from './share-funding-report-dialog.component';
 
@@ -40,7 +40,7 @@ describe('ShareFundingReportDialogComponent', () => {
           shareReport: () => of(inviteEmails),
         }),
         MockProvider(Clipboard, { copy: () => true }),
-        MockProvider(OpenPanelService),
+        MockProvider(ProductAnalyticsService),
         { provide: MAT_DIALOG_DATA, useValue: data },
       ],
     }).compileComponents();
@@ -127,12 +127,12 @@ describe('ShareFundingReportDialogComponent', () => {
   });
 
   it('tracks the copy so links shared outside email are counted', () => {
-    const openPanel = TestBed.inject(OpenPanelService);
-    spyOn(openPanel, 'trackEvent');
+    const analytics = TestBed.inject(ProductAnalyticsService);
+    spyOn(analytics, 'trackEvent');
 
     component.copyLink();
 
-    expect(openPanel.trackEvent).toHaveBeenCalledWith(
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
       'funding_report.shared_link.copied',
       { scenario_id: 7 }
     );
@@ -143,14 +143,14 @@ describe('ShareFundingReportDialogComponent', () => {
     spyOn(service, 'getPublicUrl').and.returnValue(of({ public_url: '' }));
     const clipboard = TestBed.inject(Clipboard);
     const copySpy = spyOn(clipboard, 'copy');
-    const openPanel = TestBed.inject(OpenPanelService);
-    spyOn(openPanel, 'trackEvent');
+    const analytics = TestBed.inject(ProductAnalyticsService);
+    spyOn(analytics, 'trackEvent');
     const snackbar = spyOn<any>(component, 'showSnackbar');
 
     component.copyLink();
 
     expect(copySpy).not.toHaveBeenCalled();
-    expect(openPanel.trackEvent).not.toHaveBeenCalled();
+    expect(analytics.trackEvent).not.toHaveBeenCalled();
     expect(snackbar).toHaveBeenCalledWith(
       'The link is not available yet. Please try again.'
     );

--- a/src/interface/src/app/funding/share-funding-report-dialog/share-funding-report-dialog.component.ts
+++ b/src/interface/src/app/funding/share-funding-report-dialog/share-funding-report-dialog.component.ts
@@ -18,7 +18,7 @@ import {
 import { FlameLengthInterval } from '@types';
 import { SNACK_BOTTOM_NOTICE_CONFIG } from '@shared';
 import { FundingReportService } from '@services/funding-report.service';
-import { OpenPanelService } from '@services/open-panel.service';
+import { ProductAnalyticsService } from '@services/product-analytics.service';
 import {
   ShareDialogComponent,
   SharePrimaryEvent,
@@ -46,7 +46,7 @@ export class ShareFundingReportDialogComponent {
     private dialogRef: MatDialogRef<ShareFundingReportDialogComponent>,
     private fundingReportService: FundingReportService,
     private clipboard: Clipboard,
-    private openPanelService: OpenPanelService,
+    private productAnalyticsService: ProductAnalyticsService,
     @Inject(MAT_DIALOG_DATA)
     public data: ShareFundingReportDialogData
   ) {}
@@ -122,9 +122,12 @@ export class ShareFundingReportDialogComponent {
       this.clipboard.copy(url);
       // Links also travel by copy/paste, so counting only the emailed ones
       // would understate how widely a report was shared.
-      this.openPanelService.trackEvent('funding_report.shared_link.copied', {
-        scenario_id: this.data.scenarioId,
-      });
+      this.productAnalyticsService.trackEvent(
+        'funding_report.shared_link.copied',
+        {
+          scenario_id: this.data.scenarioId,
+        }
+      );
       this.showSnackbar('Link copied');
     });
   }

--- a/src/interface/src/app/services/mixpanel.service.spec.ts
+++ b/src/interface/src/app/services/mixpanel.service.spec.ts
@@ -22,7 +22,6 @@ describe('MixpanelService', () => {
     spyOn(mixpanel, 'init');
     spyOn(mixpanel, 'identify');
     spyOn(mixpanel, 'reset');
-    spyOn(mixpanel, 'track');
     // `mixpanel.people` only exists once the real `init` has run, and we stub
     // that out here, so we provide the bits the service reaches for.
     peopleSet = jasmine.createSpy('people.set');
@@ -108,66 +107,6 @@ describe('MixpanelService', () => {
       service.init();
 
       expect(mixpanel.init).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('data-track clicks', () => {
-    let host: HTMLElement;
-
-    beforeEach(() => {
-      environment.mixpanel_enabled = true;
-      environment.mixpanel_token = 'some-token';
-      service.init();
-      host = document.createElement('div');
-      document.body.appendChild(host);
-    });
-
-    afterEach(() => {
-      host.remove();
-    });
-
-    it('emits the data-track name with data-* attributes as properties', () => {
-      host.innerHTML = `
-        <a data-track="partner-link" data-name="Partner" data-report-id="9">
-          <img alt="logo" />
-        </a>`;
-      host.querySelector('img')!.click();
-
-      expect(mixpanel.track).toHaveBeenCalledWith('partner-link', {
-        name: 'Partner',
-        reportId: '9',
-      });
-    });
-
-    it('tracks a button with no extra attributes', () => {
-      host.innerHTML = `<button data-track="generate-funding-report"></button>`;
-      host.querySelector('button')!.click();
-
-      expect(mixpanel.track).toHaveBeenCalledWith(
-        'generate-funding-report',
-        {}
-      );
-    });
-
-    it('ignores clicks on elements without data-track', () => {
-      host.innerHTML = `<button></button>`;
-      host.querySelector('button')!.click();
-
-      expect(mixpanel.track).not.toHaveBeenCalled();
-    });
-
-    it('prefers the nearest button over the nearest anchor, like OpenPanel', () => {
-      host.innerHTML = `
-        <a data-track="outer-anchor">
-          <button data-track="inner-button"></button>
-        </a>`;
-      host.querySelector('button')!.click();
-
-      expect(mixpanel.track).toHaveBeenCalledWith('inner-button', {});
-      expect(mixpanel.track).not.toHaveBeenCalledWith(
-        'outer-anchor',
-        jasmine.anything()
-      );
     });
   });
 });

--- a/src/interface/src/app/services/mixpanel.service.spec.ts
+++ b/src/interface/src/app/services/mixpanel.service.spec.ts
@@ -22,6 +22,7 @@ describe('MixpanelService', () => {
     spyOn(mixpanel, 'init');
     spyOn(mixpanel, 'identify');
     spyOn(mixpanel, 'reset');
+    spyOn(mixpanel, 'track');
     // `mixpanel.people` only exists once the real `init` has run, and we stub
     // that out here, so we provide the bits the service reaches for.
     peopleSet = jasmine.createSpy('people.set');
@@ -99,6 +100,74 @@ describe('MixpanelService', () => {
       loggedInUser$.next(null);
 
       expect(mixpanel.reset).toHaveBeenCalled();
+    });
+
+    it('only initializes once, so a second call does not double up', () => {
+      (mixpanel.init as jasmine.Spy).calls.reset();
+
+      service.init();
+
+      expect(mixpanel.init).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('data-track clicks', () => {
+    let host: HTMLElement;
+
+    beforeEach(() => {
+      environment.mixpanel_enabled = true;
+      environment.mixpanel_token = 'some-token';
+      service.init();
+      host = document.createElement('div');
+      document.body.appendChild(host);
+    });
+
+    afterEach(() => {
+      host.remove();
+    });
+
+    it('emits the data-track name with data-* attributes as properties', () => {
+      host.innerHTML = `
+        <a data-track="partner-link" data-name="Partner" data-report-id="9">
+          <img alt="logo" />
+        </a>`;
+      host.querySelector('img')!.click();
+
+      expect(mixpanel.track).toHaveBeenCalledWith('partner-link', {
+        name: 'Partner',
+        reportId: '9',
+      });
+    });
+
+    it('tracks a button with no extra attributes', () => {
+      host.innerHTML = `<button data-track="generate-funding-report"></button>`;
+      host.querySelector('button')!.click();
+
+      expect(mixpanel.track).toHaveBeenCalledWith(
+        'generate-funding-report',
+        {}
+      );
+    });
+
+    it('ignores clicks on elements without data-track', () => {
+      host.innerHTML = `<button></button>`;
+      host.querySelector('button')!.click();
+
+      expect(mixpanel.track).not.toHaveBeenCalled();
+    });
+
+    it('prefers the nearest button over the nearest anchor, like OpenPanel', () => {
+      host.innerHTML = `
+        <a data-track="outer-anchor">
+          <button data-track="inner-button"></button>
+        </a>`;
+      host.querySelector('button')!.click();
+
+      expect(mixpanel.track).toHaveBeenCalledWith('inner-button', {});
+      expect(mixpanel.track).not.toHaveBeenCalledWith(
+        'outer-anchor',
+        jasmine.anything()
+      );
     });
   });
 });

--- a/src/interface/src/app/services/mixpanel.service.ts
+++ b/src/interface/src/app/services/mixpanel.service.ts
@@ -1,32 +1,17 @@
-import { Injectable, NgZone, OnDestroy } from '@angular/core';
+import { Injectable } from '@angular/core';
 import mixpanel from 'mixpanel-browser';
 
 import { environment } from '@env/environment';
 import { User } from '@types';
 import { AuthService } from '@services/auth.service';
 
-/** `data-report-id` -> `reportId`, matching OpenPanel's attribute naming. */
-function camelCase(name: string): string {
-  return name.replace(/([-_][a-z])/gi, (match) =>
-    match.toUpperCase().replace('-', '').replace('_', '')
-  );
-}
-
 @Injectable({
   providedIn: 'root',
 })
-export class MixpanelService implements OnDestroy {
+export class MixpanelService {
   private enabled = false;
-  private readonly abortController = new AbortController();
 
-  constructor(
-    private authService: AuthService,
-    private zone: NgZone
-  ) {}
-
-  ngOnDestroy(): void {
-    this.abortController.abort();
-  }
+  constructor(private authService: AuthService) {}
 
   /**
    * Initializes Mixpanel and keeps the profile in sync with the logged in user.
@@ -61,58 +46,6 @@ export class MixpanelService implements OnDestroy {
       } else {
         this.reset();
       }
-    });
-
-    this.trackAttributeClicks();
-  }
-
-  /**
-   * Mirrors OpenPanel's `trackAttributes`, so a `data-track` element emits the
-   * same named event to both SDKs while we run them side by side. Element
-   * lookup and property naming follow the OpenPanel implementation on purpose -
-   * if the two disagree, the event counts won't be comparable.
-   *
-   * Note this is on top of what autocapture already sends: the same click also
-   * shows up as `$mp_click`. Different event name, so no double counting.
-   */
-  private trackAttributeClicks(): void {
-    // Outside the zone - a document-wide click listener would otherwise kick
-    // off change detection on every click in the app.
-    this.zone.runOutsideAngular(() => {
-      document.addEventListener(
-        'click',
-        (event) => {
-          const target = event.target as Element | null;
-          if (!target || typeof target.closest !== 'function') {
-            return;
-          }
-          // OpenPanel prefers the nearest button over the nearest anchor.
-          const button = target.closest('button');
-          const anchor = target.closest('a');
-          const element = button?.getAttribute('data-track')
-            ? button
-            : anchor?.getAttribute('data-track')
-              ? anchor
-              : null;
-          const name = element?.getAttribute('data-track');
-          if (!element || !name) {
-            return;
-          }
-
-          const properties: Record<string, string> = {};
-          for (const attribute of Array.from(element.attributes)) {
-            if (
-              attribute.name.startsWith('data-') &&
-              attribute.name !== 'data-track'
-            ) {
-              properties[camelCase(attribute.name.replace(/^data-/, ''))] =
-                attribute.value;
-            }
-          }
-          this.track(name, properties);
-        },
-        { signal: this.abortController.signal }
-      );
     });
   }
 

--- a/src/interface/src/app/services/mixpanel.service.ts
+++ b/src/interface/src/app/services/mixpanel.service.ts
@@ -1,24 +1,43 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone, OnDestroy } from '@angular/core';
 import mixpanel from 'mixpanel-browser';
 
 import { environment } from '@env/environment';
 import { User } from '@types';
 import { AuthService } from '@services/auth.service';
 
+/** `data-report-id` -> `reportId`, matching OpenPanel's attribute naming. */
+function camelCase(name: string): string {
+  return name.replace(/([-_][a-z])/gi, (match) =>
+    match.toUpperCase().replace('-', '').replace('_', '')
+  );
+}
+
 @Injectable({
   providedIn: 'root',
 })
-export class MixpanelService {
+export class MixpanelService implements OnDestroy {
   private enabled = false;
+  private readonly abortController = new AbortController();
 
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private zone: NgZone
+  ) {}
+
+  ngOnDestroy(): void {
+    this.abortController.abort();
+  }
 
   /**
    * Initializes Mixpanel and keeps the profile in sync with the logged in user.
-   * Called once, on app startup.
+   * Safe to call more than once - only the first call runs.
    */
   init(): void {
-    if (!environment.mixpanel_enabled || !environment.mixpanel_token) {
+    if (
+      this.enabled ||
+      !environment.mixpanel_enabled ||
+      !environment.mixpanel_token
+    ) {
       return;
     }
 
@@ -42,6 +61,58 @@ export class MixpanelService {
       } else {
         this.reset();
       }
+    });
+
+    this.trackAttributeClicks();
+  }
+
+  /**
+   * Mirrors OpenPanel's `trackAttributes`, so a `data-track` element emits the
+   * same named event to both SDKs while we run them side by side. Element
+   * lookup and property naming follow the OpenPanel implementation on purpose -
+   * if the two disagree, the event counts won't be comparable.
+   *
+   * Note this is on top of what autocapture already sends: the same click also
+   * shows up as `$mp_click`. Different event name, so no double counting.
+   */
+  private trackAttributeClicks(): void {
+    // Outside the zone - a document-wide click listener would otherwise kick
+    // off change detection on every click in the app.
+    this.zone.runOutsideAngular(() => {
+      document.addEventListener(
+        'click',
+        (event) => {
+          const target = event.target as Element | null;
+          if (!target || typeof target.closest !== 'function') {
+            return;
+          }
+          // OpenPanel prefers the nearest button over the nearest anchor.
+          const button = target.closest('button');
+          const anchor = target.closest('a');
+          const element = button?.getAttribute('data-track')
+            ? button
+            : anchor?.getAttribute('data-track')
+              ? anchor
+              : null;
+          const name = element?.getAttribute('data-track');
+          if (!element || !name) {
+            return;
+          }
+
+          const properties: Record<string, string> = {};
+          for (const attribute of Array.from(element.attributes)) {
+            if (
+              attribute.name.startsWith('data-') &&
+              attribute.name !== 'data-track'
+            ) {
+              properties[camelCase(attribute.name.replace(/^data-/, ''))] =
+                attribute.value;
+            }
+          }
+          this.track(name, properties);
+        },
+        { signal: this.abortController.signal }
+      );
     });
   }
 

--- a/src/interface/src/app/services/product-analytics.service.spec.ts
+++ b/src/interface/src/app/services/product-analytics.service.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { MockProvider } from 'ng-mocks';
+
+import { MixpanelService } from '@services/mixpanel.service';
+import { OpenPanelService } from '@services/open-panel.service';
+import { ProductAnalyticsService } from '@services/product-analytics.service';
+
+describe('ProductAnalyticsService', () => {
+  let service: ProductAnalyticsService;
+  let openPanel: OpenPanelService;
+  let mixpanel: MixpanelService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProductAnalyticsService,
+        MockProvider(OpenPanelService),
+        MockProvider(MixpanelService),
+      ],
+    });
+    service = TestBed.inject(ProductAnalyticsService);
+    openPanel = TestBed.inject(OpenPanelService);
+    mixpanel = TestBed.inject(MixpanelService);
+  });
+
+  it('starts both SDKs', () => {
+    spyOn(openPanel, 'init');
+    spyOn(mixpanel, 'init');
+
+    service.init();
+
+    expect(openPanel.init).toHaveBeenCalled();
+    expect(mixpanel.init).toHaveBeenCalled();
+  });
+
+  it('sends every event to both SDKs so the data sets stay comparable', () => {
+    spyOn(openPanel, 'trackEvent');
+    spyOn(mixpanel, 'track');
+
+    service.trackEvent('funding_report.shared_link.copied', { scenario_id: 7 });
+
+    expect(openPanel.trackEvent).toHaveBeenCalledWith(
+      'funding_report.shared_link.copied',
+      { scenario_id: 7 }
+    );
+    expect(mixpanel.track).toHaveBeenCalledWith(
+      'funding_report.shared_link.copied',
+      { scenario_id: 7 }
+    );
+  });
+});

--- a/src/interface/src/app/services/product-analytics.service.ts
+++ b/src/interface/src/app/services/product-analytics.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+
+import { MixpanelService } from '@services/mixpanel.service';
+import { OpenPanelService } from '@services/open-panel.service';
+
+/**
+ * Single entry point for product analytics while we migrate from OpenPanel to
+ * Mixpanel. Mirrors the backend's `_dispatch` (`planscape/openpanel.py`): every
+ * event goes to both SDKs, so the two data sets stay comparable until the
+ * backfill is signed off. Dropping OpenPanel means deleting one line per method
+ * here rather than hunting down call sites.
+ *
+ * Distinct from `AnalyticsService`, which is Google Analytics.
+ *
+ * Event names follow the backend convention (`app.model.verb`) so client and
+ * server events for the same flow line up.
+ *
+ * Reach for `trackEvent` when the event needs properties from component state,
+ * or when it fires on something other than a click. Otherwise prefer what the
+ * SDKs already track:
+ * - a plain click on a button or anchor: add `data-track="event.name"` to the
+ *   element (plus any `data-*` attributes as properties) and both SDKs pick it
+ *   up - OpenPanel via `trackAttributes`, Mixpanel via `MixpanelService`
+ * - navigation: `screen_view` on OpenPanel, `$mp_web_page_view` on Mixpanel
+ * - clicks on links to other hosts: `link_out` on OpenPanel, `$mp_click` on
+ *   Mixpanel
+ *
+ * Those are automatic on both sides, so re-emitting them here double counts.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ProductAnalyticsService {
+  constructor(
+    private openPanelService: OpenPanelService,
+    private mixpanelService: MixpanelService
+  ) {}
+
+  /** Starts both SDKs. Safe to call more than once. */
+  init(): void {
+    this.openPanelService.init();
+    this.mixpanelService.init();
+  }
+
+  trackEvent(name: string, properties?: Record<string, unknown>): void {
+    this.openPanelService.trackEvent(name, properties);
+    this.mixpanelService.track(name, properties);
+  }
+}

--- a/src/interface/src/app/services/product-analytics.service.ts
+++ b/src/interface/src/app/services/product-analytics.service.ts
@@ -5,27 +5,18 @@ import { OpenPanelService } from '@services/open-panel.service';
 
 /**
  * Single entry point for product analytics while we migrate from OpenPanel to
- * Mixpanel. Mirrors the backend's `_dispatch` (`planscape/openpanel.py`): every
- * event goes to both SDKs, so the two data sets stay comparable until the
- * backfill is signed off. Dropping OpenPanel means deleting one line per method
- * here rather than hunting down call sites.
+ * Mixpanel.
  *
  * Distinct from `AnalyticsService`, which is Google Analytics.
  *
  * Event names follow the backend convention (`app.model.verb`) so client and
  * server events for the same flow line up.
  *
- * Reach for `trackEvent` when the event needs properties from component state,
- * or when it fires on something other than a click. Otherwise prefer what the
- * SDKs already track:
- * - a plain click on a button or anchor: add `data-track="event.name"` to the
- *   element (plus any `data-*` attributes as properties) and both SDKs pick it
- *   up - OpenPanel via `trackAttributes`, Mixpanel via `MixpanelService`
- * - navigation: `screen_view` on OpenPanel, `$mp_web_page_view` on Mixpanel
- * - clicks on links to other hosts: `link_out` on OpenPanel, `$mp_click` on
- *   Mixpanel
+ * Call `trackEvent` explicitly for anything worth naming. T
  *
- * Those are automatic on both sides, so re-emitting them here double counts.
+ * What you should NOT re-emit here, because both SDKs already send it:
+ * - navigation: `screen_view` on OpenPanel, `$mp_web_page_view` on Mixpanel
+ * - any click: `link_out` on OpenPanel, `$mp_click` on Mixpanel
  */
 @Injectable({
   providedIn: 'root',

--- a/src/interface/src/styleguide/tool-info-card/tool-info-card.component.html
+++ b/src/interface/src/styleguide/tool-info-card/tool-info-card.component.html
@@ -31,12 +31,11 @@
 
   <section class="partners" *ngIf="partners.length > 0">
     <a
-      data-track="partner-link"
-      [attr.data-name]="partner.name"
       *ngFor="let partner of partners"
       [href]="partner.url"
       [title]="partner.name"
-      target="_blank">
+      target="_blank"
+      (click)="clickPartner.emit(partner)">
       <img [src]="partner.logo" [alt]="partner.name" />
     </a>
   </section>

--- a/src/interface/src/styleguide/tool-info-card/tool-info-card.component.spec.ts
+++ b/src/interface/src/styleguide/tool-info-card/tool-info-card.component.spec.ts
@@ -19,4 +19,31 @@ describe('ToolInfoCardComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('emits the partner when its logo is clicked, so consumers can track it', () => {
+    const partner = {
+      name: 'Partner',
+      url: 'https://partner.example',
+      logo: 'logo.png',
+    };
+    component.partners = [partner];
+    fixture.detectChanges();
+    const emitted: unknown[] = [];
+    component.clickPartner.subscribe((p) => emitted.push(p));
+
+    const link: HTMLAnchorElement =
+      fixture.nativeElement.querySelector('.partners a');
+    // The anchor navigates on click, which karma would follow.
+    link.addEventListener('click', (event) => event.preventDefault());
+    link.click();
+
+    expect(emitted).toEqual([partner]);
+  });
+
+  it('renders nothing in the partners section without partners', () => {
+    component.partners = [];
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.partners')).toBeNull();
+  });
 });

--- a/src/interface/src/styleguide/tool-info-card/tool-info-card.component.ts
+++ b/src/interface/src/styleguide/tool-info-card/tool-info-card.component.ts
@@ -3,6 +3,12 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 
+export interface ToolInfoCardPartner {
+  name: string;
+  url: string;
+  logo: string;
+}
+
 @Component({
   selector: 'sg-tool-info-card',
   standalone: true,
@@ -30,10 +36,17 @@ export class ToolInfoCardComponent {
   /** Whether to show the tooltip (help) button */
   @Input() showTooltipButton = true;
   /** Additional partners */
-  @Input() partners: { name: string; url: string; logo: string }[] = [];
+  @Input() partners: ToolInfoCardPartner[] = [];
 
   /** Action when clicking on tooltip. */
   @Output() clickTooltip = new EventEmitter<void>();
+
+  /**
+   * Fires when a partner logo is clicked. Exposed as an output so the consumer
+   * can decide whether it is worth tracking - the styleguide stays free of
+   * analytics dependencies.
+   */
+  @Output() clickPartner = new EventEmitter<ToolInfoCardPartner>();
 
   /**
    * @ignore


### PR DESCRIPTION
Migrates a couple of events and centralizes some things for easy removal of open panel.
Adds some tests to check we are migrating the custom events