### PR TITLE
use links for workspaces cards

### DIFF
--- a/src/interface/src/app/workspaces/workspaces.component.html
+++ b/src/interface/src/app/workspaces/workspaces.component.html
@@ -60,7 +60,7 @@
           [userCanRename]="can(workspace, 'change_workspace')"
           [userCanDelete]="can(workspace, 'remove_workspace')"
           [userCanShare]="can(workspace, 'add_collaborator')"
-          (clicked)="goToWorkspace(workspace)"
+          [link]="['/workspace', workspace.id]"
           (rename)="renameWorkspace(workspace)"
           (delete)="deleteWorkspace(workspace)"></sg-workspace-card>
       </div>

--- a/src/interface/src/app/workspaces/workspaces.component.spec.ts
+++ b/src/interface/src/app/workspaces/workspaces.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of, Subject, throwError } from 'rxjs';
 import { MockProvider } from 'ng-mocks';
 
@@ -15,7 +15,6 @@ describe('WorkspacesComponent', () => {
   let fixture: ComponentFixture<WorkspacesComponent>;
   let actionsService: WorkspaceActionsService;
   let workspacesService: WorkspacesService;
-  let router: Router;
   let snackbar: MatSnackBar;
 
   const workspace: Workspace = {
@@ -48,7 +47,6 @@ describe('WorkspacesComponent', () => {
     );
 
     actionsService = TestBed.inject(WorkspaceActionsService);
-    router = TestBed.inject(Router);
     snackbar = TestBed.inject(MatSnackBar);
 
     fixture = TestBed.createComponent(WorkspacesComponent);
@@ -57,11 +55,10 @@ describe('WorkspacesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorkspacesComponent, NoopAnimationsModule],
+      imports: [WorkspacesComponent, NoopAnimationsModule, RouterTestingModule],
       providers: [
         MockProvider(WorkspaceActionsService),
         MockProvider(WorkspacesService),
-        MockProvider(Router),
         MockProvider(MatSnackBar),
       ],
     }).compileComponents();
@@ -101,12 +98,12 @@ describe('WorkspacesComponent', () => {
       expect(spy).toHaveBeenCalledWith('list');
     });
 
-    it('navigates to the workspace when a card is clicked', () => {
-      const spy = spyOn(router, 'navigate');
+    it('links each card to its workspace', () => {
+      const link = fixture.nativeElement.querySelector(
+        'sg-workspace-card a.card-link'
+      );
 
-      fixture.nativeElement.querySelector('sg-workspace-card').click();
-
-      expect(spy).toHaveBeenCalledWith(['/workspace', 7]);
+      expect(link.getAttribute('href')).toBe('/workspace/7');
     });
   });
 

--- a/src/interface/src/app/workspaces/workspaces.component.ts
+++ b/src/interface/src/app/workspaces/workspaces.component.ts
@@ -2,7 +2,6 @@ import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
 import {
   BehaviorSubject,
   catchError,
@@ -62,7 +61,6 @@ const PAGE_SIZE = 12;
 export class WorkspacesComponent {
   private workspaceActionsService = inject(WorkspaceActionsService);
   private workspacesService = inject(WorkspacesService);
-  private router = inject(Router);
   private snackbar = inject(MatSnackBar);
 
   private reload$ = new BehaviorSubject<void>(undefined);
@@ -226,10 +224,6 @@ export class WorkspacesComponent {
     } else {
       this.reload$.next();
     }
-  }
-
-  goToWorkspace(workspace: Workspace) {
-    this.router.navigate(['/workspace', workspace.id]);
   }
 
   can(workspace: Workspace, permission: string): boolean {

--- a/src/interface/src/styleguide/index.ts
+++ b/src/interface/src/styleguide/index.ts
@@ -29,6 +29,7 @@ export * from '@styleguide/project-area-expander/project-area-expander.component
 export * from '@styleguide/scenario-card/scenario-card.component';
 export * from '@styleguide/search-bar/search-bar.component';
 export * from '@styleguide/search-result-card/search-result-card.component';
+export * from '@styleguide/selectable-link/selectable-link.directive';
 export * from '@styleguide/section/section.component';
 export * from '@styleguide/share-dialog/share-dialog.component';
 export * from '@styleguide/sequence-icon/sequence-icon.component';

--- a/src/interface/src/styleguide/selectable-link/selectable-link.directive.spec.ts
+++ b/src/interface/src/styleguide/selectable-link/selectable-link.directive.spec.ts
@@ -1,0 +1,99 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+
+import { SelectableLinkDirective } from './selectable-link.directive';
+
+@Component({
+  standalone: true,
+  imports: [RouterLink, SelectableLinkDirective],
+  template: `<a sgSelectableLink [routerLink]="['/somewhere', 7]">
+    <span>Some link text</span>
+    <button type="button" (click)="onButton($event)">A control</button>
+  </a>`,
+})
+class HostComponent {
+  clicked = false;
+
+  onButton(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.clicked = true;
+  }
+}
+
+describe('SelectableLinkDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let navigate: jasmine.Spy;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [{ provide: ActivatedRoute, useValue: { firstChild: {} } }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    navigate = spyOn(TestBed.inject(Router), 'navigateByUrl').and.returnValue(
+      Promise.resolve(true)
+    );
+  });
+
+  function link(): HTMLAnchorElement {
+    return fixture.nativeElement.querySelector('a');
+  }
+
+  function clickWithSelectionOn(element: Element) {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    element.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+    selection.removeAllRanges();
+  }
+
+  it('makes the link undraggable so a drag selects text instead', () => {
+    expect(link().getAttribute('draggable')).toBe('false');
+    expect(link().style.userSelect).toBe('text');
+  });
+
+  it('does not navigate when a click ends a selection inside the link', () => {
+    clickWithSelectionOn(fixture.nativeElement.querySelector('span'));
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when the selection ends on the link itself', () => {
+    clickWithSelectionOn(link());
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('still lets buttons inside the link be clicked while text is selected', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    clickWithSelectionOn(fixture.nativeElement.querySelector('span'));
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const range = document.createRange();
+    range.selectNodeContents(fixture.nativeElement.querySelector('span'));
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    button.dispatchEvent(event);
+    selection.removeAllRanges();
+
+    expect(fixture.componentInstance.clicked).toBe(true);
+  });
+
+  it('navigates on a plain click', () => {
+    link().dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+
+    expect(navigate).toHaveBeenCalled();
+  });
+});

--- a/src/interface/src/styleguide/selectable-link/selectable-link.directive.ts
+++ b/src/interface/src/styleguide/selectable-link/selectable-link.directive.ts
@@ -1,0 +1,42 @@
+import { Directive, ElementRef, OnInit, Renderer2 } from '@angular/core';
+
+/**
+ * Lets the user select the text inside a link.
+ *
+ * Chrome drags a link rather than selecting the text under the cursor, and the
+ * mouseup that ends a selection still counts as a click, which RouterLink would
+ * follow. This turns off the drag and swallows that click.
+ */
+@Directive({
+  selector: 'a[sgSelectableLink]',
+  standalone: true,
+})
+export class SelectableLinkDirective implements OnInit {
+  constructor(
+    private el: ElementRef<HTMLAnchorElement>,
+    private renderer: Renderer2
+  ) {}
+
+  ngOnInit() {
+    const link = this.el.nativeElement;
+    // Chrome needs all three, or a drag on the link never becomes a selection.
+    this.renderer.setAttribute(link, 'draggable', 'false');
+    this.renderer.setStyle(link, 'user-select', 'text');
+    this.renderer.setStyle(link, '-webkit-user-drag', 'none');
+    // RouterLink handles clicks on the bubble phase, so vetoing one means
+    // getting in first — which only the capture phase allows.
+    link.addEventListener('click', this.cancelClick, true);
+  }
+
+  private cancelClick = (event: Event) => {
+    // Buttons inside the link handle their own clicks, and clicking one does
+    // not clear the selection, so they would otherwise never fire.
+    if ((event.target as HTMLElement).closest('button')) {
+      return;
+    }
+    if (window.getSelection()?.toString()) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  };
+}

--- a/src/interface/src/styleguide/workspace-card/workspace-card.component.html
+++ b/src/interface/src/styleguide/workspace-card/workspace-card.component.html
@@ -1,66 +1,72 @@
-<div class="title-row">
-  <mat-icon class="material-symbols-outlined workspace-icon">folder</mat-icon>
+<a
+  sgSelectableLink
+  class="card-link"
+  [routerLink]="link"
+  [attr.aria-label]="name">
+  <div class="title-row">
+    <mat-icon class="material-symbols-outlined workspace-icon">folder</mat-icon>
 
-  <button
-    [matMenuTriggerFor]="menu"
-    aria-label="More workspace options"
-    class="more-menu-button"
-    (click)="stopEventPropagation($event)"
-    mat-icon-button
-    matTooltip="More actions">
-    <mat-icon>more_vert</mat-icon>
-  </button>
-  <mat-menu #menu="matMenu" class="workspace-more-menu">
     <button
-      mat-menu-item
-      class="action-button"
-      *ngIf="userCanRename"
-      (click)="rename.emit()">
-      <mat-icon class="material-symbols-outlined">edit</mat-icon>
-      <span>Rename</span>
+      [matMenuTriggerFor]="menu"
+      aria-label="More workspace options"
+      class="more-menu-button"
+      (click)="handleMenuClick($event)"
+      mat-icon-button
+      matTooltip="More actions">
+      <mat-icon>more_vert</mat-icon>
     </button>
-    <button
-      mat-menu-item
-      class="action-button"
-      *ngIf="userCanShare"
-      (click)="share.emit()">
-      <mat-icon class="material-symbols-outlined">share</mat-icon>
-      <span>Share</span>
-    </button>
-    <button
-      mat-menu-item
-      class="action-button delete"
-      *ngIf="userCanDelete"
-      (click)="delete.emit()">
-      <mat-icon class="material-symbols-outlined">delete</mat-icon>
-      <span>Delete</span>
-    </button>
-  </mat-menu>
-</div>
-
-<div class="workspace-name">{{ name }}</div>
-
-<div class="planning-areas">
-  {{ planningAreasCount | number: '1.0-0' }} {{ planningAreasLabel }}
-</div>
-
-<div class="detail-row">
-  <div class="detail-line">
-    <mat-icon class="material-symbols-outlined detail-icon">person</mat-icon>
-    <span
-      >Creator: <span class="detail-info">{{ creator || 'N/A' }}</span>
-    </span>
+    <mat-menu #menu="matMenu" class="workspace-more-menu">
+      <button
+        mat-menu-item
+        class="action-button"
+        *ngIf="userCanRename"
+        (click)="rename.emit()">
+        <mat-icon class="material-symbols-outlined">edit</mat-icon>
+        <span>Rename</span>
+      </button>
+      <button
+        mat-menu-item
+        class="action-button"
+        *ngIf="userCanShare"
+        (click)="share.emit()">
+        <mat-icon class="material-symbols-outlined">share</mat-icon>
+        <span>Share</span>
+      </button>
+      <button
+        mat-menu-item
+        class="action-button delete"
+        *ngIf="userCanDelete"
+        (click)="delete.emit()">
+        <mat-icon class="material-symbols-outlined">delete</mat-icon>
+        <span>Delete</span>
+      </button>
+    </mat-menu>
   </div>
-  <span class="separator" aria-hidden="true">&bull;</span>
-  <div class="detail-line">
-    <mat-icon class="material-symbols-outlined detail-icon"
-      >calendar_month
-    </mat-icon>
-    <span
-      >Created Date:
-      <span class="detail-info">{{
-        createdAt ? (createdAt | date: 'MMM d, y') : '-'
-      }}</span>
-    </span>
+
+  <div class="workspace-name">{{ name }}</div>
+
+  <div class="planning-areas">
+    {{ planningAreasCount | number: '1.0-0' }} {{ planningAreasLabel }}
   </div>
-</div>
+
+  <div class="detail-row">
+    <div class="detail-line">
+      <mat-icon class="material-symbols-outlined detail-icon">person</mat-icon>
+      <span
+        >Creator: <span class="detail-info">{{ creator || 'N/A' }}</span>
+      </span>
+    </div>
+    <span class="separator" aria-hidden="true">&bull;</span>
+    <div class="detail-line">
+      <mat-icon class="material-symbols-outlined detail-icon"
+        >calendar_month
+      </mat-icon>
+      <span
+        >Created Date:
+        <span class="detail-info">{{
+          createdAt ? (createdAt | date: 'MMM d, y') : '-'
+        }}</span>
+      </span>
+    </div>
+  </div>
+</a>

--- a/src/interface/src/styleguide/workspace-card/workspace-card.component.scss
+++ b/src/interface/src/styleguide/workspace-card/workspace-card.component.scss
@@ -3,6 +3,11 @@
 
 :host {
   display: flex;
+}
+
+.card-link {
+  flex: 1;
+  display: flex;
   flex-direction: column;
   gap: 8px;
   padding: 16px;
@@ -11,9 +16,16 @@
   background-color: $color-white;
   box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.16);
   cursor: pointer;
+  color: inherit;
+  text-decoration: none;
 
   &:hover {
     background-color: $color-lighter-gray;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-standard-blue;
+    outline-offset: 2px;
   }
 }
 

--- a/src/interface/src/styleguide/workspace-card/workspace-card.component.spec.ts
+++ b/src/interface/src/styleguide/workspace-card/workspace-card.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 import { WorkspaceCardComponent } from './workspace-card.component';
 
@@ -9,7 +10,8 @@ describe('WorkspaceCardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorkspaceCardComponent, NoopAnimationsModule],
+      imports: [WorkspaceCardComponent, NoopAnimationsModule, RouterLink],
+      providers: [{ provide: ActivatedRoute, useValue: { firstChild: {} } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(WorkspaceCardComponent);
@@ -51,14 +53,103 @@ describe('WorkspaceCardComponent', () => {
     expect(text).toContain('Created Date: -');
   });
 
-  it('emits clicked when the card is clicked', () => {
-    const spy = jasmine.createSpy('clicked');
-    component.clicked.subscribe(spy);
+  it('makes the whole card a link named after the workspace', () => {
+    component.name = 'My Workspace';
+    component.link = ['/workspace', 7];
     fixture.detectChanges();
 
-    fixture.nativeElement.click();
+    const link = fixture.nativeElement.querySelector('a.card-link');
+    expect(link.getAttribute('href')).toBe('/workspace/7');
+    expect(link.getAttribute('aria-label')).toBe('My Workspace');
+  });
 
-    expect(spy).toHaveBeenCalled();
+  function clickWithSelectionOn(selector: string) {
+    const el = fixture.nativeElement.querySelector(selector);
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    el.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+    selection.removeAllRanges();
+  }
+
+  it('does not navigate when a click ends a text selection', () => {
+    const navigate = spyOn(
+      TestBed.inject(Router),
+      'navigateByUrl'
+    ).and.returnValue(Promise.resolve(true));
+    component.name = 'My Workspace';
+    component.link = ['/workspace', 7];
+    fixture.detectChanges();
+
+    clickWithSelectionOn('.workspace-name');
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when the selection ends on the link itself', () => {
+    const navigate = spyOn(
+      TestBed.inject(Router),
+      'navigateByUrl'
+    ).and.returnValue(Promise.resolve(true));
+    component.name = 'My Workspace';
+    component.link = ['/workspace', 7];
+    fixture.detectChanges();
+
+    clickWithSelectionOn('.card-link');
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates on a plain click', () => {
+    const navigate = spyOn(
+      TestBed.inject(Router),
+      'navigateByUrl'
+    ).and.returnValue(Promise.resolve(true));
+    component.link = ['/workspace', 7];
+    fixture.detectChanges();
+
+    fixture.nativeElement
+      .querySelector('.workspace-name')
+      .dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      );
+
+    expect(navigate).toHaveBeenCalled();
+  });
+
+  it('leaves modified clicks to the browser', () => {
+    const navigate = spyOn(
+      TestBed.inject(Router),
+      'navigateByUrl'
+    ).and.returnValue(Promise.resolve(true));
+    component.link = ['/workspace', 7];
+    fixture.detectChanges();
+
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+    fixture.nativeElement.querySelector('.workspace-name').dispatchEvent(event);
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('does not navigate when the menu button is clicked', () => {
+    fixture.detectChanges();
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    fixture.nativeElement
+      .querySelector('.more-menu-button')
+      .dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it('only shows menu actions the user is allowed to perform', () => {

--- a/src/interface/src/styleguide/workspace-card/workspace-card.component.spec.ts
+++ b/src/interface/src/styleguide/workspace-card/workspace-card.component.spec.ts
@@ -130,15 +130,26 @@ describe('WorkspaceCardComponent', () => {
     component.link = ['/workspace', 7];
     fixture.detectChanges();
 
-    const event = new MouseEvent('click', {
-      bubbles: true,
-      cancelable: true,
-      metaKey: true,
-    });
-    fixture.nativeElement.querySelector('.workspace-name').dispatchEvent(event);
+    // RouterLink leaves a modified click alone, which means the browser would
+    // really follow the href and reload the test page. Record its decision,
+    // then stop the navigation.
+    let leftToTheBrowser = false;
+    const stopRealNavigation = (event: Event) => {
+      leftToTheBrowser = !event.defaultPrevented;
+      event.preventDefault();
+    };
+    document.addEventListener('click', stopRealNavigation);
+    fixture.nativeElement.querySelector('.workspace-name').dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+      })
+    );
+    document.removeEventListener('click', stopRealNavigation);
 
     expect(navigate).not.toHaveBeenCalled();
-    expect(event.defaultPrevented).toBe(false);
+    expect(leftToTheBrowser).toBe(true);
   });
 
   it('does not navigate when the menu button is clicked', () => {

--- a/src/interface/src/styleguide/workspace-card/workspace-card.component.ts
+++ b/src/interface/src/styleguide/workspace-card/workspace-card.component.ts
@@ -1,15 +1,11 @@
-import {
-  Component,
-  EventEmitter,
-  HostListener,
-  Input,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DatePipe, DecimalPipe, NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { SelectableLinkDirective } from '../selectable-link/selectable-link.directive';
 
 /**
  * Workspace Card for displaying a workspace on the workspaces list
@@ -21,6 +17,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     DatePipe,
     DecimalPipe,
     NgIf,
+    RouterLink,
+    SelectableLinkDirective,
     MatIconModule,
     MatMenuModule,
     MatButtonModule,
@@ -35,11 +33,13 @@ export class WorkspaceCardComponent {
   @Input() creator = '';
   @Input() createdAt = '';
 
+  /** Where the card navigates. The whole card is the link. */
+  @Input() link: string | any[] = [];
+
   @Input() userCanRename = false;
   @Input() userCanDelete = false;
   @Input() userCanShare = false;
 
-  @Output() clicked = new EventEmitter<void>();
   @Output() rename = new EventEmitter<void>();
   @Output() share = new EventEmitter<void>();
   @Output() delete = new EventEmitter<void>();
@@ -48,12 +48,9 @@ export class WorkspaceCardComponent {
     return this.planningAreasCount === 1 ? 'Planning Area' : 'Planning Areas';
   }
 
-  @HostListener('click')
-  handleClick() {
-    this.clicked.emit();
-  }
-
-  stopEventPropagation(event: Event) {
+  /** The menu sits inside the card's link, so its clicks must not navigate. */
+  handleMenuClick(event: Event) {
+    event.preventDefault();
     event.stopPropagation();
   }
 }

--- a/src/interface/src/styleguide/workspace-card/workspace-card.stories.ts
+++ b/src/interface/src/styleguide/workspace-card/workspace-card.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { applicationConfig, argsToTemplate } from '@storybook/angular';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 import { WorkspaceCardComponent } from './workspace-card.component';
 
 const meta: Meta<WorkspaceCardComponent> = {
@@ -8,7 +9,7 @@ const meta: Meta<WorkspaceCardComponent> = {
   component: WorkspaceCardComponent,
   decorators: [
     applicationConfig({
-      providers: [provideAnimations()],
+      providers: [provideAnimations(), provideRouter([])],
     }),
   ],
   tags: ['autodocs'],
@@ -26,6 +27,7 @@ type Story = StoryObj<WorkspaceCardComponent>;
 export const Default: Story = {
   args: {
     name: 'Name',
+    link: ['/workspace', 1],
     planningAreasCount: 0,
     creator: 'Name',
     createdAt: '2025-07-11 12:34:00',


### PR DESCRIPTION
Changes the click handler for a link on the workspaces card, while also allowing the user to select text and interact with the card.
We probably want to do this on other cards, so added a directive to handle an edge case where selecting text bubbles up to a click event 