### PR TITLE
PLAN-3885: workspace invites and member management

### DIFF
--- a/src/planscape/templates/invites/new_workspace_invite_message.html
+++ b/src/planscape/templates/invites/new_workspace_invite_message.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <!--[if gte mso 9]>
+      <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG />
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+      </xml>
+    <![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <!--<![endif]-->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+    rel="stylesheet" />
+  <title></title>
+  <style type="text/css">
+    body {
+      font-family: "Public Sans", Arial, Helvetica, sans-serif;
+      mso-font-alt: "Arial", Helvetica, sans-serif;
+      margin-top: 4%;
+      font-size: 14px;
+      color: black;
+    }
+
+    .message-container {
+      width: 50%;
+      height: 100%;
+      padding: 24px;
+      background: white;
+      border-radius: 4px;
+      overflow: hidden;
+      margin-left: auto;
+      margin-right: auto;
+      border: 1px lightgray solid;
+      color:black;
+    }
+
+    @media screen and(max-width:800px) {
+      body.message-container {
+        width: 70%;
+      }
+    }
+    @media screen and(max-width:500px) {
+      body.message-container {
+        width: 80%;
+      }
+    }
+  </style>
+  <!--[if mso]>
+  <style>
+    table {  border-collapse: collapse;  border-spacing: 0;  margin: 0}
+    tr {  height: 40px;}
+    .ExternalClass {  width: 80%;}
+  </style>
+ <![endif] -->
+
+</head>
+
+<body style="-webkit-text-size-adjust: 100%">
+  <!--[if true]>
+  <table role="presentation" cellpadding="10" cellspacing="0" maxWidth="700" margin="auto" style="border-style:solid;border-color:#aaaaaa;" border="0.5px">
+    <![endif]-->
+  <div class="message-container" style="font-family: 'Public Sans', Arial, Helvetica, sans-serif; width:70%; border: 1px lightgray solid; padding: 20px;">
+
+    <!--[if gte mso 9]>
+   <tr height="30px"><td>
+    <![endif]-->
+    <div style="width: 100%; padding:10px;">
+      <img src="{{ frontend_assets }}/png/Planscape-logo-color-black-green-icon.png"
+        alt="[Planscape]" style="width: 120px; max-width: 100%; display: block" />
+    </div>
+    <!--[if gte mso 9]>
+    </td></tr><tr><td>
+    <![endif]-->
+    <div style="width: 100%; padding: 10px; color: black;">
+      <span style="font-size: 22px; font-weight: 500; line-height: 32px">{{ inviter.get_full_name|default:"Someone" }}</span><span
+        style="font-size: 22px; font-weight: 600"> </span>
+      <span style="font-size: 22px; font-weight: 500">invited you to be {{ role_article }} </span>
+      <span
+      style="font-size: 22px; font-weight: 700">{{ role }}</span>
+       <span style="font-size: 22px; font-weight: 500"> on the workspace </span>
+       <span style="font-size: 22px; font-weight: 400"> “{{ workspace.name }}”</span>
+    </div>
+    <!--[if gte mso 9]>
+    </td></tr><tr><td>
+    <![endif]-->
+    <div style="width: 100%; padding: 10px">
+      <span style="color: #4a4a4a; font-weight: 400; line-height: 22px">Log in to <a href="{{ frontend_url }}">Planscape</a> is required to view the
+        workspace. If you don’t have a Planscape account, please </span><span
+        style="color: #064bba; font-weight: 500; text-decoration: underline"><a href="{{ create_account_link }}">click
+          here</a></span><span style="color: #4a4a4a; font-weight: 400; line-height: 22px">.</span>
+    </div>
+    <!--[if gte mso 9]>
+    </td></tr><tr><td>
+    <![endif]-->
+    <div style="width: 100%; padding: 10px">
+      <span style="color: #4a4a4a; font-weight: 400; line-height: 22px">To find out more about collaboration and roles, click <a href="https://github.com/OurPlanscape/Planscape/wiki/Planscape-User-Guide#collaboration">here</a>.
+    </span></div>
+    {% if message %}
+
+    <div style="border-bottom: 1px #e1e1e1 solid; padding-bottom: 2px"></div>
+    <!--[if gte mso 9]>
+    </td></tr><tr><td>
+    <![endif]-->
+    <div style="width: 100%; padding: 10px">
+      <div style="padding-top: 16px; padding-bottom: 20px">
+        <div style="
+                font-size: 16px;
+                width: 100%;
+                font-weight: 600;
+                line-height: 14px;
+              ">
+          Message
+        </div>
+        <div style="
+                width: 94%;
+                font-weight: 400;
+                line-height: 22px;
+                padding: 12px;
+              ">
+        </div>
+        {{ message }}
+      </div>
+    </div>
+    {% endif %}
+    <!--[if gte mso 9]>
+    </td></tr>
+    <tr valign="middle"><td valign="middle">
+    <![endif]-->
+
+    <div style="width: 100%;">
+      <div style="
+              padding-top: 10px;
+              padding-bottom: 10px;
+              background: #064bba;
+              border-radius: 4px;
+              width: 100%;
+            ">
+        <div style="padding-top: 2px; padding-bottom: 2px; align-items: center">
+          <a href="{{ workspace_link }}">
+            <div style="
+                    color: white;
+                    font-weight: 500;
+                    line-height: 16px;
+                    text-align: center;
+                    text-decoration: none;
+                  ">
+              View workspace
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+  </div>
+  <!--[if true]>
+		</td>
+	</tr>
+</table>
+<![endif]-->
+</body>
+
+</html>

--- a/src/planscape/templates/invites/new_workspace_invite_message.txt
+++ b/src/planscape/templates/invites/new_workspace_invite_message.txt
@@ -1,0 +1,14 @@
+{{ inviter.get_full_name|default:"Someone" }} invited you to be {{ role_article }} {{ role }} on the workspace "{{ workspace.name }}".
+
+Log in to Planscape is required to view the workspace. If you don't have a Planscape account, please click here: {{ create_account_link }}.
+
+To find out more about collaboration and roles, click here:
+https://github.com/OurPlanscape/Planscape/wiki/Planscape-User-Guide#collaboration
+
+{% if message %}
+Message:
+{{ message }}
+{% endif %}
+
+You can view and accept the invite to workspace "{{ workspace.name }}" here:
+{{ workspace_link }}.

--- a/src/planscape/workspaces/admin.py
+++ b/src/planscape/workspaces/admin.py
@@ -22,7 +22,15 @@ class WorkspaceAdmin(admin.ModelAdmin):
 
 @admin.register(UserAccessWorkspace)
 class UserAccessWorkspaceAdmin(admin.ModelAdmin):
-    list_display = ("id", "user", "workspace", "role", "created_at", "updated_at")
+    list_display = (
+        "id",
+        "user",
+        "email",
+        "workspace",
+        "role",
+        "created_at",
+        "updated_at",
+    )
     list_filter = ("role",)
-    search_fields = ("user__email", "workspace__name")
+    search_fields = ("user__email", "email", "workspace__name")
     readonly_fields = ("created_at", "updated_at")

--- a/src/planscape/workspaces/migrations/0004_workspace_invite_fields.py
+++ b/src/planscape/workspaces/migrations/0004_workspace_invite_fields.py
@@ -1,0 +1,67 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workspaces", "0003_workspace_planning_fields"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="useraccessworkspace",
+            name="unique_user_workspace_access",
+        ),
+        migrations.AddField(
+            model_name="useraccessworkspace",
+            name="email",
+            field=models.EmailField(
+                blank=True,
+                help_text="Email the invite was sent to.",
+                max_length=254,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="useraccessworkspace",
+            name="invited_by",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="User that sent the invite, if this row originated from one.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="sent_workspace_invites",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="useraccessworkspace",
+            name="user",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Set once a pending invite is accepted. Null while the invite is pending.",
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="workspace_access",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="useraccessworkspace",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("user__isnull", False)),
+                fields=("user", "workspace"),
+                name="unique_user_workspace_access",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="useraccessworkspace",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("user__isnull", True)),
+                fields=("email", "workspace"),
+                name="unique_email_workspace_invite",
+            ),
+        ),
+    ]

--- a/src/planscape/workspaces/models.py
+++ b/src/planscape/workspaces/models.py
@@ -5,7 +5,12 @@ from django.contrib.gis.db import models
 from django.db.models import Count, Q
 from django_stubs_ext.db.models import TypedModelMeta
 
-from core.models import AliveObjectsManager, CreatedAtMixin, DeletedAtMixin, UpdatedAtMixin
+from core.models import (
+    AliveObjectsManager,
+    CreatedAtMixin,
+    DeletedAtMixin,
+    UpdatedAtMixin,
+)
 from datasets.models import VisibilityOptions
 
 if TYPE_CHECKING:
@@ -119,6 +124,27 @@ class UserAccessWorkspace(CreatedAtMixin, UpdatedAtMixin, models.Model):
         User,
         related_name="workspace_access",
         on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        help_text="Set once a pending invite is accepted. Null while the invite is pending.",
+    )
+
+    # Set on invite creation, kept around for pending rows (user is null) and
+    # for audit purposes once accepted.
+    email = models.EmailField(
+        max_length=254,
+        null=True,
+        blank=True,
+        help_text="Email the invite was sent to.",
+    )
+
+    invited_by = models.ForeignKey(
+        User,
+        related_name="sent_workspace_invites",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        help_text="User that sent the invite, if this row originated from one.",
     )
 
     workspace_id: int
@@ -141,5 +167,11 @@ class UserAccessWorkspace(CreatedAtMixin, UpdatedAtMixin, models.Model):
             models.UniqueConstraint(
                 fields=["user", "workspace"],
                 name="unique_user_workspace_access",
-            )
+                condition=Q(user__isnull=False),
+            ),
+            models.UniqueConstraint(
+                fields=["email", "workspace"],
+                name="unique_email_workspace_invite",
+                condition=Q(user__isnull=True),
+            ),
         ]

--- a/src/planscape/workspaces/permissions.py
+++ b/src/planscape/workspaces/permissions.py
@@ -78,6 +78,30 @@ class WorkspacePermission(CheckPermissionMixin):
     def can_remove(user: AbstractUser, workspace: Workspace) -> bool:
         return get_workspace_role(user, workspace) == WorkspaceRole.OWNER
 
+    @staticmethod
+    def can_manage_members(user: AbstractUser, workspace: Workspace) -> bool:
+        return get_workspace_role(user, workspace) == WorkspaceRole.OWNER
+
 
 class WorkspaceViewPermission(PlanscapePermission):
     permission_set = WorkspacePermission
+
+    def has_object_permission(self, request, view, obj):
+        match view.action:
+            case "invite":
+                return self.permission_set.can_manage_members(request.user, obj)
+            case "accept_invite":
+                # Authorization here is "there's a pending invite matching
+                # your email", which the service layer checks (and 404s on).
+                # The requester doesn't have workspace access yet, so the
+                # usual can_view gate doesn't apply.
+                return True
+            case "manage_user":
+                user_id = view.kwargs.get("user_id")
+                if request.method == "DELETE" and str(request.user.pk) == str(user_id):
+                    # Self-leave; the creator-can't-leave rule is enforced in
+                    # the service layer, not here.
+                    return True
+                return self.permission_set.can_manage_members(request.user, obj)
+            case _:
+                return super().has_object_permission(request, view, obj)

--- a/src/planscape/workspaces/serializers.py
+++ b/src/planscape/workspaces/serializers.py
@@ -187,23 +187,14 @@ class UpdatePlanningWorkspaceSerializer(serializers.ModelSerializer):
         validators = []
 
 
-# Members can be invited/reassigned as COLLABORATOR or VIEWER only. Ownership
-# transfer isn't supported yet, so OWNER is excluded here.
-INVITABLE_ROLE_CHOICES = [
-    (choice, label)
-    for choice, label in WorkspaceRole.choices
-    if choice != WorkspaceRole.OWNER
-]
-
-
 class InviteWorkspaceMemberSerializer(serializers.Serializer):
     email = serializers.EmailField()
-    role = serializers.ChoiceField(choices=INVITABLE_ROLE_CHOICES)
+    role = serializers.ChoiceField(choices=WorkspaceRole.choices)
     message = serializers.CharField(required=False, allow_blank=True, default="")
 
 
 class UpdateWorkspaceMemberSerializer(serializers.Serializer):
-    role = serializers.ChoiceField(choices=INVITABLE_ROLE_CHOICES)
+    role = serializers.ChoiceField(choices=WorkspaceRole.choices)
 
 
 class WorkspaceMemberSerializer(serializers.ModelSerializer):

--- a/src/planscape/workspaces/serializers.py
+++ b/src/planscape/workspaces/serializers.py
@@ -1,7 +1,7 @@
 from datasets.models import Dataset, Style
 from rest_framework import serializers
 
-from workspaces.models import UserAccessWorkspace, Workspace
+from workspaces.models import UserAccessWorkspace, Workspace, WorkspaceRole
 from workspaces.permissions import get_workspace_permissions, get_workspace_role
 
 
@@ -166,9 +166,7 @@ class CreatePlanningWorkspaceSerializer(serializers.ModelSerializer):
 class UpdatePlanningWorkspaceSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         if not attrs.get("name"):
-            raise serializers.ValidationError(
-                {"name": "A workspace name is required."}
-            )
+            raise serializers.ValidationError({"name": "A workspace name is required."})
         instance = self.instance
         if (
             Workspace.objects.filter(
@@ -187,3 +185,55 @@ class UpdatePlanningWorkspaceSerializer(serializers.ModelSerializer):
         model = Workspace
         fields = ("name",)
         validators = []
+
+
+# Members can be invited/reassigned as COLLABORATOR or VIEWER only. Ownership
+# transfer isn't supported yet, so OWNER is excluded here.
+INVITABLE_ROLE_CHOICES = [
+    (choice, label)
+    for choice, label in WorkspaceRole.choices
+    if choice != WorkspaceRole.OWNER
+]
+
+
+class InviteWorkspaceMemberSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    role = serializers.ChoiceField(choices=INVITABLE_ROLE_CHOICES)
+    message = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class UpdateWorkspaceMemberSerializer(serializers.Serializer):
+    role = serializers.ChoiceField(choices=INVITABLE_ROLE_CHOICES)
+
+
+class WorkspaceMemberSerializer(serializers.ModelSerializer):
+    """Planning-facing roster entry: covers both accepted members (user set)
+    and pending invites (user is null, email set)."""
+
+    email = serializers.SerializerMethodField()
+    first_name = serializers.SerializerMethodField()
+    last_name = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+
+    def get_email(self, instance) -> str:
+        return instance.user.email if instance.user_id else instance.email
+
+    def get_first_name(self, instance) -> str:
+        return instance.user.first_name if instance.user_id else ""
+
+    def get_last_name(self, instance) -> str:
+        return instance.user.last_name if instance.user_id else ""
+
+    def get_status(self, instance) -> str:
+        return "ACTIVE" if instance.user_id else "PENDING"
+
+    class Meta:
+        model = UserAccessWorkspace
+        fields = [
+            "user_id",
+            "email",
+            "first_name",
+            "last_name",
+            "role",
+            "status",
+        ]

--- a/src/planscape/workspaces/services.py
+++ b/src/planscape/workspaces/services.py
@@ -5,6 +5,7 @@ from actstream import action
 from django.contrib.auth.models import AbstractUser
 from django.db import transaction
 from planscape.analytics import track_event
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 
 from workspaces.models import (
     UserAccessWorkspace,
@@ -13,6 +14,7 @@ from workspaces.models import (
     WorkspaceRole,
 )
 from workspaces.permissions import WorkspacePermission
+from workspaces.tasks import send_workspace_invitation
 
 logger = logging.getLogger(__name__)
 
@@ -75,3 +77,141 @@ def delete_workspace(
         user_id=user.pk,
     )
     return (True, "deleted")
+
+
+@transaction.atomic()
+def invite_member(
+    inviter: AbstractUser,
+    workspace: Workspace,
+    email: str,
+    role: str,
+    message: str = "",
+) -> UserAccessWorkspace:
+    """Invites a user to a workspace by email. The invite is always created as
+    pending (user=None) - even if the email already belongs to a registered
+    user - and must be accepted via `accept_invite`."""
+    if not WorkspacePermission.can_manage_members(inviter, workspace):
+        raise PermissionDenied(
+            "You do not have permission to invite members to this workspace."
+        )
+
+    email = email.lower()
+    already_member = workspace.user_access.filter(user__email__iexact=email).exists()
+    if already_member:
+        raise ValidationError(
+            {"email": "This user is already a member of the workspace."}
+        )
+
+    access, _created = UserAccessWorkspace.objects.update_or_create(
+        email=email,
+        workspace=workspace,
+        user=None,
+        defaults={"role": role, "invited_by": inviter},
+    )
+
+    send_workspace_invitation.delay(access.pk, message)
+
+    track_event(
+        name="workspace.member.invited",
+        properties={
+            "workspace_id": workspace.pk,
+            "role": role,
+            "invitee_email": email,
+            "email": inviter.email if inviter else None,
+        },
+        user_id=inviter.pk,
+    )
+    return access
+
+
+@transaction.atomic()
+def accept_invite(user: AbstractUser, workspace: Workspace) -> UserAccessWorkspace:
+    """Upserts a pending invite (matched by the requester's email) into an
+    active membership row for the requesting user."""
+    access = UserAccessWorkspace.objects.filter(
+        workspace=workspace,
+        user__isnull=True,
+        email__iexact=user.email,
+    ).first()
+    if not access:
+        raise NotFound("No pending invite found for this user and workspace.")
+
+    access.user = user
+    access.save()
+
+    track_event(
+        name="workspace.member.invite_accepted",
+        properties={"workspace_id": workspace.pk, "email": user.email},
+        user_id=user.pk,
+    )
+    return access
+
+
+def update_member_role(
+    actor: AbstractUser,
+    workspace: Workspace,
+    target_user_id: int,
+    role: str,
+) -> UserAccessWorkspace:
+    if not WorkspacePermission.can_manage_members(actor, workspace):
+        raise PermissionDenied(
+            "You do not have permission to change roles in this workspace."
+        )
+    if workspace.created_by_id and workspace.created_by_id == int(target_user_id):
+        raise ValidationError(
+            {"role": "The workspace creator's role cannot be changed."}
+        )
+
+    access = workspace.user_access.filter(user_id=target_user_id).first()
+    if not access:
+        raise NotFound("This user is not a member of the workspace.")
+
+    access.role = role
+    access.save()
+
+    track_event(
+        name="workspace.member.role_changed",
+        properties={
+            "workspace_id": workspace.pk,
+            "target_user_id": target_user_id,
+            "role": role,
+            "email": actor.email if actor else None,
+        },
+        user_id=actor.pk,
+    )
+    return access
+
+
+def remove_member(
+    actor: AbstractUser,
+    workspace: Workspace,
+    target_user_id: int,
+) -> None:
+    is_self = actor.pk == int(target_user_id)
+
+    if workspace.created_by_id and workspace.created_by_id == int(target_user_id):
+        raise ValidationError(
+            {
+                "user_id": "The workspace creator cannot leave or be removed. "
+                "Delete the workspace instead."
+            }
+        )
+
+    if not is_self and not WorkspacePermission.can_manage_members(actor, workspace):
+        raise PermissionDenied("You do not have permission to remove this member.")
+
+    access = workspace.user_access.filter(user_id=target_user_id).first()
+    if not access:
+        raise NotFound("This user is not a member of the workspace.")
+
+    access.delete()
+
+    track_event(
+        name="workspace.member.left" if is_self else "workspace.member.removed",
+        properties={
+            "workspace_id": workspace.pk,
+            "target_user_id": target_user_id,
+            "email": actor.email if actor else None,
+        },
+        user_id=actor.pk,
+    )

--- a/src/planscape/workspaces/services.py
+++ b/src/planscape/workspaces/services.py
@@ -94,9 +94,6 @@ def invite_member(
         raise PermissionDenied(
             "You do not have permission to invite members to this workspace."
         )
-    if role == WorkspaceRole.OWNER:
-        raise ValidationError({"role": "Members cannot be invited as owner."})
-
     email = email.lower()
     already_member = workspace.user_access.filter(user__email__iexact=email).exists()
     if already_member:
@@ -163,9 +160,6 @@ def update_member_role(
         raise ValidationError(
             {"role": "The workspace creator's role cannot be changed."}
         )
-    if role == WorkspaceRole.OWNER:
-        raise ValidationError({"role": "Members cannot be promoted to owner."})
-
     access = workspace.user_access.filter(user_id=target_user_id).first()
     if not access:
         raise NotFound("This user is not a member of the workspace.")

--- a/src/planscape/workspaces/services.py
+++ b/src/planscape/workspaces/services.py
@@ -94,6 +94,8 @@ def invite_member(
         raise PermissionDenied(
             "You do not have permission to invite members to this workspace."
         )
+    if role == WorkspaceRole.OWNER:
+        raise ValidationError({"role": "Members cannot be invited as owner."})
 
     email = email.lower()
     already_member = workspace.user_access.filter(user__email__iexact=email).exists()
@@ -161,6 +163,8 @@ def update_member_role(
         raise ValidationError(
             {"role": "The workspace creator's role cannot be changed."}
         )
+    if role == WorkspaceRole.OWNER:
+        raise ValidationError({"role": "Members cannot be promoted to owner."})
 
     access = workspace.user_access.filter(user_id=target_user_id).first()
     if not access:

--- a/src/planscape/workspaces/tasks.py
+++ b/src/planscape/workspaces/tasks.py
@@ -1,0 +1,82 @@
+import logging
+import smtplib
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from planscape.celery import app
+from utils.frontend import get_frontend_url
+
+from workspaces.models import UserAccessWorkspace
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(Exception, smtplib.SMTPDataError),
+    retry_backoff=True,
+    retry_jitter=True,
+    retry_kwargs={"max_retries": 3},
+)
+def send_workspace_invitation(
+    self,
+    user_access_workspace_id: int,
+    message: str,
+) -> None:
+    try:
+        access = UserAccessWorkspace.objects.select_related(
+            "workspace", "invited_by"
+        ).get(pk=user_access_workspace_id)
+        workspace = access.workspace
+        role = access.role.lower()
+        role_article = "a"
+        if role == "owner":
+            role_article = "an"
+
+        context = {
+            "inviter": access.invited_by,
+            "role_article": role_article,
+            "role": role,
+            "workspace": workspace,
+            "message": message,
+            "frontend_url": get_frontend_url("home"),
+            "frontend_assets": get_frontend_url("assets"),
+            "workspace_link": get_frontend_url(f"workspaces/{workspace.pk}"),
+            "create_account_link": get_frontend_url(
+                "signup",
+                query_params={"redirect": f"workspaces/{workspace.pk}"},
+            ),
+        }
+
+        inviter_name = (
+            access.invited_by.get_full_name() if access.invited_by else "Someone"
+        )
+        subject = f"[Planscape] {inviter_name} invited you to be {role_article} {role} on '{workspace.name}'"
+
+        txt = render_to_string("invites/new_workspace_invite_message.txt", context)
+        html = render_to_string("invites/new_workspace_invite_message.html", context)
+        send_mail(
+            subject=subject,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[access.email],
+            message=txt,
+            html_message=html,
+        )
+        logger.info("Email sent inviting user to workspace %s", workspace.pk)
+    except UserAccessWorkspace.DoesNotExist:
+        logger.exception(
+            "Can't find UserAccessWorkspace with id %s", user_access_workspace_id
+        )
+    except smtplib.SMTPDataError:
+        if self.request.retries >= self.max_retries:
+            logger.exception("Failed to send email. SMTP server side error.")
+        else:
+            logger.warning("Failed to send email. SMTP server side error. Retrying.")
+        raise
+    except Exception:
+        if self.request.retries >= self.max_retries:
+            logger.exception("Something unexpected happened. Take a look!")
+        else:
+            logger.warning("Something unexpected happened. Retrying.")
+        raise

--- a/src/planscape/workspaces/tests/test_views.py
+++ b/src/planscape/workspaces/tests/test_views.py
@@ -642,6 +642,16 @@ class UpdateWorkspaceMemberTest(APITestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_cannot_promote_a_member_to_owner(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self._patch(self.member.pk, role=WorkspaceRole.OWNER)
+
+        self.assertEqual(response.status_code, 400)
+        access = UserAccessWorkspace.objects.get(
+            workspace=self.workspace, user=self.member
+        )
+        self.assertEqual(access.role, WorkspaceRole.COLLABORATOR)
+
 
 class RemoveWorkspaceMemberTest(APITestCase):
     def setUp(self):

--- a/src/planscape/workspaces/tests/test_views.py
+++ b/src/planscape/workspaces/tests/test_views.py
@@ -1,9 +1,16 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 from planning.tests.factories import PlanningAreaFactory
 from planscape.tests.factories import UserFactory
 from rest_framework.test import APITestCase
 
-from workspaces.models import UserAccessWorkspace, Workspace, WorkspaceKind, WorkspaceRole
+from workspaces.models import (
+    UserAccessWorkspace,
+    Workspace,
+    WorkspaceKind,
+    WorkspaceRole,
+)
 from workspaces.tests.factories import (
     PlanningWorkspaceFactory,
     UserAccessWorkspaceFactory,
@@ -12,6 +19,11 @@ from workspaces.tests.factories import (
 
 LIST_URL = "api:workspaces:workspaces-list"
 DETAIL_URL = "api:workspaces:workspaces-detail"
+INVITE_URL = "api:workspaces:workspaces-invite"
+ACCEPT_INVITE_URL = "api:workspaces:workspaces-accept-invite"
+USERS_URL = "api:workspaces:workspaces-users"
+MANAGE_USER_URL = "api:workspaces:workspaces-manage-user"
+PLANNING_AREAS_URL = "api:workspaces:workspaces-planning-areas"
 
 
 class CreateWorkspaceTest(APITestCase):
@@ -151,9 +163,7 @@ class ListWorkspaceTest(APITestCase):
     def test_list_counts_planning_areas(self):
         workspace = PlanningWorkspaceFactory.create(created_by=self.user)
         PlanningAreaFactory.create_batch(2, user=self.user, workspace=workspace)
-        PlanningAreaFactory.create(
-            user=self.user, workspace=workspace
-        ).delete()
+        PlanningAreaFactory.create(user=self.user, workspace=workspace).delete()
         PlanningAreaFactory.create(user=self.user)
 
         self.client.force_authenticate(user=self.user)
@@ -183,14 +193,18 @@ class RetrieveWorkspaceTest(APITestCase):
 
     def test_retrieve_by_owner_returns_200(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.get(reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}))
+        response = self.client.get(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk})
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["name"], "Falcon")
 
     def test_retrieve_by_stranger_returns_404(self):
         self.client.force_authenticate(user=self.other)
-        response = self.client.get(reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}))
+        response = self.client.get(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk})
+        )
 
         self.assertEqual(response.status_code, 404)
 
@@ -201,7 +215,9 @@ class RetrieveWorkspaceTest(APITestCase):
         )
 
         self.client.force_authenticate(user=self.other)
-        response = self.client.get(reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk}))
+        response = self.client.get(
+            reverse(DETAIL_URL, kwargs={"pk": self.workspace.pk})
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["creator"], self.user.get_full_name())
@@ -290,9 +306,7 @@ class DeleteWorkspaceTest(APITestCase):
 
         self.assertEqual(response.status_code, 204)
         self.assertFalse(Workspace.objects.filter(pk=self.workspace.pk).exists())
-        self.assertTrue(
-            Workspace.dead_or_alive.filter(pk=self.workspace.pk).exists()
-        )
+        self.assertTrue(Workspace.dead_or_alive.filter(pk=self.workspace.pk).exists())
 
     def test_viewer_cannot_delete(self):
         self.client.force_authenticate(user=self.viewer)
@@ -420,3 +434,310 @@ class PlanningAreaWorkspaceTest(APITestCase):
 
         ids = [row["id"] for row in response.json()["results"]]
         self.assertEqual(ids, [loose.pk])
+
+
+class InviteWorkspaceMemberTest(APITestCase):
+    def setUp(self):
+        self.owner = UserFactory.create()
+        self.collaborator = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.owner)
+        UserAccessWorkspaceFactory.create(
+            user=self.collaborator,
+            workspace=self.workspace,
+            role=WorkspaceRole.COLLABORATOR,
+        )
+
+    def _invite(self, **payload):
+        return self.client.post(
+            reverse(INVITE_URL, kwargs={"pk": self.workspace.pk}),
+            data={
+                "email": "invitee@example.com",
+                "role": WorkspaceRole.VIEWER,
+                **payload,
+            },
+            format="json",
+        )
+
+    def test_invite_requires_authentication(self):
+        response = self._invite()
+        self.assertIn(response.status_code, (401, 403))
+
+    @patch("workspaces.services.send_workspace_invitation.delay")
+    def test_owner_can_invite(self, send_invitation):
+        self.client.force_authenticate(user=self.owner)
+        response = self._invite()
+
+        self.assertEqual(response.status_code, 201, response.json())
+        access = UserAccessWorkspace.objects.get(
+            workspace=self.workspace, email="invitee@example.com"
+        )
+        self.assertIsNone(access.user)
+        self.assertEqual(access.role, WorkspaceRole.VIEWER)
+        self.assertEqual(access.invited_by, self.owner)
+        send_invitation.assert_called_once()
+
+    @patch("workspaces.services.send_workspace_invitation.delay")
+    def test_collaborator_cannot_invite(self, send_invitation):
+        self.client.force_authenticate(user=self.collaborator)
+        response = self._invite()
+
+        self.assertEqual(response.status_code, 403)
+        send_invitation.assert_not_called()
+
+    @patch("workspaces.services.send_workspace_invitation.delay")
+    def test_inviting_an_existing_member_returns_400(self, send_invitation):
+        self.client.force_authenticate(user=self.owner)
+        response = self._invite(email=self.collaborator.email)
+
+        self.assertEqual(response.status_code, 400)
+        send_invitation.assert_not_called()
+
+    @patch("workspaces.services.send_workspace_invitation.delay")
+    def test_re_inviting_updates_the_pending_role(self, send_invitation):
+        self.client.force_authenticate(user=self.owner)
+        self._invite(role=WorkspaceRole.VIEWER)
+        response = self._invite(role=WorkspaceRole.COLLABORATOR)
+
+        self.assertEqual(response.status_code, 201, response.json())
+        self.assertEqual(
+            UserAccessWorkspace.objects.filter(
+                workspace=self.workspace, email="invitee@example.com"
+            ).count(),
+            1,
+        )
+        access = UserAccessWorkspace.objects.get(
+            workspace=self.workspace, email="invitee@example.com"
+        )
+        self.assertEqual(access.role, WorkspaceRole.COLLABORATOR)
+
+    def test_inviting_as_owner_role_is_rejected(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self._invite(role=WorkspaceRole.OWNER)
+
+        self.assertEqual(response.status_code, 400)
+
+
+class AcceptWorkspaceInviteTest(APITestCase):
+    def setUp(self):
+        self.owner = UserFactory.create()
+        self.invitee = UserFactory.create(email="invitee@example.com")
+        self.stranger = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.owner)
+        self.pending = UserAccessWorkspace.objects.create(
+            workspace=self.workspace,
+            email="invitee@example.com",
+            role=WorkspaceRole.VIEWER,
+            invited_by=self.owner,
+        )
+
+    def _accept(self):
+        return self.client.post(
+            reverse(ACCEPT_INVITE_URL, kwargs={"pk": self.workspace.pk})
+        )
+
+    def test_accept_requires_authentication(self):
+        response = self._accept()
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_invitee_can_accept(self):
+        self.client.force_authenticate(user=self.invitee)
+        response = self._accept()
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.pending.refresh_from_db()
+        self.assertEqual(self.pending.user, self.invitee)
+        self.assertEqual(response.json()["status"], "ACTIVE")
+
+    def test_non_invited_user_gets_404(self):
+        self.client.force_authenticate(user=self.stranger)
+        response = self._accept()
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_accepting_twice_returns_404_the_second_time(self):
+        self.client.force_authenticate(user=self.invitee)
+        self._accept()
+        response = self._accept()
+
+        self.assertEqual(response.status_code, 404)
+
+
+class ListWorkspaceUsersTest(APITestCase):
+    def setUp(self):
+        self.owner = UserFactory.create()
+        self.viewer = UserFactory.create()
+        self.stranger = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.owner)
+        UserAccessWorkspaceFactory.create(
+            user=self.viewer, workspace=self.workspace, role=WorkspaceRole.VIEWER
+        )
+        UserAccessWorkspace.objects.create(
+            workspace=self.workspace,
+            email="pending@example.com",
+            role=WorkspaceRole.VIEWER,
+            invited_by=self.owner,
+        )
+
+    def test_member_can_list_users(self):
+        self.client.force_authenticate(user=self.viewer)
+        response = self.client.get(reverse(USERS_URL, kwargs={"pk": self.workspace.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        rows = {row["email"]: row["status"] for row in response.json()}
+        self.assertEqual(
+            rows,
+            {
+                self.owner.email: "ACTIVE",
+                self.viewer.email: "ACTIVE",
+                "pending@example.com": "PENDING",
+            },
+        )
+
+    def test_stranger_gets_404(self):
+        self.client.force_authenticate(user=self.stranger)
+        response = self.client.get(reverse(USERS_URL, kwargs={"pk": self.workspace.pk}))
+
+        self.assertEqual(response.status_code, 404)
+
+
+class UpdateWorkspaceMemberTest(APITestCase):
+    def setUp(self):
+        self.owner = UserFactory.create()
+        self.member = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.owner)
+        UserAccessWorkspaceFactory.create(
+            user=self.member,
+            workspace=self.workspace,
+            role=WorkspaceRole.COLLABORATOR,
+        )
+
+    def _patch(self, user_id, **payload):
+        return self.client.patch(
+            reverse(
+                MANAGE_USER_URL, kwargs={"pk": self.workspace.pk, "user_id": user_id}
+            ),
+            data={"role": WorkspaceRole.VIEWER, **payload},
+            format="json",
+        )
+
+    def test_owner_can_change_a_members_role(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self._patch(self.member.pk)
+
+        self.assertEqual(response.status_code, 200, response.json())
+        access = UserAccessWorkspace.objects.get(
+            workspace=self.workspace, user=self.member
+        )
+        self.assertEqual(access.role, WorkspaceRole.VIEWER)
+
+    def test_non_owner_cannot_change_roles(self):
+        self.client.force_authenticate(user=self.member)
+        response = self._patch(self.owner.pk)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_cannot_change_the_creators_role(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self._patch(self.owner.pk)
+
+        self.assertEqual(response.status_code, 400)
+
+
+class RemoveWorkspaceMemberTest(APITestCase):
+    def setUp(self):
+        self.owner = UserFactory.create()
+        self.member = UserFactory.create()
+        self.other_member = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.owner)
+        UserAccessWorkspaceFactory.create(
+            user=self.member,
+            workspace=self.workspace,
+            role=WorkspaceRole.COLLABORATOR,
+        )
+        UserAccessWorkspaceFactory.create(
+            user=self.other_member,
+            workspace=self.workspace,
+            role=WorkspaceRole.VIEWER,
+        )
+
+    def _delete(self, user_id):
+        return self.client.delete(
+            reverse(
+                MANAGE_USER_URL, kwargs={"pk": self.workspace.pk, "user_id": user_id}
+            )
+        )
+
+    def test_owner_can_remove_a_member(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self._delete(self.member.pk)
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(
+            UserAccessWorkspace.objects.filter(
+                workspace=self.workspace, user=self.member
+            ).exists()
+        )
+
+    def test_member_cannot_remove_another_member(self):
+        self.client.force_authenticate(user=self.member)
+        response = self._delete(self.other_member.pk)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_member_can_leave(self):
+        self.client.force_authenticate(user=self.member)
+        response = self._delete(self.member.pk)
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(
+            UserAccessWorkspace.objects.filter(
+                workspace=self.workspace, user=self.member
+            ).exists()
+        )
+
+    def test_creator_cannot_leave(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self._delete(self.owner.pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(
+            UserAccessWorkspace.objects.filter(
+                workspace=self.workspace, user=self.owner
+            ).exists()
+        )
+
+
+class WorkspacePlanningAreasListTest(APITestCase):
+    def setUp(self):
+        self.owner = UserFactory.create()
+        self.viewer = UserFactory.create()
+        self.stranger = UserFactory.create()
+        self.workspace = PlanningWorkspaceFactory.create(created_by=self.owner)
+        UserAccessWorkspaceFactory.create(
+            user=self.viewer, workspace=self.workspace, role=WorkspaceRole.VIEWER
+        )
+        # Created by the owner, not the viewer - proves this endpoint gates on
+        # workspace role rather than per-planning-area collaboration.
+        self.inside = PlanningAreaFactory.create(
+            user=self.owner, workspace=self.workspace
+        )
+        PlanningAreaFactory.create(user=self.owner, workspace=self.workspace).delete()
+        PlanningAreaFactory.create(user=self.owner, workspace=None)
+
+    def test_member_sees_all_workspace_planning_areas(self):
+        self.client.force_authenticate(user=self.viewer)
+        response = self.client.get(
+            reverse(PLANNING_AREAS_URL, kwargs={"pk": self.workspace.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        ids = [row["id"] for row in response.json()]
+        self.assertEqual(ids, [self.inside.pk])
+
+    def test_stranger_gets_404(self):
+        self.client.force_authenticate(user=self.stranger)
+        response = self.client.get(
+            reverse(PLANNING_AREAS_URL, kwargs={"pk": self.workspace.pk})
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/src/planscape/workspaces/tests/test_views.py
+++ b/src/planscape/workspaces/tests/test_views.py
@@ -510,11 +510,16 @@ class InviteWorkspaceMemberTest(APITestCase):
         )
         self.assertEqual(access.role, WorkspaceRole.COLLABORATOR)
 
-    def test_inviting_as_owner_role_is_rejected(self):
+    @patch("workspaces.services.send_workspace_invitation.delay")
+    def test_owner_can_invite_as_owner(self, send_invitation):
         self.client.force_authenticate(user=self.owner)
         response = self._invite(role=WorkspaceRole.OWNER)
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 201, response.json())
+        access = UserAccessWorkspace.objects.get(
+            workspace=self.workspace, email="invitee@example.com"
+        )
+        self.assertEqual(access.role, WorkspaceRole.OWNER)
 
 
 class AcceptWorkspaceInviteTest(APITestCase):
@@ -642,15 +647,15 @@ class UpdateWorkspaceMemberTest(APITestCase):
 
         self.assertEqual(response.status_code, 400)
 
-    def test_cannot_promote_a_member_to_owner(self):
+    def test_owner_can_promote_a_member_to_owner(self):
         self.client.force_authenticate(user=self.owner)
         response = self._patch(self.member.pk, role=WorkspaceRole.OWNER)
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200, response.json())
         access = UserAccessWorkspace.objects.get(
             workspace=self.workspace, user=self.member
         )
-        self.assertEqual(access.role, WorkspaceRole.COLLABORATOR)
+        self.assertEqual(access.role, WorkspaceRole.OWNER)
 
 
 class RemoveWorkspaceMemberTest(APITestCase):

--- a/src/planscape/workspaces/views.py
+++ b/src/planscape/workspaces/views.py
@@ -1,20 +1,33 @@
 from core.serializers import MultiSerializerMixin
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema, extend_schema_view
+from planning.serializers import ListPlanningAreaSerializer
 from planscape.filters import TrackedFilterBackend
 from planscape.serializers import BaseErrorMessageSerializer
 from rest_framework import pagination, status, viewsets
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
 from workspaces.filters import PlanningWorkspaceFilterSet
-from workspaces.models import Workspace
+from workspaces.models import Workspace, WorkspaceKind
 from workspaces.permissions import WorkspaceViewPermission
 from workspaces.serializers import (
     CreatePlanningWorkspaceSerializer,
+    InviteWorkspaceMemberSerializer,
     ListWorkspaceSerializer,
     UpdatePlanningWorkspaceSerializer,
+    UpdateWorkspaceMemberSerializer,
+    WorkspaceMemberSerializer,
 )
-from workspaces.services import create_workspace, delete_workspace
+from workspaces.services import (
+    accept_invite,
+    create_workspace,
+    delete_workspace,
+    invite_member,
+    remove_member,
+    update_member_role,
+)
 
 
 @extend_schema_view(
@@ -97,4 +110,98 @@ class WorkspaceViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
         delete_workspace(
             user=self.request.user,
             workspace=instance,
+        )
+
+    @extend_schema(
+        description="Invite a user to this Workspace by email.",
+        request=InviteWorkspaceMemberSerializer,
+        responses={201: WorkspaceMemberSerializer},
+    )
+    @action(detail=True, methods=["post"], url_path="invite")
+    def invite(self, request, pk=None):
+        workspace = self.get_object()
+        serializer = InviteWorkspaceMemberSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        access = invite_member(
+            inviter=request.user,
+            workspace=workspace,
+            email=serializer.validated_data["email"],
+            role=serializer.validated_data["role"],
+            message=serializer.validated_data.get("message", ""),
+        )
+        return Response(
+            WorkspaceMemberSerializer(access).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @extend_schema(
+        description="Accept a pending invite to this Workspace.",
+        request=None,
+        responses={200: WorkspaceMemberSerializer},
+    )
+    @action(detail=True, methods=["post"], url_path="invite/accept")
+    def accept_invite(self, request, pk=None):
+        # Deliberately not self.get_object(): the requester doesn't have
+        # workspace access yet (that's exactly what accepting grants them),
+        # so the standard access-scoped queryset would 404 them out.
+        workspace = get_object_or_404(
+            Workspace.objects.filter(kind=WorkspaceKind.PLANNING),
+            pk=pk,
+        )
+        access = accept_invite(user=request.user, workspace=workspace)
+        return Response(WorkspaceMemberSerializer(access).data)
+
+    @extend_schema(
+        description="List members of, and pending invites to, this Workspace.",
+        responses=WorkspaceMemberSerializer(many=True),
+    )
+    @action(detail=True, methods=["get"], url_path="users")
+    def users(self, request, pk=None):
+        workspace = self.get_object()
+        qs = workspace.user_access.select_related("user").all()
+        return Response(WorkspaceMemberSerializer(qs, many=True).data)
+
+    @extend_schema(
+        description="Change a member's role (PATCH), or remove/leave the "
+        "Workspace (DELETE).",
+        request=UpdateWorkspaceMemberSerializer,
+        responses={200: WorkspaceMemberSerializer, 204: None},
+    )
+    @action(
+        detail=True,
+        methods=["patch", "delete"],
+        url_path=r"users/(?P<user_id>\d+)",
+    )
+    def manage_user(self, request, pk=None, user_id=None):
+        workspace = self.get_object()
+
+        if request.method == "DELETE":
+            remove_member(
+                actor=request.user,
+                workspace=workspace,
+                target_user_id=int(user_id),
+            )
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        serializer = UpdateWorkspaceMemberSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        access = update_member_role(
+            actor=request.user,
+            workspace=workspace,
+            target_user_id=int(user_id),
+            role=serializer.validated_data["role"],
+        )
+        return Response(WorkspaceMemberSerializer(access).data)
+
+    @extend_schema(
+        description="List Planning Areas that belong to this Workspace.",
+        responses=ListPlanningAreaSerializer(many=True),
+    )
+    @action(detail=True, methods=["get"], url_path="planning-areas")
+    def planning_areas(self, request, pk=None):
+        workspace = self.get_object()
+        qs = workspace.planning_areas.filter(deleted_at=None)
+        return Response(
+            ListPlanningAreaSerializer(qs, many=True, context={"request": request}).data
         )


### PR DESCRIPTION
Backend work for PLAN-3885.

- Invite users to a workspace by email, accept invite (PLAN-3898, PLAN-3904)
- List/update/remove workspace users (PLAN-3899, PLAN-3900, PLAN-3901, PLAN-3902)
- Role-gated permission class for workspace actions (PLAN-3896)
- List planning areas in a workspace (PLAN-3907)

PLAN-3889, PLAN-3903, PLAN-3905 confirmed already done, no changes needed.
PLAN-3888 left alone, handled by the workspace-migration branch.

Tests: workspaces suite 68 -> 89 passing. Also ran planning and collaboration suites, no regressions.