### PR TITLE
PLAN-3945: Expanded groups by default

### DIFF
--- a/src/interface/src/styleguide/selectable-list/selectable-list.component.ts
+++ b/src/interface/src/styleguide/selectable-list/selectable-list.component.ts
@@ -99,6 +99,12 @@ export class SelectableListComponent<T extends Item> implements OnChanges {
       },
       {} as Record<string, T[]>
     );
+
+    // Expand the group by default if there is only 1 group
+    const keys = Object.keys(this.groupedData);
+    if (keys.length === 1 && !this.isExpanded(keys[0])) {
+      this.openedGroups.push(keys[0]);
+    }
   }
 
   private resolvePath(obj: any, path: string): string {

--- a/src/interface/src/styleguide/selectable-list/selectable-list.stories.ts
+++ b/src/interface/src/styleguide/selectable-list/selectable-list.stories.ts
@@ -165,3 +165,11 @@ export const WithSelectAll: Story = {
     selectAllEnabled: true,
   },
 };
+
+export const WithOnlyOneGroup: Story = {
+  args: {
+    items: [groupedItems[0]],
+    groupBy: 'dataset.name',
+    colorPath: 'nested[0].properties.color',
+  },
+};


### PR DESCRIPTION
I talked with Abby about this, and the idea is to display the first group expanded if there’s only one group. If there are multiple groups, we’ll display all of them collapsed, as we’re doing now, so the user can see all the groups.

Jira: https://sig-gis.atlassian.net/browse/PLAN-3945