### PR TITLE
adding workspace CRUD actions

### DIFF
--- a/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.html
+++ b/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.html
@@ -16,7 +16,7 @@
         size="full"
         [error]="displayError"
         showSupportMessage="on-error"
-        supportMessage="Something went wrong while creating your workspace. Please try again in a moment.">
+        supportMessage="This name is already in use by another Workspace.">
         <input
           sgInput
           name="name"

--- a/src/planscape/planning/filters.py
+++ b/src/planscape/planning/filters.py
@@ -69,10 +69,19 @@ class PlanningAreaFilter(filters.FilterSet):
         given_param="creator",
         help_text="Creator(s) ID(s) of Planning Area(s)",
     )
+    workspace = filters.NumberFilter(
+        field_name="workspace_id",
+        help_text="Only Planning Areas belonging to this Workspace.",
+    )
+    without_workspace = filters.BooleanFilter(
+        field_name="workspace_id",
+        lookup_expr="isnull",
+        help_text="Only Planning Areas that do not belong to any Workspace.",
+    )
 
     class Meta:
         model = PlanningArea
-        fields = ["name", "region_name", "creator"]
+        fields = ["name", "region_name", "creator", "workspace", "without_workspace"]
 
 
 def get_planning_areas_for_filter(request: Optional[Request]) -> QuerySet:

--- a/src/planscape/planning/migrations/0075_recalculate_planningarea_capabilities.py
+++ b/src/planscape/planning/migrations/0075_recalculate_planningarea_capabilities.py
@@ -9,9 +9,23 @@ def recalculate_planning_area_capabilities(apps, schema_editor):
     from modules.base import compute_planning_area_capabilities
     from planning.models import PlanningArea
 
-    for planning_area in PlanningArea.objects.all().iterator(
-        chunk_size=ROW_FETCH_CHUNK_SIZE
-    ):
+    # This has to use the live model, because compute_planning_area_capabilities
+    # needs model methods that historical models don't carry. The live model may
+    # declare columns that don't exist in the database yet at this point in the
+    # migration history, so defer anything the historical model doesn't know.
+    historical = apps.get_model("planning", "PlanningArea")
+    known = {field.attname for field in historical._meta.concrete_fields}
+    unknown = [
+        field.name
+        for field in PlanningArea._meta.concrete_fields
+        if field.attname not in known
+    ]
+
+    planning_areas = PlanningArea.objects.all()
+    if unknown:
+        planning_areas = planning_areas.defer(*unknown)
+
+    for planning_area in planning_areas.iterator(chunk_size=ROW_FETCH_CHUNK_SIZE):
         planning_area.capabilities = compute_planning_area_capabilities(planning_area)
         planning_area.save(update_fields=["capabilities"])
 

--- a/src/planscape/planning/migrations/0093_planningarea_workspace.py
+++ b/src/planscape/planning/migrations/0093_planningarea_workspace.py
@@ -1,0 +1,24 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("planning", "0092_scenario_parent_alter_scenario_type"),
+        ("workspaces", "0003_workspace_planning_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="planningarea",
+            name="workspace",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Workspace this Planning Area belongs to.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="planning_areas",
+                to="workspaces.workspace",
+            ),
+        ),
+    ]

--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -94,6 +94,16 @@ class PlanningArea(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model)
         help_text="User ID that created the Planning Area.",
     )
 
+    workspace_id: int
+    workspace = models.ForeignKey(
+        "workspaces.Workspace",
+        related_name="planning_areas",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        help_text="Workspace this Planning Area belongs to.",
+    )
+
     region_name: models.CharField = models.CharField(
         max_length=120,
         choices=RegionChoices.choices,

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -30,6 +30,9 @@ from planning.models import (
     User,
     UserPrefs,
 )
+from workspaces.models import Workspace, WorkspaceKind
+from workspaces.permissions import WorkspacePermission
+
 from planning.services import (
     calculate_scenario_treatable_area,
     get_acreage,
@@ -100,6 +103,7 @@ class ListPlanningAreaSerializer(serializers.ModelSerializer):
             "role",
             "permissions",
             "map_status",
+            "workspace",
         )
         model = PlanningArea
 
@@ -112,6 +116,22 @@ class CreatePlanningAreaSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
     )
+    workspace = serializers.PrimaryKeyRelatedField(
+        queryset=Workspace.objects.filter(kind=WorkspaceKind.PLANNING),
+        required=False,
+        allow_null=True,
+        help_text="Optional Workspace to create the Planning Area in.",
+    )
+
+    def validate_workspace(self, workspace):
+        if workspace is None:
+            return workspace
+        user = self.context["request"].user
+        if not WorkspacePermission.can_add(user, workspace):
+            raise serializers.ValidationError(
+                "You do not have permission to add planning areas to this workspace."
+            )
+        return workspace
 
     def validate(self, attrs):
         region_val = attrs.get("region_name")
@@ -159,6 +179,7 @@ class CreatePlanningAreaSerializer(serializers.ModelSerializer):
             "region_name",
             "geometry",
             "notes",
+            "workspace",
         )
         validators = []
 
@@ -214,6 +235,7 @@ class PlanningAreaSerializer(
             "permissions",
             "geometry",
             "map_status",
+            "workspace",
         )
         model = PlanningArea
         geo_field = "geometry"

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -117,6 +117,7 @@ def create_planning_area(
     region_name: str | None = None,
     geometry: Any = None,
     notes: str | None = None,
+    workspace: Any = None,
 ) -> PlanningArea:
     from planning.tasks import (
         async_create_stands,
@@ -139,6 +140,7 @@ def create_planning_area(
         region_name=region_name,
         geometry=geometry,
         notes=notes,
+        workspace=workspace,
         map_status=PlanningAreaMapStatus.PENDING,
     )
     planning_area.capabilities = compute_planning_area_capabilities(planning_area)

--- a/src/planscape/planscape/urls_v2.py
+++ b/src/planscape/planscape/urls_v2.py
@@ -6,6 +6,7 @@ from django.urls import include, path
 from impacts.routers import router as impacts_router
 from modules.routers import router as modules_router
 from planning.routers import router as planning_router
+from workspaces.routers import router as workspaces_router
 from rest_framework.routers import SimpleRouter
 
 core_router = SimpleRouter()
@@ -21,6 +22,7 @@ urlpatterns = [
     path("", include((core_router.urls, "core"), namespace="core")),
     path("", include((datasets_router.urls, "datasets"), namespace="datasets")),
     path("", include((modules_router.urls, "modules"), namespace="modules")),
+    path("", include((workspaces_router.urls, "workspaces"), namespace="workspaces")),
     path(
         "",
         include(

--- a/src/planscape/workspaces/admin.py
+++ b/src/planscape/workspaces/admin.py
@@ -5,9 +5,18 @@ from workspaces.models import UserAccessWorkspace, Workspace
 
 @admin.register(Workspace)
 class WorkspaceAdmin(admin.ModelAdmin):
-    list_display = ("id", "name", "visibility", "created_at", "updated_at", "deleted_at")
-    list_filter = ("visibility",)
-    search_fields = ("name",)
+    list_display = (
+        "id",
+        "name",
+        "kind",
+        "visibility",
+        "creator_name",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+    )
+    list_filter = ("kind", "visibility")
+    search_fields = ("name", "creator_name")
     readonly_fields = ("created_at", "updated_at", "deleted_at")
 
 

--- a/src/planscape/workspaces/admin_views.py
+++ b/src/planscape/workspaces/admin_views.py
@@ -18,7 +18,12 @@ from rest_framework.viewsets import GenericViewSet
 
 from datasets.models import VisibilityOptions
 from workspaces.filters import WorkspaceFilterSet
-from workspaces.models import UserAccessWorkspace, Workspace, WorkspaceRole
+from workspaces.models import (
+    UserAccessWorkspace,
+    Workspace,
+    WorkspaceKind,
+    WorkspaceRole,
+)
 from workspaces.serializers import (
     CreateWorkspaceSerializer,
     UpdateWorkspaceSerializer,
@@ -54,9 +59,8 @@ class AdminWorkspaceViewSet(
     def get_queryset(self):
         user = self.request.user
         return (
-            Workspace.objects.filter(
-                Q(visibility=VisibilityOptions.PUBLIC) | Q(user_access__user=user)
-            )
+            Workspace.objects.filter(kind=WorkspaceKind.DATA)
+            .filter(Q(visibility=VisibilityOptions.PUBLIC) | Q(user_access__user=user))
             .annotate(
                 datasets_count=Count("datasets", distinct=True),
                 styles_count=Count("styles", distinct=True),

--- a/src/planscape/workspaces/filters.py
+++ b/src/planscape/workspaces/filters.py
@@ -12,3 +12,19 @@ class WorkspaceFilterSet(filters.FilterSet):
     class Meta:
         model = Workspace
         fields = ["name"]
+
+
+class PlanningWorkspaceFilterSet(filters.FilterSet):
+    name = filters.CharFilter(
+        lookup_expr="icontains",
+        help_text="Case insensitive search for workspace name.",
+    )
+    search = filters.CharFilter(
+        field_name="name",
+        lookup_expr="icontains",
+        help_text="Case insensitive search for workspace name.",
+    )
+
+    class Meta:
+        model = Workspace
+        fields = ["name", "search"]

--- a/src/planscape/workspaces/migrations/0003_workspace_planning_fields.py
+++ b/src/planscape/workspaces/migrations/0003_workspace_planning_fields.py
@@ -1,0 +1,65 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("workspaces", "0002_create_default_workspace"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="workspace",
+            options={
+                "ordering": ["-created_at"],
+                "verbose_name": "Workspace",
+                "verbose_name_plural": "Workspaces",
+            },
+        ),
+        migrations.AddField(
+            model_name="workspace",
+            name="kind",
+            field=models.CharField(
+                choices=[("DATA", "Data Catalog"), ("PLANNING", "Planning")],
+                default="DATA",
+                help_text=(
+                    "What this workspace groups: data catalog entries "
+                    "or planning areas."
+                ),
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="workspace",
+            name="created_by",
+            field=models.ForeignKey(
+                help_text="User that created the Workspace.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="created_workspaces",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="workspace",
+            name="creator_name",
+            field=models.CharField(
+                help_text=(
+                    "Name of the user that created the Workspace, "
+                    "at creation time."
+                ),
+                max_length=256,
+                null=True,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="workspace",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("deleted_at", None)),
+                fields=("created_by", "name"),
+                name="unique_workspace_name_per_creator",
+            ),
+        ),
+    ]

--- a/src/planscape/workspaces/models.py
+++ b/src/planscape/workspaces/models.py
@@ -1,9 +1,15 @@
+from typing import TYPE_CHECKING
+
 from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models
+from django.db.models import Count, Q
 from django_stubs_ext.db.models import TypedModelMeta
 
-from core.models import CreatedAtMixin, DeletedAtMixin, UpdatedAtMixin
+from core.models import AliveObjectsManager, CreatedAtMixin, DeletedAtMixin, UpdatedAtMixin
 from datasets.models import VisibilityOptions
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractUser
 
 User = get_user_model()
 
@@ -12,6 +18,42 @@ class WorkspaceRole(models.TextChoices):
     OWNER = "OWNER", "Owner"
     COLLABORATOR = "COLLABORATOR", "Collaborator"
     VIEWER = "VIEWER", "Viewer"
+
+
+class WorkspaceKind(models.TextChoices):
+    """
+    Separates the data-catalog workspaces (which group Datasets, Styles and
+    DataLayers and are managed through the admin API) from the user-facing
+    workspaces that group Planning Areas.
+    """
+
+    DATA = "DATA", "Data Catalog"
+    PLANNING = "PLANNING", "Planning"
+
+
+class WorkspaceManager(AliveObjectsManager):
+    def list_by_user(self, user: "AbstractUser") -> models.QuerySet:
+        if not user or not user.is_authenticated:
+            return self.get_queryset().none()
+        return self.get_queryset().filter(
+            kind=WorkspaceKind.PLANNING,
+            user_access__user=user,
+        )
+
+    def list_for_api(self, user: "AbstractUser") -> models.QuerySet:
+        return (
+            self.list_by_user(user)
+            .annotate(
+                planning_areas_count=Count(
+                    "planning_areas",
+                    filter=Q(planning_areas__deleted_at=None),
+                    distinct=True,
+                ),
+                collaborators_count=Count("user_access", distinct=True),
+            )
+            .select_related("created_by")
+            .distinct()
+        )
 
 
 class Workspace(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
@@ -24,12 +66,49 @@ class Workspace(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
         max_length=16,
     )
 
+    kind = models.CharField(
+        choices=WorkspaceKind.choices,
+        default=WorkspaceKind.DATA,
+        max_length=16,
+        help_text="What this workspace groups: data catalog entries or planning areas.",
+    )
+
+    created_by_id: int
+    created_by = models.ForeignKey(
+        User,
+        related_name="created_workspaces",
+        on_delete=models.SET_NULL,
+        null=True,
+        help_text="User that created the Workspace.",
+    )
+
+    # Snapshot taken at creation time so the creator keeps being displayed even
+    # if they leave the workspace or their account goes away.
+    creator_name = models.CharField(
+        max_length=256,
+        null=True,
+        help_text="Name of the user that created the Workspace, at creation time.",
+    )
+
+    objects: WorkspaceManager = WorkspaceManager()
+
     def __str__(self) -> str:
         return self.name
 
     class Meta(TypedModelMeta):
         verbose_name = "Workspace"
         verbose_name_plural = "Workspaces"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=[
+                    "created_by",
+                    "name",
+                ],
+                name="unique_workspace_name_per_creator",
+                condition=Q(deleted_at=None),
+            )
+        ]
 
 
 class UserAccessWorkspace(CreatedAtMixin, UpdatedAtMixin, models.Model):

--- a/src/planscape/workspaces/permissions.py
+++ b/src/planscape/workspaces/permissions.py
@@ -1,0 +1,83 @@
+from typing import Optional
+
+from collaboration.permissions import CheckPermissionMixin
+from django.contrib.auth.models import AbstractUser
+from planscape.permissions import PlanscapePermission
+
+from workspaces.models import UserAccessWorkspace, Workspace, WorkspaceRole
+
+
+def get_workspace_role(
+    user: AbstractUser,
+    workspace: Workspace,
+) -> Optional[str]:
+    """
+    Returns the role the user holds in the workspace, or None.
+    The creator is always treated as an owner, even if the access row is gone.
+    """
+    if not user or not user.is_authenticated:
+        return None
+
+    if workspace.created_by_id and workspace.created_by_id == user.pk:
+        return WorkspaceRole.OWNER
+
+    access = UserAccessWorkspace.objects.filter(
+        user=user,
+        workspace=workspace,
+    ).first()
+    return access.role if access else None
+
+
+VIEWER_PERMISSIONS = [
+    "view_workspace",
+]
+COLLABORATOR_PERMISSIONS = VIEWER_PERMISSIONS + [
+    "add_planningarea",
+]
+OWNER_PERMISSIONS = COLLABORATOR_PERMISSIONS + [
+    "change_workspace",
+    "remove_workspace",
+    "view_collaborator",
+    "add_collaborator",
+    "change_collaborator",
+    "delete_collaborator",
+]
+
+WORKSPACE_PERMISSIONS = {
+    WorkspaceRole.OWNER: OWNER_PERMISSIONS,
+    WorkspaceRole.COLLABORATOR: COLLABORATOR_PERMISSIONS,
+    WorkspaceRole.VIEWER: VIEWER_PERMISSIONS,
+}
+
+
+def get_workspace_permissions(
+    user: AbstractUser,
+    workspace: Workspace,
+) -> list:
+    role = get_workspace_role(user, workspace)
+    return list(WORKSPACE_PERMISSIONS.get(role, []))
+
+
+class WorkspacePermission(CheckPermissionMixin):
+    @staticmethod
+    def can_view(user: AbstractUser, workspace: Workspace) -> bool:
+        return get_workspace_role(user, workspace) is not None
+
+    @staticmethod
+    def can_add(user: AbstractUser, workspace: Workspace) -> bool:
+        return get_workspace_role(user, workspace) in (
+            WorkspaceRole.OWNER,
+            WorkspaceRole.COLLABORATOR,
+        )
+
+    @staticmethod
+    def can_change(user: AbstractUser, workspace: Workspace) -> bool:
+        return get_workspace_role(user, workspace) == WorkspaceRole.OWNER
+
+    @staticmethod
+    def can_remove(user: AbstractUser, workspace: Workspace) -> bool:
+        return get_workspace_role(user, workspace) == WorkspaceRole.OWNER
+
+
+class WorkspaceViewPermission(PlanscapePermission):
+    permission_set = WorkspacePermission

--- a/src/planscape/workspaces/routers.py
+++ b/src/planscape/workspaces/routers.py
@@ -1,0 +1,10 @@
+from rest_framework.routers import SimpleRouter
+
+from workspaces.views import WorkspaceViewSet
+
+router = SimpleRouter()
+router.register(
+    "workspaces",
+    WorkspaceViewSet,
+    basename="workspaces",
+)

--- a/src/planscape/workspaces/serializers.py
+++ b/src/planscape/workspaces/serializers.py
@@ -2,6 +2,7 @@ from datasets.models import Dataset, Style
 from rest_framework import serializers
 
 from workspaces.models import UserAccessWorkspace, Workspace
+from workspaces.permissions import get_workspace_permissions, get_workspace_role
 
 
 class WorkspaceSerializer(serializers.ModelSerializer):
@@ -82,3 +83,107 @@ class WorkspaceUserAccessSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserAccessWorkspace
         fields = ["user_id", "email", "first_name", "last_name", "role"]
+
+
+class ListWorkspaceSerializer(serializers.ModelSerializer):
+    """User facing representation of a planning Workspace."""
+
+    creator = serializers.CharField(
+        source="creator_name",
+        read_only=True,
+        help_text="Name of the user that created the Workspace, at creation time.",
+    )
+    planning_areas_count = serializers.SerializerMethodField(
+        help_text="Number of Planning Areas in the Workspace."
+    )
+    collaborators_count = serializers.SerializerMethodField(
+        help_text="Number of users with access to the Workspace."
+    )
+    role = serializers.SerializerMethodField(
+        help_text="Requester role in the Workspace."
+    )
+    permissions = serializers.SerializerMethodField(
+        help_text="Requester permissions for the Workspace."
+    )
+
+    def get_planning_areas_count(self, instance) -> int:
+        count = getattr(instance, "planning_areas_count", None)
+        if count is not None:
+            return count
+        return instance.planning_areas.filter(deleted_at=None).count()
+
+    def get_collaborators_count(self, instance) -> int:
+        count = getattr(instance, "collaborators_count", None)
+        if count is not None:
+            return count
+        return instance.user_access.count()
+
+    def get_role(self, instance):
+        return get_workspace_role(self.context["request"].user, instance)
+
+    def get_permissions(self, instance):
+        return get_workspace_permissions(self.context["request"].user, instance)
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "id",
+            "name",
+            "creator",
+            "created_by",
+            "created_at",
+            "updated_at",
+            "planning_areas_count",
+            "collaborators_count",
+            "role",
+            "permissions",
+        )
+        read_only_fields = fields
+
+
+class CreatePlanningWorkspaceSerializer(serializers.ModelSerializer):
+    created_by = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    def validate(self, attrs):
+        if Workspace.objects.filter(
+            created_by=attrs["created_by"],
+            name=attrs["name"],
+        ).exists():
+            raise serializers.ValidationError(
+                {"name": "A workspace with this name already exists."}
+            )
+        return attrs
+
+    class Meta:
+        model = Workspace
+        fields = (
+            "created_by",
+            "name",
+        )
+        validators = []
+
+
+class UpdatePlanningWorkspaceSerializer(serializers.ModelSerializer):
+    def validate(self, attrs):
+        if not attrs.get("name"):
+            raise serializers.ValidationError(
+                {"name": "A workspace name is required."}
+            )
+        instance = self.instance
+        if (
+            Workspace.objects.filter(
+                created_by=instance.created_by,
+                name=attrs["name"],
+            )
+            .exclude(id=instance.pk)
+            .exists()
+        ):
+            raise serializers.ValidationError(
+                {"name": "A workspace with this name already exists."}
+            )
+        return attrs
+
+    class Meta:
+        model = Workspace
+        fields = ("name",)
+        validators = []

--- a/src/planscape/workspaces/services.py
+++ b/src/planscape/workspaces/services.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Tuple
+
+from actstream import action
+from django.contrib.auth.models import AbstractUser
+from django.db import transaction
+from planscape.analytics import track_event
+
+from workspaces.models import (
+    UserAccessWorkspace,
+    Workspace,
+    WorkspaceKind,
+    WorkspaceRole,
+)
+from workspaces.permissions import WorkspacePermission
+
+logger = logging.getLogger(__name__)
+
+
+@transaction.atomic()
+def create_workspace(
+    user: AbstractUser,
+    name: str,
+    **kwargs,
+) -> Workspace:
+    """Canonical method to create a new planning workspace."""
+    workspace = Workspace.objects.create(
+        name=name,
+        kind=WorkspaceKind.PLANNING,
+        created_by=user,
+        creator_name=user.get_full_name(),
+        **kwargs,
+    )
+    UserAccessWorkspace.objects.create(
+        user=user,
+        workspace=workspace,
+        role=WorkspaceRole.OWNER,
+    )
+    action.send(user, verb="created", action_object=workspace)
+    track_event(
+        name="workspace.workspace.created",
+        properties={
+            "workspace_id": workspace.pk,
+            "email": user.email if user else None,
+        },
+        user_id=user.pk,
+    )
+    return workspace
+
+
+def delete_workspace(
+    user: AbstractUser,
+    workspace: Workspace,
+) -> Tuple[bool, str]:
+    if not WorkspacePermission.can_remove(user, workspace):
+        logger.error(f"User {user} has no permission to delete {workspace.pk}")
+        return (
+            False,
+            f"User does not have permission to delete workspace {workspace.pk}.",
+        )
+
+    action.send(user, verb="deleted", action_object=workspace)
+    # Planning areas outlive the workspace. The delete below is a soft delete,
+    # so on_delete=SET_NULL never fires and we have to detach them by hand to
+    # avoid leaving live planning areas pointing at a dead workspace.
+    workspace.planning_areas.update(workspace=None)
+    workspace.delete()
+    track_event(
+        name="workspace.workspace.deleted",
+        properties={
+            "soft": True,
+            "workspace_id": workspace.pk,
+            "email": user.email if user else None,
+        },
+        user_id=user.pk,
+    )
+    return (True, "deleted")

--- a/src/planscape/workspaces/tests/factories.py
+++ b/src/planscape/workspaces/tests/factories.py
@@ -2,7 +2,12 @@ import factory
 from planscape.tests.factories import UserFactory
 
 from datasets.models import VisibilityOptions
-from workspaces.models import UserAccessWorkspace, Workspace, WorkspaceRole
+from workspaces.models import (
+    UserAccessWorkspace,
+    Workspace,
+    WorkspaceKind,
+    WorkspaceRole,
+)
 
 
 class WorkspaceFactory(factory.django.DjangoModelFactory):
@@ -11,6 +16,7 @@ class WorkspaceFactory(factory.django.DjangoModelFactory):
 
     name = factory.Sequence(lambda x: f"Workspace {x}")
     visibility = VisibilityOptions.PRIVATE
+    kind = WorkspaceKind.DATA
 
 
     @factory.post_generation
@@ -44,3 +50,23 @@ class UserAccessWorkspaceFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
     workspace = factory.SubFactory(WorkspaceFactory)
     role = WorkspaceRole.VIEWER
+
+
+class PlanningWorkspaceFactory(WorkspaceFactory):
+    """A user-facing workspace, always owned by its creator."""
+
+    kind = WorkspaceKind.PLANNING
+    created_by = factory.SubFactory(UserFactory)
+    creator_name = factory.LazyAttribute(
+        lambda workspace: workspace.created_by.get_full_name()
+    )
+
+    @factory.post_generation
+    def creator_access(self, create, extracted, **kwargs):
+        if not create or not self.created_by:
+            return
+        UserAccessWorkspaceFactory.create(
+            user=self.created_by,
+            workspace=self,
+            role=WorkspaceRole.OWNER,
+        )

--- a/src/planscape/workspaces/tests/test_views.py
+++ b/src/planscape/workspaces/tests/test_views.py
@@ -1,0 +1,422 @@
+from django.urls import reverse
+from planning.tests.factories import PlanningAreaFactory
+from planscape.tests.factories import UserFactory
+from rest_framework.test import APITestCase
+
+from workspaces.models import UserAccessWorkspace, Workspace, WorkspaceKind, WorkspaceRole
+from workspaces.tests.factories import (
+    PlanningWorkspaceFactory,
+    UserAccessWorkspaceFactory,
+    WorkspaceFactory,
+)
+
+LIST_URL = "api:workspaces:workspaces-list"
+DETAIL_URL = "api:workspaces:workspaces-detail"
+
+
+class CreateWorkspaceTest(APITestCase):
+    def setUp(self):
+        self.user = UserFactory.create(first_name="Han", last_name="Solo")
+
+    def test_create_requires_authentication(self):
+        response = self.client.post(
+            reverse(LIST_URL), data={"name": "Falcon"}, format="json"
+        )
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_create_returns_201_and_metadata(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse(LIST_URL), data={"name": "Falcon"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["name"], "Falcon")
+        self.assertEqual(data["creator"], "Han Solo")
+        self.assertEqual(data["planning_areas_count"], 0)
+        self.assertEqual(data["role"], WorkspaceRole.OWNER)
+        self.assertIsNotNone(data["created_at"])
+
+    def test_create_makes_the_creator_an_owner(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse(LIST_URL), data={"name": "Falcon"}, format="json"
+        )
+
+        workspace = Workspace.objects.get(pk=response.json()["id"])
+        self.assertEqual(workspace.kind, WorkspaceKind.PLANNING)
+        self.assertEqual(workspace.created_by, self.user)
+        self.assertEqual(workspace.creator_name, "Han Solo")
+        self.assertTrue(
+            UserAccessWorkspace.objects.filter(
+                user=self.user, workspace=workspace, role=WorkspaceRole.OWNER
+            ).exists()
+        )
+
+    def test_create_without_name_returns_400(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(reverse(LIST_URL), data={}, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("name", response.json()["errors"])
+
+    def test_create_with_duplicate_name_returns_400(self):
+        PlanningWorkspaceFactory.create(name="Falcon", created_by=self.user)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            reverse(LIST_URL), data={"name": "Falcon"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": "Validation error.",
+                "errors": {"name": ["A workspace with this name already exists."]},
+            },
+        )
+
+    def test_create_with_name_taken_by_another_user_returns_201(self):
+        PlanningWorkspaceFactory.create(name="Falcon")
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            reverse(LIST_URL), data={"name": "Falcon"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 201)
+
+    def test_create_reusing_a_soft_deleted_name_returns_201(self):
+        workspace = PlanningWorkspaceFactory.create(name="Falcon", created_by=self.user)
+        workspace.delete()
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            reverse(LIST_URL), data={"name": "Falcon"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 201)
+
+
+class ListWorkspaceTest(APITestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.other = UserFactory.create()
+
+    def test_list_requires_authentication(self):
+        response = self.client.get(reverse(LIST_URL))
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_list_returns_only_workspaces_the_user_can_access(self):
+        PlanningWorkspaceFactory.create(name="Mine", created_by=self.user)
+        shared = PlanningWorkspaceFactory.create(name="Shared")
+        UserAccessWorkspaceFactory.create(
+            user=self.user, workspace=shared, role=WorkspaceRole.VIEWER
+        )
+        PlanningWorkspaceFactory.create(name="Theirs", created_by=self.other)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse(LIST_URL))
+
+        self.assertEqual(response.status_code, 200)
+        names = {row["name"] for row in response.json()["results"]}
+        self.assertEqual(names, {"Mine", "Shared"})
+        self.assertEqual(response.json()["count"], 2)
+
+    def test_list_excludes_data_catalog_workspaces(self):
+        catalog = WorkspaceFactory.create(name="Default")
+        UserAccessWorkspaceFactory.create(
+            user=self.user, workspace=catalog, role=WorkspaceRole.COLLABORATOR
+        )
+        PlanningWorkspaceFactory.create(name="Mine", created_by=self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse(LIST_URL))
+
+        names = {row["name"] for row in response.json()["results"]}
+        self.assertEqual(names, {"Mine"})
+
+    def test_list_excludes_soft_deleted_workspaces(self):
+        PlanningWorkspaceFactory.create(name="Alive", created_by=self.user)
+        PlanningWorkspaceFactory.create(name="Gone", created_by=self.user).delete()
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse(LIST_URL))
+
+        names = {row["name"] for row in response.json()["results"]}
+        self.assertEqual(names, {"Alive"})
+
+    def test_list_counts_planning_areas(self):
+        workspace = PlanningWorkspaceFactory.create(created_by=self.user)
+        PlanningAreaFactory.create_batch(2, user=self.user, workspace=workspace)
+        PlanningAreaFactory.create(
+            user=self.user, workspace=workspace
+        ).delete()
+        PlanningAreaFactory.create(user=self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse(LIST_URL))
+
+        row = response.json()["results"][0]
+        self.assertEqual(row["planning_areas_count"], 2)
+
+    def test_search_filters_by_name(self):
+        PlanningWorkspaceFactory.create(name="Wildfire North", created_by=self.user)
+        PlanningWorkspaceFactory.create(name="Coastal", created_by=self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse(LIST_URL), {"search": "wildfire"})
+
+        names = [row["name"] for row in response.json()["results"]]
+        self.assertEqual(names, ["Wildfire North"])
+
+
+class RetrieveWorkspaceTest(APITestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.other = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(
+            name="Falcon", created_by=self.user
+        )
+
+    def test_retrieve_by_owner_returns_200(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["name"], "Falcon")
+
+    def test_retrieve_by_stranger_returns_404(self):
+        self.client.force_authenticate(user=self.other)
+        response = self.client.get(reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_creator_name_survives_the_creator_leaving(self):
+        UserAccessWorkspace.objects.filter(workspace=self.workspace).delete()
+        UserAccessWorkspaceFactory.create(
+            user=self.other, workspace=self.workspace, role=WorkspaceRole.OWNER
+        )
+
+        self.client.force_authenticate(user=self.other)
+        response = self.client.get(reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["creator"], self.user.get_full_name())
+
+
+class UpdateWorkspaceTest(APITestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.collaborator = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(
+            name="Falcon", created_by=self.user
+        )
+        UserAccessWorkspaceFactory.create(
+            user=self.collaborator,
+            workspace=self.workspace,
+            role=WorkspaceRole.COLLABORATOR,
+        )
+
+    def test_owner_can_rename(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}),
+            data={"name": "Millennium"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["name"], "Millennium")
+        self.workspace.refresh_from_db()
+        self.assertEqual(self.workspace.name, "Millennium")
+
+    def test_collaborator_cannot_rename(self):
+        self.client.force_authenticate(user=self.collaborator)
+        response = self.client.patch(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}),
+            data={"name": "Millennium"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_rename_to_taken_name_returns_400(self):
+        PlanningWorkspaceFactory.create(name="Millennium", created_by=self.user)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}),
+            data={"name": "Millennium"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": "Validation error.",
+                "errors": {"name": ["A workspace with this name already exists."]},
+            },
+        )
+
+    def test_rename_to_same_name_returns_200(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}),
+            data={"name": "Falcon"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+
+class DeleteWorkspaceTest(APITestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.viewer = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.user)
+        UserAccessWorkspaceFactory.create(
+            user=self.viewer, workspace=self.workspace, role=WorkspaceRole.VIEWER
+        )
+
+    def test_owner_can_delete(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk})
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Workspace.objects.filter(pk=self.workspace.pk).exists())
+        self.assertTrue(
+            Workspace.dead_or_alive.filter(pk=self.workspace.pk).exists()
+        )
+
+    def test_viewer_cannot_delete(self):
+        self.client.force_authenticate(user=self.viewer)
+        response = self.client.delete(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk})
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_keeps_planning_areas_reachable(self):
+        planning_area = PlanningAreaFactory.create(
+            user=self.user, workspace=self.workspace
+        )
+        self.client.force_authenticate(user=self.user)
+        self.client.delete(reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}))
+
+        planning_area.refresh_from_db()
+        self.assertIsNone(planning_area.workspace)
+        self.assertIsNone(planning_area.deleted_at)
+
+
+class PlanningAreaWorkspaceTest(APITestCase):
+    """
+    Planning areas must work with and without a workspace, and the unscoped
+    planning area endpoints must keep returning all of them either way.
+    """
+
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.user)
+        self.client.force_authenticate(user=self.user)
+
+    def _create(self, payload):
+        return self.client.post(
+            reverse("api:planning:planningareas-list"),
+            data=payload,
+            format="json",
+        )
+
+    @property
+    def geometry(self):
+        return {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-120.14, 39.05],
+                                [-120.14, 39.15],
+                                [-120.04, 39.15],
+                                [-120.04, 39.05],
+                                [-120.14, 39.05],
+                            ]
+                        ],
+                    },
+                }
+            ],
+        }
+
+    def test_create_without_workspace(self):
+        response = self._create({"name": "No Workspace", "geometry": self.geometry})
+
+        self.assertEqual(response.status_code, 201, response.json())
+        self.assertIsNone(response.json()["workspace"])
+
+    def test_create_with_workspace(self):
+        response = self._create(
+            {
+                "name": "In Workspace",
+                "geometry": self.geometry,
+                "workspace": self.workspace.pk,
+            }
+        )
+
+        self.assertEqual(response.status_code, 201, response.json())
+        self.assertEqual(response.json()["workspace"], self.workspace.pk)
+
+    def test_create_in_a_workspace_without_access_returns_400(self):
+        stranger_workspace = PlanningWorkspaceFactory.create()
+
+        response = self._create(
+            {
+                "name": "Nope",
+                "geometry": self.geometry,
+                "workspace": stranger_workspace.pk,
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("workspace", response.json()["errors"])
+
+    def test_list_returns_planning_areas_with_and_without_workspace(self):
+        PlanningAreaFactory.create(user=self.user, workspace=self.workspace)
+        PlanningAreaFactory.create(user=self.user, workspace=None)
+
+        response = self.client.get(reverse("api:planning:planningareas-list"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
+
+    def test_list_can_be_filtered_by_workspace(self):
+        inside = PlanningAreaFactory.create(user=self.user, workspace=self.workspace)
+        PlanningAreaFactory.create(user=self.user, workspace=None)
+
+        response = self.client.get(
+            reverse("api:planning:planningareas-list"),
+            {"workspace": self.workspace.pk},
+        )
+
+        ids = [row["id"] for row in response.json()["results"]]
+        self.assertEqual(ids, [inside.pk])
+
+    def test_list_can_be_filtered_to_planning_areas_without_workspace(self):
+        PlanningAreaFactory.create(user=self.user, workspace=self.workspace)
+        loose = PlanningAreaFactory.create(user=self.user, workspace=None)
+
+        response = self.client.get(
+            reverse("api:planning:planningareas-list"),
+            {"without_workspace": "true"},
+        )
+
+        ids = [row["id"] for row in response.json()["results"]]
+        self.assertEqual(ids, [loose.pk])

--- a/src/planscape/workspaces/views.py
+++ b/src/planscape/workspaces/views.py
@@ -1,0 +1,100 @@
+from core.serializers import MultiSerializerMixin
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from planscape.serializers import BaseErrorMessageSerializer
+from rest_framework import pagination, status, viewsets
+from rest_framework.filters import OrderingFilter
+from rest_framework.response import Response
+
+from workspaces.filters import PlanningWorkspaceFilterSet
+from workspaces.models import Workspace
+from workspaces.permissions import WorkspaceViewPermission
+from workspaces.serializers import (
+    CreatePlanningWorkspaceSerializer,
+    ListWorkspaceSerializer,
+    UpdatePlanningWorkspaceSerializer,
+)
+from workspaces.services import create_workspace, delete_workspace
+
+
+@extend_schema_view(
+    list=extend_schema(description="List Workspaces the requester has access to."),
+    retrieve=extend_schema(
+        description="Detail a Workspace.",
+        responses={200: ListWorkspaceSerializer, 404: BaseErrorMessageSerializer},
+    ),
+    destroy=extend_schema(
+        description="Delete a Workspace.",
+        responses={204: None, 404: BaseErrorMessageSerializer},
+    ),
+    update=extend_schema(
+        description="Update a Workspace.",
+        responses={200: ListWorkspaceSerializer, 404: BaseErrorMessageSerializer},
+    ),
+    partial_update=extend_schema(
+        description="Update a Workspace.",
+        responses={200: ListWorkspaceSerializer, 404: BaseErrorMessageSerializer},
+    ),
+)
+class WorkspaceViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
+    # this member is configured for introspection and swagger automatic generation
+    queryset = Workspace.objects.none()
+    permission_classes = [WorkspaceViewPermission]
+    serializer_class = ListWorkspaceSerializer
+    serializer_classes = {
+        "create": CreatePlanningWorkspaceSerializer,
+        "update": UpdatePlanningWorkspaceSerializer,
+        "partial_update": UpdatePlanningWorkspaceSerializer,
+    }
+    pagination_class = pagination.LimitOffsetPagination
+    filterset_class = PlanningWorkspaceFilterSet
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = [
+        "name",
+        "created_at",
+        "updated_at",
+        "planning_areas_count",
+    ]
+    ordering = ["-created_at"]
+
+    def get_queryset(self):
+        return Workspace.objects.list_for_api(user=self.request.user)
+
+    @extend_schema(description="Create a Workspace.")
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        data = dict(serializer.validated_data)
+        user = data.pop("created_by")
+        workspace = create_workspace(user=user, **data)
+
+        out_serializer = ListWorkspaceSerializer(
+            instance=workspace,
+            context={"request": request},
+        )
+        headers = self.get_success_headers(out_serializer.data)
+        return Response(
+            out_serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop("partial", False)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        out_serializer = ListWorkspaceSerializer(
+            instance=self.get_queryset().get(pk=instance.pk),
+            context={"request": request},
+        )
+        return Response(out_serializer.data)
+
+    def perform_destroy(self, instance):
+        delete_workspace(
+            user=self.request.user,
+            workspace=instance,
+        )


### PR DESCRIPTION
Workspace CRUD API

  User-facing Workspace API at /planscape-backend/v2/workspaces/.

  {"id": 1, "name": "Falcon", "creator": "Han Solo", "created_at": "...",
   "planning_areas_count": 4, "role": "OWNER", "permissions": [...]}

  Included

  - PLAN-3886 — creator snapshot; name stays static after they leave
  - PLAN-3887 — nullable PlanningArea.workspace FK
  - PLAN-3889 — no Visitor role exists anywhere; verified, no code change
  - PLAN-3890 — POST /workspaces/
  - PLAN-3891 — GET /workspaces/
  - PLAN-3892 — GET /workspaces/?search=
  - PLAN-3893 — GET /workspaces/{id}
  - PLAN-3894 — PATCH /workspaces/{id} (owner only)
  - PLAN-3895 — DELETE /workspaces/{id} (owner only, soft delete)
  - PLAN-3896 — role-gated permission class
  - PLAN-3897 — routes registered in urls_v2

  Notes

  - Extends the existing workspaces.Workspace rather than adding a second model; a kind field keeps the dataset-catalog workspaces out of
  the user-facing list.
  - Planning areas work with or without a workspace. Default listing unchanged, plus ?workspace= / ?without_workspace=.
  - Name unique per creator, same validation pattern and error shape as planning areas.
  - Drive-by: planning/migrations/0075 iterated the live model and broke on any new column; now defers unknown fields.
  - 68 workspace tests; 467 pass across planning/collaboration/impacts. Two pre-existing forsys failures unrelated (fail on main too).

  Not included

  - PLAN-3888 — backfill, split out; both migrations are additive and write no rows
  - Sharing: no invite/add/remove-collaborator endpoints; the only access row written is the creator's OWNER
  - Frontend: WorkspacesService still mocked
  - Reassigning a planning area's workspace after create