### PR TITLE
plan-3925-preprocessing-to-child-scenarios

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -5,10 +5,11 @@ import logging
 import math
 import os
 import zipfile
+from collections.abc import Collection
 from datetime import date, datetime, time
 from functools import partial
 from pathlib import Path
-from typing import Any, Collection, Dict, List, Optional, Tuple, Type, Union
+from typing import Any
 
 import fiona
 from actstream import action
@@ -39,8 +40,8 @@ from modules.base import (
     compute_planning_area_capabilities,
     compute_scenario_capabilities,
 )
-from planscape.exceptions import InvalidGeometry
 from planscape.analytics import track_event
+from planscape.exceptions import InvalidGeometry
 from pyproj import Geod
 from shapely import wkt
 from stands.models import Stand, StandMetric, StandSizeChoices, area_from_size
@@ -66,11 +67,11 @@ from planning.models import (
 
 logger = logging.getLogger(__name__)
 
-DataLayerList = List[DataLayer]
+DataLayerList = list[DataLayer]
 
 
 def create_metrics_task(
-    stand_ids: List[int],
+    stand_ids: list[int],
     datalayer: DataLayer,
 ):
     from planning.tasks import (
@@ -90,7 +91,7 @@ def create_metrics_task(
 def get_truncated_stands_grid_keys(
     planning_area: PlanningArea,
     stand_size: StandSizeChoices,
-) -> List[str]:
+) -> list[str]:
     stands = planning_area.get_stands(stand_size=stand_size)
     precision = get_stand_grid_key_search_precision(stand_size)
     truncated_stand_grid_keys = (
@@ -105,9 +106,9 @@ def get_truncated_stands_grid_keys(
 def create_planning_area(
     user: User,
     name: str,
-    region_name: Optional[str] = None,
+    region_name: str | None = None,
     geometry: Any = None,
-    notes: Optional[str] = None,
+    notes: str | None = None,
 ) -> PlanningArea:
     from planning.tasks import (
         async_create_stands,
@@ -220,8 +221,8 @@ def delete_planning_area(
 
 
 def get_treatment_goal_from_configuration(
-    configuration: Dict[str, Any],
-) -> Optional[TreatmentGoal]:
+    configuration: dict[str, Any],
+) -> TreatmentGoal | None:
     """Get the treatment goal from the configuration."""
     question_id = configuration.get("question_id")
     if not question_id:
@@ -239,18 +240,18 @@ def get_treatment_goal_from_configuration(
 
 def create_config(
     *,
-    stand_size: Optional[StandSizeChoices] = None,
-    targets: Dict[str, Any],
-    constraints: List[Dict[str, Any]],
+    stand_size: StandSizeChoices | None = None,
+    targets: dict[str, Any],
+    constraints: list[dict[str, Any]],
     included_areas: DataLayerList,
     excluded_areas: DataLayerList,
-    priorities: List[Dict[str, Any]],
+    priorities: list[dict[str, Any]],
     cobenefits: DataLayerList,
-    seed: Optional[int] = None,
-    planning_approach: Optional[ScenarioPlanningApproach] = None,
-    sub_units_layer: Optional[int] = None,
-) -> Dict[str, Any]:
-    config: Dict[str, Any] = {}
+    seed: int | None = None,
+    planning_approach: ScenarioPlanningApproach | None = None,
+    sub_units_layer: int | None = None,
+) -> dict[str, Any]:
+    config: dict[str, Any] = {}
 
     if stand_size is not None:
         config["stand_size"] = stand_size
@@ -382,7 +383,7 @@ def union_geojson(uploaded_geojson) -> GEOSGeometry:
 
 def feature_to_project_area(
     scenario: Scenario,
-    geometry_dict: Dict[str, Any],
+    geometry_dict: dict[str, Any],
     idx: int = 1,
 ):
     user = scenario.user
@@ -502,7 +503,7 @@ def create_scenario_from_upload(validated_data, user) -> Scenario:
 @transaction.atomic
 def delete_scenario(
     user: User,
-    scenario: Type[Scenario],
+    scenario: type[Scenario],
 ):
     if not ScenarioPermission.can_remove(user, scenario):
         logger.error(f"User {user} has no permission to delete {scenario.pk}")
@@ -560,7 +561,7 @@ def is_project_areas_child(scenario: Scenario) -> bool:
 
 def get_project_areas_stands_lookup_table(
     scenario: Scenario,
-) -> dict[str, List[int]]:
+) -> dict[str, list[int]]:
     parent = scenario.parent
     if not parent:
         return {}
@@ -581,7 +582,7 @@ def get_project_areas_stands_lookup_table(
 def get_project_areas_child_stand_ids(
     scenario: Scenario,
     stand_size: str,
-) -> List[int]:
+) -> list[int]:
     parent = scenario.parent
     if not parent:
         return []
@@ -596,7 +597,69 @@ def get_project_areas_child_stand_ids(
     return list(stand_ids)
 
 
-def build_run_configuration(scenario: "Scenario") -> Dict[str, Any]:
+@transaction.atomic()
+def calculate_child_project_areas(scenario: Scenario) -> list[ProjectArea]:
+    if not is_project_areas_child(scenario):
+        return []
+
+    parent = scenario.parent
+    if not parent:
+        return []
+
+    stand_size = (scenario.configuration or {}).get("stand_size")
+    if not stand_size:
+        return []
+
+    project_areas = []
+
+    for idx, parent_project_area in enumerate(
+        parent.project_areas.all(),
+        start=1,
+    ):
+        stands = parent_project_area.get_stands(stand_size=stand_size)
+        stand_count = stands.count()
+
+        if stand_count == 0:
+            continue
+
+        geometry = stands.aggregate(geometry=UnionOp("geometry"))["geometry"]
+
+        if not geometry:
+            continue
+
+        geometry = to_multipolygon(geometry)
+
+        treatment_rank = (parent_project_area.data or {}).get(
+            "treatment_rank",
+            idx,
+        )
+
+        project_area, _ = ProjectArea.objects.update_or_create(
+            scenario=scenario,
+            name=parent_project_area.name,
+            defaults={
+                "created_by": scenario.user,
+                "geometry": geometry,
+                "data": {
+                    "proj_id": parent_project_area.pk,
+                    "treatment_rank": treatment_rank,
+                    "stand_count": stand_count,
+                },
+            },
+        )
+
+        project_area.data = {
+            **(project_area.data or {}),
+            "project_id": project_area.pk,
+        }
+        project_area.save(update_fields=["data"])
+
+        project_areas.append(project_area)
+
+    return project_areas
+
+
+def build_run_configuration(scenario: "Scenario") -> dict[str, Any]:
     tx_goal = scenario.treatment_goal
     datalayers = []
 
@@ -748,8 +811,8 @@ def build_run_configuration(scenario: "Scenario") -> Dict[str, Any]:
     }
 
 
-def validate_scenario_configuration(scenario: "Scenario") -> List[str]:
-    errors: List[str] = []
+def validate_scenario_configuration(scenario: "Scenario") -> list[str]:
+    errors: list[str] = []
 
     if scenario.result_status not in {
         ScenarioResultStatus.PENDING,
@@ -952,7 +1015,7 @@ def get_cost_per_acre(configuration: dict) -> float:
     return configuration.get("est_cost") or settings.DEFAULT_ESTIMATED_COST
 
 
-def get_max_treatable_area(configuration: Dict[str, Any]) -> float:
+def get_max_treatable_area(configuration: dict[str, Any]) -> float:
     max_budget = configuration.get("max_budget") or None
     cost_per_acre = get_cost_per_acre(configuration=configuration)
     if max_budget:
@@ -993,8 +1056,8 @@ def get_acreage(geometry: GEOSGeometry) -> float:
 
 def validate_scenario_treatment_ratio(
     planning_area: PlanningArea,
-    configuration: Dict[str, Any],
-) -> Tuple[bool, str]:
+    configuration: dict[str, Any],
+) -> tuple[bool, str]:
     planning_area_acres = get_acreage(planning_area.geometry)
     max_treatable_area = get_max_treatable_area(configuration)
 
@@ -1054,14 +1117,14 @@ def map_property_for_numeric_export(key_value_pair):
 
 
 def get_schema(
-    geojson: Union[Collection[Dict[str, Any]], Dict[str, Any]],
-    extra_properties: Dict[str, Any] = {},
-) -> Dict[str, Any]:
+    geojson: Collection[dict[str, Any]] | dict[str, Any],
+    extra_properties: dict[str, Any] = {},
+) -> dict[str, Any]:
     feature = {}
     match geojson:
         case {"type": "FeatureCollection", "features": features}:
             feature = features[0]
-        case {"properties": _properties, "geometry": _geometry}:  # noqa
+        case {"properties": _properties, "geometry": _geometry}:
             feature = geojson
         case list() as features:
             feature = features[0]
@@ -1098,7 +1161,7 @@ def _get_datalayers_id_lookup_table(scenario):
     return dl_lookup
 
 
-def _get_sub_units_lookup_table(scenario: Scenario) -> Optional[Dict[int, Any]]:
+def _get_sub_units_lookup_table(scenario: Scenario) -> dict[int, Any] | None:
     if scenario.planning_approach != ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS:
         return None
     geojson = get_flatten_geojson(scenario)
@@ -1109,7 +1172,7 @@ def _get_sub_units_lookup_table(scenario: Scenario) -> Optional[Dict[int, Any]]:
     return ret
 
 
-def get_flatten_geojson(scenario: Scenario) -> Dict[str, Any]:
+def get_flatten_geojson(scenario: Scenario) -> dict[str, Any]:
     """
     Get the geojson result of a scenario.
     This function modifies the properties of the geojson features
@@ -1138,7 +1201,7 @@ def get_flatten_geojson(scenario: Scenario) -> Dict[str, Any]:
     return geojson
 
 
-def get_weighing_from_input(stand_inputs: Dict[int, Dict]):
+def get_weighing_from_input(stand_inputs: dict[int, dict]):
     weighting_data = {}
     if stand_inputs:
         sample_stand_data = dict(list(stand_inputs.values())[0])
@@ -1187,7 +1250,7 @@ def export_to_shapefile(scenario: Scenario) -> Path:
 
 
 def export_scenario_stand_outputs_to_geopackage(
-    scenario: Scenario, geopackage_path: Path, stand_inputs: Dict[int, Dict]
+    scenario: Scenario, geopackage_path: Path, stand_inputs: dict[int, dict]
 ) -> None:
     forsys_folder = scenario.get_forsys_folder()
     stnd_file = forsys_folder / f"stnd_{scenario.uuid}.csv"
@@ -1303,7 +1366,7 @@ def export_scenario_stand_outputs_to_geopackage(
 
 def export_scenario_inputs_to_geopackage(
     scenario: Scenario, geopackage_path: Path
-) -> Dict[int, Dict]:
+) -> dict[int, dict]:
     configuration = scenario.configuration
     tx_goal = scenario.treatment_goal
     if tx_goal:
@@ -1422,7 +1485,7 @@ def export_scenario_inputs_to_geopackage(
 def export_scenario_project_areas_outputs_to_geopackage(
     scenario: Scenario,
     geopackage_path: Path,
-    stand_inputs: Dict[int, Dict],
+    stand_inputs: dict[int, dict],
 ) -> None:
     geojson = get_flatten_geojson(scenario)
 
@@ -1456,7 +1519,7 @@ def export_scenario_project_areas_outputs_to_geopackage(
 def export_scenario_sub_units_outputs_to_geopackage(
     scenario: Scenario,
     geopackage_path: Path,
-    stand_inputs: Dict[int, Dict],
+    stand_inputs: dict[int, dict],
 ) -> None:
     geojson = get_flatten_geojson(scenario)
 
@@ -1630,7 +1693,7 @@ def export_planning_area_to_geopackage(
         raise e
 
 
-def export_to_geopackage(scenario: Scenario, regenerate=False) -> Optional[str]:
+def export_to_geopackage(scenario: Scenario, regenerate=False) -> str | None:
     try:
         if not regenerate and scenario.geopackage_url:
             logger.info(
@@ -1793,9 +1856,9 @@ def get_excluded_stands(stands_qs, datalayer: DataLayer):
 def get_constrained_stands(
     stands_qs,
     datalayer: DataLayer,
-    operator: Optional[str] = None,
-    value: Union[str, float] = 1.0,
-    metric_column: Optional[str] = None,
+    operator: str | None = None,
+    value: str | float = 1.0,
+    metric_column: str | None = None,
     usage_type: TreatmentGoalUsageType = TreatmentGoalUsageType.THRESHOLD,
 ):
     if not metric_column:
@@ -1857,10 +1920,10 @@ def get_available_stands(
     scenario: Scenario,
     *,
     stand_size: str = "LARGE",
-    includes: Optional[List[DataLayer]] = None,
-    excludes: Optional[List[DataLayer]] = None,
-    constraints: Optional[List[Dict[str, Any]]] = None,
-    sub_unit: Optional[DataLayer] = None,
+    includes: list[DataLayer] | None = None,
+    excludes: list[DataLayer] | None = None,
+    constraints: list[dict[str, Any]] | None = None,
+    sub_unit: DataLayer | None = None,
     **kwargs,
 ):
     if not includes:
@@ -1959,8 +2022,8 @@ def get_available_stands(
 def get_available_stand_ids(
     scenario: Scenario,
     stand_size: str = "LARGE",
-    excludes: Optional[QuerySet[DataLayer]] = None,
-) -> List[int]:
+    excludes: QuerySet[DataLayer] | None = None,
+) -> list[int]:
     planning_area = scenario.planning_area
 
     if is_project_areas_child(scenario):
@@ -2003,8 +2066,8 @@ def get_available_stand_ids(
 
 def calculate_scenario_treatable_area(
     scenario: Scenario,
-    includes: Optional[QuerySet[DataLayer]] = None,
-) -> Optional[MultiPolygon]:
+    includes: QuerySet[DataLayer] | None = None,
+) -> MultiPolygon | None:
     planning_area = scenario.planning_area
     pa_geometry = planning_area.geometry
 
@@ -2048,7 +2111,7 @@ def get_min_project_area(scenario: Scenario) -> float:
 @cached(timeout=settings.SUB_UNITS_DETAILS_TTL)
 def get_sub_units_areas(
     scenario: Scenario, stand_size: StandSizeChoices, datalayer: DataLayer
-) -> Optional[List[int]]:
+) -> list[int] | None:
     planning_area = scenario.planning_area
     geometry = planning_area.geometry
     DynamicModel = model_from_fiona(datalayer)
@@ -2081,9 +2144,9 @@ def get_sub_units_details(
     scenario: Scenario,
     stand_size: StandSizeChoices,
     datalayer: DataLayer,
-    fixed_target: Optional[bool] = None,
-    target_value: Optional[float] = None,
-) -> Optional[dict[str, Optional[float]]]:
+    fixed_target: bool | None = None,
+    target_value: float | None = None,
+) -> dict[str, float | None] | None:
 
     areas = get_sub_units_areas(scenario, stand_size, datalayer)
 
@@ -2114,7 +2177,7 @@ def get_sub_units_details(
 
 def get_sub_units_stands_lookup_table(
     scenario: Scenario, datalayer: DataLayer
-) -> dict[int, List[int]]:
+) -> dict[int, list[int]]:
     stand_size = scenario.get_stand_size()
     planning_area = scenario.planning_area
     geometry = planning_area.geometry
@@ -2154,8 +2217,8 @@ def calculate_and_update_scenario_result(scenario: Scenario):
 
 def get_rx_leverage_priority_names(
     scenario: Scenario,
-    features: List,
-) -> List[str]:
+    features: list,
+) -> list[str]:
     stored_names = {
         name
         for feature in features
@@ -2228,8 +2291,8 @@ def get_rx_leverage_priority_names(
 
 def calculate_and_update_rx_leverage(
     scenario: Scenario,
-    features: List,
-) -> List:
+    features: list,
+) -> list:
     if not features:
         return features
     names = get_rx_leverage_priority_names(
@@ -2250,7 +2313,7 @@ def calculate_and_update_rx_leverage(
     return features
 
 
-def calculate_and_update_pct_treatable_area(scenario: Scenario, features: List) -> List:
+def calculate_and_update_pct_treatable_area(scenario: Scenario, features: list) -> list:
     forsys_input = scenario.forsys_input or {}
 
     number_of_stands = len(forsys_input.get("stand_ids", []))

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -9,7 +9,7 @@ from collections.abc import Collection
 from datetime import date, datetime, time
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, Collection, Dict, List, Optional, Tuple, Type, Union
 
 import fiona
 from actstream import action

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -9,7 +9,15 @@ from collections.abc import Collection
 from datetime import date, datetime, time
 from functools import partial
 from pathlib import Path
-from typing import Any, Collection, Dict, List, Optional, Tuple, Type, Union
+from typing import (  # noqa: F401
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import fiona
 from actstream import action

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from datasets.models import DataLayerType, GeometryType
 from datasets.tests.factories import DataLayerFactory
+from django.contrib.gis.db.models import Union as UnionOp
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 from django.test import TestCase
 from django.urls import reverse
@@ -451,7 +452,7 @@ class ListScenariosForPlanningAreaTest(APITestCase):
         response_data = response.json()
         expected_acres_order = [40000, 40000, 40000, 104, 103, 102, 101, 100]
         budget_results = [s["max_treatment_area"] for s in response_data]
-        self.assertEquals(budget_results, expected_acres_order)
+        self.assertEqual(budget_results, expected_acres_order)
 
     def test_sort_scenario_by_reverse_acres_v3(self):
         for acres in range(100, 105):
@@ -527,7 +528,7 @@ class ListScenariosForPlanningAreaTest(APITestCase):
             "test scenario",
         ]
         name_results = [s["name"] for s in response_data]
-        self.assertEquals(expected_names, name_results)
+        self.assertEqual(expected_names, name_results)
 
     def test_filter_by_planning_area_returns_filtered_records(self):
         planning_area = PlanningAreaFactory.create()
@@ -1913,6 +1914,64 @@ class PatchScenarioConfigurationTest(APITestCase):
             ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
         )
 
+    def test_patch_draft_calculates_project_areas_from_parent_stands(self):
+        parent = ScenarioFactory.create(
+            user=self.user,
+            planning_area=self.planning_area,
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        parent_project_area = ProjectAreaFactory.create(
+            scenario=parent,
+            name="Project Area 1",
+            geometry=self.planning_area.geometry,
+            data={"treatment_rank": 1},
+        )
+        child = ScenarioFactory.create(
+            user=self.user,
+            planning_area=self.planning_area,
+            parent=parent,
+            configuration={},
+            treatment_goal=None,
+            planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+        )
+
+        self.assertEqual(child.project_areas.count(), 0)
+
+        url = reverse(
+            "api:planning:scenarios-patch-draft",
+            args=[child.pk],
+        )
+        payload = {
+            "configuration": {
+                "stand_size": "LARGE",
+            }
+        }
+
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        child.refresh_from_db()
+
+        self.assertEqual(child.project_areas.count(), 1)
+
+        child_project_area = child.project_areas.get()
+        expected_stands = parent_project_area.get_stands(stand_size="LARGE")
+        expected_geometry = expected_stands.aggregate(geometry=UnionOp("geometry"))[
+            "geometry"
+        ]
+
+        self.assertTrue(child_project_area.geometry.equals(expected_geometry))
+        self.assertEqual(
+            child_project_area.data["proj_id"],
+            parent_project_area.pk,
+        )
+        self.assertEqual(
+            child_project_area.data["stand_count"],
+            expected_stands.count(),
+        )
+
 
 class ScenarioCapabilitiesViewTest(APITestCase):
     def setUp(self):
@@ -2254,7 +2313,7 @@ class RunScenarioEndpointTest(APITestCase):
             mock.patch(
                 "planning.views_v2.validate_scenario_configuration", return_value=[]
             ) as validate_mock,  # noqa: F841
-            mock.patch("planning.views_v2.trigger_scenario_run") as trigger_mock,  # noqa
+            mock.patch("planning.views_v2.trigger_scenario_run") as trigger_mock,
         ):
             response = self.client.post(self.url, format="json")
 
@@ -2274,7 +2333,7 @@ class RunScenarioEndpointTest(APITestCase):
                 "planning.views_v2.validate_scenario_configuration",
                 return_value=["Provide either `max_budget` or `max_area`."],
             ) as validate_mock,  # noqa: F841
-            mock.patch("planning.views_v2.trigger_scenario_run") as trigger_mock,  # noqa
+            mock.patch("planning.views_v2.trigger_scenario_run") as trigger_mock,
         ):
             response = self.client.post(self.url, format="json")
 

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -93,6 +93,7 @@ from planning.serializers import (
     UpsertScenarioV3Serializer,
 )
 from planning.services import (
+    calculate_child_project_areas,
     create_config,
     create_planning_area,
     create_scenario,
@@ -464,6 +465,10 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
                     ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS
                 )
         configuration_data = serializer.validated_data.get("configuration")
+        should_calculate_child_project_areas = (
+            "parent" in serializer.validated_data
+            or (configuration_data is not None and "stand_size" in configuration_data)
+        )
         if configuration_data:
             existing = instance.configuration or {}
             incoming_config = create_config(
@@ -484,6 +489,8 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             serializer.validated_data["configuration"] = updated_config
         self.perform_update(serializer)
         instance.refresh_from_db()
+        if should_calculate_child_project_areas:
+            calculate_child_project_areas(instance)
         instance.capabilities = compute_scenario_capabilities(instance)
         instance.save(update_fields=["capabilities"])
         response_serializer = ScenarioV3Serializer(instance)


### PR DESCRIPTION
@roquebetioljr @lastminutediorama, Add preprocessing to child scenarios to calculate project areas from parent, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3925

1. src/planscape/planning/services.py: new function to calculate geometry
2. src/planscape/planning/tests/test_v2_scenario_views.py: new test
3. src/planscape/planning/views_v2.py: exposure