### PR TITLE
Replace plan input for checking empty scenarios

### DIFF
--- a/src/interface/src/app/plan/plan-summary/scenarios-list/scenarios-list.component.html
+++ b/src/interface/src/app/plan/plan-summary/scenarios-list/scenarios-list.component.html
@@ -13,7 +13,8 @@
       <app-scenarios-empty-list
         *ngIf="
           planningAreaIsReady && !planningAreaIsLarge && !planningAreaFailed
-        "></app-scenarios-empty-list>
+        "
+        [plan]="plan"></app-scenarios-empty-list>
 
       <div *ngIf="planningAreaIsLarge" class="large-message">
         <p>


### PR DESCRIPTION
I think I accidentally removed this when editng that template, but _this_ component does need the plan input.