### PR TITLE
plan-3979-subunit-details

### DIFF
--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -2193,24 +2193,15 @@ def get_sub_units_areas(
 
 def get_project_areas_child_areas(
     scenario: Scenario,
-    stand_size: StandSizeChoices,
 ) -> list[float] | None:
     parent = scenario.parent
     if not parent:
         return None
 
-    stand_area = get_min_project_area(stand_size)
-    areas = []
-
-    for project_area in parent.project_areas.all():
-        stand_count = get_project_areas_child_stands(
-            scenario=scenario,
-            project_area=project_area,
-            stand_size=stand_size,
-        ).count()
-
-        if stand_count > 0:
-            areas.append(stand_count * stand_area)
+    areas = [
+        get_acreage(project_area.geometry)
+        for project_area in parent.project_areas.all()
+    ]
 
     return areas or None
 
@@ -2225,7 +2216,6 @@ def get_sub_units_details(
     if is_project_areas_child(scenario):
         areas = get_project_areas_child_areas(
             scenario=scenario,
-            stand_size=stand_size,
         )
     elif datalayer:
         areas = get_sub_units_areas(

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -1747,6 +1747,46 @@ class SubUnitsDetailsTest(TestCase):
         # 100 + 200 + 300 + 400 + 500 + 550 (of 600) + 550 (of 700) + 550 (of 800) + 550 (of 900) + 550 (of 100))
         self.assertEqual(details.get("targeted_area"), 4250)
 
+    @mock.patch(
+        "planning.services.get_acreage",
+        side_effect=[5.0, 15.0],
+    )
+    def test_project_areas_child_uses_project_area_acreage(
+        self,
+        mock_get_acreage,
+    ):
+        parent = ScenarioFactory.create(
+            type=ScenarioType.PROJECT_AREAS,
+        )
+        child = ScenarioFactory.create(
+            parent=parent,
+            planning_area=parent.planning_area,
+            planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+            configuration={"stand_size": StandSizeChoices.LARGE},
+        )
+
+        ProjectAreaFactory.create(
+            scenario=parent,
+            name="Project Area 1",
+        )
+        ProjectAreaFactory.create(
+            scenario=parent,
+            name="Project Area 2",
+        )
+
+        details = get_sub_units_details(
+            child,
+            child.get_stand_size(),
+        )
+
+        self.assertEqual(details["avg"], 10.0)
+        self.assertEqual(details["min"], 5.0)
+        self.assertEqual(details["max"], 15.0)
+        self.assertEqual(details["sum"], 20.0)
+        self.assertIsNone(details["targeted_area"])
+
+        self.assertEqual(mock_get_acreage.call_count, 2)
+
 
 class CalculateAndUpdateScenarioResult(TestCase):
     def setUp(self):


### PR DESCRIPTION
@roquebetioljr @lastminutediorama, On Treatment Targets Step, the Subunit details are showing odd results, https://sig-gis.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PLAN-3979

1. src/planscape/planning/services.py: used parent Project Area acreage for child subunit details instead
2. src/planscape/planning/tests/test_services.py:  added test for Project Area acreage calculation