### PR TITLE
Workspaces frontend

### DIFF
--- a/src/interface/src/app/services/errors.spec.ts
+++ b/src/interface/src/app/services/errors.spec.ts
@@ -1,0 +1,55 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { getFieldError } from './errors';
+
+describe('getFieldError', () => {
+  function httpError(body: unknown) {
+    return new HttpErrorResponse({ status: 400, error: body });
+  }
+
+  it('returns the first message for the field', () => {
+    const error = httpError({
+      detail: 'Validation error.',
+      errors: { name: ['A workspace with this name already exists.'] },
+    });
+
+    expect(getFieldError(error, 'name')).toBe(
+      'A workspace with this name already exists.'
+    );
+  });
+
+  it('accepts a bare string instead of a list', () => {
+    const error = httpError({ errors: { name: 'Too long.' } });
+
+    expect(getFieldError(error, 'name')).toBe('Too long.');
+  });
+
+  it('returns null for a different field', () => {
+    const error = httpError({ errors: { geometry: ['Invalid.'] } });
+
+    expect(getFieldError(error, 'name')).toBeNull();
+  });
+
+  it('returns null when there are no errors', () => {
+    expect(
+      getFieldError(httpError({ detail: 'Server error.' }), 'name')
+    ).toBeNull();
+  });
+
+  it('returns null for a non-http error', () => {
+    expect(getFieldError(new Error('nope'), 'name')).toBeNull();
+  });
+
+  it('returns null for null and undefined', () => {
+    expect(getFieldError(null, 'name')).toBeNull();
+    expect(getFieldError(undefined, 'name')).toBeNull();
+  });
+
+  it('returns null when the message list is empty or not strings', () => {
+    expect(
+      getFieldError(httpError({ errors: { name: [] } }), 'name')
+    ).toBeNull();
+    expect(
+      getFieldError(httpError({ errors: { name: [42] } }), 'name')
+    ).toBeNull();
+  });
+});

--- a/src/interface/src/app/services/errors.ts
+++ b/src/interface/src/app/services/errors.ts
@@ -25,3 +25,19 @@ export class InvalidCoordinatesError extends Error {
     super(message);
   }
 }
+
+/**
+ * Backend validation errors come back as
+ * `{ detail: 'Validation error.', errors: { name: ['...'] } }`.
+ * Returns the first message for `field`, or null if the response isn't a
+ * validation error for that field.
+ */
+export function getFieldError(error: unknown, field: string): string | null {
+  const errors = (error as { error?: { errors?: Record<string, unknown> } })
+    ?.error?.errors;
+  const messages = errors?.[field];
+  if (Array.isArray(messages) && typeof messages[0] === 'string') {
+    return messages[0];
+  }
+  return typeof messages === 'string' ? messages : null;
+}

--- a/src/interface/src/app/services/workspaces.service.spec.ts
+++ b/src/interface/src/app/services/workspaces.service.spec.ts
@@ -1,28 +1,136 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { WorkspacesService } from './workspaces.service';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
 import { Workspace } from '@types';
+import { WorkspacesService } from './workspaces.service';
 
 describe('WorkspacesService', () => {
   let service: WorkspacesService;
+  let httpTestingController: HttpTestingController;
+
+  const workspace: Workspace = {
+    id: 1,
+    name: 'My workspace',
+    creator: 'Han Solo',
+    created_by: 3,
+    created_at: '2026-08-21T00:00:00Z',
+    updated_at: '2026-08-21T00:00:00Z',
+    planning_areas_count: 0,
+    collaborators_count: 1,
+    role: 'OWNER',
+    permissions: ['view_workspace'],
+  };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [WorkspacesService],
+    });
     service = TestBed.inject(WorkspacesService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
-  it('creates a workspace with the given name', fakeAsync(() => {
-    let workspace: Workspace | undefined;
+  describe('listWorkspaces', () => {
+    it('requests the workspace list', () => {
+      let result: Workspace[] | undefined;
+      service.listWorkspaces().subscribe((page) => (result = page.results));
 
-    service
-      .createWorkspace({ name: 'My workspace' })
-      .subscribe((w) => (workspace = w));
-    tick(1000);
+      const req = httpTestingController.expectOne(service.v2Path);
+      expect(req.request.method).toEqual('GET');
+      req.flush({ count: 1, results: [workspace] });
 
-    expect(workspace?.name).toBe('My workspace');
-    expect(workspace?.id).toEqual(jasmine.any(Number));
-  }));
+      expect(result).toEqual([workspace]);
+    });
+
+    it('passes the search term', () => {
+      service.listWorkspaces('wild').subscribe();
+
+      const req = httpTestingController.expectOne(
+        `${service.v2Path}?search=wild`
+      );
+      expect(req.request.params.get('search')).toBe('wild');
+      req.flush({ count: 0, results: [] });
+    });
+
+    it('omits the search param when not given', () => {
+      service.listWorkspaces().subscribe();
+
+      const req = httpTestingController.expectOne(service.v2Path);
+      expect(req.request.params.has('search')).toBeFalse();
+      req.flush({ count: 0, results: [] });
+    });
+  });
+
+  describe('getWorkspace', () => {
+    it('requests a single workspace', () => {
+      service.getWorkspace(1).subscribe();
+
+      const req = httpTestingController.expectOne(service.v2Path + '1/');
+      expect(req.request.method).toEqual('GET');
+      req.flush(workspace);
+    });
+
+    it('propagates a 404 as an http error', () => {
+      let status: number | undefined;
+      service.getWorkspace(404).subscribe({
+        error: (error) => (status = error.status),
+      });
+
+      httpTestingController
+        .expectOne(service.v2Path + '404/')
+        .flush(
+          { detail: 'Not found.' },
+          { status: 404, statusText: 'Not Found' }
+        );
+
+      expect(status).toBe(404);
+    });
+  });
+
+  describe('createWorkspace', () => {
+    it('posts the name', () => {
+      let result: Workspace | undefined;
+      service
+        .createWorkspace({ name: 'My workspace' })
+        .subscribe((w) => (result = w));
+
+      const req = httpTestingController.expectOne(service.v2Path);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ name: 'My workspace' });
+      req.flush(workspace);
+
+      expect(result).toEqual(workspace);
+    });
+  });
+
+  describe('updateWorkspace', () => {
+    it('patches the name', () => {
+      service.updateWorkspace(1, { name: 'Renamed' }).subscribe();
+
+      const req = httpTestingController.expectOne(service.v2Path + '1/');
+      expect(req.request.method).toEqual('PATCH');
+      expect(req.request.body).toEqual({ name: 'Renamed' });
+      req.flush(workspace);
+    });
+  });
+
+  describe('deleteWorkspace', () => {
+    it('deletes the workspace', () => {
+      service.deleteWorkspace(1).subscribe();
+
+      const req = httpTestingController.expectOne(service.v2Path + '1/');
+      expect(req.request.method).toEqual('DELETE');
+      req.flush(null);
+    });
+  });
 });

--- a/src/interface/src/app/services/workspaces.service.ts
+++ b/src/interface/src/app/services/workspaces.service.ts
@@ -1,55 +1,57 @@
 import { Injectable } from '@angular/core';
-import { delay, Observable, of, throwError } from 'rxjs';
-import { CreateWorkspacePayload, Workspace } from '@types';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  CreateWorkspacePayload,
+  Pagination,
+  UpdateWorkspacePayload,
+  Workspace,
+} from '@types';
+import { environment } from '@env/environment';
 
-/**
- * TODO: mocked until the backend endpoints exist.
- */
 @Injectable({
   providedIn: 'root',
 })
 export class WorkspacesService {
-  private readonly mockLatency = 600;
+  readonly v2Path = environment.backend_endpoint + '/v2/workspaces/';
 
-  createWorkspace(payload: CreateWorkspacePayload): Observable<Workspace> {
-    const workspace: Workspace = {
-      id: this.mockId(),
-      name: payload.name,
-      creator: '',
-      created_at: new Date().toISOString(),
-    };
+  constructor(private http: HttpClient) {}
 
-    return of(workspace).pipe(delay(this.mockLatency));
+  listWorkspaces(search?: string): Observable<Pagination<Workspace>> {
+    const params: Record<string, string> = {};
+    if (search) {
+      params['search'] = search;
+    }
+    return this.http.get<Pagination<Workspace>>(this.v2Path, {
+      withCredentials: true,
+      params,
+    });
   }
 
   getWorkspace(id: number): Observable<Workspace> {
-    // Mocking an error
-    if (id === 404) {
-      return throwError(
-        () =>
-          new HttpErrorResponse({
-            status: 404,
-            statusText: 'Not Found',
-            error: {
-              detail: 'Workspace not found',
-            },
-          })
-      ).pipe(delay(this.mockLatency));
-    }
-
-    // Mocking a workspace
-    const workspace: Workspace = {
-      id,
-      name: 'Mock Workspace',
-      creator: 'Han Solo',
-      created_at: new Date().toISOString(),
-    };
-
-    return of(workspace).pipe(delay(this.mockLatency));
+    return this.http.get<Workspace>(`${this.v2Path}${id}/`, {
+      withCredentials: true,
+    });
   }
 
-  private mockId(): number {
-    return Math.floor(Math.random() * 100000);
+  createWorkspace(payload: CreateWorkspacePayload): Observable<Workspace> {
+    return this.http.post<Workspace>(this.v2Path, payload, {
+      withCredentials: true,
+    });
+  }
+
+  updateWorkspace(
+    id: number,
+    payload: UpdateWorkspacePayload
+  ): Observable<Workspace> {
+    return this.http.patch<Workspace>(`${this.v2Path}${id}/`, payload, {
+      withCredentials: true,
+    });
+  }
+
+  deleteWorkspace(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.v2Path}${id}/`, {
+      withCredentials: true,
+    });
   }
 }

--- a/src/interface/src/app/shared/top-bar/top-bar.component.html
+++ b/src/interface/src/app/shared/top-bar/top-bar.component.html
@@ -48,7 +48,9 @@
 
       <!--  Logged in-->
       <ng-container *ngIf="loggedIn$ | async">
-        <button mat-menu-item routerLink="/home" data-id="home">Plans</button>
+        <button mat-menu-item routerLink="/home" data-id="home">
+          {{ homeLabel }}
+        </button>
         <button
           mat-menu-item
           routerLink="/account/information"
@@ -75,7 +77,7 @@
     </ng-container>
 
     <ng-container *ngIf="loggedIn$ | async">
-      <a routerLink="/home">Plans</a>
+      <a routerLink="/home">{{ homeLabel }}</a>
       <a routerLink="/account/information">Account</a>
     </ng-container>
 

--- a/src/interface/src/app/shared/top-bar/top-bar.component.scss
+++ b/src/interface/src/app/shared/top-bar/top-bar.component.scss
@@ -86,7 +86,6 @@ a.navbar-item {
   text-underline-position: under;
 }
 
-
 .mat-menu-trigger {
   height: 100%;
 }

--- a/src/interface/src/app/shared/top-bar/top-bar.component.spec.ts
+++ b/src/interface/src/app/shared/top-bar/top-bar.component.spec.ts
@@ -17,6 +17,8 @@ import { LegacyMaterialModule } from '@material/legacy-material.module';
 import { MockDeclarations } from 'ng-mocks';
 import { ButtonComponent } from '@styleguide';
 import { MatMenuHarness } from '@angular/material/menu/testing';
+import { FeaturesModule } from '@features/features.module';
+import { overrideFeatureFlags } from '@features/testing';
 
 describe('TopBarComponent', () => {
   let component: TopBarComponent;
@@ -41,6 +43,7 @@ describe('TopBarComponent', () => {
         LegacyMaterialModule,
         RouterTestingModule,
         NoopAnimationsModule,
+        FeaturesModule,
       ],
       declarations: [TopBarComponent, MockDeclarations(ButtonComponent)],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -115,6 +118,20 @@ describe('TopBarComponent', () => {
         );
 
         expect(texts).toEqual(['Plans', 'Account', 'Sign Out']);
+      });
+
+      it('says `workspaces` instead of `plans` when the flag is on', async () => {
+        overrideFeatureFlags('WORKSPACES');
+        setUpComponent();
+        const harness = await loader.getHarness(MatMenuHarness);
+        await harness.open();
+        const items = await harness.getItems();
+
+        const texts = await Promise.all(
+          items.map(async (item) => await item.getText())
+        );
+
+        expect(texts).toEqual(['Workspaces', 'Account', 'Sign Out']);
       });
     });
   });

--- a/src/interface/src/app/shared/top-bar/top-bar.component.ts
+++ b/src/interface/src/app/shared/top-bar/top-bar.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { map, switchMap } from 'rxjs';
 
 import { AuthService } from '@services';
+import { FeatureService } from '@app/features/feature.service';
 import { KNOWLEDGE_BASE_URL, SUPPORT_URL } from '@app/shared';
 
 @Component({
@@ -37,8 +38,16 @@ export class TopBarComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private featureService: FeatureService
   ) {}
+
+  /** `/home` lists workspaces once the flag is on, plans otherwise. */
+  get homeLabel(): string {
+    return this.featureService.isFeatureEnabled('WORKSPACES')
+      ? 'Workspaces'
+      : 'Plans';
+  }
 
   ngOnInit(): void {
     this.router.events.subscribe((event) => {

--- a/src/interface/src/app/types/workspace.types.ts
+++ b/src/interface/src/app/types/workspace.types.ts
@@ -1,11 +1,23 @@
-// shape TODO
+export type WorkspaceRole = 'OWNER' | 'COLLABORATOR' | 'VIEWER';
+
 export interface Workspace {
   id: number;
   name: string;
+  /** Snapshot of the creator's name, static even if they leave the workspace. */
   creator: string;
+  created_by: number | null;
   created_at: string;
+  updated_at: string;
+  planning_areas_count: number;
+  collaborators_count: number;
+  role: WorkspaceRole | null;
+  permissions: string[];
 }
 
 export interface CreateWorkspacePayload {
+  name: string;
+}
+
+export interface UpdateWorkspacePayload {
   name: string;
 }

--- a/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.html
+++ b/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.html
@@ -16,7 +16,7 @@
         size="full"
         [error]="displayError"
         showSupportMessage="on-error"
-        supportMessage="This name is already in use by another Workspace.">
+        [supportMessage]="errorMessage || ''">
         <input
           sgInput
           name="name"

--- a/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.spec.ts
+++ b/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { of, throwError } from 'rxjs';
@@ -17,8 +18,14 @@ describe('CreateWorkspaceModalComponent', () => {
   const workspace: Workspace = {
     id: 1,
     name: 'My workspace',
-    creator: '',
+    creator: 'Han Solo',
+    created_by: 3,
     created_at: '2026-08-21T00:00:00Z',
+    updated_at: '2026-08-21T00:00:00Z',
+    planning_areas_count: 0,
+    collaborators_count: 1,
+    role: 'OWNER',
+    permissions: ['view_workspace'],
   };
 
   beforeEach(async () => {
@@ -72,7 +79,7 @@ describe('CreateWorkspaceModalComponent', () => {
     expect(fakeDialogRef.close).toHaveBeenCalledWith(workspace);
   });
 
-  it('shows an error and stays open when saving fails', () => {
+  it('shows a generic error and stays open when saving fails', () => {
     spyOn(workspacesService, 'createWorkspace').and.returnValue(
       throwError(() => new Error('nope'))
     );
@@ -81,9 +88,48 @@ describe('CreateWorkspaceModalComponent', () => {
     component.handleSubmit();
 
     expect(component.displayError).toBeTrue();
+    expect(component.errorMessage).toBe(
+      'Something went wrong. Please try again.'
+    );
     expect(component.submitting).toBeFalse();
     expect(component.primaryCTA).toBe('Try Again');
     expect(fakeDialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the backend message when the name is taken', () => {
+    spyOn(workspacesService, 'createWorkspace').and.returnValue(
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 400,
+            error: {
+              detail: 'Validation error.',
+              errors: { name: ['A workspace with this name already exists.'] },
+            },
+          })
+      )
+    );
+    component.form.setValue({ name: 'Taken' });
+
+    component.handleSubmit();
+
+    expect(component.errorMessage).toBe(
+      'A workspace with this name already exists.'
+    );
+    expect(fakeDialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('shows a generic error for a non-validation http failure', () => {
+    spyOn(workspacesService, 'createWorkspace').and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 500, error: 'boom' }))
+    );
+    component.form.setValue({ name: 'My workspace' });
+
+    component.handleSubmit();
+
+    expect(component.errorMessage).toBe(
+      'Something went wrong. Please try again.'
+    );
   });
 
   it('closes with no workspace on cancel', () => {

--- a/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.ts
+++ b/src/interface/src/app/workspaces/create-workspace-modal/create-workspace-modal.component.ts
@@ -7,12 +7,15 @@ import {
 } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { WorkspacesService } from '@services';
+import { getFieldError } from '@app/services/errors';
 import {
   InputDirective,
   InputFieldComponent,
   ModalComponent,
 } from '@styleguide';
 import { Workspace } from '@types';
+
+const GENERIC_ERROR = 'Something went wrong. Please try again.';
 
 /**
  * Closes with the created `Workspace`, or `undefined` when cancelled.
@@ -40,7 +43,11 @@ export class CreateWorkspaceModalComponent {
   });
 
   submitting = false;
-  displayError = false;
+  errorMessage: string | null = null;
+
+  get displayError(): boolean {
+    return this.errorMessage !== null;
+  }
 
   handleSubmit() {
     if (this.form.invalid || this.submitting) {
@@ -52,12 +59,14 @@ export class CreateWorkspaceModalComponent {
       .subscribe({
         next: (workspace) => {
           this.submitting = false;
-          this.displayError = false;
+          this.errorMessage = null;
           this.dialogRef.close(workspace);
         },
-        error: () => {
+        error: (error) => {
           this.submitting = false;
-          this.displayError = true;
+          // A duplicate name comes back as a validation error on `name`;
+          // anything else is a failure we can't explain to the user.
+          this.errorMessage = getFieldError(error, 'name') ?? GENERIC_ERROR;
         },
       });
   }

--- a/src/interface/src/app/workspaces/workspace-creation.service.spec.ts
+++ b/src/interface/src/app/workspaces/workspace-creation.service.spec.ts
@@ -18,8 +18,14 @@ describe('WorkspaceCreationService', () => {
   const workspace: Workspace = {
     id: 5,
     name: 'My workspace',
-    creator: '',
+    creator: 'Han Solo',
+    created_by: 3,
     created_at: '2026-08-21T00:00:00Z',
+    updated_at: '2026-08-21T00:00:00Z',
+    planning_areas_count: 0,
+    collaborators_count: 1,
+    role: 'OWNER',
+    permissions: ['view_workspace'],
   };
 
   function setUp(closedWith: Workspace | undefined) {

--- a/src/interface/src/app/workspaces/workspace-dashboard/workspace-dashboard.component.spec.ts
+++ b/src/interface/src/app/workspaces/workspace-dashboard/workspace-dashboard.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { WorkspaceDashboardComponent } from './workspace-dashboard.component';
@@ -9,7 +10,7 @@ describe('WorkspaceDashboardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorkspaceDashboardComponent],
+      imports: [WorkspaceDashboardComponent, HttpClientTestingModule],
       providers: [
         {
           provide: ActivatedRoute,

--- a/src/interface/src/app/workspaces/workspaces.component.html
+++ b/src/interface/src/app/workspaces/workspaces.component.html
@@ -1,8 +1,43 @@
+<sg-overlay-loader *ngIf="isLoading$ | async"></sg-overlay-loader>
+
 <sg-empty-state
-  icon="folder"
-  title="Workspace: A shared space for smarter planning"
-  description="Get started by creating a workspace to collaborate with your team and organize everything you need for planning.">
-  <button sg-button variant="primary" (click)="createWorkspace()">
-    Create Workspace
-  </button>
+  *ngIf="hasError$ | async"
+  icon="error"
+  title="We couldn't load your workspaces"
+  description="Something went wrong. Please try again.">
+  <button sg-button variant="primary" (click)="retry()">Try Again</button>
 </sg-empty-state>
+
+<ng-container *ngIf="workspaces$ | async as workspaces">
+  <sg-empty-state
+    *ngIf="workspaces.length === 0; else workspaceList"
+    icon="folder"
+    title="Workspace: A shared space for smarter planning"
+    description="Get started by creating a workspace to collaborate with your team and organize everything you need for planning.">
+    <button sg-button variant="primary" (click)="createWorkspace()">
+      Create Workspace
+    </button>
+  </sg-empty-state>
+
+  <ng-template #workspaceList>
+    <div class="workspaces-header">
+      <h1>Workspaces</h1>
+      <button sg-button variant="primary" (click)="createWorkspace()">
+        Create Workspace
+      </button>
+    </div>
+
+    <div class="workspaces-grid">
+      <sg-workspace-card
+        *ngFor="let workspace of workspaces; trackBy: trackById"
+        [name]="workspace.name"
+        [planningAreasCount]="workspace.planning_areas_count"
+        [creator]="workspace.creator"
+        [createdAt]="workspace.created_at"
+        [userCanRename]="can(workspace, 'change_workspace')"
+        [userCanDelete]="can(workspace, 'remove_workspace')"
+        [userCanShare]="can(workspace, 'add_collaborator')"
+        (clicked)="goToWorkspace(workspace)"></sg-workspace-card>
+    </div>
+  </ng-template>
+</ng-container>

--- a/src/interface/src/app/workspaces/workspaces.component.scss
+++ b/src/interface/src/app/workspaces/workspaces.component.scss
@@ -3,11 +3,36 @@
 :host {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
   flex: 1 0 0;
   height: 100%;
   box-sizing: border-box;
   padding: 16px;
   background-color: $color-white;
+  overflow-y: auto;
+}
+
+sg-empty-state {
+  flex: 1 0 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.workspaces-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+
+  h1 {
+    margin: 0;
+  }
+}
+
+.workspaces-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
 }

--- a/src/interface/src/app/workspaces/workspaces.component.spec.ts
+++ b/src/interface/src/app/workspaces/workspaces.component.spec.ts
@@ -1,51 +1,133 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
 import { MockProvider } from 'ng-mocks';
 
 import { WorkspacesComponent } from '@app/workspaces/workspaces.component';
 import { WorkspaceCreationService } from '@app/workspaces/workspace-creation.service';
+import { WorkspacesService } from '@services';
+import { Workspace } from '@types';
 
 describe('WorkspacesComponent', () => {
-  let component: WorkspacesComponent;
   let fixture: ComponentFixture<WorkspacesComponent>;
   let creationService: WorkspaceCreationService;
+  let workspacesService: WorkspacesService;
+  let router: Router;
+
+  const workspace: Workspace = {
+    id: 7,
+    name: 'Wildfire North',
+    creator: 'Han Solo',
+    created_by: 3,
+    created_at: '2026-08-21T00:00:00Z',
+    updated_at: '2026-08-21T00:00:00Z',
+    planning_areas_count: 4,
+    collaborators_count: 2,
+    role: 'OWNER',
+    permissions: ['view_workspace', 'change_workspace', 'remove_workspace'],
+  };
+
+  function setup(listResult = of({ count: 1, results: [workspace] })) {
+    workspacesService = TestBed.inject(WorkspacesService);
+    spyOn(workspacesService, 'listWorkspaces').and.returnValue(
+      listResult as any
+    );
+
+    creationService = TestBed.inject(WorkspaceCreationService);
+    router = TestBed.inject(Router);
+
+    fixture = TestBed.createComponent(WorkspacesComponent);
+    fixture.detectChanges();
+  }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [WorkspacesComponent],
-      providers: [MockProvider(WorkspaceCreationService)],
+      providers: [
+        MockProvider(WorkspaceCreationService),
+        MockProvider(WorkspacesService),
+        MockProvider(Router),
+      ],
     }).compileComponents();
-
-    creationService = TestBed.inject(WorkspaceCreationService);
-
-    fixture = TestBed.createComponent(WorkspacesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    setup();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('shows the empty state with a create workspace action', () => {
-    const element = fixture.nativeElement;
+  describe('when the user has workspaces', () => {
+    beforeEach(() => setup());
 
-    expect(element.textContent).toContain(
-      'Workspace: A shared space for smarter planning'
-    );
-    expect(element.querySelector('button[sg-button]').textContent).toContain(
-      'Create Workspace'
-    );
+    it('renders a card per workspace', () => {
+      const cards = fixture.nativeElement.querySelectorAll('sg-workspace-card');
+
+      expect(cards.length).toBe(1);
+      expect(fixture.nativeElement.textContent).toContain('Wildfire North');
+    });
+
+    it('does not show the empty state', () => {
+      expect(fixture.nativeElement.textContent).not.toContain(
+        'Workspace: A shared space for smarter planning'
+      );
+    });
+
+    it('navigates to the workspace when a card is clicked', () => {
+      const spy = spyOn(router, 'navigate');
+
+      fixture.nativeElement.querySelector('sg-workspace-card').click();
+
+      expect(spy).toHaveBeenCalledWith(['/workspace', 7]);
+    });
   });
 
-  it('starts the create flow from the empty state', () => {
-    const spy = spyOn(
-      creationService,
-      'openCreateWorkspaceModal'
-    ).and.returnValue(of(null));
+  describe('when the user has no workspaces', () => {
+    beforeEach(() => setup(of({ count: 0, results: [] })));
 
-    fixture.nativeElement.querySelector('button[sg-button]').click();
+    it('shows the empty state with a create workspace action', () => {
+      expect(fixture.nativeElement.textContent).toContain(
+        'Workspace: A shared space for smarter planning'
+      );
+    });
 
-    expect(spy).toHaveBeenCalledWith('empty-state');
+    it('starts the create flow from the empty state', () => {
+      const spy = spyOn(
+        creationService,
+        'openCreateWorkspaceModal'
+      ).and.returnValue(of(null));
+
+      fixture.nativeElement.querySelector('button[sg-button]').click();
+
+      expect(spy).toHaveBeenCalledWith('empty-state');
+    });
+
+    it('reloads the list after a workspace is created', () => {
+      spyOn(creationService, 'openCreateWorkspaceModal').and.returnValue(
+        of(workspace)
+      );
+
+      fixture.componentInstance.createWorkspace();
+
+      expect(workspacesService.listWorkspaces).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('when loading fails', () => {
+    beforeEach(() => setup(throwError(() => new Error('nope'))));
+
+    it('shows an error state instead of the empty state', () => {
+      expect(fixture.nativeElement.textContent).toContain(
+        "We couldn't load your workspaces"
+      );
+      expect(fixture.nativeElement.textContent).not.toContain(
+        'Workspace: A shared space for smarter planning'
+      );
+    });
+
+    it('retries on demand', () => {
+      fixture.componentInstance.retry();
+
+      expect(workspacesService.listWorkspaces).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/interface/src/app/workspaces/workspaces.component.ts
+++ b/src/interface/src/app/workspaces/workspaces.component.ts
@@ -1,20 +1,95 @@
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import { ButtonComponent, EmptyStateComponent } from '@styleguide';
+import { Router } from '@angular/router';
+import {
+  BehaviorSubject,
+  catchError,
+  concat,
+  map,
+  Observable,
+  of,
+  shareReplay,
+  switchMap,
+} from 'rxjs';
+import {
+  ButtonComponent,
+  EmptyStateComponent,
+  OverlayLoaderComponent,
+  WorkspaceCardComponent,
+} from '@styleguide';
+import { WorkspacesService } from '@services';
+import { LoadedResult, Resource, Workspace } from '@types';
 import { WorkspaceCreationService } from './workspace-creation.service';
 
 @Component({
   selector: 'app-workspaces',
   standalone: true,
-  imports: [ButtonComponent, EmptyStateComponent],
+  imports: [
+    AsyncPipe,
+    ButtonComponent,
+    EmptyStateComponent,
+    NgFor,
+    NgIf,
+    OverlayLoaderComponent,
+    WorkspaceCardComponent,
+  ],
   templateUrl: './workspaces.component.html',
   styleUrl: './workspaces.component.scss',
 })
 export class WorkspacesComponent {
   private workspaceCreationService = inject(WorkspaceCreationService);
+  private workspacesService = inject(WorkspacesService);
+  private router = inject(Router);
+
+  private reload$ = new BehaviorSubject<void>(undefined);
+
+  private workspacesResource$: Observable<Resource<Workspace[]>> =
+    this.reload$.pipe(
+      switchMap(() =>
+        concat(
+          of({ isLoading: true } as Resource<Workspace[]>),
+          this.workspacesService.listWorkspaces().pipe(
+            map(
+              (page) =>
+                ({
+                  data: page.results,
+                  isLoading: false,
+                }) as LoadedResult<Workspace[]>
+            ),
+            catchError((error) => of({ isLoading: false, error }))
+          )
+        )
+      ),
+      shareReplay(1)
+    );
+
+  isLoading$ = this.workspacesResource$.pipe(map((r) => r.isLoading));
+  hasError$ = this.workspacesResource$.pipe(map((r) => !!r.error));
+  workspaces$ = this.workspacesResource$.pipe(map((r) => r.data));
 
   createWorkspace() {
     this.workspaceCreationService
       .openCreateWorkspaceModal('empty-state')
-      .subscribe();
+      .subscribe((workspace) => {
+        if (workspace) {
+          this.reload$.next();
+        }
+      });
+  }
+
+  goToWorkspace(workspace: Workspace) {
+    this.router.navigate(['/workspace', workspace.id]);
+  }
+
+  can(workspace: Workspace, permission: string): boolean {
+    return workspace.permissions.includes(permission);
+  }
+
+  trackById(_index: number, workspace: Workspace) {
+    return workspace.id;
+  }
+
+  retry() {
+    this.reload$.next();
   }
 }


### PR DESCRIPTION
  Replaces the mocked WorkspacesService with real endpoints and fixes a menu label to say workspaces if the flag is on.

  Not included: card rename/share/delete handlers (menu renders, clicks are no-ops) · search input · pagination 