### PR TITLE
Add Mixpanel tracking for search and filtering

### DIFF
--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from urllib.parse import urlencode
 
 from django.contrib.auth import get_user_model
@@ -91,6 +92,30 @@ class TestDataLayerViewSet(APITestCase):
         self.assertEqual(1, data.get("count"))
         self.assertEqual(datalayer.name, data.get("results")[0].get("name"))
 
+    @mock.patch("planscape.filters.track_event")
+    def test_full_text_search_tracks_search_event(self, track_event_mock):
+        # `search` on this endpoint is handled ad hoc in get_queryset(), not
+        # through the FilterSet - confirms it's still tracked via
+        # DataLayerViewSet.tracked_query_params.
+        self.client.force_authenticate(user=self.normal)
+        DataLayerFactory.create(
+            dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
+        )
+        filter = {"search": "Forest"}
+        url = f"{reverse('api:datasets:datalayers-list')}?{urlencode(filter)}"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        track_event_mock.assert_called_once_with(
+            name="search.filtered",
+            properties={
+                "resource": "DataLayer",
+                "params": {"search": "Forest"},
+                "email": self.normal.email,
+            },
+            user_id=self.normal.pk,
+        )
+
     def test_filter_by_full_text_search_datalayer_name_multiple_return(self):
         self.client.force_authenticate(user=self.normal)
         DataLayerFactory.create(
@@ -157,7 +182,7 @@ class TestDataLayerViewSet(APITestCase):
                 dataset=self.dataset, name=f"Foo {i}", type=DataLayerType.RASTER
             )
             datalayer_ids.append(str(datalayer.pk))
-        
+
         filter = {
             "id__in": ",".join(datalayer_ids[:3]),
         }
@@ -217,7 +242,9 @@ class TestDataLayerViewSet(APITestCase):
 
         for i in range(2):
             DataLayerFactory.create(
-                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+                dataset=private_dataset,
+                name=f"private R {i}",
+                type=DataLayerType.RASTER,
             )
 
         for i in range(3):
@@ -237,7 +264,9 @@ class TestDataLayerViewSet(APITestCase):
 
         for i in range(2):
             DataLayerFactory.create(
-                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+                dataset=private_dataset,
+                name=f"private R {i}",
+                type=DataLayerType.RASTER,
             )
 
         for i in range(3):
@@ -264,9 +293,7 @@ class TestDataLayerViewSet(APITestCase):
             workspace=shared_workspace,
         )
 
-        hidden_workspace = WorkspaceFactory.create(
-            owner=self.normal
-        )
+        hidden_workspace = WorkspaceFactory.create(owner=self.normal)
         hidden_dataset = DatasetFactory(
             visibility=VisibilityOptions.PRIVATE,
             workspace=hidden_workspace,
@@ -274,16 +301,16 @@ class TestDataLayerViewSet(APITestCase):
 
         for i in range(5):
             DataLayerFactory.create(
-                dataset=shared_dataset, 
-                name=f"shared private R {i}", 
+                dataset=shared_dataset,
+                name=f"shared private R {i}",
                 type=DataLayerType.RASTER,
-                workspace=shared_workspace
+                workspace=shared_workspace,
             )
             DataLayerFactory.create(
-                dataset=hidden_dataset, 
-                name=f"hidden private R {i}", 
+                dataset=hidden_dataset,
+                name=f"hidden private R {i}",
                 type=DataLayerType.RASTER,
-                workspace=hidden_workspace
+                workspace=hidden_workspace,
             )
 
         for test in [
@@ -298,10 +325,11 @@ class TestDataLayerViewSet(APITestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(data.get("results")), test.get("expected_result"))
 
-
     def test_retrieve_public_datalayer_succeeds(self):
         self.client.force_authenticate(user=self.normal)
-        datalayer = DataLayerFactory.create(dataset=self.dataset, type=DataLayerType.RASTER)
+        datalayer = DataLayerFactory.create(
+            dataset=self.dataset, type=DataLayerType.RASTER
+        )
         url = reverse("api:datasets:datalayers-detail", kwargs={"pk": datalayer.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -310,7 +338,9 @@ class TestDataLayerViewSet(APITestCase):
     def test_retrieve_private_datalayer_as_normal_user_returns_404(self):
         self.client.force_authenticate(user=self.normal)
         private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
-        datalayer = DataLayerFactory.create(dataset=private_dataset, type=DataLayerType.RASTER)
+        datalayer = DataLayerFactory.create(
+            dataset=private_dataset, type=DataLayerType.RASTER
+        )
         url = reverse("api:datasets:datalayers-detail", kwargs={"pk": datalayer.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
@@ -318,14 +348,18 @@ class TestDataLayerViewSet(APITestCase):
     def test_retrieve_private_datalayer_as_staff_succeeds(self):
         self.client.force_authenticate(user=self.admin)
         private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
-        datalayer = DataLayerFactory.create(dataset=private_dataset, type=DataLayerType.RASTER)
+        datalayer = DataLayerFactory.create(
+            dataset=private_dataset, type=DataLayerType.RASTER
+        )
         url = reverse("api:datasets:datalayers-detail", kwargs={"pk": datalayer.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["id"], datalayer.pk)
 
     def test_retrieve_unauthenticated_public_datalayer_succeeds(self):
-        datalayer = DataLayerFactory.create(dataset=self.dataset, type=DataLayerType.RASTER)
+        datalayer = DataLayerFactory.create(
+            dataset=self.dataset, type=DataLayerType.RASTER
+        )
         url = reverse("api:datasets:datalayers-detail", kwargs={"pk": datalayer.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -359,6 +393,49 @@ class TestDataLayerViewSet(APITestCase):
         for row in data["results"]:
             self.assertEqual("RASTER", row["data"]["type"])
 
+    @mock.patch("datasets.views.track_event")
+    def test_find_anything_tracks_search_event(self, track_event_mock):
+        self.client.force_authenticate(user=self.normal)
+        DataLayerFactory.create(
+            dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
+        )
+        params = {"term": "forest", "type": "RASTER"}
+        url = f"{reverse('api:datasets:datalayers-find-anything')}?{urlencode(params)}"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        track_event_mock.assert_called_once_with(
+            name="search.filtered",
+            properties={
+                "resource": "find_anything",
+                "params": {"term": "forest", "type": "RASTER"},
+                "result_count": 1,
+                "email": self.normal.email,
+            },
+            user_id=self.normal.pk,
+        )
+
+    @mock.patch("datasets.views.track_event")
+    def test_find_anything_tracks_anonymous_search(self, track_event_mock):
+        DataLayerFactory.create(
+            dataset=self.dataset, name="Forest", type=DataLayerType.RASTER
+        )
+        params = {"term": "forest", "type": "RASTER"}
+        url = f"{reverse('api:datasets:datalayers-find-anything')}?{urlencode(params)}"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        track_event_mock.assert_called_once_with(
+            name="search.filtered",
+            properties={
+                "resource": "find_anything",
+                "params": {"term": "forest", "type": "RASTER"},
+                "result_count": 1,
+                "email": None,
+            },
+            user_id=None,
+        )
+
     def test_find_anything_type_vector_returns_vectors(self):
         self.client.force_authenticate(user=self.normal)
         for i in range(3):
@@ -385,7 +462,9 @@ class TestDataLayerViewSet(APITestCase):
 
         for i in range(5):
             DataLayerFactory.create(
-                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+                dataset=private_dataset,
+                name=f"private R {i}",
+                type=DataLayerType.RASTER,
             )
 
         params = {"term": "priv", "type": "RASTER"}
@@ -394,14 +473,16 @@ class TestDataLayerViewSet(APITestCase):
         data = resp.json()
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(5, data.get("count"))
-        
+
     def test_find_anything_private_as_normal_user(self):
         self.client.force_authenticate(user=self.normal)
         private_dataset = DatasetFactory(visibility=VisibilityOptions.PRIVATE)
 
         for i in range(5):
             DataLayerFactory.create(
-                dataset=private_dataset, name=f"private R {i}", type=DataLayerType.RASTER
+                dataset=private_dataset,
+                name=f"private R {i}",
+                type=DataLayerType.RASTER,
             )
 
         params = {"term": "priv", "type": "RASTER"}
@@ -424,9 +505,7 @@ class TestDataLayerViewSet(APITestCase):
             workspace=shared_workspace,
         )
 
-        hidden_workspace = WorkspaceFactory.create(
-            owner=self.normal
-        )
+        hidden_workspace = WorkspaceFactory.create(owner=self.normal)
         hidden_dataset = DatasetFactory(
             visibility=VisibilityOptions.PRIVATE,
             workspace=hidden_workspace,
@@ -434,16 +513,16 @@ class TestDataLayerViewSet(APITestCase):
 
         for i in range(5):
             DataLayerFactory.create(
-                dataset=shared_dataset, 
-                name=f"shared private R {i}", 
+                dataset=shared_dataset,
+                name=f"shared private R {i}",
                 type=DataLayerType.RASTER,
-                workspace=shared_workspace
+                workspace=shared_workspace,
             )
             DataLayerFactory.create(
-                dataset=hidden_dataset, 
-                name=f"hidden private R {i}", 
+                dataset=hidden_dataset,
+                name=f"hidden private R {i}",
                 type=DataLayerType.RASTER,
-                workspace=hidden_workspace
+                workspace=hidden_workspace,
             )
 
         for test in [
@@ -539,7 +618,9 @@ class TestPublicAccess(APITestCase):
         self.public_dataset = DatasetFactory.create(visibility=VisibilityOptions.PUBLIC)
         self.public_datalayer = DataLayerFactory.create(dataset=self.public_dataset)
 
-        self.private_dataset = DatasetFactory.create(visibility=VisibilityOptions.PRIVATE)
+        self.private_dataset = DatasetFactory.create(
+            visibility=VisibilityOptions.PRIVATE
+        )
         self.private_datalayer = DataLayerFactory.create(dataset=self.private_dataset)
 
     def test_datasets_list_is_public(self):
@@ -550,9 +631,13 @@ class TestPublicAccess(APITestCase):
 
     def test_all_public_endpoints_are_readable(self):
         urls = [
-            reverse("api:datasets:datasets-browse", kwargs={"pk": self.public_dataset.pk}),
+            reverse(
+                "api:datasets:datasets-browse", kwargs={"pk": self.public_dataset.pk}
+            ),
             f"{reverse('api:datasets:datalayers-find-anything')}?term=x&type=RASTER",
-            reverse("api:datasets:datalayers-urls", kwargs={"pk": self.public_datalayer.pk}),
+            reverse(
+                "api:datasets:datalayers-urls", kwargs={"pk": self.public_datalayer.pk}
+            ),
         ]
         for url in urls:
             with self.subTest(url=url):
@@ -561,8 +646,12 @@ class TestPublicAccess(APITestCase):
 
     def test_private_endpoints_are_not_visible(self):
         urls = [
-            reverse("api:datasets:datasets-browse", kwargs={"pk": self.private_dataset.pk}),
-            reverse("api:datasets:datalayers-urls", kwargs={"pk": self.private_datalayer.pk}),
+            reverse(
+                "api:datasets:datasets-browse", kwargs={"pk": self.private_dataset.pk}
+            ),
+            reverse(
+                "api:datasets:datalayers-urls", kwargs={"pk": self.private_datalayer.pk}
+            ),
         ]
         for url in urls:
             with self.subTest(url=url):

--- a/src/planscape/datasets/tests/test_views.py
+++ b/src/planscape/datasets/tests/test_views.py
@@ -405,10 +405,11 @@ class TestDataLayerViewSet(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         track_event_mock.assert_called_once_with(
-            name="search.filtered",
+            name="datasets.datalayer.find_anything",
             properties={
-                "resource": "find_anything",
-                "params": {"term": "forest", "type": "RASTER"},
+                "term": "forest",
+                "type": "RASTER",
+                "module": None,
                 "result_count": 1,
                 "email": self.normal.email,
             },
@@ -426,10 +427,11 @@ class TestDataLayerViewSet(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         track_event_mock.assert_called_once_with(
-            name="search.filtered",
+            name="datasets.datalayer.find_anything",
             properties={
-                "resource": "find_anything",
-                "params": {"term": "forest", "type": "RASTER"},
+                "term": "forest",
+                "type": "RASTER",
+                "module": None,
                 "result_count": 1,
                 "email": None,
             },

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -134,14 +134,11 @@ class DataLayerViewSet(
         user = request.user
         is_authenticated = bool(user and user.is_authenticated)
         track_event(
-            name="search.filtered",
+            name="datasets.datalayer.find_anything",
             properties={
-                "resource": "find_anything",
-                "params": {
-                    key: str(value)
-                    for key, value in serializer.validated_data.items()
-                    if value not in (None, "")
-                },
+                "term": serializer.validated_data.get("term"),
+                "type": serializer.validated_data.get("type"),
+                "module": serializer.validated_data.get("module"),
                 "result_count": len(search_results),
                 "email": user.email if is_authenticated else None,
             },

--- a/src/planscape/datasets/views.py
+++ b/src/planscape/datasets/views.py
@@ -40,8 +40,10 @@ class DatasetViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
 
     def get_queryset(self):
         user = self.request.user if self.request else None
-        return Dataset.objects.all().accessible_by(user).select_related(
-            "organization", "created_by"
+        return (
+            Dataset.objects.all()
+            .accessible_by(user)
+            .select_related("organization", "created_by")
         )
 
     @extend_schema(
@@ -95,7 +97,9 @@ class DatasetViewSet(ListModelMixin, MultiSerializerMixin, GenericViewSet):
         return list(datalayers.all())
 
 
-class DataLayerViewSet(RetrieveModelMixin, ListModelMixin, MultiSerializerMixin, GenericViewSet):
+class DataLayerViewSet(
+    RetrieveModelMixin, ListModelMixin, MultiSerializerMixin, GenericViewSet
+):
     queryset = DataLayer.objects.none()
     permission_classes = [IsAuthenticatedOrReadOnly]
     pagination_class = LimitOffsetPagination
@@ -104,6 +108,10 @@ class DataLayerViewSet(RetrieveModelMixin, ListModelMixin, MultiSerializerMixin,
         "list": DataLayerSerializer,
     }
     filterset_class = DataLayerFilterSet
+    # `search` is handled ad hoc in get_queryset() below (full-text search),
+    # not through the FilterSet - list it explicitly so TrackedFilterBackend
+    # still tracks it.
+    tracked_query_params = ["search"]
 
     @action(detail=True, methods=["get"])
     def urls(self, request, pk=None):
@@ -122,6 +130,24 @@ class DataLayerViewSet(RetrieveModelMixin, ListModelMixin, MultiSerializerMixin,
 
         results = find_anything(user=request.user, **serializer.validated_data)
         search_results = list(results.values())
+
+        user = request.user
+        is_authenticated = bool(user and user.is_authenticated)
+        track_event(
+            name="search.filtered",
+            properties={
+                "resource": "find_anything",
+                "params": {
+                    key: str(value)
+                    for key, value in serializer.validated_data.items()
+                    if value not in (None, "")
+                },
+                "result_count": len(search_results),
+                "email": user.email if is_authenticated else None,
+            },
+            user_id=user.pk if is_authenticated else None,
+        )
+
         page = self.paginate_queryset(search_results)  # type: ignore
         if page is not None:
             out_serializer = SearchResultsSerializer(

--- a/src/planscape/impacts/views.py
+++ b/src/planscape/impacts/views.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.http import FileResponse
-from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiTypes, extend_schema, extend_schema_view
 from impacts.filters import TreatmentPlanFilterSet, TreatmentPlanNoteFilterSet
 from impacts.models import (
@@ -49,6 +48,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
 from planscape.analytics import track_event
+from planscape.filters import TrackedFilterBackend
 from planscape.serializers import BaseErrorMessageSerializer
 
 log = logging.getLogger(__name__)
@@ -447,7 +447,7 @@ class TreatmentPlanNoteViewSet(viewsets.ModelViewSet):
         "create": TreatmentPlanNoteCreateSerializer,
     }
     filterset_class = TreatmentPlanNoteFilterSet
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [TrackedFilterBackend]
 
     def get_serializer_class(self):
         return (

--- a/src/planscape/planning/views_v2.py
+++ b/src/planscape/planning/views_v2.py
@@ -8,7 +8,6 @@ from django.db.models import Q
 from django.db.models.expressions import RawSQL
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from funding_report.models import (
     FundingOpportunityReport,
@@ -44,6 +43,7 @@ from funding_report.tasks import (
 )
 from modules.base import compute_scenario_capabilities
 from planscape.analytics import track_event
+from planscape.filters import TrackedFilterBackend
 from planscape.serializers import BaseErrorMessageSerializer
 from rest_framework import mixins, pagination, permissions, status, viewsets
 from rest_framework.decorators import action
@@ -157,7 +157,7 @@ class PlanningAreaViewSet(viewsets.ModelViewSet):
     pagination_class = pagination.LimitOffsetPagination
     filterset_class = PlanningAreaFilter
     filter_backends = [
-        DjangoFilterBackend,
+        TrackedFilterBackend,
         PlanningAreaOrderingFilter,
         OrderingFilter,
     ]
@@ -257,7 +257,7 @@ class ScenarioViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
 
     filterset_class = ScenarioFilter
     filter_backends = [
-        DjangoFilterBackend,
+        TrackedFilterBackend,
         ScenarioOrderingFilter,
     ]
 
@@ -960,7 +960,7 @@ class TreatmentGoalViewSet(
     serializer_class = TreatmentGoalSerializer
     filterset_class = TreatmentGoalFilter
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filter_backends = [TrackedFilterBackend, OrderingFilter]
     ordering_fields = ["category", "name"]
     ordering = ["category", "name"]
 

--- a/src/planscape/planscape/filters.py
+++ b/src/planscape/planscape/filters.py
@@ -1,4 +1,7 @@
 from django_filters import filters
+from django_filters.rest_framework import DjangoFilterBackend
+
+from planscape.analytics import track_event
 
 
 class CharArrayFilter(filters.BaseCSVFilter, filters.CharFilter):
@@ -20,3 +23,55 @@ class MultipleValueFilter(filters.CharFilter):
         all_values = request.query_params.getlist(self.given_param)
         filter_expr = {f"{self.field_name}__in": all_values}
         return queryset.filter(**filter_expr)
+
+
+class TrackedFilterBackend(DjangoFilterBackend):
+    """Drop-in replacement for DjangoFilterBackend that also fires a
+    `search.filtered` analytics event whenever a list request actually
+    supplies filter query params - so we can see what people search/filter
+    for across the API without instrumenting every view by hand.
+
+    Tracks any query param declared on the view's `filterset_class`. A view
+    that filters its queryset ad hoc (outside a FilterSet - e.g. a raw
+    `?search=` handled in `get_queryset()`) can still get those params
+    tracked by listing them on a `tracked_query_params` class attribute.
+
+    This is wired in as the project-wide default filter backend
+    (settings.REST_FRAMEWORK["DEFAULT_FILTER_BACKENDS"]); views that
+    override `filter_backends` locally need to list this class instead of
+    DjangoFilterBackend to keep getting tracked.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        queryset = super().filter_queryset(request, queryset, view)
+
+        if getattr(view, "action", None) != "list":
+            return queryset
+
+        tracked_params = set(getattr(view, "tracked_query_params", ()))
+        filterset_class = self.get_filterset_class(view, queryset)
+        if filterset_class is not None:
+            tracked_params |= set(filterset_class.base_filters)
+        if not tracked_params:
+            return queryset
+
+        applied = {
+            key: value
+            for key, value in request.query_params.items()
+            if key in tracked_params and value not in (None, "")
+        }
+        if not applied:
+            return queryset
+
+        user = getattr(request, "user", None)
+        is_authenticated = bool(user and user.is_authenticated)
+        track_event(
+            name="search.filtered",
+            properties={
+                "resource": queryset.model.__name__,
+                "params": applied,
+                "email": user.email if is_authenticated else None,
+            },
+            user_id=user.pk if is_authenticated else None,
+        )
+        return queryset

--- a/src/planscape/planscape/settings.py
+++ b/src/planscape/planscape/settings.py
@@ -219,7 +219,7 @@ REST_FRAMEWORK = {
     ),
     "NON_FIELD_ERRORS_KEY": "global",
     "DEFAULT_FILTER_BACKENDS": [
-        "django_filters.rest_framework.DjangoFilterBackend",
+        "planscape.filters.TrackedFilterBackend",
         "rest_framework.filters.OrderingFilter",
     ],
     "DEFAULT_PAGINATION_CLASS": None,

--- a/src/planscape/planscape/tests/test_filters.py
+++ b/src/planscape/planscape/tests/test_filters.py
@@ -1,0 +1,66 @@
+from unittest import mock
+
+from django.urls import reverse
+from planscape.tests.factories import UserFactory
+from rest_framework.test import APITestCase
+from workspaces.tests.factories import PlanningWorkspaceFactory
+
+LIST_URL = "api:workspaces:workspaces-list"
+DETAIL_URL = "api:workspaces:workspaces-detail"
+
+
+class TrackedFilterBackendTest(APITestCase):
+    """Exercises TrackedFilterBackend through a real filterable endpoint
+    (the planning Workspace list, which has a `search` filter)."""
+
+    def setUp(self):
+        self.user = UserFactory.create()
+        PlanningWorkspaceFactory.create(name="Falcon", created_by=self.user)
+        self.client.force_authenticate(user=self.user)
+
+    @mock.patch("planscape.filters.track_event")
+    def test_filtering_fires_a_tracked_event(self, track_event_mock):
+        response = self.client.get(reverse(LIST_URL), {"search": "Fal"})
+
+        self.assertEqual(response.status_code, 200)
+        track_event_mock.assert_called_once_with(
+            name="search.filtered",
+            properties={
+                "resource": "Workspace",
+                "params": {"search": "Fal"},
+                "email": self.user.email,
+            },
+            user_id=self.user.pk,
+        )
+
+    @mock.patch("planscape.filters.track_event")
+    def test_listing_without_filter_params_does_not_track(self, track_event_mock):
+        response = self.client.get(reverse(LIST_URL))
+
+        self.assertEqual(response.status_code, 200)
+        track_event_mock.assert_not_called()
+
+    @mock.patch("planscape.filters.track_event")
+    def test_blank_filter_value_does_not_track(self, track_event_mock):
+        response = self.client.get(reverse(LIST_URL), {"search": ""})
+
+        self.assertEqual(response.status_code, 200)
+        track_event_mock.assert_not_called()
+
+    @mock.patch("planscape.filters.track_event")
+    def test_retrieve_does_not_track_even_with_matching_query_params(
+        self, track_event_mock
+    ):
+        workspace = PlanningWorkspaceFactory.create(
+            name="Millennium", created_by=self.user
+        )
+        # Note: django-filter applies filterset filtering on retrieve too
+        # (via get_object() -> filter_queryset()), same as with a plain
+        # DjangoFilterBackend - so the query param has to match the object
+        # being retrieved or this would 404 regardless of tracking.
+        response = self.client.get(
+            reverse(DETAIL_URL, kwargs={"pk": workspace.pk}), {"search": "Mill"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        track_event_mock.assert_not_called()

--- a/src/planscape/workspaces/admin_views.py
+++ b/src/planscape/workspaces/admin_views.py
@@ -1,6 +1,5 @@
 from core.serializers import MultiSerializerMixin
 from django.db.models import Count, Q
-from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
@@ -17,6 +16,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from datasets.models import VisibilityOptions
+from planscape.filters import TrackedFilterBackend
 from workspaces.filters import WorkspaceFilterSet
 from workspaces.models import (
     UserAccessWorkspace,
@@ -53,7 +53,7 @@ class AdminWorkspaceViewSet(
         "partial_update": UpdateWorkspaceSerializer,
     }
     pagination_class = LimitOffsetPagination
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [TrackedFilterBackend]
     filterset_class = WorkspaceFilterSet
 
     def get_queryset(self):

--- a/src/planscape/workspaces/views.py
+++ b/src/planscape/workspaces/views.py
@@ -1,6 +1,6 @@
 from core.serializers import MultiSerializerMixin
-from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
+from planscape.filters import TrackedFilterBackend
 from planscape.serializers import BaseErrorMessageSerializer
 from rest_framework import pagination, status, viewsets
 from rest_framework.filters import OrderingFilter
@@ -48,7 +48,7 @@ class WorkspaceViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     }
     pagination_class = pagination.LimitOffsetPagination
     filterset_class = PlanningWorkspaceFilterSet
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filter_backends = [TrackedFilterBackend, OrderingFilter]
     ordering_fields = [
         "name",
         "created_at",


### PR DESCRIPTION
Backend only.

Tracks a `search.filtered` event whenever someone searches or filters:
- `find_anything` (the global search) - tracked directly in the view
- Every list endpoint with a filterset_class (planning areas, scenarios, treatment goals/plans, data layers, styles, climate foresight, workspaces) - via a new TrackedFilterBackend, wired in as the default filter backend, so future filterable endpoints get tracked automatically
- DataLayer's `?search=` (a raw full-text search outside the FilterSet) - opted in via a small tracked_query_params list on the view

Tests: new planscape/tests/test_filters.py plus tracking tests in datasets. Full suite for every touched app passing.