### PR TITLE
feat(planning): Adding support to new operators for stand level constraints

### DIFF
--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -558,6 +558,24 @@ class ConstraintSerializer(serializers.Serializer):
         required=True,
     )
 
+    def validate_value(self, value):
+        if "," in str(value):
+            values = value.strip().replace(" ", "").split(",", maxsplit=1)
+            values.sort()
+            min_value, max_value = values
+            try:
+                min_value = float(min_value)
+                max_value = float(max_value)
+                return f"{min_value},{max_value}"
+            except:
+                raise serializers.ValidationError("Invalid constraint value(s)")
+        else:
+            try:
+                float(value)
+                return value
+            except:
+                raise serializers.ValidationError("Invalid constraint value")
+
 
 class ConstraintReadSerializer(serializers.Serializer):
     datalayer = serializers.IntegerField()

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -549,20 +549,22 @@ class ConstraintSerializer(serializers.Serializer):
     )
 
     operator = serializers.ChoiceField(
-        choices=["eq", "lt", "lte", "gt", "gte"],
+        choices=["eq", "dne", "lt", "lte", "gt", "gte", "btw"],
         required=True,
     )
 
     value = serializers.CharField(
-        max_length=16,
+        max_length=32,
         required=True,
     )
 
 
 class ConstraintReadSerializer(serializers.Serializer):
     datalayer = serializers.IntegerField()
-    operator = serializers.ChoiceField(choices=["eq", "lt", "lte", "gt", "gte"])
-    value = serializers.CharField(max_length=16)
+    operator = serializers.ChoiceField(
+        choices=["eq", "dne", "lt", "lte", "gt", "gte", "btw"]
+    )
+    value = serializers.CharField(max_length=32)
 
 
 class TargetsSerializer(serializers.Serializer):

--- a/src/planscape/planning/serializers.py
+++ b/src/planscape/planning/serializers.py
@@ -567,13 +567,13 @@ class ConstraintSerializer(serializers.Serializer):
                 min_value = float(min_value)
                 max_value = float(max_value)
                 return f"{min_value},{max_value}"
-            except:
+            except ValueError:
                 raise serializers.ValidationError("Invalid constraint value(s)")
         else:
             try:
                 float(value)
                 return value
-            except:
+            except ValueError:
                 raise serializers.ValidationError("Invalid constraint value")
 
 

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -730,10 +730,10 @@ def calculate_child_project_areas(scenario: Scenario) -> list[ProjectArea]:
     return project_areas
 
 
-def _get_operation(operator: str, value: Any) -> str:
+def _get_operation(operator: str, value: str) -> str:
     match operator:
         case "btw":
-            values = str(value).split(",", maxsplit=1)
+            values = value.strip().replace(" ", "").split(",", maxsplit=1)
             values.sort()
             min_value, max_value = values
             return f"value >= {min_value.strip()} & value <= {max_value.strip()}"

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -733,7 +733,9 @@ def calculate_child_project_areas(scenario: Scenario) -> list[ProjectArea]:
 def _get_operation(operator: str, value: Any) -> str:
     match operator:
         case "btw":
-            min_value, max_value = str(value).split(",", maxsplit=1)
+            values = str(value).split(",", maxsplit=1)
+            values.sort()
+            min_value, max_value = values
             return f"value >= {min_value.strip()} & value <= {max_value.strip()}"
         case _:
             # normal cases

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -736,7 +736,7 @@ def _get_operation(operator: str, value: str) -> str:
             values = value.strip().replace(" ", "").split(",", maxsplit=1)
             values.sort()
             min_value, max_value = values
-            return f"value >= {min_value.strip()} & value <= {max_value.strip()}"
+            return f"value >= {float(min_value)} & value <= {float(max_value)}"
         case _:
             # normal cases
             # constraints datalayers from scenario configuration

--- a/src/planscape/planning/services.py
+++ b/src/planscape/planning/services.py
@@ -730,6 +730,26 @@ def calculate_child_project_areas(scenario: Scenario) -> list[ProjectArea]:
     return project_areas
 
 
+def _get_operation(operator: str, value: Any) -> str:
+    match operator:
+        case "btw":
+            min_value, max_value = str(value).split(",", maxsplit=1)
+            return f"value >= {min_value.strip()} & value <= {max_value.strip()}"
+        case _:
+            # normal cases
+            # constraints datalayers from scenario configuration
+            OPERATOR_MAP = {
+                "eq": "=",
+                "dne": "!=",
+                "lt": "<",
+                "lte": "<=",
+                "gt": ">",
+                "gte": ">=",
+            }
+
+            return f"value {OPERATOR_MAP.get(operator, operator)} {value}"
+
+
 def build_run_configuration(scenario: "Scenario") -> dict[str, Any]:
     tx_goal = scenario.treatment_goal
     datalayers = []
@@ -749,14 +769,6 @@ def build_run_configuration(scenario: "Scenario") -> dict[str, Any]:
 
             datalayers.append(item)
 
-    # constraints datalayers from scenario configuration
-    OPERATOR_MAP = {
-        "eq": "=",
-        "lt": "<",
-        "lte": "<=",
-        "gt": ">",
-        "gte": ">=",
-    }
     cfg = getattr(scenario, "configuration", {}) or {}
     constraints = cfg.get("constraints") or []
     priorities = cfg.get("priorities") or []
@@ -776,9 +788,7 @@ def build_run_configuration(scenario: "Scenario") -> dict[str, Any]:
 
         # Defer custom objectives/cobenefits so their thresholds get applied later.
         if datalayer_id in custom_datalayer_ids:
-            custom_thresholds[datalayer_id] = (
-                f"value {OPERATOR_MAP.get(operator, operator)} {value}"
-            )
+            custom_thresholds[datalayer_id] = _get_operation(operator, value)
             continue
 
         dl = DataLayer.objects.get(pk=datalayer_id)
@@ -789,7 +799,7 @@ def build_run_configuration(scenario: "Scenario") -> dict[str, Any]:
                 "metric": get_datalayer_metric(dl),
                 "type": dl.type,
                 "geometry_type": dl.geometry_type,
-                "threshold": f"value {OPERATOR_MAP.get(operator, operator)} {value}",
+                "threshold": _get_operation(operator, value),
                 "usage_type": "THRESHOLD",
                 "weight": None,
             }

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -117,6 +117,102 @@ class MaxAreaProjectTest(TestCase):
         self.assertEqual(max_project_area, 494.0)
 
 
+class BuildRunConfigurationTest(TestCase):
+    def setUp(self):
+        self.planning_area = PlanningAreaFactory.create()
+
+    def test_build_run_configuration_renders_constraint_operators(self):
+        dne_datalayer = DataLayerFactory.create(type=DataLayerType.RASTER)
+        btw_datalayer = DataLayerFactory.create(type=DataLayerType.RASTER)
+        scenario = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            treatment_goal=None,
+            configuration={
+                "stand_size": StandSizeChoices.LARGE,
+                "targets": {"max_area": 1000},
+                "constraints": [
+                    {
+                        "datalayer": dne_datalayer.pk,
+                        "operator": "dne",
+                        "value": "10",
+                    },
+                    {
+                        "datalayer": btw_datalayer.pk,
+                        "operator": "btw",
+                        "value": "10,20",
+                    },
+                ],
+            },
+        )
+
+        run_configuration = build_run_configuration(scenario)
+
+        datalayers = {
+            datalayer["id"]: datalayer
+            for datalayer in run_configuration["datalayers"]
+        }
+        self.assertEqual(datalayers[dne_datalayer.pk]["threshold"], "value != 10")
+        self.assertEqual(
+            datalayers[btw_datalayer.pk]["threshold"],
+            "value >= 10 & value <= 20",
+        )
+        self.assertEqual(
+            datalayers[dne_datalayer.pk]["usage_type"],
+            TreatmentGoalUsageType.THRESHOLD,
+        )
+        self.assertEqual(
+            datalayers[btw_datalayer.pk]["usage_type"],
+            TreatmentGoalUsageType.THRESHOLD,
+        )
+
+    def test_build_run_configuration_applies_constraints_to_custom_datalayers(self):
+        priority = DataLayerFactory.create(type=DataLayerType.RASTER)
+        cobenefit = DataLayerFactory.create(type=DataLayerType.RASTER)
+        scenario = ScenarioFactory.create(
+            planning_area=self.planning_area,
+            treatment_goal=None,
+            type=ScenarioType.CUSTOM,
+            configuration={
+                "stand_size": StandSizeChoices.LARGE,
+                "targets": {"max_area": 1000},
+                "priorities": [{"datalayer": priority.pk, "weight": 2}],
+                "cobenefits": [cobenefit.pk],
+                "constraints": [
+                    {
+                        "datalayer": priority.pk,
+                        "operator": "dne",
+                        "value": "10",
+                    },
+                    {
+                        "datalayer": cobenefit.pk,
+                        "operator": "btw",
+                        "value": "10, 20",
+                    },
+                ],
+            },
+        )
+
+        run_configuration = build_run_configuration(scenario)
+
+        datalayers = {
+            datalayer["id"]: datalayer
+            for datalayer in run_configuration["datalayers"]
+        }
+        self.assertEqual(datalayers[priority.pk]["threshold"], "value != 10")
+        self.assertEqual(
+            datalayers[cobenefit.pk]["threshold"],
+            "value >= 10 & value <= 20",
+        )
+        self.assertEqual(
+            datalayers[priority.pk]["usage_type"],
+            TreatmentGoalUsageType.PRIORITY,
+        )
+        self.assertEqual(
+            datalayers[cobenefit.pk]["usage_type"],
+            TreatmentGoalUsageType.SECONDARY_METRIC,
+        )
+
+
 class ValidateScenarioTreatmentRatioTest(TestCase):
     def setUp(self) -> None:
         # Test Polygon is 12165389.42118729 spherical acres

--- a/src/planscape/planning/tests/test_services.py
+++ b/src/planscape/planning/tests/test_services.py
@@ -154,7 +154,7 @@ class BuildRunConfigurationTest(TestCase):
         self.assertEqual(datalayers[dne_datalayer.pk]["threshold"], "value != 10")
         self.assertEqual(
             datalayers[btw_datalayer.pk]["threshold"],
-            "value >= 10 & value <= 20",
+            "value >= 10.0 & value <= 20.0",
         )
         self.assertEqual(
             datalayers[dne_datalayer.pk]["usage_type"],
@@ -201,7 +201,7 @@ class BuildRunConfigurationTest(TestCase):
         self.assertEqual(datalayers[priority.pk]["threshold"], "value != 10")
         self.assertEqual(
             datalayers[cobenefit.pk]["threshold"],
-            "value >= 10 & value <= 20",
+            "value >= 10.0 & value <= 20.0",
         )
         self.assertEqual(
             datalayers[priority.pk]["usage_type"],

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -1278,6 +1278,53 @@ class PatchScenarioConfigurationTest(APITestCase):
         self.assertEqual(config.get("stand_size"), "SMALL")
         self.assertEqual(config.get("targets").get("estimated_cost"), 12345)
 
+    def test_patch_scenario_configuration_accepts_dne_and_btw_constraints(self):
+        dne_datalayer = DataLayerFactory(
+            type=DataLayerType.VECTOR,
+            geometry_type=GeometryType.POLYGON,
+        )
+        btw_datalayer = DataLayerFactory(
+            type=DataLayerType.VECTOR,
+            geometry_type=GeometryType.POLYGON,
+        )
+        payload = {
+            "configuration": {
+                "constraints": [
+                    {
+                        "datalayer": dne_datalayer.pk,
+                        "operator": "dne",
+                        "value": "10",
+                    },
+                    {
+                        "datalayer": btw_datalayer.pk,
+                        "operator": "btw",
+                        "value": "10,20",
+                    },
+                ],
+            }
+        }
+
+        self.client.force_authenticate(self.user)
+        response = self.client.patch(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        config = response.data.get("configuration", {})
+        self.assertEqual(
+            config["constraints"],
+            [
+                {
+                    "datalayer": dne_datalayer.pk,
+                    "operator": "dne",
+                    "value": "10",
+                },
+                {
+                    "datalayer": btw_datalayer.pk,
+                    "operator": "btw",
+                    "value": "10,20",
+                },
+            ],
+        )
+
     # Test sequential patches, ensure we retain values as expected
     @mock.patch(
         "planning.serializers.calculate_scenario_treatable_area",

--- a/src/planscape/planning/tests/test_v2_scenario_views.py
+++ b/src/planscape/planning/tests/test_v2_scenario_views.py
@@ -1320,7 +1320,7 @@ class PatchScenarioConfigurationTest(APITestCase):
                 {
                     "datalayer": btw_datalayer.pk,
                     "operator": "btw",
-                    "value": "10,20",
+                    "value": "10.0,20.0",
                 },
             ],
         )


### PR DESCRIPTION
Adding operators DNE (does not equal) and BTW (between) to stand thresholds.

The input for BTW operator must be a string with a comma dividing values. eg: "10,20"