### PR TITLE
fix: Available Stands with Sub-Units

### DIFF
--- a/src/planscape/planning/models.py
+++ b/src/planscape/planning/models.py
@@ -576,6 +576,13 @@ class Scenario(CreatedAtMixin, UpdatedAtMixin, DeletedAtMixin, models.Model):
             return ScenarioVersion.V1
         return ScenarioVersion.V2
 
+    @cached_property
+    def sub_unit_datalayer(self) -> Optional[DataLayer]:
+        sub_units_layer_id = self.configuration.get("sub_units_layer")
+        if not sub_units_layer_id:
+            return None
+        return DataLayer.objects.filter(pk=sub_units_layer_id).first()
+
     def creator_name(self) -> str:
         return self.user.get_full_name()
 

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -1964,6 +1964,9 @@ def get_available_stands(
         excludes = list()
     if not constraints:
         constraints = list()
+    if not sub_unit:
+        sub_unit = scenario.sub_unit_datalayer
+
     planning_area = scenario.planning_area
     area_transform = Area(Transform("geometry", settings.AREA_SRID))
     if feature_enabled("ADD_INCLUDES") and scenario.treatable_area is not None:

--- a/src/planscape/planning/tests/test_models.py
+++ b/src/planscape/planning/tests/test_models.py
@@ -118,3 +118,19 @@ class ScenarioModelTest(TestCase):
 
         self.assertEqual(child.parent, parent)
         self.assertIn(child, parent.children.all())
+
+    def test_sub_unit_datalayer_returns_none_without_config_value(self):
+        scenario = ScenarioFactory(configuration={})
+
+        self.assertIsNone(scenario.sub_unit_datalayer)
+
+    def test_sub_unit_datalayer_returns_configured_datalayer(self):
+        datalayer = DataLayerFactory.create(type=DataLayerType.VECTOR)
+        scenario = ScenarioFactory(configuration={"sub_units_layer": datalayer.pk})
+
+        self.assertEqual(scenario.sub_unit_datalayer, datalayer)
+
+    def test_sub_unit_datalayer_returns_none_for_missing_datalayer_id(self):
+        scenario = ScenarioFactory(configuration={"sub_units_layer": 99999999})
+
+        self.assertIsNone(scenario.sub_unit_datalayer)

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -1110,6 +1110,33 @@ class TestRemoveExcludes(TestCase):
             self.assertEqual(17, len(stands))
             self.assertLess(len(stand_ids), len(stands) - 1)
 
+    def test_get_available_stands_uses_scenario_sub_unit_datalayer(self):
+        stand_to_remove = self.stands[0]
+        stand_ids = [stand.id for stand in self.stands]
+        sub_unit_stands = Stand.objects.filter(id__in=stand_ids).exclude(
+            id=stand_to_remove.pk
+        )
+        scenario = ScenarioFactory(
+            planning_area=self.planning_area,
+            planning_approach=ScenarioPlanningApproach.PRIORITIZE_SUB_UNITS,
+            configuration={"sub_units_layer": self.datalayer.pk},
+        )
+
+        with mock.patch(
+            "planning.services.get_stands_from_sub_units", return_value=sub_unit_stands
+        ) as get_stands_from_sub_units_mock:
+            result = get_available_stands(
+                scenario,
+                stand_size=StandSizeChoices.LARGE,
+            )
+
+        get_stands_from_sub_units_mock.assert_called_once()
+        self.assertEqual(
+            get_stands_from_sub_units_mock.call_args.args[3],
+            self.datalayer,
+        )
+        self.assertIn(stand_to_remove.pk, result["unavailable"]["by_exclusions"])
+
     def test_get_available_stands_applies_forsys_constraint(self):
         self.datalayer.metadata = {
             "modules": {"forsys": {"enabled": True, "metric_column": "majority"}}


### PR DESCRIPTION
Using stored Sub-Units ID to calculate available stands if not defined on request.