### PR TITLE
Track project area upload validation

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -7,6 +7,7 @@ from datasets.models import DataLayer, DataLayerStatus, DataLayerType, GeometryT
 from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 from django.utils import timezone
+from planscape.analytics import track_event
 from planscape.exceptions import InvalidGeometry
 from rest_framework import serializers
 from rest_framework_gis import serializers as gis_serializers
@@ -37,7 +38,7 @@ from planning.services import (
     calculate_scenario_treatable_area,
     get_acreage,
     get_min_project_area,
-    planning_area_covers,
+    planning_area_covering_source,
     union_geojson,
 )
 
@@ -1482,11 +1483,30 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
             exists = exists.exclude(pk=self.instance.pk)
 
         if exists.exists():
+            self._track_upload_validation(
+                stage="duplicate_name",
+                status="failed",
+                planning_area_id=planning_area_id,
+                stand_size=stand_size,
+                error="A scenario with this name already exists.",
+            )
             raise serializers.ValidationError(
                 {"name": "A scenario with this name already exists."}
             )
 
-        if not self._is_inside_planning_area(geometry, planning_area_id, stand_size):
+        covering_source = self._get_planning_area_covering_source(
+            geometry,
+            planning_area_id,
+            stand_size,
+        )
+        if not covering_source:
+            self._track_upload_validation(
+                stage="containment",
+                status="failed",
+                planning_area_id=planning_area_id,
+                stand_size=stand_size,
+                error="The uploaded geometry is not within the selected planning area.",
+            )
             raise serializers.ValidationError(
                 {
                     "global": [
@@ -1494,6 +1514,18 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
                     ]
                 }
             )
+        attrs["clip_project_areas_to_planning_area"] = (
+            covering_source == "buffered_geometry"
+        )
+        self._track_upload_validation(
+            stage=covering_source,
+            status="passed",
+            planning_area_id=planning_area_id,
+            stand_size=stand_size,
+            clip_project_areas_to_planning_area=attrs[
+                "clip_project_areas_to_planning_area"
+            ],
+        )
         return attrs
 
     def validate_geometry(self, value):
@@ -1505,6 +1537,11 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
                 if fc.get("type") == "FeatureCollection":
                     merged_feature_collection["features"].extend(fc.get("features", []))
                 else:
+                    self._track_upload_validation(
+                        stage="geometry_format",
+                        status="failed",
+                        error="All items must be GeoJSON FeatureCollection objects",
+                    )
                     raise ValueError(
                         "All items must be GeoJSON FeatureCollection objects"
                     )
@@ -1512,26 +1549,89 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
 
         # convert if neither dict nor list
         if not isinstance(value, (dict, list)):
-            value = json.loads(value)
+            try:
+                value = json.loads(value)
+            except ValueError as e:
+                self._track_upload_validation(
+                    stage="geometry_format",
+                    status="failed",
+                    error=str(e),
+                )
+                raise e
 
         geojson_serializer = GeoJSONSerializer(data=value)
-        geojson_serializer.is_valid(raise_exception=True)
+        if not geojson_serializer.is_valid():
+            self._track_upload_validation(
+                stage="geometry_format",
+                status="failed",
+                error=geojson_serializer.errors,
+            )
+            raise serializers.ValidationError(geojson_serializer.errors)
         return geojson_serializer.validated_data
 
-    def _is_inside_planning_area(self, geometry, planning_area_id, stand_size) -> bool:
+    def _get_planning_area_covering_source(
+        self, geometry, planning_area_id, stand_size
+    ) -> str | None:
         try:
             uploaded_geos = union_geojson(geometry)
         except ValueError as e:
+            self._track_upload_validation(
+                stage="polygon_union",
+                status="failed",
+                planning_area_id=planning_area_id,
+                stand_size=stand_size,
+                error=str(e),
+            )
             raise serializers.ValidationError({"global": [str(e)]})
         try:
             planning_area = PlanningArea.objects.get(pk=planning_area_id)
         except PlanningArea.DoesNotExist:
+            self._track_upload_validation(
+                stage="planning_area_lookup",
+                status="failed",
+                planning_area_id=planning_area_id,
+                stand_size=stand_size,
+                error="Planning area does not exist.",
+            )
             raise serializers.ValidationError("Planning area does not exist.")
 
-        return planning_area_covers(
+        return planning_area_covering_source(
             planning_area=planning_area,
             geometry=uploaded_geos,
             stand_size=stand_size or StandSizeChoices.SMALL,
+        )
+
+    def _track_upload_validation(
+        self,
+        stage: str,
+        status: str,
+        planning_area_id: int | None = None,
+        stand_size: str | None = None,
+        error=None,
+        clip_project_areas_to_planning_area: bool | None = None,
+    ) -> None:
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        properties = {
+            "stage": stage,
+            "status": status,
+            "planning_area_id": planning_area_id
+            or self.initial_data.get("planning_area"),
+            "stand_size": stand_size or self.initial_data.get("stand_size"),
+            "scenario_name": self.initial_data.get("name"),
+            "email": getattr(user, "email", None),
+        }
+        if error:
+            properties["error"] = str(error)
+        if clip_project_areas_to_planning_area is not None:
+            properties[
+                "clip_project_areas_to_planning_area"
+            ] = clip_project_areas_to_planning_area
+
+        track_event(
+            name="planning.project_areas_upload.validation",
+            properties=properties,
+            user_id=getattr(user, "pk", None),
         )
 
 

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -56,7 +56,12 @@ from stands.models import Stand, StandMetric, StandSizeChoices, area_from_size
 from stands.services import get_datalayer_metric, get_stand_grid_key_search_precision
 from utils.geometry import to_multi
 
-from planning.geometry import coerce_geojson, coerce_geometry, to_multipolygon
+from planning.geometry import (
+    coerce_geojson,
+    coerce_geometry,
+    fix_geometry,
+    to_multipolygon,
+)
 from planning.models import (
     GeoPackageStatus,
     PlanningArea,
@@ -395,6 +400,7 @@ def feature_to_project_area(
     scenario: Scenario,
     geometry_dict: dict[str, Any],
     idx: int = 1,
+    clip_to_planning_area: bool = False,
 ):
     user = scenario.user
     stand_size = scenario.get_stand_size()
@@ -403,6 +409,10 @@ def feature_to_project_area(
         logger.info("creating project area %s %s", area_name, geometry_dict)
         _bbox = geometry_dict.pop("bbox", None)
         geometry = coerce_geometry(geometry_dict)
+        if clip_to_planning_area:
+            geometry = to_multipolygon(
+                fix_geometry(geometry.intersection(scenario.planning_area.geometry))
+            )
 
         stand_count = Stand.objects.within_polygon(
             geometry,
@@ -438,6 +448,7 @@ def feature_to_project_area(
 def create_scenario_from_upload(validated_data, user) -> Scenario:
     planning_area = PlanningArea.objects.get(pk=validated_data["planning_area"])
     feature_collection = validated_data["geometry"]
+    clip_to_planning_area = validated_data.get("clip_project_areas_to_planning_area")
 
     if planning_area.map_status == PlanningAreaMapStatus.OVERSIZE:
         raise ValueError(
@@ -476,6 +487,7 @@ def create_scenario_from_upload(validated_data, user) -> Scenario:
                 scenario=scenario,
                 idx=i[0],
                 geometry_dict=i[1].get("geometry", {}),
+                clip_to_planning_area=clip_to_planning_area,
             ),
             enumerate(feature_collection.get("features"), 1),
         )
@@ -1861,6 +1873,22 @@ def planning_area_covers(
     stand_size: StandSizeChoices,
     buffer_size: float = -1.0,
 ) -> bool:
+    return bool(
+        planning_area_covering_source(
+            planning_area=planning_area,
+            geometry=geometry,
+            stand_size=stand_size,
+            buffer_size=buffer_size,
+        )
+    )
+
+
+def planning_area_covering_source(
+    planning_area: PlanningArea,
+    geometry: GEOSGeometry,
+    stand_size: StandSizeChoices,
+    buffer_size: float = -1.0,
+) -> str | None:
     """Specialized version of `covers` predicate for Planning Area.
     This is necessary because some times our users want to upload
     project areas that are slightly off the planning area. So this
@@ -1870,7 +1898,7 @@ def planning_area_covers(
     """
     if planning_area.geometry.covers(geometry):
         logger.info("Planning Area covers geometry using DE9IM matrix.")
-        return True
+        return "planning_area"
 
     all_stands = Stand.objects.within_polygon(
         planning_area.geometry,
@@ -1878,11 +1906,11 @@ def planning_area_covers(
     ).aggregate(geometry=UnionOp("geometry"))["geometry"]
 
     if all_stands is None:
-        return False
+        return None
 
     if all_stands.covers(geometry):
         logger.info("Planning Area covers geometry using stands DE9IM matrix.")
-        return True
+        return "stands"
 
     # units here are in meters
     test_geometry = geometry.transform(settings.AREA_SRID, clone=True)
@@ -1892,8 +1920,8 @@ def planning_area_covers(
         logger.info(
             "Planning Area covers geometry using a buffered version of test geometry."
         )
-        return True
-    return False
+        return "buffered_geometry"
+    return None
 
 
 def get_excluded_stands(stands_qs, datalayer: DataLayer):

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -14,7 +14,7 @@ from datasets.models import DataLayerType, GeometryType
 from datasets.tasks import datalayer_uploaded
 from datasets.tests.factories import DataLayerFactory
 from django.conf import settings
-from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 from django.db import connection
 from django.test import TestCase, override_settings
 from fiona.crs import to_string
@@ -35,6 +35,7 @@ from planning.services import (
     calculate_and_update_scenario_result,
     create_planning_area,
     create_scenario,
+    create_scenario_from_upload,
     export_planning_area_to_geopackage,
     export_scenario_inputs_to_geopackage,
     export_scenario_stand_outputs_to_geopackage,
@@ -50,6 +51,7 @@ from planning.services import (
     get_max_treatable_stand_count,
     get_schema,
     get_sub_units_details,
+    planning_area_covering_source,
     planning_area_covers,
     sanitize_shp_field_name,
     trigger_scenario_run,
@@ -834,6 +836,82 @@ class TestPlanningAreaCovers(TestCase):
                 stand_size=StandSizeChoices.LARGE,
             )
         )
+
+    def test_covering_source_identifies_buffered_geometry_fallback(self):
+        outside_geometry = GEOSGeometry(
+            "POLYGON ((-121.2 40.3, -120.6 40.4, -120.0 40.0, -120.0 41.2, -120.4 41.1, -121.0 40.6, -121.2 40.3))",
+            srid=4269,
+        )
+        stands_geometry = mock.Mock()
+        stands_geometry.covers.side_effect = [False, True]
+        stands_qs = mock.Mock()
+        stands_qs.aggregate.return_value = {"geometry": stands_geometry}
+
+        with mock.patch(
+            "planning.services.Stand.objects.within_polygon",
+            return_value=stands_qs,
+        ):
+            source = planning_area_covering_source(
+                self.real_world_planning_area,
+                outside_geometry,
+                stand_size=StandSizeChoices.LARGE,
+            )
+
+        self.assertEqual(source, "buffered_geometry")
+
+
+class CreateScenarioFromUploadTest(TestCase):
+    def test_clips_project_area_geometry_to_planning_area_when_requested(self):
+        user = UserFactory.create()
+        planning_area = PlanningAreaFactory.create(
+            user=user,
+            geometry=MultiPolygon(
+                Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0))),
+                srid=4269,
+            ),
+        )
+        uploaded_geometry = {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [0, 0],
+                    [0, 1],
+                    [2, 1],
+                    [2, 0],
+                    [0, 0],
+                ]
+            ],
+        }
+        stands_qs = mock.Mock()
+        stands_qs.count.return_value = 0
+
+        with mock.patch(
+            "planning.services.Stand.objects.within_polygon",
+            return_value=stands_qs,
+        ):
+            scenario = create_scenario_from_upload(
+                {
+                    "name": "uploaded scenario",
+                    "planning_area": planning_area.pk,
+                    "stand_size": StandSizeChoices.SMALL,
+                    "geometry": {
+                        "type": "FeatureCollection",
+                        "features": [
+                            {
+                                "type": "Feature",
+                                "properties": {},
+                                "geometry": uploaded_geometry,
+                            }
+                        ],
+                    },
+                    "clip_project_areas_to_planning_area": True,
+                },
+                user=user,
+            )
+
+        project_area = scenario.project_areas.get()
+        self.assertTrue(planning_area.geometry.covers(project_area.geometry))
+        self.assertAlmostEqual(project_area.geometry.area, planning_area.geometry.area)
 
 
 # compare with known turf.js results

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -1055,7 +1055,8 @@ class CreateScenariosFromUpload(APITestCase):
         )
         self.assertEqual(response.status_code, 401)
 
-    def test_create_from_multi_feature_shpjs(self):
+    @mock.patch("planning.serializers.track_event")
+    def test_create_from_multi_feature_shpjs(self, track_event_mock):
         self.client.force_authenticate(self.owner_user)
         payload = {
             "geometry": json.dumps(self.pasadena_pomona),
@@ -1083,7 +1084,16 @@ class CreateScenariosFromUpload(APITestCase):
         for f in result_record.result["features"]:
             self.assertIn("project_id", f["properties"])
 
-    def test_create_uncontained_geometry(self):
+        validation_call = next(
+            call
+            for call in track_event_mock.call_args_list
+            if call.kwargs["name"] == "planning.project_areas_upload.validation"
+        )
+        self.assertEqual(validation_call.kwargs["properties"]["status"], "passed")
+        self.assertIn("stage", validation_call.kwargs["properties"])
+
+    @mock.patch("planning.serializers.track_event")
+    def test_create_uncontained_geometry(self, track_event_mock):
         self.client.force_authenticate(self.owner_user)
         payload = {
             "geometry": json.dumps(self.sandiego),
@@ -1108,6 +1118,19 @@ class CreateScenariosFromUpload(APITestCase):
             },
         }
         self.assertEqual(response.json(), expected_error)
+        track_event_mock.assert_called_once_with(
+            name="planning.project_areas_upload.validation",
+            properties={
+                "stage": "containment",
+                "status": "failed",
+                "planning_area_id": self.planning_area.pk,
+                "stand_size": "LARGE",
+                "scenario_name": "new scenario",
+                "email": self.owner_user.email,
+                "error": "The uploaded geometry is not within the selected planning area.",
+            },
+            user_id=self.owner_user.pk,
+        )
 
     def test_create_with_duplicate_names(self):
         self.client.force_authenticate(self.owner_user)

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -410,7 +410,10 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         from planscape.exceptions import InvalidGeometry
         from rest_framework.exceptions import ValidationError as DRFValidationError
 
-        serializer = UploadedScenarioDataSerializer(data=request.data)
+        serializer = UploadedScenarioDataSerializer(
+            data=request.data,
+            context={"request": request},
+        )
         serializer.is_valid(raise_exception=True)
         try:
             new_scenario = create_scenario_from_upload(


### PR DESCRIPTION
Summary:
- Clip uploaded project areas to planning area geometry when validation passes via the buffered fallback.
- Track project area upload validation stage/pass/fail events in Mixpanel.
- Add focused coverage for clipping and validation stage tracking.

Testing:
- uv run ruff check planning/services.py planning/serializers.py planning/tests/test_services.py planning/tests/test_v2_views.py
- uv run python manage.py check
- uv run pytest planning/tests/test_v2_views.py::CreateScenariosFromUpload::test_create_from_multi_feature_shpjs planning/tests/test_v2_views.py::CreateScenariosFromUpload::test_create_uncontained_geometry planning/tests/test_services.py::TestPlanningAreaCovers::test_covering_source_identifies_buffered_geometry_fallback planning/tests/test_services.py::CreateScenarioFromUploadTest::test_clips_project_area_geometry_to_planning_area_when_requested (blocked locally: configured Postgres host db is not resolvable)