### PR TITLE
Remove rank number from proj-area flow

### DIFF
--- a/src/interface/src/app/maplibre-map/scenario-map/scenario-map.component.html
+++ b/src/interface/src/app/maplibre-map/scenario-map/scenario-map.component.html
@@ -87,7 +87,7 @@
         [showHoveredProjectAreas]="false"
         [mapLibreMap]="mapLibreMap"
         [hasParent]="true"
-        [labelField]="'rank'"
+        [labelField]="''"
         [planningApproach]="
           (planningApproach$ | async) || 'PRIORITIZE_SUB_UNITS'
         ">


### PR DESCRIPTION
This PR just hides the rank numbers from the project areas scenario flow map, but keeps them on the results map.

<img width="1012" height="665" alt="Screenshot From 2026-08-28 15-54-16" src="https://github.com/user-attachments/assets/3105f8c6-c8da-4881-be8c-14d5cc8bdaed" />

<img width="1012" height="665" alt="Screenshot From 2026-08-28 15-53-43" src="https://github.com/user-attachments/assets/60c78451-fcf0-466c-bee6-5ab5f3a68b8a" />
