### PR TITLE
Available Stands endpoint constraints filter

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -6,7 +6,7 @@ COPY src/interface/package.json src/interface/package-lock.json ./
 RUN npm ci
 
 COPY src/interface/ ./
-RUN npm run build -- --configuration production --output-path=dist/out
+RUN npm run build -- --configuration docker --output-path=dist/out
 
 FROM nginx:1.27-alpine
 

--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -564,9 +564,10 @@ class DataLayer(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
         return self.styles.all().first()
 
     def has_module(self, module) -> bool:
-        module_enabled = (
-            self.metadata.get("modules", {}).get(module, {}).get("enabled", False)
-        )
+        module_config = self.metadata.get("modules", {}).get(module)
+        if module_config is None:
+            return False
+        module_enabled = module_config.get("enabled", True)
         return module_enabled
 
     def __str__(self) -> str:

--- a/src/planscape/datasets/models.py
+++ b/src/planscape/datasets/models.py
@@ -563,6 +563,12 @@ class DataLayer(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
     def get_assigned_style(self) -> Optional[Style]:
         return self.styles.all().first()
 
+    def has_module(self, module) -> bool:
+        module_enabled = (
+            self.metadata.get("modules", {}).get(module, {}).get("enabled", False)
+        )
+        return module_enabled
+
     def __str__(self) -> str:
         return f"{self.name} [{self.type}]"
 

--- a/src/planscape/datasets/tests/test_models.py
+++ b/src/planscape/datasets/tests/test_models.py
@@ -98,3 +98,29 @@ class DataLayerModelTest(TestCase):
 
         self.assertEqual(DataLayer.objects.all().count(), 3)
         self.assertEqual(DataLayer.dead_or_alive.all().count(), 3)
+
+    def test_has_module_returns_true_when_enabled(self):
+        datalayer = DataLayerFactory.create(
+            metadata={"modules": {"forsys": {"enabled": True}}}
+        )
+
+        self.assertTrue(datalayer.has_module("forsys"))
+
+    def test_has_module_returns_false_when_disabled(self):
+        datalayer = DataLayerFactory.create(
+            metadata={"modules": {"forsys": {"enabled": False}}}
+        )
+
+        self.assertFalse(datalayer.has_module("forsys"))
+
+    def test_has_module_returns_false_when_module_missing(self):
+        datalayer = DataLayerFactory.create(
+            metadata={"modules": {"impacts": {"enabled": True}}}
+        )
+
+        self.assertFalse(datalayer.has_module("forsys"))
+
+    def test_has_module_returns_false_when_modules_missing(self):
+        datalayer = DataLayerFactory.create(metadata={})
+
+        self.assertFalse(datalayer.has_module("forsys"))

--- a/src/planscape/datasets/tests/test_models.py
+++ b/src/planscape/datasets/tests/test_models.py
@@ -106,6 +106,11 @@ class DataLayerModelTest(TestCase):
 
         self.assertTrue(datalayer.has_module("forsys"))
 
+    def test_has_module_returns_true_when_enabled_key_missing(self):
+        datalayer = DataLayerFactory.create(metadata={"modules": {"forsys": {}}})
+
+        self.assertTrue(datalayer.has_module("forsys"))
+
     def test_has_module_returns_false_when_disabled(self):
         datalayer = DataLayerFactory.create(
             metadata={"modules": {"forsys": {"enabled": False}}}

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -44,6 +44,7 @@ from fiona.crs import from_epsg
 from gis.info import get_gdal_env
 from impacts.calculator import truncate_result
 from modules.base import (
+    ForsysModule,
     PrioritizeSubUnitsModule,
     compute_planning_area_capabilities,
     compute_scenario_capabilities,
@@ -1996,6 +1997,11 @@ def get_available_stands(
 
         excluded_ids.extend(list(stand_ids))
 
+    constraints = [
+        constraint
+        for constraint in constraints
+        if constraint.get("datalayer").has_module(ForsysModule.name)
+    ]
     for constraint in constraints:
         stands_queryset = stands.all()
         constrained_stands = get_constrained_stands(

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -42,6 +42,7 @@ from planning.services import (
     export_to_shapefile,
     get_acreage,
     get_available_stand_ids,
+    get_available_stands,
     get_constrained_stands,
     get_excluded_stands,
     get_flatten_geojson,
@@ -1108,6 +1109,44 @@ class TestRemoveExcludes(TestCase):
             stands = self.planning_area.get_stands(StandSizeChoices.LARGE)
             self.assertEquals(17, len(stands))
             self.assertLess(len(stand_ids), len(stands) - 1)
+
+    def test_get_available_stands_applies_forsys_constraint(self):
+        self.datalayer.metadata = {
+            "modules": {"forsys": {"enabled": True, "metric_column": "majority"}}
+        }
+        self.datalayer.save(update_fields=["metadata"])
+
+        result = get_available_stands(
+            self.scenario,
+            stand_size=StandSizeChoices.LARGE,
+            constraints=[
+                {
+                    "datalayer": self.datalayer,
+                    "operator": None,
+                    "value": 1,
+                }
+            ],
+        )
+
+        self.assertEqual(6, len(result["unavailable"]["by_thresholds"]))
+
+    def test_get_available_stands_ignores_non_forsys_constraint(self):
+        self.datalayer.metadata = {"modules": {"forsys": {"enabled": False}}}
+        self.datalayer.save(update_fields=["metadata"])
+
+        result = get_available_stands(
+            self.scenario,
+            stand_size=StandSizeChoices.LARGE,
+            constraints=[
+                {
+                    "datalayer": self.datalayer,
+                    "operator": None,
+                    "value": 1,
+                }
+            ],
+        )
+
+        self.assertEqual(0, len(result["unavailable"]["by_thresholds"]))
 
 
 class ValidateScenarioConfigurationTest(TestCase):


### PR DESCRIPTION
Filtering stands with constraints of Datalayers that has module ForSys enabled.

Others Datalayers doesn't have stand metrics calculated to the entire CONUS.