### PR TITLE
plan-3926-update-backend-query-to-handle-includes

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -567,6 +567,27 @@ def is_project_areas_child(scenario: Scenario) -> bool:
     )
 
 
+def get_project_areas_child_stands(
+    scenario: Scenario,
+    project_area: ProjectArea,
+    stand_size: str,
+) -> QuerySet[Stand]:
+    geometry = project_area.geometry
+
+    if scenario.treatable_area:
+        geometry = geometry.intersection(scenario.treatable_area)
+
+        if geometry.empty:
+            return Stand.objects.none()
+
+        geometry = to_multipolygon(geometry)
+
+    return Stand.objects.within_polygon(
+        geometry,
+        stand_size,
+    )
+
+
 def get_project_areas_stands_lookup_table(
     scenario: Scenario,
 ) -> dict[str, list[int]]:
@@ -578,9 +599,11 @@ def get_project_areas_stands_lookup_table(
     stand_size = scenario.get_stand_size()
 
     for project_area in parent.project_areas.all():
-        stand_ids = project_area.get_stands(stand_size=stand_size).values_list(
-            "id", flat=True
-        )
+        stand_ids = get_project_areas_child_stands(
+            scenario=scenario,
+            project_area=project_area,
+            stand_size=stand_size,
+        ).values_list("id", flat=True)
 
         lookup_table[str(project_area.pk)] = list(stand_ids)
 
@@ -599,7 +622,11 @@ def get_project_areas_child_stand_ids(
 
     for project_area in parent.project_areas.all():
         stand_ids.update(
-            project_area.get_stands(stand_size=stand_size).values_list("id", flat=True)
+            get_project_areas_child_stands(
+                scenario=scenario,
+                project_area=project_area,
+                stand_size=stand_size,
+            ).values_list("id", flat=True)
         )
 
     return list(stand_ids)
@@ -624,7 +651,11 @@ def calculate_child_project_areas(scenario: Scenario) -> list[ProjectArea]:
         parent.project_areas.all(),
         start=1,
     ):
-        stands = parent_project_area.get_stands(stand_size=stand_size)
+        stands = get_project_areas_child_stands(
+            scenario=scenario,
+            project_area=parent_project_area,
+            stand_size=stand_size,
+        )
         stand_count = stands.count()
 
         if stand_count == 0:

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -1934,9 +1934,7 @@ class PatchScenarioConfigurationTest(APITestCase):
             treatment_goal=None,
             planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
         )
-
         self.assertEqual(child.project_areas.count(), 0)
-
         url = reverse(
             "api:planning:scenarios-patch-draft",
             args=[child.pk],
@@ -1946,22 +1944,16 @@ class PatchScenarioConfigurationTest(APITestCase):
                 "stand_size": "LARGE",
             }
         }
-
         self.client.force_authenticate(self.user)
         response = self.client.patch(url, payload, format="json")
-
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         child.refresh_from_db()
-
         self.assertEqual(child.project_areas.count(), 1)
-
         child_project_area = child.project_areas.get()
         expected_stands = parent_project_area.get_stands(stand_size="LARGE")
         expected_geometry = expected_stands.aggregate(geometry=UnionOp("geometry"))[
             "geometry"
         ]
-
         self.assertTrue(child_project_area.geometry.equals(expected_geometry))
         self.assertEqual(
             child_project_area.data["proj_id"],
@@ -1970,6 +1962,76 @@ class PatchScenarioConfigurationTest(APITestCase):
         self.assertEqual(
             child_project_area.data["stand_count"],
             expected_stands.count(),
+        )
+
+    @mock.patch("planning.serializers.calculate_scenario_treatable_area")
+    def test_patch_draft_with_includes_recalculates_child_project_areas(
+        self, calculate_scenario_treatable_area_mock
+    ):
+        parent = ScenarioFactory.create(
+            user=self.user,
+            planning_area=self.planning_area,
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        parent_project_area = ProjectAreaFactory.create(
+            scenario=parent,
+            name="Project Area 1",
+            geometry=self.planning_area.geometry,
+            data={"treatment_rank": 1},
+        )
+        child = ScenarioFactory.create(
+            user=self.user,
+            planning_area=self.planning_area,
+            parent=parent,
+            configuration={},
+            treatment_goal=None,
+            planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+        )
+        url = reverse(
+            "api:planning:scenarios-patch-draft",
+            args=[child.pk],
+        )
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(
+            url,
+            {"configuration": {"stand_size": "LARGE"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        child.refresh_from_db()
+        child_project_area = child.project_areas.get()
+        original_stand_count = child_project_area.data["stand_count"]
+        included_stand = parent_project_area.get_stands(stand_size="LARGE").first()
+        self.assertIsNotNone(included_stand)
+        included_geometry = included_stand.geometry
+        if included_geometry.geom_type == "Polygon":
+            included_geometry = MultiPolygon(
+                included_geometry,
+                srid=included_geometry.srid,
+            )
+        calculate_scenario_treatable_area_mock.return_value = included_geometry
+        included_layer = DataLayerFactory.create(
+            type=DataLayerType.VECTOR,
+            geometry_type=GeometryType.POLYGON,
+        )
+        response = self.client.patch(
+            url,
+            {
+                "configuration": {
+                    "included_areas": [included_layer.pk],
+                }
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        child.refresh_from_db()
+        child_project_area.refresh_from_db()
+        self.assertTrue(child.treatable_area.equals(included_geometry))
+        self.assertTrue(child_project_area.geometry.equals(included_geometry))
+        self.assertEqual(child_project_area.data["stand_count"], 1)
+        self.assertLess(
+            child_project_area.data["stand_count"],
+            original_stand_count,
         )
 
 

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -467,7 +467,13 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         configuration_data = serializer.validated_data.get("configuration")
         should_calculate_child_project_areas = (
             "parent" in serializer.validated_data
-            or (configuration_data is not None and "stand_size" in configuration_data)
+            or (
+                configuration_data is not None
+                and (
+                    "stand_size" in configuration_data
+                    or "included_areas_ids" in configuration_data
+                )
+            )
         )
         if configuration_data:
             existing = instance.configuration or {}


### PR DESCRIPTION
@roque.betioljr @lastminutediorama, update backend layer query to handle includes, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3926

1. `src/planscape/planning/services.py`: restrict child Project Area stands/geometry to the scenario's included/treatable area.
2. `src/planscape/planning/tests/test_v2_scenario_views.py`: add test confirming includes recalculate child Project Areas.
3. `src/planscape/planning/views_v2.py`: recalculate child Project Areas when included areas change.

----------------

Still need to do Martin changes