### PR TITLE
create advanced stand-level constraints modal

### DIFF
--- a/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.html
+++ b/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.html
@@ -1,0 +1,108 @@
+<sg-modal
+  title="Stand-level Constraints Configuration"
+  [showClose]="true"
+  primaryButtonText="Apply"
+  [hasSecondaryButton]="false"
+  [hasPrimarySpinner]="true"
+  (clickedClose)="cancel()"
+  (clickedPrimary)="handleApply()"
+  [primaryButtonDisabled]="form.invalid">
+  <div modalBodyContent>
+    <sg-modal-info
+      modalInfoBox
+      infoType="info"
+      leadingIcon="info_filled"
+      message="Advanced constraints will be applied to results but are not shown on the map.">
+    </sg-modal-info>
+    <div *ngIf="dataLayerName" class="form-heading-row">
+      Only treat stands where
+      <span class="datalayer-name">{{ dataLayerName }}</span> is:
+    </div>
+    <form [formGroup]="form" class="constraints-form">
+      <div class="inputs-grid">
+        <div class="col-left">
+          <div class="label">Operator <span class="required">*</span></div>
+          <mat-form-field
+            class="operator-picker"
+            appearance="outline"
+            subscriptSizing="dynamic">
+            <mat-select
+              name="constraintOperator"
+              formControlName="constraintOperator">
+              <mat-option class="nav-page-item" value="eq"
+                >Equal to (=)</mat-option
+              >
+              <mat-option class="nav-page-item" value="dne"
+                >Does not equal (!=)</mat-option
+              >
+              <mat-option class="nav-page-item" value="gt"
+                >Greater than (&gt;)</mat-option
+              >
+              <mat-option class="nav-page-item" value="gte"
+                >Greater than or equal to (&ge;)</mat-option
+              >
+              <mat-option class="nav-page-item" value="lt"
+                >Less than (&lt;)</mat-option
+              >
+              <mat-option class="nav-page-item" value="lte"
+                >Less than or equal to (&le;)</mat-option
+              >
+              <mat-option class="nav-page-item" value="btw">Between</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <div class="col-right">
+          <sg-input-field
+            [disabled]="false"
+            class="value-input"
+            label="{{ showSecondValue ? 'Min' : 'Value' }}"
+            showSupportMessage="on-error"
+            size="full"
+            [error]="
+              (form?.hasError('requiredOne') &&
+                form.get('constraintValueOne')?.touched === true) ??
+              false
+            ">
+            <input
+              sgInput
+              placeholder="Value"
+              name="constraintValueOne"
+              cdkFocusInitial
+              formControlName="constraintValueOne"
+              required
+              id="constraintValueOne"
+              type="number" />
+          </sg-input-field>
+        </div>
+
+        <ng-container *ngIf="showSecondValue">
+          <div class="row-text row-2">
+            <sg-input-field
+              [disabled]="false"
+              class="value-input"
+              label="Max"
+              required
+              showSupportMessage="on-error"
+              [error]="
+                (form?.hasError('requiredTwo') &&
+                  form.get('constraintValueTwo')?.touched === true) ??
+                false
+              "
+              size="full">
+              <input
+                sgInput
+                placeholder="Value"
+                name="constraintValueTwo"
+                cdkFocusInitial
+                formControlName="constraintValueTwo"
+                required
+                id="constraintValueTwo"
+                type="number" />
+            </sg-input-field>
+          </div>
+        </ng-container>
+      </div>
+    </form>
+  </div>
+</sg-modal>

--- a/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.scss
+++ b/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.scss
@@ -1,0 +1,47 @@
+@import "colors";
+@import "mixins";
+
+
+.datalayer-name {
+    font-weight: bold;
+}
+
+.form-heading-row {
+    @include small-input-label();
+    padding: 24px 0;
+}
+
+.inputs-grid {
+    display: grid;
+    grid-template-columns: minmax(250px, 1.2fr) 1fr;
+    grid-template-rows: auto;
+    gap: 16px;
+
+    .row-2 {
+        grid-column: 2;
+    }
+}
+
+.label {
+    @include small-input-label();
+    color: $color-black;
+    margin-bottom: 4px;
+}
+
+.required {
+    color: $color-error;
+}
+
+
+.constraints-form ::ng-deep .value-input .label {
+    @include small-input-label();
+
+}
+
+.operator-picker {
+    width: 100%;
+}
+
+.value-input {
+    width: 100%;
+}

--- a/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.spec.ts
+++ b/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.spec.ts
@@ -1,0 +1,101 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdvStandLevelConstraintsModalComponent } from './adv-stand-level-constraints-modal.component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('AdvStandLevelConstraintsModalComponent', () => {
+  let component: AdvStandLevelConstraintsModalComponent;
+  let fixture: ComponentFixture<AdvStandLevelConstraintsModalComponent>;
+  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<AdvStandLevelConstraintsModalComponent>>;
+
+  beforeEach(async () => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [AdvStandLevelConstraintsModalComponent, BrowserAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: MAT_DIALOG_DATA, useValue: { dataLayerName: 'Test Layer Alpha' } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdvStandLevelConstraintsModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create and initialize dataLayerName from dialog data', () => {
+    expect(component).toBeTruthy();
+    expect(component.dataLayerName).toBe('Test Layer Alpha');
+  });
+
+  it('should invalidate the form if valueOne is empty', () => {
+    component.form.patchValue({ constraintOperator: 'eq', constraintValueOne: null });
+    expect(component.form.valid).toBeFalse();
+    expect(component.isButtonDisabled).toBeTrue();
+  });
+
+  it('should validate the form if valueOne is present for standard operators', () => {
+    component.form.patchValue({ constraintOperator: 'eq', constraintValueOne: 42 });
+    expect(component.form.valid).toBeTrue();
+    expect(component.isButtonDisabled).toBeFalse();
+  });
+
+  it('should toggle showSecondValue and enable/disable constraintValueTwo when operator changes', () => {
+    const valTwoControl = component.form.get('constraintValueTwo');
+
+    // Switch to 'btw'
+    component.form.patchValue({ constraintOperator: 'btw' });
+    expect(component.showSecondValue).toBeTrue();
+    expect(valTwoControl?.enabled).toBeTrue();
+
+    // Switch back to 'eq'
+    component.form.patchValue({ constraintOperator: 'eq' });
+    expect(component.showSecondValue).toBeFalse();
+    expect(valTwoControl?.disabled).toBeTrue();
+    expect(valTwoControl?.value).toBeNull();
+  });
+
+  it('should require both valueOne and value2 when operator is "btw"', () => {
+    component.form.patchValue({
+      constraintOperator: 'btw',
+      constraintValueOne: 10,
+      constraintValueTwo: null,
+    });
+    expect(component.form.valid).toBeFalse();
+
+    component.form.patchValue({ constraintValueTwo: 20 });
+    expect(component.form.valid).toBeTrue();
+  });
+
+  it('should close dialog with correct payload including value2 on handleApply for "btw"', () => {
+    component.form.patchValue({
+      constraintOperator: 'btw',
+      constraintValueOne: 10,
+      constraintValueTwo: 50,
+    });
+
+    component.handleApply();
+
+    expect(dialogRefSpy.close).toHaveBeenCalledWith({
+      operator: 'btw',
+      value: 10,
+      value2: 50,
+    });
+  });
+
+  it('should close dialog without value2 on handleApply for standard operators', () => {
+    component.form.patchValue({
+      constraintOperator: 'gte',
+      constraintValueOne: 25,
+    });
+
+    component.handleApply();
+
+    expect(dialogRefSpy.close).toHaveBeenCalledWith({
+      operator: 'gte',
+      value: 25,
+    });
+  });
+});

--- a/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.spec.ts
+++ b/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.spec.ts
@@ -7,16 +7,24 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 describe('AdvStandLevelConstraintsModalComponent', () => {
   let component: AdvStandLevelConstraintsModalComponent;
   let fixture: ComponentFixture<AdvStandLevelConstraintsModalComponent>;
-  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<AdvStandLevelConstraintsModalComponent>>;
+  let dialogRefSpy: jasmine.SpyObj<
+    MatDialogRef<AdvStandLevelConstraintsModalComponent>
+  >;
 
   beforeEach(async () => {
     dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
 
     await TestBed.configureTestingModule({
-      imports: [AdvStandLevelConstraintsModalComponent, BrowserAnimationsModule],
+      imports: [
+        AdvStandLevelConstraintsModalComponent,
+        BrowserAnimationsModule,
+      ],
       providers: [
         { provide: MatDialogRef, useValue: dialogRefSpy },
-        { provide: MAT_DIALOG_DATA, useValue: { dataLayerName: 'Test Layer Alpha' } },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { dataLayerName: 'Test Layer Alpha' },
+        },
       ],
     }).compileComponents();
 
@@ -31,13 +39,19 @@ describe('AdvStandLevelConstraintsModalComponent', () => {
   });
 
   it('should invalidate the form if valueOne is empty', () => {
-    component.form.patchValue({ constraintOperator: 'eq', constraintValueOne: null });
+    component.form.patchValue({
+      constraintOperator: 'eq',
+      constraintValueOne: null,
+    });
     expect(component.form.valid).toBeFalse();
     expect(component.isButtonDisabled).toBeTrue();
   });
 
   it('should validate the form if valueOne is present for standard operators', () => {
-    component.form.patchValue({ constraintOperator: 'eq', constraintValueOne: 42 });
+    component.form.patchValue({
+      constraintOperator: 'eq',
+      constraintValueOne: 42,
+    });
     expect(component.form.valid).toBeTrue();
     expect(component.isButtonDisabled).toBeFalse();
   });

--- a/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.ts
+++ b/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.ts
@@ -21,8 +21,9 @@ import {
   ModalInfoComponent,
 } from '@styleguide';
 
-
-export const betweenValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+export const betweenValidator: ValidatorFn = (
+  control: AbstractControl
+): ValidationErrors | null => {
   const operator = control.get('constraintOperator')?.value;
   if (operator !== 'btw') {
     return null;
@@ -60,7 +61,9 @@ export const betweenValidator: ValidatorFn = (control: AbstractControl): Validat
   styleUrl: './adv-stand-level-constraints-modal.component.scss',
 })
 export class AdvStandLevelConstraintsModalComponent implements OnInit {
-  readonly dialogRef = inject(MatDialogRef<AdvStandLevelConstraintsModalComponent>);
+  readonly dialogRef = inject(
+    MatDialogRef<AdvStandLevelConstraintsModalComponent>
+  );
   readonly data = inject(MAT_DIALOG_DATA);
 
   dataLayerName = this.data?.dataLayerName;
@@ -70,7 +73,9 @@ export class AdvStandLevelConstraintsModalComponent implements OnInit {
       constraintOperator: new FormControl<CONSTRAINT_OPERATOR | null>('eq', {
         nonNullable: false,
       }),
-      constraintValueOne: new FormControl<number | null>(null, [Validators.required]),
+      constraintValueOne: new FormControl<number | null>(null, [
+        Validators.required,
+      ]),
       constraintValueTwo: new FormControl<number | null>(null),
     },
     { validators: [betweenValidator] }
@@ -98,7 +103,7 @@ export class AdvStandLevelConstraintsModalComponent implements OnInit {
     });
   }
 
-handleApply() {
+  handleApply() {
     if (this.form.valid) {
       const formVal = this.form.value;
       const operator = formVal.constraintOperator ?? 'eq';
@@ -106,7 +111,11 @@ handleApply() {
         operator,
         value: formVal.constraintValueOne ?? 0,
       };
-      if (operator === 'btw' && formVal.constraintValueTwo !== null && formVal.constraintValueTwo !== undefined) {
+      if (
+        operator === 'btw' &&
+        formVal.constraintValueTwo !== null &&
+        formVal.constraintValueTwo !== undefined
+      ) {
         constraintSelection.value2 = formVal.constraintValueTwo;
       }
       this.dialogRef.close(constraintSelection);

--- a/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.ts
+++ b/src/interface/src/app/scenario-creation/step3/adv-stand-level-constraints-modal/adv-stand-level-constraints-modal.component.ts
@@ -1,0 +1,119 @@
+import { NgIf } from '@angular/common';
+import { Component, inject, OnInit } from '@angular/core';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { CONSTRAINT_OPERATOR } from '@app/types';
+import {
+  InputDirective,
+  InputFieldComponent,
+  ModalComponent,
+  ModalInfoComponent,
+} from '@styleguide';
+
+
+export const betweenValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  const operator = control.get('constraintOperator')?.value;
+  if (operator !== 'btw') {
+    return null;
+  }
+
+  const valOne = control.get('constraintValueOne')?.value;
+  const valTwo = control.get('constraintValueTwo')?.value;
+  const errors: ValidationErrors = {};
+
+  if (valOne === null || valOne === undefined || valOne === '') {
+    errors['requiredOne'] = true;
+  }
+  if (valTwo === null || valTwo === undefined || valTwo === '') {
+    errors['requiredTwo'] = true;
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+};
+
+@Component({
+  selector: 'app-adv-stand-level-constraints-modal',
+  standalone: true,
+  imports: [
+    InputDirective,
+    InputFieldComponent,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    ModalComponent,
+    ModalInfoComponent,
+    NgIf,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './adv-stand-level-constraints-modal.component.html',
+  styleUrl: './adv-stand-level-constraints-modal.component.scss',
+})
+export class AdvStandLevelConstraintsModalComponent implements OnInit {
+  readonly dialogRef = inject(MatDialogRef<AdvStandLevelConstraintsModalComponent>);
+  readonly data = inject(MAT_DIALOG_DATA);
+
+  dataLayerName = this.data?.dataLayerName;
+
+  form = new FormGroup(
+    {
+      constraintOperator: new FormControl<CONSTRAINT_OPERATOR | null>('eq', {
+        nonNullable: false,
+      }),
+      constraintValueOne: new FormControl<number | null>(null, [Validators.required]),
+      constraintValueTwo: new FormControl<number | null>(null),
+    },
+    { validators: [betweenValidator] }
+  );
+
+  get showSecondValue(): boolean {
+    return this.form.get('constraintOperator')?.value === 'btw';
+  }
+  get isButtonDisabled(): boolean {
+    return this.form.invalid;
+  }
+
+  ngOnInit() {
+    this.form.get('constraintOperator')?.valueChanges.subscribe((operator) => {
+      const valTwoControl = this.form.get('constraintValueTwo');
+
+      if (operator === 'btw') {
+        valTwoControl?.enable();
+      } else {
+        valTwoControl?.disable();
+        // clear it, so it doesn't get submitted
+        valTwoControl?.setValue(null);
+        valTwoControl?.markAsUntouched();
+      }
+    });
+  }
+
+handleApply() {
+    if (this.form.valid) {
+      const formVal = this.form.value;
+      const operator = formVal.constraintOperator ?? 'eq';
+      const constraintSelection: any = {
+        operator,
+        value: formVal.constraintValueOne ?? 0,
+      };
+      if (operator === 'btw' && formVal.constraintValueTwo !== null && formVal.constraintValueTwo !== undefined) {
+        constraintSelection.value2 = formVal.constraintValueTwo;
+      }
+      this.dialogRef.close(constraintSelection);
+    }
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}

--- a/src/interface/src/app/types/scenario.types.ts
+++ b/src/interface/src/app/types/scenario.types.ts
@@ -177,10 +177,20 @@ export interface ScenarioGoal {
 }
 
 // Backend constraint definition (thresholds for stands).
+export type CONSTRAINT_OPERATOR =
+  | 'eq'
+  | 'dne'
+  | 'lt'
+  | 'lte'
+  | 'gt'
+  | 'gte'
+  | 'btw';
+
 export interface Constraint {
   datalayer: number;
-  operator: 'eq' | 'lt' | 'lte' | 'gt' | 'gte';
+  operator: CONSTRAINT_OPERATOR;
   value: number; // be supports string
+  value2?: number; // be supports string //TODO: rename?
 }
 
 export interface ScenarioPriority {


### PR DESCRIPTION
This just adds a dialog that accepts a data layer name as input and returns an object with operator, value, and an optional second value.

<img width="397" height="309" alt="Screenshot From 2026-08-24 11-13-53" src="https://github.com/user-attachments/assets/a339f2c3-55e8-40f9-b8bf-73eedec22ad3" />

When "Between" is selected, the layout is updated and the second field is required.
<img width="398" height="380" alt="Screenshot From 2026-08-24 11-14-17" src="https://github.com/user-attachments/assets/dbdbe6a4-d104-4ae4-a676-1dfce3925c1d" />
