### PR TITLE
 plan-sub-unit-calculation-from-parent

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -2179,15 +2179,51 @@ def get_sub_units_areas(
     return areas
 
 
+def get_project_areas_child_areas(
+    scenario: Scenario,
+    stand_size: StandSizeChoices,
+) -> list[float] | None:
+    parent = scenario.parent
+    if not parent:
+        return None
+
+    stand_area = get_min_project_area(scenario)
+    areas = []
+
+    for project_area in parent.project_areas.all():
+        stand_count = get_project_areas_child_stands(
+            scenario=scenario,
+            project_area=project_area,
+            stand_size=stand_size,
+        ).count()
+
+        if stand_count > 0:
+            areas.append(stand_count * stand_area)
+
+    return areas or None
+
+
 def get_sub_units_details(
     scenario: Scenario,
     stand_size: StandSizeChoices,
-    datalayer: DataLayer,
+    datalayer: DataLayer | None = None,
     fixed_target: bool | None = None,
     target_value: float | None = None,
 ) -> dict[str, float | None] | None:
 
-    areas = get_sub_units_areas(scenario, stand_size, datalayer)
+    if is_project_areas_child(scenario):
+        areas = get_project_areas_child_areas(
+            scenario=scenario,
+            stand_size=stand_size,
+        )
+    elif datalayer:
+        areas = get_sub_units_areas(
+            scenario,
+            stand_size,
+            datalayer,
+        )
+    else:
+        return None
 
     if areas is None:
         return

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -2684,3 +2684,56 @@ class SubUnitsDetailsTest(APITestCase):
         mock_service.assert_called_once_with(
             self.scenario, self.scenario.get_stand_size(), override_layer, False, 80
         )
+
+    @mock.patch(
+        "planning.views_v2.get_sub_units_details",
+        return_value={
+            "avg": 100,
+            "max": 200,
+            "min": 50,
+            "sum": 350,
+            "targeted_area": None,
+        },
+    )
+    def test_get_sub_units_details__project_areas_child_without_sub_units_layer(
+        self, mock_service
+    ):
+        parent = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.user,
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        child = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            user=self.user,
+            parent=parent,
+            planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+            configuration={"stand_size": "LARGE"},
+        )
+
+        url = reverse(
+            "api:planning:scenarios-get-sub-units-details",
+            args=[child.pk],
+        )
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "avg": 100,
+                "max": 200,
+                "min": 50,
+                "sum": 350,
+                "targeted_area": None,
+            },
+        )
+        mock_service.assert_called_once_with(
+            child,
+            child.get_stand_size(),
+            None,
+            None,
+            None,
+        )

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -102,6 +102,7 @@ from planning.services import (
     delete_scenario,
     get_available_stands,
     get_sub_units_details,
+    is_project_areas_child,
     toggle_scenario_status,
     trigger_scenario_run,
     validate_scenario_configuration,
@@ -718,14 +719,20 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         )
         query_params_serializer.is_valid(raise_exception=True)
 
-        datalayer_pk = query_params_serializer.validated_data.get(
-            "sub_units_layer"
-        ) or scenario.configuration.get("sub_units_layer")
-        if not datalayer_pk:
-            return Response(
-                {"errors": "Sub-Unit layer not selected."},
-                status=status.HTTP_412_PRECONDITION_FAILED,
-            )
+        datalayer = None
+
+        if not is_project_areas_child(scenario):
+            datalayer_pk = query_params_serializer.validated_data.get(
+                "sub_units_layer"
+            ) or scenario.configuration.get("sub_units_layer")
+
+            if not datalayer_pk:
+                return Response(
+                    {"errors": "Sub-Unit layer not selected."},
+                    status=status.HTTP_412_PRECONDITION_FAILED,
+                )
+
+            datalayer = DataLayer.objects.get(pk=datalayer_pk)
 
         sub_units_fixed_target = query_params_serializer.validated_data.get(
             "sub_units_fixed_target"
@@ -734,7 +741,6 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
             "sub_units_target_value"
         )
 
-        datalayer = DataLayer.objects.get(pk=datalayer_pk)
         stand_size = scenario.get_stand_size()
         details = get_sub_units_details(
             scenario,


### PR DESCRIPTION
@roquebetioljr @lastminutediorama, fix: modified endpoint to calculate sub unit details using the parent's project areas as reference, and a test to make sure it's working


