### PR TITLE
PLAN-3859: Missing ngOninit

### DIFF
--- a/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
+++ b/src/interface/src/app/maplibre-map/planning-area-layer/planning-area-layer.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 import {
   FeatureComponent,
   GeoJSONSourceComponent,
@@ -24,7 +30,7 @@ import { MARTIN_SOURCES } from '@treatments/map.sources';
   ],
   templateUrl: './planning-area-layer.component.html',
 })
-export class PlanningAreaLayerComponent implements OnChanges {
+export class PlanningAreaLayerComponent implements OnChanges, OnInit {
   @Input() before = '';
 
   @Input() lineColor: string = BASE_COLORS.blue;
@@ -49,6 +55,10 @@ export class PlanningAreaLayerComponent implements OnChanges {
   tilesUrl$!: Observable<string>;
 
   readonly sourceName = MARTIN_SOURCES.planningArea.sources.planningArea;
+
+  ngOnInit(): void {
+    this.setTilesUrl();
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['planId'] || changes['sharedLinkUuid']) {


### PR DESCRIPTION
Fixing an issue where I forgot to include an ngOnInit for the case where we DON'T have a `planId `or a `sharedLinkUuid`. 

<img width="1068" height="1038" alt="image" src="https://github.com/user-attachments/assets/aee380b8-7764-470f-a38e-a3c69ed07619" />

<img width="963" height="1181" alt="image" src="https://github.com/user-attachments/assets/a948e00a-504a-49ed-a55f-8892e2958c0b" />

