### PR TITLE
fix: handle None min/max raster stats in default style

### DIFF
--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -273,7 +273,12 @@ class DataLayerQuerySet(models.QuerySet):
         return temp_geometry
 
     def by_meta_module(self, module: str):
-        return self.all().filter(metadata__modules__has_key=module)
+        enabled_lookup = f"metadata__modules__{module}__enabled"
+        return (
+            self.all()
+            .filter(metadata__modules__has_key=module)
+            .filter(Q(**{enabled_lookup: True}) | Q(**{f"{enabled_lookup}__isnull": True}))
+        )
 
     def by_meta_name(self, name: str):
         query = {"modules": {"forsys": {"name": name}}}

--- a/src/planscape/datasets/styles.py
+++ b/src/planscape/datasets/styles.py
@@ -44,11 +44,17 @@ def get_raster_style(datalayer: DataLayer, style: Style) -> Dict[str, Any]:
 
 
 def get_default_raster_style(
-    min: float,
-    max: float,
+    min: Optional[float] = None,
+    max: Optional[float] = None,
     nodata: Optional[float] = None,
     **kwargs,
 ) -> Dict[str, Any]:
+    # min/max can be None when the raster's stats couldn't be computed
+    # (e.g. an all-nodata band gets sanitized from NaN to None before
+    # being stored). Fall back to a 0-1 range so we still produce a style.
+    if min is None or max is None:
+        min, max = 0.0, 1.0
+
     steps = 7
     delta = max - min
     interval = delta / (steps - 1)

--- a/src/planscape/datasets/tests/test_models.py
+++ b/src/planscape/datasets/tests/test_models.py
@@ -44,6 +44,28 @@ class ValidateDatasetModulesTest(TestCase):
             validate_dataset_modules(["not-a-module"])
 
 
+class ByMetaModuleTest(TestCase):
+    def test_includes_layer_without_enabled_key(self):
+        DataLayerFactory.create(metadata={"modules": {"forsys": {}}})
+
+        self.assertEqual(DataLayer.objects.all().by_meta_module("forsys").count(), 1)
+
+    def test_includes_layer_with_enabled_true(self):
+        DataLayerFactory.create(metadata={"modules": {"forsys": {"enabled": True}}})
+
+        self.assertEqual(DataLayer.objects.all().by_meta_module("forsys").count(), 1)
+
+    def test_excludes_layer_with_enabled_false(self):
+        DataLayerFactory.create(metadata={"modules": {"forsys": {"enabled": False}}})
+
+        self.assertEqual(DataLayer.objects.all().by_meta_module("forsys").count(), 0)
+
+    def test_excludes_layer_without_module_key(self):
+        DataLayerFactory.create(metadata={"modules": {"other": {"enabled": True}}})
+
+        self.assertEqual(DataLayer.objects.all().by_meta_module("forsys").count(), 0)
+
+
 class DataLayerModelTest(TestCase):
     def setUp(self):
         DataLayerFactory.create(name="Layer 1")

--- a/src/planscape/datasets/tests/test_styles.py
+++ b/src/planscape/datasets/tests/test_styles.py
@@ -66,3 +66,17 @@ class TestGetDefaultRasterStyle(SimpleTestCase):
 
         self.assertEqual(result["no_data"]["values"], ["nan"])
         json.dumps(result, allow_nan=False)
+
+    def test_none_min_and_max_falls_back_to_default_range(self):
+        result = get_default_raster_style(min=None, max=None)["data"]
+
+        self.assertEqual(len(result["entries"]), 7)
+        self.assertEqual(result["entries"][0]["value"], 0.0)
+        self.assertEqual(result["entries"][-1]["value"], 1.0)
+
+    def test_none_max_falls_back_to_default_range(self):
+        result = get_default_raster_style(min=5, max=None)["data"]
+
+        self.assertEqual(len(result["entries"]), 7)
+        self.assertEqual(result["entries"][0]["value"], 0.0)
+        self.assertEqual(result["entries"][-1]["value"], 1.0)

--- a/src/planscape/modules/base.py
+++ b/src/planscape/modules/base.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Optional, Type, Union
 
-from datasets.models import DataLayer, Dataset, PreferredDisplayType
+from datasets.models import DataLayer, DataLayerType, Dataset, PreferredDisplayType
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.db.models import Q, QuerySet
@@ -285,7 +285,10 @@ class PrioritizeSubUnitsModule(BaseModule):
         user = kwargs.get("user")
         options = super()._get_options(**kwargs)
         sub_units_layers = (
-            DataLayer.objects.all().accessible_by(user).by_meta_module(self.name)
+            DataLayer.objects.all()
+            .accessible_by(user)
+            .by_meta_module(self.name)
+            .filter(type=DataLayerType.VECTOR)
         )
         return {**options, "sub_units": list(sub_units_layers)}
 

--- a/src/planscape/modules/tests/test_modules.py
+++ b/src/planscape/modules/tests/test_modules.py
@@ -260,7 +260,11 @@ class PrioritizeSubUnitsModuleTest(TestCase):
             visibility=VisibilityOptions.PUBLIC, 
             modules=["prioritize_sub_units"],
         )
-        DataLayerFactory.create(dataset=base_dataset, metadata={"modules": {"prioritize_sub_units": {"enabled": True}}})
+        DataLayerFactory.create(
+            dataset=base_dataset,
+            type=DataLayerType.VECTOR,
+            metadata={"modules": {"prioritize_sub_units": {"enabled": True}}},
+        )
 
         module = get_module("prioritize_sub_units")
         configuration: Dict[str, Any] = module.get_configuration()
@@ -286,6 +290,30 @@ class PrioritizeSubUnitsModuleTest(TestCase):
         self.assertEqual(len(base), 1)
         self.assertEqual(len(sub_units), 1)
 
+    def test_excludes_raster_layers(self):
+        base_dataset = DatasetFactory.create(
+            name="base1",
+            preferred_display_type=PreferredDisplayType.BASE_DATALAYERS,
+            visibility=VisibilityOptions.PUBLIC,
+            modules=["prioritize_sub_units"],
+        )
+        DataLayerFactory.create(
+            dataset=base_dataset,
+            type=DataLayerType.VECTOR,
+            metadata={"modules": {"prioritize_sub_units": {"enabled": True}}},
+        )
+        DataLayerFactory.create(
+            dataset=base_dataset,
+            type=DataLayerType.RASTER,
+            metadata={"modules": {"prioritize_sub_units": {"enabled": True}}},
+        )
+
+        module = get_module("prioritize_sub_units")
+        configuration: Dict[str, Any] = module.get_configuration()
+        sub_units = configuration["options"]["sub_units"]
+
+        self.assertEqual(len(sub_units), 1)
+        self.assertEqual(sub_units[0].type, DataLayerType.VECTOR)
 
     def test_returns_private_dataset_for_staff_users(self):
         private_base_dataset = DatasetFactory.create(
@@ -312,8 +340,16 @@ class PrioritizeSubUnitsModuleTest(TestCase):
             visibility=VisibilityOptions.PUBLIC, 
             modules=["prioritize_sub_units"],
         )
-        DataLayerFactory.create(dataset=private_base_dataset, metadata={"modules": {"prioritize_sub_units": {"enabled": True}}})
-        DataLayerFactory.create(dataset=public_base_dataset, metadata={"modules": {"prioritize_sub_units": {"enabled": True}}})
+        DataLayerFactory.create(
+            dataset=private_base_dataset,
+            type=DataLayerType.VECTOR,
+            metadata={"modules": {"prioritize_sub_units": {"enabled": True}}},
+        )
+        DataLayerFactory.create(
+            dataset=public_base_dataset,
+            type=DataLayerType.VECTOR,
+            metadata={"modules": {"prioritize_sub_units": {"enabled": True}}},
+        )
 
         staff_user = UserFactory.create(is_staff=True)
         standard_user = UserFactory.create(is_staff=False)


### PR DESCRIPTION
Fixes a Sentry crash: `get_default_raster_style` did `max - min` assuming floats, but raster stats can be `None` (e.g. all-nodata band gets sanitized from NaN to None). Falls back to 0-1 range in that case.

Also filters `prioritize_sub_units` sub_units option to vector layers only.

Fixes: https://spatial-informatics-group.sentry.io/issues/7691772811/