### PR TITLE
change one chart color

### DIFF
--- a/src/interface/src/app/scenario/scenario-results-charts.service.ts
+++ b/src/interface/src/app/scenario/scenario-results-charts.service.ts
@@ -5,7 +5,7 @@ const AVAILABLE_COLORS: string[] = [
   '#483D78',
   '#A59CCD',
   '#BBE3B6',
-  '#FFDB69',
+  '#E598DA',
   '#F18226',
   '#CC4678',
   '#FB6F92',


### PR DESCRIPTION
This PR just swaps out one yellow in the charts -- it was a little too similar to the yellow in the treated stands map view.