### PR TITLE
Fix project area upload validation rejecting valid uploads

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -37,7 +37,6 @@ from planning.services import (
     calculate_scenario_treatable_area,
     get_acreage,
     get_min_project_area,
-    planning_area_covering_source,
     union_geojson,
 )
 
@@ -1473,7 +1472,6 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
     geometry = serializers.JSONField(required=True)
 
     def validate(self, attrs):
-        geometry = attrs.get("geometry")
         planning_area_id = attrs.get("planning_area")
         stand_size = attrs.get("stand_size")
         name = attrs.get("name")
@@ -1498,37 +1496,25 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
                 {"name": "A scenario with this name already exists."}
             )
 
-        covering_source = self._get_planning_area_covering_source(
-            geometry,
-            planning_area_id,
-            stand_size,
-        )
-        if not covering_source:
+        if not PlanningArea.objects.filter(pk=planning_area_id).exists():
             self._track_upload_validation(
-                stage="containment",
+                stage="planning_area_lookup",
                 status="failed",
                 planning_area_id=planning_area_id,
                 stand_size=stand_size,
-                error="The uploaded geometry is not within the selected planning area.",
+                error="Planning area does not exist.",
             )
-            raise serializers.ValidationError(
-                {
-                    "global": [
-                        "The uploaded geometry is not within the selected planning area."
-                    ]
-                }
-            )
-        attrs["clip_project_areas_to_planning_area"] = (
-            covering_source == "buffered_geometry"
-        )
+            raise serializers.ValidationError("Planning area does not exist.")
+
+        # Containment is no longer validated here: project areas are always
+        # clipped to the planning area's geometry (see
+        # planning.services.feature_to_project_area), and
+        # create_scenario_from_upload raises if that leaves nothing behind.
         self._track_upload_validation(
-            stage=covering_source,
+            stage="upload",
             status="passed",
             planning_area_id=planning_area_id,
             stand_size=stand_size,
-            clip_project_areas_to_planning_area=attrs[
-                "clip_project_areas_to_planning_area"
-            ],
         )
         return attrs
 
@@ -1573,38 +1559,6 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
             raise serializers.ValidationError(geojson_serializer.errors)
         return geojson_serializer.validated_data
 
-    def _get_planning_area_covering_source(
-        self, geometry, planning_area_id, stand_size
-    ) -> str | None:
-        try:
-            uploaded_geos = union_geojson(geometry)
-        except ValueError as e:
-            self._track_upload_validation(
-                stage="polygon_union",
-                status="failed",
-                planning_area_id=planning_area_id,
-                stand_size=stand_size,
-                error=str(e),
-            )
-            raise serializers.ValidationError({"global": [str(e)]})
-        try:
-            planning_area = PlanningArea.objects.get(pk=planning_area_id)
-        except PlanningArea.DoesNotExist:
-            self._track_upload_validation(
-                stage="planning_area_lookup",
-                status="failed",
-                planning_area_id=planning_area_id,
-                stand_size=stand_size,
-                error="Planning area does not exist.",
-            )
-            raise serializers.ValidationError("Planning area does not exist.")
-
-        return planning_area_covering_source(
-            planning_area=planning_area,
-            geometry=uploaded_geos,
-            stand_size=stand_size or StandSizeChoices.SMALL,
-        )
-
     def _track_upload_validation(
         self,
         stage: str,
@@ -1612,7 +1566,6 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
         planning_area_id: int | None = None,
         stand_size: str | None = None,
         error=None,
-        clip_project_areas_to_planning_area: bool | None = None,
     ) -> None:
         request = self.context.get("request")
         user = getattr(request, "user", None)
@@ -1627,10 +1580,6 @@ class UploadedScenarioDataSerializer(serializers.Serializer):
         }
         if error:
             properties["error"] = str(error)
-        if clip_project_areas_to_planning_area is not None:
-            properties["clip_project_areas_to_planning_area"] = (
-                clip_project_areas_to_planning_area
-            )
 
         track_event(
             name="planning.project_areas_upload.validation",

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -400,8 +400,11 @@ def feature_to_project_area(
     scenario: Scenario,
     geometry_dict: dict[str, Any],
     idx: int = 1,
-    clip_to_planning_area: bool = False,
 ):
+    """Creates a ProjectArea from an uploaded geometry. The stored geometry is
+    always the intersection with the Scenario's Planning Area - returns None
+    (no ProjectArea is created) if the uploaded shape doesn't overlap the
+    planning area at all."""
     user = scenario.user
     stand_size = scenario.get_stand_size()
     try:
@@ -409,10 +412,12 @@ def feature_to_project_area(
         logger.info("creating project area %s %s", area_name, geometry_dict)
         _bbox = geometry_dict.pop("bbox", None)
         geometry = coerce_geometry(geometry_dict)
-        if clip_to_planning_area:
-            geometry = to_multipolygon(
-                fix_geometry(geometry.intersection(scenario.planning_area.geometry))
-            )
+
+        geometry = geometry.intersection(scenario.planning_area.geometry)
+        if geometry.empty:
+            logger.info("%s does not overlap the planning area, skipping", area_name)
+            return None
+        geometry = to_multipolygon(fix_geometry(geometry))
 
         stand_count = Stand.objects.within_polygon(
             geometry,
@@ -448,7 +453,6 @@ def feature_to_project_area(
 def create_scenario_from_upload(validated_data, user) -> Scenario:
     planning_area = PlanningArea.objects.get(pk=validated_data["planning_area"])
     feature_collection = validated_data["geometry"]
-    clip_to_planning_area = validated_data.get("clip_project_areas_to_planning_area")
 
     if planning_area.map_status == PlanningAreaMapStatus.OVERSIZE:
         raise ValueError(
@@ -481,17 +485,22 @@ def create_scenario_from_upload(validated_data, user) -> Scenario:
             target=scenario.planning_area,
         )
     )
-    project_areas = list(
-        map(
-            lambda i: feature_to_project_area(
+    project_areas = [
+        project_area
+        for project_area in (
+            feature_to_project_area(
                 scenario=scenario,
-                idx=i[0],
-                geometry_dict=i[1].get("geometry", {}),
-                clip_to_planning_area=clip_to_planning_area,
-            ),
-            enumerate(feature_collection.get("features"), 1),
+                idx=idx,
+                geometry_dict=feature.get("geometry", {}),
+            )
+            for idx, feature in enumerate(feature_collection.get("features"), 1)
         )
-    )
+        if project_area is not None
+    ]
+    if not project_areas:
+        raise ValueError(
+            "None of the uploaded project areas overlap the selected planning area."
+        )
     result = {
         "type": "FeatureCollection",
         "features": [
@@ -1869,63 +1878,6 @@ def toggle_scenario_status(scenario: Scenario, user: User) -> Scenario:
     return scenario
 
 
-def planning_area_covers(
-    planning_area: PlanningArea,
-    geometry: GEOSGeometry,
-    stand_size: StandSizeChoices,
-    buffer_size: float = -1.0,
-) -> bool:
-    return bool(
-        planning_area_covering_source(
-            planning_area=planning_area,
-            geometry=geometry,
-            stand_size=stand_size,
-            buffer_size=buffer_size,
-        )
-    )
-
-
-def planning_area_covering_source(
-    planning_area: PlanningArea,
-    geometry: GEOSGeometry,
-    stand_size: StandSizeChoices,
-    buffer_size: float = -1.0,
-) -> str | None:
-    """Specialized version of `covers` predicate for Planning Area.
-    This is necessary because some times our users want to upload
-    project areas that are slightly off the planning area. So this
-    function first considers the Planning Area itself, then all the
-    stands that make up the planning area and lastly it considers
-    a buffered version of the test geometry (negative means smaller).
-    """
-    if planning_area.geometry.covers(geometry):
-        logger.info("Planning Area covers geometry using DE9IM matrix.")
-        return "planning_area"
-
-    all_stands = Stand.objects.within_polygon(
-        planning_area.geometry,
-        stand_size,
-    ).aggregate(geometry=UnionOp("geometry"))["geometry"]
-
-    if all_stands is None:
-        return None
-
-    if all_stands.covers(geometry):
-        logger.info("Planning Area covers geometry using stands DE9IM matrix.")
-        return "stands"
-
-    # units here are in meters
-    test_geometry = geometry.transform(settings.AREA_SRID, clone=True)
-    test_geometry = test_geometry.buffer(buffer_size).transform(4269, clone=True)
-
-    if all_stands.covers(test_geometry):
-        logger.info(
-            "Planning Area covers geometry using a buffered version of test geometry."
-        )
-        return "buffered_geometry"
-    return None
-
-
 def get_excluded_stands(stands_qs, datalayer: DataLayer):
     return stands_qs.filter(
         metrics__datalayer_id=datalayer.pk, metrics__majority=1
@@ -2249,7 +2201,6 @@ def get_sub_units_details(
     fixed_target: bool | None = None,
     target_value: float | None = None,
 ) -> dict[str, float | None] | None:
-
     if is_project_areas_child(scenario):
         areas = get_project_areas_child_areas(
             scenario=scenario,

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from unittest import mock
 
 import fiona
-import shapely
 from cacheops import invalidate_all
 from datasets.dynamic_models import qualify_for_django
 from datasets.models import DataLayerType, GeometryType
@@ -51,8 +50,6 @@ from planning.services import (
     get_max_treatable_stand_count,
     get_schema,
     get_sub_units_details,
-    planning_area_covering_source,
-    planning_area_covers,
     sanitize_shp_field_name,
     trigger_scenario_run,
     validate_scenario_configuration,
@@ -795,81 +792,42 @@ class TestExportToGeopackage(TestCase):
         shutil.rmtree("/tmp/planscape-test-output", ignore_errors=True)
 
 
-class TestPlanningAreaCovers(TestCase):
-    def setUp(self):
-        self.real_world_geom = "MULTIPOLYGON (((-120.592804 40.388397, -120.653229 40.089629, -121.098175 40.043386, -121.308289 40.179923, -121.059723 40.687928, -120.433502 41.088667, -120.013275 41.096947, -120.009155 40.701464, -120.010529 39.949753, -120.592804 40.388397)))"
-        self.real_world_planning_area = PlanningAreaFactory.create(
-            geometry=GEOSGeometry(self.real_world_geom, srid=4269)
-        )
-        self.covers_de9im = GEOSGeometry(
-            "POLYGON ((-121.13497533859726 40.378055548860004, -120.5974285753569 40.45918503498109, -120.0351560371661 40.02304123541387, -120.0295412055665 41.05622374781322, -120.40813814721828 41.0493352414621, -120.99739165146956 40.63587551109521, -121.13497533859726 40.378055548860004))",
-            srid=4269,
-        )
-        # in this is not necessary to create the stands, they are present by the usage of a migration
-        # that autoloads the LARGE stands.
-
-    def test_real_world(self):
-        with fiona.open(
-            "planning/tests/test_data/project_areas_for_pa_covers.shp"
-        ) as shapefile:
-            features = [f for f in shapefile]
-            # this convoluted conversion step is because Django automatically
-            # considers geometries coming FROM geojson to be 4326
-            geometries = [shapely.geometry.shape(f.geometry) for f in features]
-            geometries = MultiPolygon(
-                [GEOSGeometry(g.wkt, srid=4269) for g in geometries], srid=4269
-            )
-            test_geometry = geometries.unary_union
-        self.assertTrue(
-            planning_area_covers(
-                self.real_world_planning_area,
-                test_geometry,
-                stand_size=StandSizeChoices.LARGE,
-            )
-        )
-
-    def test_de9im_covers(self):
-        self.assertTrue(
-            planning_area_covers(
-                self.real_world_planning_area,
-                self.covers_de9im,
-                stand_size=StandSizeChoices.LARGE,
-            )
-        )
-
-    def test_covering_source_identifies_buffered_geometry_fallback(self):
-        outside_geometry = GEOSGeometry(
-            "POLYGON ((-121.2 40.3, -120.6 40.4, -120.0 40.0, -120.0 41.2, -120.4 41.1, -121.0 40.6, -121.2 40.3))",
-            srid=4269,
-        )
-        stands_geometry = mock.Mock()
-        stands_geometry.covers.side_effect = [False, True]
-        stands_qs = mock.Mock()
-        stands_qs.aggregate.return_value = {"geometry": stands_geometry}
-
-        with mock.patch(
-            "planning.services.Stand.objects.within_polygon",
-            return_value=stands_qs,
-        ):
-            source = planning_area_covering_source(
-                self.real_world_planning_area,
-                outside_geometry,
-                stand_size=StandSizeChoices.LARGE,
-            )
-
-        self.assertEqual(source, "buffered_geometry")
-
-
 class CreateScenarioFromUploadTest(TestCase):
-    def test_clips_project_area_geometry_to_planning_area_when_requested(self):
-        user = UserFactory.create()
-        planning_area = PlanningAreaFactory.create(
-            user=user,
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.planning_area = PlanningAreaFactory.create(
+            user=self.user,
             geometry=MultiPolygon(
                 Polygon(((0, 0), (0, 1), (1, 1), (1, 0), (0, 0))),
                 srid=4269,
             ),
         )
+        stands_qs = mock.Mock()
+        stands_qs.count.return_value = 0
+        self.stands_patcher = mock.patch(
+            "planning.services.Stand.objects.within_polygon",
+            return_value=stands_qs,
+        )
+        self.stands_patcher.start()
+        self.addCleanup(self.stands_patcher.stop)
+
+    def _upload(self, geometry, name="uploaded scenario"):
+        return create_scenario_from_upload(
+            {
+                "name": name,
+                "planning_area": self.planning_area.pk,
+                "stand_size": StandSizeChoices.SMALL,
+                "geometry": {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {"type": "Feature", "properties": {}, "geometry": geometry}
+                    ],
+                },
+            },
+            user=self.user,
+        )
+
+    def test_clips_project_area_geometry_to_planning_area(self):
         uploaded_geometry = {
             "type": "Polygon",
             "coordinates": [
@@ -882,36 +840,32 @@ class CreateScenarioFromUploadTest(TestCase):
                 ]
             ],
         }
-        stands_qs = mock.Mock()
-        stands_qs.count.return_value = 0
-
-        with mock.patch(
-            "planning.services.Stand.objects.within_polygon",
-            return_value=stands_qs,
-        ):
-            scenario = create_scenario_from_upload(
-                {
-                    "name": "uploaded scenario",
-                    "planning_area": planning_area.pk,
-                    "stand_size": StandSizeChoices.SMALL,
-                    "geometry": {
-                        "type": "FeatureCollection",
-                        "features": [
-                            {
-                                "type": "Feature",
-                                "properties": {},
-                                "geometry": uploaded_geometry,
-                            }
-                        ],
-                    },
-                    "clip_project_areas_to_planning_area": True,
-                },
-                user=user,
-            )
+        scenario = self._upload(uploaded_geometry)
 
         project_area = scenario.project_areas.get()
-        self.assertTrue(planning_area.geometry.covers(project_area.geometry))
-        self.assertAlmostEqual(project_area.geometry.area, planning_area.geometry.area)
+        self.assertTrue(self.planning_area.geometry.covers(project_area.geometry))
+        self.assertAlmostEqual(
+            project_area.geometry.area, self.planning_area.geometry.area
+        )
+
+    def test_raises_when_no_project_area_overlaps_the_planning_area(self):
+        outside_geometry = {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [10, 10],
+                    [10, 11],
+                    [11, 11],
+                    [11, 10],
+                    [10, 10],
+                ]
+            ],
+        }
+        with self.assertRaisesMessage(
+            ValueError,
+            "None of the uploaded project areas overlap the selected planning area.",
+        ):
+            self._upload(outside_geometry)
 
 
 # compare with known turf.js results
@@ -1654,7 +1608,6 @@ class SubUnitsDetailsTest(TestCase):
 
     @mock.patch("planning.services.get_sub_units_areas", return_value=None)
     def test_no_areas(self, mock_get_units_area):
-
         details = get_sub_units_details(
             self.scenario, self.scenario.get_stand_size(), self.datalayer
         )

--- a/src/planscape/planning/tests/test_v2_views.py
+++ b/src/planscape/planning/tests/test_v2_views.py
@@ -1092,8 +1092,9 @@ class CreateScenariosFromUpload(APITestCase):
         self.assertEqual(validation_call.kwargs["properties"]["status"], "passed")
         self.assertIn("stage", validation_call.kwargs["properties"])
 
-    @mock.patch("planning.serializers.track_event")
-    def test_create_uncontained_geometry(self, track_event_mock):
+    def test_create_uncontained_geometry(self):
+        # San Diego doesn't overlap the LA-area planning area at all, so
+        # every uploaded project area is clipped down to nothing.
         self.client.force_authenticate(self.owner_user)
         payload = {
             "geometry": json.dumps(self.sandiego),
@@ -1113,24 +1114,11 @@ class CreateScenariosFromUpload(APITestCase):
             "detail": "Validation error.",
             "errors": {
                 "global": [
-                    "The uploaded geometry is not within the selected planning area."
+                    "None of the uploaded project areas overlap the selected planning area."
                 ]
             },
         }
         self.assertEqual(response.json(), expected_error)
-        track_event_mock.assert_called_once_with(
-            name="planning.project_areas_upload.validation",
-            properties={
-                "stage": "containment",
-                "status": "failed",
-                "planning_area_id": self.planning_area.pk,
-                "stand_size": "LARGE",
-                "scenario_name": "new scenario",
-                "email": self.owner_user.email,
-                "error": "The uploaded geometry is not within the selected planning area.",
-            },
-            user_id=self.owner_user.pk,
-        )
 
     def test_create_with_duplicate_names(self):
         self.client.force_authenticate(self.owner_user)


### PR DESCRIPTION
Follow-up to #4289.

Project areas are now always clipped to the intersection with the planning area. Removed the old 3-stage covers check (exact, stands, buffered fallback) - the stands check was unreliable near planning area edges and rejected valid uploads. Now we only error if none of the uploaded project areas overlap the planning area at all.

Verified against a real repro (uploaded shapefiles): previously rejected with a 400, now creates all project areas with zero area outside the planning area.

Tests: planning suite 299/299 passing.